### PR TITLE
[codex] feat(content): publish raw 32-type en mbti variant authority

### DIFF
--- a/content_baselines/personality/mbti.en.json
+++ b/content_baselines/personality/mbti.en.json
@@ -3,7 +3,7 @@
     "schema_version": "v2",
     "scale_code": "MBTI",
     "locale": "en",
-    "source": "committed canonical base authority + placeholder variant authority until raw 32 source exists",
+    "source": "committed canonical base authority + raw 32 en variant authority",
     "generated_at": "2026-03-17T00:00:00Z"
   },
   "profiles": [
@@ -2797,26 +2797,460 @@
       "runtime_type_code": "ENFJ-A",
       "canonical_type_code": "ENFJ",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Protagonist",
+        "nickname": "Steadfast Guide",
+        "rarity_text": "Approx. 2–5%",
+        "keywords_json": [
+          "empathy",
+          "vision",
+          "harmonizer",
+          "service-oriented leadership",
+          "value-driven",
+          "self-confidence"
+        ],
+        "hero_summary_md": "You are like a warm light with direction: you tend to help people grow together around a meaningful direction. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Intuitive · Feeling · Judging · Assertive | the “Steadfast Guide”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ENFJ-A personalities often bring warmth, vision, and people-centered execution.\n\nYou feel most like yourself when there is a mission worth believing in, people worth investing in, and enough structure to move the vision forward.\n\nFor you, life works best when you can help people grow together around a meaningful direction rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where guidance, communication, and support can clearly improve both people and outcomes.\n\nWhen the environment becomes cold, fragmented, or purely transactional, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ENFJ-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "People growth and coaching",
+                "description": "Roles that let you support development while holding a bigger vision.",
+                "examples": [
+                  "coaching, mentoring, or counseling-related work",
+                  "teaching, training, and learning design",
+                  "people development, talent growth, or community leadership"
+                ]
+              },
+              {
+                "group_title": "Mission-led leadership",
+                "description": "Fields that combine service, direction, and practical influence.",
+                "examples": [
+                  "team leadership and project ownership",
+                  "people operations or organizational development",
+                  "nonprofit, NGO, or social impact programs"
+                ]
+              },
+              {
+                "group_title": "Communication and advocacy",
+                "description": "Work that turns values into messages people can believe in.",
+                "examples": [
+                  "brand communication and public relations",
+                  "content strategy and community building",
+                  "customer success or partnerships built on trust"
+                ]
+              },
+              {
+                "group_title": "Cross-functional coordination",
+                "description": "Environments where alignment matters as much as execution.",
+                "examples": [
+                  "program management",
+                  "stakeholder coordination roles",
+                  "culture, internal communications, or team enablement"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into over-functioning and carrying too much responsibility for the emotional climate.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Seeing people grow, receiving sincere trust, and knowing that your effort moved something meaningful forward usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Seeing people grow, receiving sincere trust, and knowing that your effort moved something meaningful forward usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Cold cultures, unresolved relational tension, and long stretches of emotional labor without reciprocity can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Cold cultures, unresolved relational tension, and long stretches of emotional labor without reciprocity can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be warm, growth-oriented, and deeply invested in mutual understanding.\n\nYour main challenge is over-functioning and carrying too much responsibility for the emotional climate.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often become a source of encouragement, emotional safety, and forward movement in healthy relationships.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often become a source of encouragement, emotional safety, and forward movement in healthy relationships.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "When a bond becomes one-sided, you may keep trying to heal it long after the imbalance has become costly to you.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "When a bond becomes one-sided, you may keep trying to heal it long after the imbalance has become costly to you.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ENFJ-A Protagonist",
+        "seo_description": "You are like a warm light with direction: you tend to help people grow together around a meaningful direction. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ENFJ-A Steadfast Guide",
+        "og_description": "You are like a warm light with direction: you tend to help people grow together around a meaningful direction. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ENFJ-A Steadfast Guide",
+        "twitter_description": "You are like a warm light with direction: you tend to help people grow together around a meaningful direction. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -2826,26 +3260,460 @@
       "runtime_type_code": "ENFJ-T",
       "canonical_type_code": "ENFJ",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Protagonist",
+        "nickname": "Gentle Guide",
+        "rarity_text": "Approx. 2–5%",
+        "keywords_json": [
+          "empathy",
+          "vision",
+          "harmonizer",
+          "service-oriented leadership",
+          "value-driven",
+          "self-reflection"
+        ],
+        "hero_summary_md": "You are like a warm light with direction: you tend to help people grow together around a meaningful direction. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Intuitive · Feeling · Judging · Turbulent | the “Gentle Guide”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ENFJ-T personalities often bring warmth, vision, and people-centered execution.\n\nYou feel most like yourself when there is a mission worth believing in, people worth investing in, and enough structure to move the vision forward.\n\nFor you, life works best when you can help people grow together around a meaningful direction rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where guidance, communication, and support can clearly improve both people and outcomes.\n\nWhen the environment becomes cold, fragmented, or purely transactional, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ENFJ-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "People growth and coaching",
+                "description": "Roles that let you support development while holding a bigger vision.",
+                "examples": [
+                  "coaching, mentoring, or counseling-related work",
+                  "teaching, training, and learning design",
+                  "people development, talent growth, or community leadership"
+                ]
+              },
+              {
+                "group_title": "Mission-led leadership",
+                "description": "Fields that combine service, direction, and practical influence.",
+                "examples": [
+                  "team leadership and project ownership",
+                  "people operations or organizational development",
+                  "nonprofit, NGO, or social impact programs"
+                ]
+              },
+              {
+                "group_title": "Communication and advocacy",
+                "description": "Work that turns values into messages people can believe in.",
+                "examples": [
+                  "brand communication and public relations",
+                  "content strategy and community building",
+                  "customer success or partnerships built on trust"
+                ]
+              },
+              {
+                "group_title": "Cross-functional coordination",
+                "description": "Environments where alignment matters as much as execution.",
+                "examples": [
+                  "program management",
+                  "stakeholder coordination roles",
+                  "culture, internal communications, or team enablement"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into over-functioning and carrying too much responsibility for the emotional climate.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Seeing people grow, receiving sincere trust, and knowing that your effort moved something meaningful forward usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Seeing people grow, receiving sincere trust, and knowing that your effort moved something meaningful forward usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Cold cultures, unresolved relational tension, and long stretches of emotional labor without reciprocity can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Cold cultures, unresolved relational tension, and long stretches of emotional labor without reciprocity can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be warm, growth-oriented, and deeply invested in mutual understanding.\n\nYour main challenge is over-functioning and carrying too much responsibility for the emotional climate.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often become a source of encouragement, emotional safety, and forward movement in healthy relationships.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often become a source of encouragement, emotional safety, and forward movement in healthy relationships.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "When a bond becomes one-sided, you may keep trying to heal it long after the imbalance has become costly to you.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "When a bond becomes one-sided, you may keep trying to heal it long after the imbalance has become costly to you.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ENFJ-T Protagonist",
+        "seo_description": "You are like a warm light with direction: you tend to help people grow together around a meaningful direction. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ENFJ-T Gentle Guide",
+        "og_description": "You are like a warm light with direction: you tend to help people grow together around a meaningful direction. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ENFJ-T Gentle Guide",
+        "twitter_description": "You are like a warm light with direction: you tend to help people grow together around a meaningful direction. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -2855,26 +3723,460 @@
       "runtime_type_code": "ENFP-A",
       "canonical_type_code": "ENFP",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Campaigner",
+        "nickname": "Inspiration Igniter",
+        "rarity_text": "Approx. 6–8%",
+        "keywords_json": [
+          "curiosity",
+          "creativity",
+          "enthusiasm",
+          "empathic ability",
+          "self-expression",
+          "free exploration"
+        ],
+        "hero_summary_md": "You are like a spark that keeps opening new doors: you tend to help people feel braver, freer, and more alive while exploring what else is possible. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Intuitive · Feeling · Prospecting · Assertive | the “Inspiration Igniter”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ENFP-A personalities often bring curiosity, emotional warmth, and possibility-driven energy.\n\nYou feel most like yourself when there is room to explore, create, connect, and keep discovering new possibilities.\n\nFor you, life works best when you can help people feel braver, freer, and more alive while exploring what else is possible rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward creativity, flexibility, human connection, and fresh thinking.\n\nWhen life starts to feel rigid, repetitive, or emotionally flat, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ENFP-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Creative communication",
+                "description": "Roles built around stories, ideas, and fresh expression.",
+                "examples": [
+                  "content strategy, writing, or media",
+                  "brand storytelling and social content",
+                  "creator, host, or facilitator roles"
+                ]
+              },
+              {
+                "group_title": "Human growth and facilitation",
+                "description": "Fields where encouragement and perspective matter.",
+                "examples": [
+                  "education, workshops, and training",
+                  "coaching or mentorship",
+                  "community-led learning experiences"
+                ]
+              },
+              {
+                "group_title": "Innovation and new ventures",
+                "description": "Fast-moving spaces that reward experimentation.",
+                "examples": [
+                  "early-stage startups",
+                  "new business incubation",
+                  "0-to-1 product or experience development"
+                ]
+              },
+              {
+                "group_title": "Partnerships and audience-facing work",
+                "description": "Roles that rely on connection and momentum.",
+                "examples": [
+                  "customer success",
+                  "business development and partnerships",
+                  "community, event, or audience growth"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into scattering your energy or drifting when connection stops evolving.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Meaningful novelty, creative freedom, emotional resonance, and the chance to inspire others usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Meaningful novelty, creative freedom, emotional resonance, and the chance to inspire others usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Stagnation, excessive control, shallow routines, and environments that suppress curiosity can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Stagnation, excessive control, shallow routines, and environments that suppress curiosity can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be open-hearted, expressive, and highly responsive to emotional resonance.\n\nYour main challenge is scattering your energy or drifting when connection stops evolving.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring freshness, hope, and emotional honesty that make relationships feel alive.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring freshness, hope, and emotional honesty that make relationships feel alive.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If a relationship becomes static or overly constraining, your energy may drift before the issue is clearly named.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If a relationship becomes static or overly constraining, your energy may drift before the issue is clearly named.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ENFP-A Campaigner",
+        "seo_description": "You are like a spark that keeps opening new doors: you tend to help people feel braver, freer, and more alive while exploring what else is possible. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ENFP-A Inspiration Igniter",
+        "og_description": "You are like a spark that keeps opening new doors: you tend to help people feel braver, freer, and more alive while exploring what else is possible. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ENFP-A Inspiration Igniter",
+        "twitter_description": "You are like a spark that keeps opening new doors: you tend to help people feel braver, freer, and more alive while exploring what else is possible. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -2884,26 +4186,460 @@
       "runtime_type_code": "ENFP-T",
       "canonical_type_code": "ENFP",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Campaigner",
+        "nickname": "Idea Generator",
+        "rarity_text": "Approx. 6–8%",
+        "keywords_json": [
+          "creativity",
+          "enthusiasm",
+          "freedom",
+          "charisma",
+          "empathy",
+          "self-exploration"
+        ],
+        "hero_summary_md": "You are like a spark that keeps opening new doors: you tend to help people feel braver, freer, and more alive while exploring what else is possible. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Intuitive · Feeling · Prospecting · Turbulent | the “Idea Generator”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ENFP-T personalities often bring curiosity, emotional warmth, and possibility-driven energy.\n\nYou feel most like yourself when there is room to explore, create, connect, and keep discovering new possibilities.\n\nFor you, life works best when you can help people feel braver, freer, and more alive while exploring what else is possible rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward creativity, flexibility, human connection, and fresh thinking.\n\nWhen life starts to feel rigid, repetitive, or emotionally flat, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ENFP-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Creative communication",
+                "description": "Roles built around stories, ideas, and fresh expression.",
+                "examples": [
+                  "content strategy, writing, or media",
+                  "brand storytelling and social content",
+                  "creator, host, or facilitator roles"
+                ]
+              },
+              {
+                "group_title": "Human growth and facilitation",
+                "description": "Fields where encouragement and perspective matter.",
+                "examples": [
+                  "education, workshops, and training",
+                  "coaching or mentorship",
+                  "community-led learning experiences"
+                ]
+              },
+              {
+                "group_title": "Innovation and new ventures",
+                "description": "Fast-moving spaces that reward experimentation.",
+                "examples": [
+                  "early-stage startups",
+                  "new business incubation",
+                  "0-to-1 product or experience development"
+                ]
+              },
+              {
+                "group_title": "Partnerships and audience-facing work",
+                "description": "Roles that rely on connection and momentum.",
+                "examples": [
+                  "customer success",
+                  "business development and partnerships",
+                  "community, event, or audience growth"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into scattering your energy or drifting when connection stops evolving.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Meaningful novelty, creative freedom, emotional resonance, and the chance to inspire others usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Meaningful novelty, creative freedom, emotional resonance, and the chance to inspire others usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Stagnation, excessive control, shallow routines, and environments that suppress curiosity can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Stagnation, excessive control, shallow routines, and environments that suppress curiosity can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be open-hearted, expressive, and highly responsive to emotional resonance.\n\nYour main challenge is scattering your energy or drifting when connection stops evolving.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring freshness, hope, and emotional honesty that make relationships feel alive.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring freshness, hope, and emotional honesty that make relationships feel alive.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If a relationship becomes static or overly constraining, your energy may drift before the issue is clearly named.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If a relationship becomes static or overly constraining, your energy may drift before the issue is clearly named.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ENFP-T Campaigner",
+        "seo_description": "You are like a spark that keeps opening new doors: you tend to help people feel braver, freer, and more alive while exploring what else is possible. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ENFP-T Idea Generator",
+        "og_description": "You are like a spark that keeps opening new doors: you tend to help people feel braver, freer, and more alive while exploring what else is possible. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ENFP-T Idea Generator",
+        "twitter_description": "You are like a spark that keeps opening new doors: you tend to help people feel braver, freer, and more alive while exploring what else is possible. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -2913,26 +4649,460 @@
       "runtime_type_code": "ENTJ-A",
       "canonical_type_code": "ENTJ",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Commander",
+        "nickname": "Strategic Helmsman",
+        "rarity_text": "Approx. 2–3%",
+        "keywords_json": [
+          "strategic vision",
+          "decision-making strength",
+          "efficiency-first",
+          "goal orientation",
+          "system building",
+          "leadership"
+        ],
+        "hero_summary_md": "You are like a strategist at the helm: you tend to turn potential into clear movement, stronger systems, and measurable progress. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Intuitive · Thinking · Judging · Assertive | the “Strategic Helmsman”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ENTJ-A personalities often bring direction, leverage, and large-scale execution.\n\nYou feel most like yourself when there is a meaningful target, real authority to act, and a system that can be improved.\n\nFor you, life works best when you can turn potential into clear movement, stronger systems, and measurable progress rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that combine strategy, decision-making, and visible impact.\n\nWhen power is unclear, standards are low, or the system resists improvement, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ENTJ-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Strategy and leadership",
+                "description": "Roles that require direction-setting and accountable execution.",
+                "examples": [
+                  "business leadership",
+                  "strategy, operations, or PMO roles",
+                  "program ownership with decision authority"
+                ]
+              },
+              {
+                "group_title": "Consulting and analysis",
+                "description": "Complex environments that reward sharp judgment.",
+                "examples": [
+                  "management consulting",
+                  "commercial or strategic analysis",
+                  "investment, market, or growth strategy"
+                ]
+              },
+              {
+                "group_title": "Operations and scaling",
+                "description": "Work that turns wins into repeatable systems.",
+                "examples": [
+                  "operations leadership",
+                  "business process design",
+                  "cross-functional execution in scaling teams"
+                ]
+              },
+              {
+                "group_title": "Entrepreneurial paths",
+                "description": "Settings where ownership and speed matter.",
+                "examples": [
+                  "startup leadership",
+                  "venture building",
+                  "0-to-1 business ownership"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into letting achievement logic overshadow emotional softness or shared pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Hard problems, trusted authority, clear stakes, and the chance to build something stronger usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Hard problems, trusted authority, clear stakes, and the chance to build something stronger usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Indecision, low accountability, misaligned incentives, and repeated inefficiency can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Indecision, low accountability, misaligned incentives, and repeated inefficiency can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be direct, responsible, and serious about building a viable future together.\n\nYour main challenge is letting achievement logic overshadow emotional softness or shared pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring steadiness, vision, and a willingness to invest in long-term growth.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring steadiness, vision, and a willingness to invest in long-term growth.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "Under stress, you may over-direct the future and leave too little room for vulnerability.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Under stress, you may over-direct the future and leave too little room for vulnerability.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ENTJ-A Commander",
+        "seo_description": "You are like a strategist at the helm: you tend to turn potential into clear movement, stronger systems, and measurable progress. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ENTJ-A Strategic Helmsman",
+        "og_description": "You are like a strategist at the helm: you tend to turn potential into clear movement, stronger systems, and measurable progress. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ENTJ-A Strategic Helmsman",
+        "twitter_description": "You are like a strategist at the helm: you tend to turn potential into clear movement, stronger systems, and measurable progress. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -2942,26 +5112,460 @@
       "runtime_type_code": "ENTJ-T",
       "canonical_type_code": "ENTJ",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Commander",
+        "nickname": "Disciplined Commander",
+        "rarity_text": "Approx. 1–3%",
+        "keywords_json": [
+          "strategy",
+          "decision-making",
+          "efficiency",
+          "goal orientation",
+          "rationality",
+          "self-improvement"
+        ],
+        "hero_summary_md": "You are like a strategist at the helm: you tend to turn potential into clear movement, stronger systems, and measurable progress. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Intuitive · Thinking · Judging · Turbulent | the “Disciplined Commander”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ENTJ-T personalities often bring direction, leverage, and large-scale execution.\n\nYou feel most like yourself when there is a meaningful target, real authority to act, and a system that can be improved.\n\nFor you, life works best when you can turn potential into clear movement, stronger systems, and measurable progress rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that combine strategy, decision-making, and visible impact.\n\nWhen power is unclear, standards are low, or the system resists improvement, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ENTJ-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Strategy and leadership",
+                "description": "Roles that require direction-setting and accountable execution.",
+                "examples": [
+                  "business leadership",
+                  "strategy, operations, or PMO roles",
+                  "program ownership with decision authority"
+                ]
+              },
+              {
+                "group_title": "Consulting and analysis",
+                "description": "Complex environments that reward sharp judgment.",
+                "examples": [
+                  "management consulting",
+                  "commercial or strategic analysis",
+                  "investment, market, or growth strategy"
+                ]
+              },
+              {
+                "group_title": "Operations and scaling",
+                "description": "Work that turns wins into repeatable systems.",
+                "examples": [
+                  "operations leadership",
+                  "business process design",
+                  "cross-functional execution in scaling teams"
+                ]
+              },
+              {
+                "group_title": "Entrepreneurial paths",
+                "description": "Settings where ownership and speed matter.",
+                "examples": [
+                  "startup leadership",
+                  "venture building",
+                  "0-to-1 business ownership"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into letting achievement logic overshadow emotional softness or shared pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Hard problems, trusted authority, clear stakes, and the chance to build something stronger usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Hard problems, trusted authority, clear stakes, and the chance to build something stronger usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Indecision, low accountability, misaligned incentives, and repeated inefficiency can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Indecision, low accountability, misaligned incentives, and repeated inefficiency can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be direct, responsible, and serious about building a viable future together.\n\nYour main challenge is letting achievement logic overshadow emotional softness or shared pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring steadiness, vision, and a willingness to invest in long-term growth.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring steadiness, vision, and a willingness to invest in long-term growth.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "Under stress, you may over-direct the future and leave too little room for vulnerability.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Under stress, you may over-direct the future and leave too little room for vulnerability.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ENTJ-T Commander",
+        "seo_description": "You are like a strategist at the helm: you tend to turn potential into clear movement, stronger systems, and measurable progress. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ENTJ-T Disciplined Commander",
+        "og_description": "You are like a strategist at the helm: you tend to turn potential into clear movement, stronger systems, and measurable progress. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ENTJ-T Disciplined Commander",
+        "twitter_description": "You are like a strategist at the helm: you tend to turn potential into clear movement, stronger systems, and measurable progress. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -2971,26 +5575,460 @@
       "runtime_type_code": "ENTP-A",
       "canonical_type_code": "ENTP",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Debater",
+        "nickname": "Brainstorm Catalyst",
+        "rarity_text": "Approx. 2–4%",
+        "keywords_json": [
+          "curiosity",
+          "idea generator",
+          "logical debate",
+          "rebellious thinking",
+          "innovation-driven",
+          "fast learning"
+        ],
+        "hero_summary_md": "You are like a mind that keeps opening windows: you tend to reframe stale problems, test ideas, and push systems toward better possibilities. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Intuitive · Thinking · Prospecting · Assertive | the “Brainstorm Catalyst”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ENTP-A personalities often bring inventive thinking, challenge, and intellectual play.\n\nYou feel most like yourself when there is something interesting to figure out, improve, or challenge.\n\nFor you, life works best when you can reframe stale problems, test ideas, and push systems toward better possibilities rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward curiosity, experimentation, debate, and conceptual agility.\n\nWhen discussion is dead, routine is rigid, or questioning is treated as troublemaking, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ENTP-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Innovation and strategy",
+                "description": "Roles built around experimentation and creative disruption.",
+                "examples": [
+                  "product strategy and 0-to-1 work",
+                  "innovation or incubation teams",
+                  "growth strategy and experimentation"
+                ]
+              },
+              {
+                "group_title": "Consulting and solutions",
+                "description": "Settings where reframing the problem is half the value.",
+                "examples": [
+                  "consulting",
+                  "advisory or research roles",
+                  "user, market, or commercial insights"
+                ]
+              },
+              {
+                "group_title": "Content and expression",
+                "description": "Work that rewards sharp ideas and lively communication.",
+                "examples": [
+                  "writing, hosting, or commentary",
+                  "creative strategy",
+                  "idea-led education or facilitation"
+                ]
+              },
+              {
+                "group_title": "Entrepreneurial generalism",
+                "description": "Open-ended settings where you can connect dots quickly.",
+                "examples": [
+                  "startup generalist work",
+                  "emerging-space business development",
+                  "project ownership across changing contexts"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into staying at the level of ideas when deeper emotional processing is needed.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Novelty, sharp conversation, experimentation, and the chance to build a better model usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Novelty, sharp conversation, experimentation, and the chance to build a better model usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Anti-questioning cultures, dead routines, and relationships where curiosity is treated as a problem can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Anti-questioning cultures, dead routines, and relationships where curiosity is treated as a problem can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be witty, exploratory, and energized by mentally alive connection.\n\nYour main challenge is staying at the level of ideas when deeper emotional processing is needed.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring energy, perspective, humor, and fresh solutions into a relationship.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring energy, perspective, humor, and fresh solutions into a relationship.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "You may debate, reframe, or joke your way around emotional depth instead of staying with it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You may debate, reframe, or joke your way around emotional depth instead of staying with it.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ENTP-A Debater",
+        "seo_description": "You are like a mind that keeps opening windows: you tend to reframe stale problems, test ideas, and push systems toward better possibilities. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ENTP-A Brainstorm Catalyst",
+        "og_description": "You are like a mind that keeps opening windows: you tend to reframe stale problems, test ideas, and push systems toward better possibilities. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ENTP-A Brainstorm Catalyst",
+        "twitter_description": "You are like a mind that keeps opening windows: you tend to reframe stale problems, test ideas, and push systems toward better possibilities. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3000,26 +6038,460 @@
       "runtime_type_code": "ENTP-T",
       "canonical_type_code": "ENTP",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Debater",
+        "nickname": "Idea Maverick",
+        "rarity_text": "Approx. 2–4%",
+        "keywords_json": [
+          "curiosity",
+          "imagination",
+          "dialectical thinking",
+          "unconventional",
+          "challenging authority",
+          "fast learning"
+        ],
+        "hero_summary_md": "You are like a mind that keeps opening windows: you tend to reframe stale problems, test ideas, and push systems toward better possibilities. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Intuitive · Thinking · Prospecting · Turbulent | the “Idea Maverick”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ENTP-T personalities often bring inventive thinking, challenge, and intellectual play.\n\nYou feel most like yourself when there is something interesting to figure out, improve, or challenge.\n\nFor you, life works best when you can reframe stale problems, test ideas, and push systems toward better possibilities rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward curiosity, experimentation, debate, and conceptual agility.\n\nWhen discussion is dead, routine is rigid, or questioning is treated as troublemaking, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ENTP-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Innovation and strategy",
+                "description": "Roles built around experimentation and creative disruption.",
+                "examples": [
+                  "product strategy and 0-to-1 work",
+                  "innovation or incubation teams",
+                  "growth strategy and experimentation"
+                ]
+              },
+              {
+                "group_title": "Consulting and solutions",
+                "description": "Settings where reframing the problem is half the value.",
+                "examples": [
+                  "consulting",
+                  "advisory or research roles",
+                  "user, market, or commercial insights"
+                ]
+              },
+              {
+                "group_title": "Content and expression",
+                "description": "Work that rewards sharp ideas and lively communication.",
+                "examples": [
+                  "writing, hosting, or commentary",
+                  "creative strategy",
+                  "idea-led education or facilitation"
+                ]
+              },
+              {
+                "group_title": "Entrepreneurial generalism",
+                "description": "Open-ended settings where you can connect dots quickly.",
+                "examples": [
+                  "startup generalist work",
+                  "emerging-space business development",
+                  "project ownership across changing contexts"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into staying at the level of ideas when deeper emotional processing is needed.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Novelty, sharp conversation, experimentation, and the chance to build a better model usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Novelty, sharp conversation, experimentation, and the chance to build a better model usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Anti-questioning cultures, dead routines, and relationships where curiosity is treated as a problem can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Anti-questioning cultures, dead routines, and relationships where curiosity is treated as a problem can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be witty, exploratory, and energized by mentally alive connection.\n\nYour main challenge is staying at the level of ideas when deeper emotional processing is needed.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring energy, perspective, humor, and fresh solutions into a relationship.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring energy, perspective, humor, and fresh solutions into a relationship.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "You may debate, reframe, or joke your way around emotional depth instead of staying with it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You may debate, reframe, or joke your way around emotional depth instead of staying with it.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ENTP-T Debater",
+        "seo_description": "You are like a mind that keeps opening windows: you tend to reframe stale problems, test ideas, and push systems toward better possibilities. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ENTP-T Idea Maverick",
+        "og_description": "You are like a mind that keeps opening windows: you tend to reframe stale problems, test ideas, and push systems toward better possibilities. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ENTP-T Idea Maverick",
+        "twitter_description": "You are like a mind that keeps opening windows: you tend to reframe stale problems, test ideas, and push systems toward better possibilities. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3029,26 +6501,460 @@
       "runtime_type_code": "ESFJ-A",
       "canonical_type_code": "ESFJ",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Consul",
+        "nickname": "Warm Organizer",
+        "rarity_text": "Approx. 6–8%",
+        "keywords_json": [
+          "consideration",
+          "organizational ability",
+          "responsibility",
+          "sense of order",
+          "social coordination",
+          "steady optimism"
+        ],
+        "hero_summary_md": "You are like a warm center that keeps everyday life working: you tend to make people feel supported while keeping the system humane and functional. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Sensing · Feeling · Judging · Assertive | the “Warm Organizer”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ESFJ-A personalities often bring care, coordination, and dependable social responsibility.\n\nYou feel most like yourself when people are treated well, expectations are clear, and day-to-day life is not falling apart.\n\nFor you, life works best when you can make people feel supported while keeping the system humane and functional rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where support, coordination, service, and relationship management all matter.\n\nWhen the environment is cold, chaotic, or dismissive of emotional labor, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ESFJ-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "People operations and support",
+                "description": "Roles that keep teams, communities, or clients well cared for.",
+                "examples": [
+                  "people operations and HR support",
+                  "customer success and community care",
+                  "program coordination or student support"
+                ]
+              },
+              {
+                "group_title": "Education and care",
+                "description": "Fields where daily presence and encouragement matter.",
+                "examples": [
+                  "teaching and school operations",
+                  "caregiving and community service",
+                  "training and onboarding"
+                ]
+              },
+              {
+                "group_title": "Service and experience",
+                "description": "Work that turns organization into a better human experience.",
+                "examples": [
+                  "hospitality or member experience",
+                  "events and guest care",
+                  "frontline operations with a people focus"
+                ]
+              },
+              {
+                "group_title": "Structured team leadership",
+                "description": "Settings where reliability and care need to coexist.",
+                "examples": [
+                  "team supervision",
+                  "store or site management",
+                  "cross-functional coordination"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into over-giving and hoping care alone will restore balance.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Being trusted, appreciated, and able to improve people’s daily experience in visible ways usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Being trusted, appreciated, and able to improve people’s daily experience in visible ways usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Invisible effort, chronic chaos, and one-sided emotional labor can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Invisible effort, chronic chaos, and one-sided emotional labor can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be attentive, dependable, and generous with practical care.\n\nYour main challenge is over-giving and hoping care alone will restore balance.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often make people feel remembered, included, and genuinely cared for.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often make people feel remembered, included, and genuinely cared for.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you keep giving without naming your needs, resentment can quietly replace warmth.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you keep giving without naming your needs, resentment can quietly replace warmth.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ESFJ-A Consul",
+        "seo_description": "You are like a warm center that keeps everyday life working: you tend to make people feel supported while keeping the system humane and functional. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ESFJ-A Warm Organizer",
+        "og_description": "You are like a warm center that keeps everyday life working: you tend to make people feel supported while keeping the system humane and functional. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ESFJ-A Warm Organizer",
+        "twitter_description": "You are like a warm center that keeps everyday life working: you tend to make people feel supported while keeping the system humane and functional. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3058,26 +6964,460 @@
       "runtime_type_code": "ESFJ-T",
       "canonical_type_code": "ESFJ",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Consul",
+        "nickname": "Warm Guardian",
+        "rarity_text": "Approx. 6–9%",
+        "keywords_json": [
+          "consideration",
+          "responsibility",
+          "organizational ability",
+          "sense of order",
+          "relationship-building",
+          "service to others"
+        ],
+        "hero_summary_md": "You are like a warm center that keeps everyday life working: you tend to make people feel supported while keeping the system humane and functional. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Sensing · Feeling · Judging · Turbulent | the “Warm Guardian”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ESFJ-T personalities often bring care, coordination, and dependable social responsibility.\n\nYou feel most like yourself when people are treated well, expectations are clear, and day-to-day life is not falling apart.\n\nFor you, life works best when you can make people feel supported while keeping the system humane and functional rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where support, coordination, service, and relationship management all matter.\n\nWhen the environment is cold, chaotic, or dismissive of emotional labor, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ESFJ-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "People operations and support",
+                "description": "Roles that keep teams, communities, or clients well cared for.",
+                "examples": [
+                  "people operations and HR support",
+                  "customer success and community care",
+                  "program coordination or student support"
+                ]
+              },
+              {
+                "group_title": "Education and care",
+                "description": "Fields where daily presence and encouragement matter.",
+                "examples": [
+                  "teaching and school operations",
+                  "caregiving and community service",
+                  "training and onboarding"
+                ]
+              },
+              {
+                "group_title": "Service and experience",
+                "description": "Work that turns organization into a better human experience.",
+                "examples": [
+                  "hospitality or member experience",
+                  "events and guest care",
+                  "frontline operations with a people focus"
+                ]
+              },
+              {
+                "group_title": "Structured team leadership",
+                "description": "Settings where reliability and care need to coexist.",
+                "examples": [
+                  "team supervision",
+                  "store or site management",
+                  "cross-functional coordination"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into over-giving and hoping care alone will restore balance.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Being trusted, appreciated, and able to improve people’s daily experience in visible ways usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Being trusted, appreciated, and able to improve people’s daily experience in visible ways usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Invisible effort, chronic chaos, and one-sided emotional labor can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Invisible effort, chronic chaos, and one-sided emotional labor can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be attentive, dependable, and generous with practical care.\n\nYour main challenge is over-giving and hoping care alone will restore balance.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often make people feel remembered, included, and genuinely cared for.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often make people feel remembered, included, and genuinely cared for.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you keep giving without naming your needs, resentment can quietly replace warmth.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you keep giving without naming your needs, resentment can quietly replace warmth.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ESFJ-T Consul",
+        "seo_description": "You are like a warm center that keeps everyday life working: you tend to make people feel supported while keeping the system humane and functional. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ESFJ-T Warm Guardian",
+        "og_description": "You are like a warm center that keeps everyday life working: you tend to make people feel supported while keeping the system humane and functional. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ESFJ-T Warm Guardian",
+        "twitter_description": "You are like a warm center that keeps everyday life working: you tend to make people feel supported while keeping the system humane and functional. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3087,26 +7427,460 @@
       "runtime_type_code": "ESFP-A",
       "canonical_type_code": "ESFP",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Entertainer",
+        "nickname": "Colorful Experience Seeker",
+        "rarity_text": "Approx. 4–9%",
+        "keywords_json": [
+          "present-moment experience",
+          "charisma",
+          "optimism",
+          "spontaneity",
+          "sensory enjoyment",
+          "action-minded"
+        ],
+        "hero_summary_md": "You are like a bright spotlight on the present moment: you tend to make life feel more immediate, enjoyable, and emotionally real. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Sensing · Feeling · Prospecting · Assertive | the “Colorful Experience Seeker”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ESFP-A personalities often bring liveliness, responsiveness, and emotionally vivid presence.\n\nYou feel most like yourself when there is room to experience, improvise, and connect in real time.\n\nFor you, life works best when you can make life feel more immediate, enjoyable, and emotionally real rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that are lively, people-facing, and grounded in immediate feedback.\n\nWhen life becomes flat, over-controlled, or repetitive, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ESFP-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Experience and events",
+                "description": "Work built around atmosphere and real-time interaction.",
+                "examples": [
+                  "events, hosting, or live experience roles",
+                  "community or activation work",
+                  "frontline lifestyle or entertainment operations"
+                ]
+              },
+              {
+                "group_title": "Service and customer connection",
+                "description": "Fields where warmth and responsiveness matter.",
+                "examples": [
+                  "customer-facing support or success",
+                  "hospitality, wellness, or premium retail",
+                  "member and guest experience roles"
+                ]
+              },
+              {
+                "group_title": "Creative and social content",
+                "description": "Spaces that reward timing and personality.",
+                "examples": [
+                  "content creation and short-form media",
+                  "lifestyle or brand storytelling",
+                  "community-led social content"
+                ]
+              },
+              {
+                "group_title": "Sales and frontline momentum",
+                "description": "Roles where energy and intuition matter.",
+                "examples": [
+                  "sales and partnerships",
+                  "field marketing or promotion",
+                  "business development with a strong live component"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into keeping things bright while avoiding slower, heavier emotions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Real people, positive feedback, fresh experiences, and immediate human impact usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Real people, positive feedback, fresh experiences, and immediate human impact usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Overcontrolled settings, dead routines, and being valued only as the mood-lifter can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Overcontrolled settings, dead routines, and being valued only as the mood-lifter can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be affectionate, present, and experience-oriented.\n\nYour main challenge is keeping things bright while avoiding slower, heavier emotions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring warmth, vitality, and a vivid sense of shared experience to the people around you.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring warmth, vitality, and a vivid sense of shared experience to the people around you.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you avoid heavier conversations for too long, surface chemistry can outpace real depth.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you avoid heavier conversations for too long, surface chemistry can outpace real depth.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ESFP-A Entertainer",
+        "seo_description": "You are like a bright spotlight on the present moment: you tend to make life feel more immediate, enjoyable, and emotionally real. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ESFP-A Colorful Experience Seeker",
+        "og_description": "You are like a bright spotlight on the present moment: you tend to make life feel more immediate, enjoyable, and emotionally real. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ESFP-A Colorful Experience Seeker",
+        "twitter_description": "You are like a bright spotlight on the present moment: you tend to make life feel more immediate, enjoyable, and emotionally real. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3116,26 +7890,460 @@
       "runtime_type_code": "ESFP-T",
       "canonical_type_code": "ESFP",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Entertainer",
+        "nickname": "Inspired Action-Taker",
+        "rarity_text": "Approx. 6–10%",
+        "keywords_json": [
+          "present-moment experience",
+          "sensory awareness",
+          "emotional contagion",
+          "improvisation",
+          "joy and sharing",
+          "self-reflective turbulence"
+        ],
+        "hero_summary_md": "You are like a bright spotlight on the present moment: you tend to make life feel more immediate, enjoyable, and emotionally real. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Sensing · Feeling · Prospecting · Turbulent | the “Inspired Action-Taker”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ESFP-T personalities often bring liveliness, responsiveness, and emotionally vivid presence.\n\nYou feel most like yourself when there is room to experience, improvise, and connect in real time.\n\nFor you, life works best when you can make life feel more immediate, enjoyable, and emotionally real rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that are lively, people-facing, and grounded in immediate feedback.\n\nWhen life becomes flat, over-controlled, or repetitive, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ESFP-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Experience and events",
+                "description": "Work built around atmosphere and real-time interaction.",
+                "examples": [
+                  "events, hosting, or live experience roles",
+                  "community or activation work",
+                  "frontline lifestyle or entertainment operations"
+                ]
+              },
+              {
+                "group_title": "Service and customer connection",
+                "description": "Fields where warmth and responsiveness matter.",
+                "examples": [
+                  "customer-facing support or success",
+                  "hospitality, wellness, or premium retail",
+                  "member and guest experience roles"
+                ]
+              },
+              {
+                "group_title": "Creative and social content",
+                "description": "Spaces that reward timing and personality.",
+                "examples": [
+                  "content creation and short-form media",
+                  "lifestyle or brand storytelling",
+                  "community-led social content"
+                ]
+              },
+              {
+                "group_title": "Sales and frontline momentum",
+                "description": "Roles where energy and intuition matter.",
+                "examples": [
+                  "sales and partnerships",
+                  "field marketing or promotion",
+                  "business development with a strong live component"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into keeping things bright while avoiding slower, heavier emotions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Real people, positive feedback, fresh experiences, and immediate human impact usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Real people, positive feedback, fresh experiences, and immediate human impact usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Overcontrolled settings, dead routines, and being valued only as the mood-lifter can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Overcontrolled settings, dead routines, and being valued only as the mood-lifter can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be affectionate, present, and experience-oriented.\n\nYour main challenge is keeping things bright while avoiding slower, heavier emotions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring warmth, vitality, and a vivid sense of shared experience to the people around you.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring warmth, vitality, and a vivid sense of shared experience to the people around you.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you avoid heavier conversations for too long, surface chemistry can outpace real depth.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you avoid heavier conversations for too long, surface chemistry can outpace real depth.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ESFP-T Entertainer",
+        "seo_description": "You are like a bright spotlight on the present moment: you tend to make life feel more immediate, enjoyable, and emotionally real. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ESFP-T Inspired Action-Taker",
+        "og_description": "You are like a bright spotlight on the present moment: you tend to make life feel more immediate, enjoyable, and emotionally real. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ESFP-T Inspired Action-Taker",
+        "twitter_description": "You are like a bright spotlight on the present moment: you tend to make life feel more immediate, enjoyable, and emotionally real. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3145,26 +8353,460 @@
       "runtime_type_code": "ESTJ-A",
       "canonical_type_code": "ESTJ",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Executive",
+        "nickname": "Order Helmsman",
+        "rarity_text": "Approx. 8–12%",
+        "keywords_json": [
+          "sense of responsibility",
+          "execution",
+          "respect for rules",
+          "results orientation",
+          "organizer",
+          "decisiveness"
+        ],
+        "hero_summary_md": "You are like a strong axis that brings order to motion: you tend to turn goals into organized reality and keep people or systems on track. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Sensing · Thinking · Judging · Assertive | the “Order Helmsman”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ESTJ-A personalities often bring structure, accountability, and practical results.\n\nYou feel most like yourself when the objective is clear, the roles are defined, and effort leads to visible progress.\n\nFor you, life works best when you can turn goals into organized reality and keep people or systems on track rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward structure, execution, and clear accountability.\n\nWhen ownership stays vague, standards stay low, or disorder is tolerated as normal, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ESTJ-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Operations and execution",
+                "description": "Roles that demand strong structure and follow-through.",
+                "examples": [
+                  "operations leadership",
+                  "project or program management",
+                  "site, team, or business-unit management"
+                ]
+              },
+              {
+                "group_title": "Compliance, quality, and control",
+                "description": "Settings where standards matter.",
+                "examples": [
+                  "quality assurance and process control",
+                  "compliance, audit, or risk management",
+                  "administrative leadership"
+                ]
+              },
+              {
+                "group_title": "Goal-oriented business roles",
+                "description": "Fields where accountability and targets are real.",
+                "examples": [
+                  "sales leadership",
+                  "business operations",
+                  "supply chain or resource planning"
+                ]
+              },
+              {
+                "group_title": "Practical management",
+                "description": "Roles where teams need clear direction and dependable systems.",
+                "examples": [
+                  "team supervision",
+                  "regional or store management",
+                  "large-scale coordination"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into turning care into control or correction without enough softness.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Clear goals, visible results, competent teams, and systems that actually function usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Clear goals, visible results, competent teams, and systems that actually function usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Disorder, repeated excuses, vague ownership, and inefficiency disguised as flexibility can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Disorder, repeated excuses, vague ownership, and inefficiency disguised as flexibility can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be reliable, straightforward, and responsibility-minded.\n\nYour main challenge is turning care into control or correction without enough softness.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often provide steadiness, clarity, and the sense that someone responsible is paying attention.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often provide steadiness, clarity, and the sense that someone responsible is paying attention.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "When stressed, you may push too hard for order and leave too little room for emotion or ambiguity.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "When stressed, you may push too hard for order and leave too little room for emotion or ambiguity.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ESTJ-A Executive",
+        "seo_description": "You are like a strong axis that brings order to motion: you tend to turn goals into organized reality and keep people or systems on track. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ESTJ-A Order Helmsman",
+        "og_description": "You are like a strong axis that brings order to motion: you tend to turn goals into organized reality and keep people or systems on track. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ESTJ-A Order Helmsman",
+        "twitter_description": "You are like a strong axis that brings order to motion: you tend to turn goals into organized reality and keep people or systems on track. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3174,26 +8816,460 @@
       "runtime_type_code": "ESTJ-T",
       "canonical_type_code": "ESTJ",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Executive",
+        "nickname": "Order Helmsman",
+        "rarity_text": "Approx. 8–12%",
+        "keywords_json": [
+          "responsibility",
+          "execution",
+          "results orientation",
+          "principled judgment",
+          "organizational ability",
+          "realism"
+        ],
+        "hero_summary_md": "You are like a strong axis that brings order to motion: you tend to turn goals into organized reality and keep people or systems on track. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Sensing · Thinking · Judging · Turbulent | the “Order Helmsman”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ESTJ-T personalities often bring structure, accountability, and practical results.\n\nYou feel most like yourself when the objective is clear, the roles are defined, and effort leads to visible progress.\n\nFor you, life works best when you can turn goals into organized reality and keep people or systems on track rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward structure, execution, and clear accountability.\n\nWhen ownership stays vague, standards stay low, or disorder is tolerated as normal, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ESTJ-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Operations and execution",
+                "description": "Roles that demand strong structure and follow-through.",
+                "examples": [
+                  "operations leadership",
+                  "project or program management",
+                  "site, team, or business-unit management"
+                ]
+              },
+              {
+                "group_title": "Compliance, quality, and control",
+                "description": "Settings where standards matter.",
+                "examples": [
+                  "quality assurance and process control",
+                  "compliance, audit, or risk management",
+                  "administrative leadership"
+                ]
+              },
+              {
+                "group_title": "Goal-oriented business roles",
+                "description": "Fields where accountability and targets are real.",
+                "examples": [
+                  "sales leadership",
+                  "business operations",
+                  "supply chain or resource planning"
+                ]
+              },
+              {
+                "group_title": "Practical management",
+                "description": "Roles where teams need clear direction and dependable systems.",
+                "examples": [
+                  "team supervision",
+                  "regional or store management",
+                  "large-scale coordination"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into turning care into control or correction without enough softness.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Clear goals, visible results, competent teams, and systems that actually function usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Clear goals, visible results, competent teams, and systems that actually function usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Disorder, repeated excuses, vague ownership, and inefficiency disguised as flexibility can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Disorder, repeated excuses, vague ownership, and inefficiency disguised as flexibility can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be reliable, straightforward, and responsibility-minded.\n\nYour main challenge is turning care into control or correction without enough softness.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often provide steadiness, clarity, and the sense that someone responsible is paying attention.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often provide steadiness, clarity, and the sense that someone responsible is paying attention.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "When stressed, you may push too hard for order and leave too little room for emotion or ambiguity.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "When stressed, you may push too hard for order and leave too little room for emotion or ambiguity.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ESTJ-T Executive",
+        "seo_description": "You are like a strong axis that brings order to motion: you tend to turn goals into organized reality and keep people or systems on track. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ESTJ-T Order Helmsman",
+        "og_description": "You are like a strong axis that brings order to motion: you tend to turn goals into organized reality and keep people or systems on track. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ESTJ-T Order Helmsman",
+        "twitter_description": "You are like a strong axis that brings order to motion: you tend to turn goals into organized reality and keep people or systems on track. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3203,26 +9279,460 @@
       "runtime_type_code": "ESTP-A",
       "canonical_type_code": "ESTP",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Entrepreneur",
+        "nickname": "Field Operator",
+        "rarity_text": "Approx. 4–6%",
+        "keywords_json": [
+          "action orientation",
+          "situational responsiveness",
+          "realism",
+          "real-time adaptability",
+          "love of challenge",
+          "results orientation"
+        ],
+        "hero_summary_md": "You are like a fast-moving operator in the middle of the action: you tend to read the field quickly, act decisively, and learn directly from reality. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Sensing · Thinking · Prospecting · Assertive | the “Field Operator”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ESTP-A personalities often bring real-time adaptability, boldness, and practical leverage.\n\nYou feel most like yourself when the pace is real, the stakes are visible, and there is enough freedom to act.\n\nFor you, life works best when you can read the field quickly, act decisively, and learn directly from reality rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where immediate feedback, autonomy, and action matter.\n\nWhen everything is overprocessed, slow, or blocked by needless procedure, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ESTP-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Business development and sales",
+                "description": "Roles that reward quick reading of people and direct action.",
+                "examples": [
+                  "sales and key accounts",
+                  "partnerships and field business development",
+                  "negotiation-heavy roles"
+                ]
+              },
+              {
+                "group_title": "Live operations and execution",
+                "description": "Settings where things happen in the moment.",
+                "examples": [
+                  "event operations",
+                  "frontline business or site management",
+                  "marketing activation or field execution"
+                ]
+              },
+              {
+                "group_title": "Entrepreneurial and commercial paths",
+                "description": "Routes where speed and ownership matter.",
+                "examples": [
+                  "small business or venture building",
+                  "new market testing",
+                  "commercial operations in fast-moving settings"
+                ]
+              },
+              {
+                "group_title": "Hands-on high-pressure roles",
+                "description": "Work that rewards composure and real-time problem solving.",
+                "examples": [
+                  "crisis handling roles",
+                  "competitive performance environments",
+                  "on-the-ground execution roles"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into moving faster than emotional understanding or long-term reflection.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Challenge, autonomy, live feedback, and the chance to make something happen now usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Challenge, autonomy, live feedback, and the chance to make something happen now usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Bureaucracy, stagnation, overtalking, and long delays between action and outcome can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Bureaucracy, stagnation, overtalking, and long delays between action and outcome can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be direct, energetic, and grounded in concrete experience.\n\nYour main challenge is moving faster than emotional understanding or long-term reflection.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring courage, realism, and problem-solving energy that can stabilize a stressful situation.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring courage, realism, and problem-solving energy that can stabilize a stressful situation.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you move too quickly, you may solve the practical issue while leaving the emotional issue untouched.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you move too quickly, you may solve the practical issue while leaving the emotional issue untouched.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ESTP-A Entrepreneur",
+        "seo_description": "You are like a fast-moving operator in the middle of the action: you tend to read the field quickly, act decisively, and learn directly from reality. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ESTP-A Field Operator",
+        "og_description": "You are like a fast-moving operator in the middle of the action: you tend to read the field quickly, act decisively, and learn directly from reality. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ESTP-A Field Operator",
+        "twitter_description": "You are like a fast-moving operator in the middle of the action: you tend to read the field quickly, act decisively, and learn directly from reality. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3232,26 +9742,460 @@
       "runtime_type_code": "ESTP-T",
       "canonical_type_code": "ESTP",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Entrepreneur",
+        "nickname": "Improvising Operator",
+        "rarity_text": "Approx. 3–5%",
+        "keywords_json": [
+          "on-the-spot reactions",
+          "action orientation",
+          "adventurousness",
+          "realism",
+          "adaptability",
+          "directness"
+        ],
+        "hero_summary_md": "You are like a fast-moving operator in the middle of the action: you tend to read the field quickly, act decisively, and learn directly from reality. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Extraverted · Sensing · Thinking · Prospecting · Turbulent | the “Improvising Operator”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "Extraversion (E)",
+                "description": "You usually regain energy through interaction, live momentum, and being part of what is happening. Real conversations often sharpen your thinking and lift your state."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ESTP-T personalities often bring real-time adaptability, boldness, and practical leverage.\n\nYou feel most like yourself when the pace is real, the stakes are visible, and there is enough freedom to act.\n\nFor you, life works best when you can read the field quickly, act decisively, and learn directly from reality rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more extraverted",
+                "description": "You usually feel more awake in live interaction. Conversation, collaboration, and visible momentum tend to energize you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where immediate feedback, autonomy, and action matter.\n\nWhen everything is overprocessed, slow, or blocked by needless procedure, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You can energize people and move conversations forward",
+                "body": "You often make interaction easier, create momentum quickly, and help ideas or decisions move through a group in real time."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may overcommit too quickly",
+                "body": "Because you move easily toward people and momentum, you may say yes before fully checking your capacity or the long-term cost."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ESTP-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Business development and sales",
+                "description": "Roles that reward quick reading of people and direct action.",
+                "examples": [
+                  "sales and key accounts",
+                  "partnerships and field business development",
+                  "negotiation-heavy roles"
+                ]
+              },
+              {
+                "group_title": "Live operations and execution",
+                "description": "Settings where things happen in the moment.",
+                "examples": [
+                  "event operations",
+                  "frontline business or site management",
+                  "marketing activation or field execution"
+                ]
+              },
+              {
+                "group_title": "Entrepreneurial and commercial paths",
+                "description": "Routes where speed and ownership matter.",
+                "examples": [
+                  "small business or venture building",
+                  "new market testing",
+                  "commercial operations in fast-moving settings"
+                ]
+              },
+              {
+                "group_title": "Hands-on high-pressure roles",
+                "description": "Work that rewards composure and real-time problem solving.",
+                "examples": [
+                  "crisis handling roles",
+                  "competitive performance environments",
+                  "on-the-ground execution roles"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Visibility also needs recovery time",
+                "body": "Being available and responsive is a strength, but it cannot be the whole rhythm. Protect quiet space so your output stays high-quality."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into moving faster than emotional understanding or long-term reflection.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You build energy through engagement",
+                "body": "Healthy interaction, feedback, and collaboration can help you move from thought into action quickly."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may outrun your own energy budget",
+                "body": "If you keep meeting the moment without checking your reserves, exhaustion can catch up in ways that are easy to ignore at first."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Challenge, autonomy, live feedback, and the chance to make something happen now usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Challenge, autonomy, live feedback, and the chance to make something happen now usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Bureaucracy, stagnation, overtalking, and long delays between action and outcome can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Bureaucracy, stagnation, overtalking, and long delays between action and outcome can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be direct, energetic, and grounded in concrete experience.\n\nYour main challenge is moving faster than emotional understanding or long-term reflection.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often take initiative in connection",
+                "body": "You are usually willing to reach out, create momentum, and help relationships feel alive rather than passive."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may take over the atmosphere",
+                "body": "Because you are quick to respond, you may start managing the whole relational climate instead of noticing what is truly mutual."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring courage, realism, and problem-solving energy that can stabilize a stressful situation.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring courage, realism, and problem-solving energy that can stabilize a stressful situation.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you move too quickly, you may solve the practical issue while leaving the emotional issue untouched.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you move too quickly, you may solve the practical issue while leaving the emotional issue untouched.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ESTP-T Entrepreneur",
+        "seo_description": "You are like a fast-moving operator in the middle of the action: you tend to read the field quickly, act decisively, and learn directly from reality. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ESTP-T Improvising Operator",
+        "og_description": "You are like a fast-moving operator in the middle of the action: you tend to read the field quickly, act decisively, and learn directly from reality. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ESTP-T Improvising Operator",
+        "twitter_description": "You are like a fast-moving operator in the middle of the action: you tend to read the field quickly, act decisively, and learn directly from reality. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3261,26 +10205,460 @@
       "runtime_type_code": "INFJ-A",
       "canonical_type_code": "INFJ",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Advocate",
+        "nickname": "Quiet Visionary",
+        "rarity_text": "Approx. 1–3%",
+        "keywords_json": [
+          "idealism",
+          "insight",
+          "empathy",
+          "self-reflection",
+          "value-driven",
+          "sense of mission"
+        ],
+        "hero_summary_md": "You are like a quiet light pointing toward meaning: you tend to understand what matters beneath the surface and guide life or people toward more coherence. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Intuitive · Feeling · Judging · Assertive | the “Quiet Visionary”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, INFJ-A personalities often bring depth, insight, and values-led long-range vision.\n\nYou feel most like yourself when your life points toward something meaningful and leaves room for depth, reflection, and integrity.\n\nFor you, life works best when you can understand what matters beneath the surface and guide life or people toward more coherence rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that combine insight, meaning, and long-term human impact.\n\nWhen values are repeatedly compromised or everything stays shallow and emotionally careless, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit INFJ-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Psychology, coaching, and guidance",
+                "description": "Roles that rely on insight and careful support.",
+                "examples": [
+                  "counseling and coaching",
+                  "student support and development work",
+                  "therapeutic or wellbeing-related roles"
+                ]
+              },
+              {
+                "group_title": "Education and thoughtful content",
+                "description": "Paths built around meaning and articulation.",
+                "examples": [
+                  "teaching and curriculum design",
+                  "writing, editorial, or reflective content",
+                  "research-backed communication or facilitation"
+                ]
+              },
+              {
+                "group_title": "Social impact and mission work",
+                "description": "Fields where ideals become real contributions.",
+                "examples": [
+                  "nonprofit or social impact programs",
+                  "advocacy or public-interest work",
+                  "community and mission-led initiatives"
+                ]
+              },
+              {
+                "group_title": "Research and strategy with a human lens",
+                "description": "Work that combines systems thinking and human sensitivity.",
+                "examples": [
+                  "user research and insights",
+                  "organizational development",
+                  "mission-led strategy roles"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into keeping too much inside and carrying hurt without naming it clearly enough.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Value alignment, depth, meaningful work, and helping people feel understood usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Value alignment, depth, meaningful work, and helping people feel understood usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Chronic value conflict, emotional noise without sincerity, and being the silent container for everyone else’s pain can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Chronic value conflict, emotional noise without sincerity, and being the silent container for everyone else’s pain can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be deep, sincere, and highly attentive to emotional truth.\n\nYour main challenge is keeping too much inside and carrying hurt without naming it clearly enough.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often offer insight, loyalty, tenderness, and a rare sense of being deeply understood.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often offer insight, loyalty, tenderness, and a rare sense of being deeply understood.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you stay silent too long about your own hurt or limits, closeness can quietly become one-sided.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you stay silent too long about your own hurt or limits, closeness can quietly become one-sided.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "INFJ-A Advocate",
+        "seo_description": "You are like a quiet light pointing toward meaning: you tend to understand what matters beneath the surface and guide life or people toward more coherence. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "INFJ-A Quiet Visionary",
+        "og_description": "You are like a quiet light pointing toward meaning: you tend to understand what matters beneath the surface and guide life or people toward more coherence. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "INFJ-A Quiet Visionary",
+        "twitter_description": "You are like a quiet light pointing toward meaning: you tend to understand what matters beneath the surface and guide life or people toward more coherence. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3290,26 +10668,460 @@
       "runtime_type_code": "INFJ-T",
       "canonical_type_code": "INFJ",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Advocate",
+        "nickname": "Quiet Idealist",
+        "rarity_text": "Approx. 1–3%",
+        "keywords_json": [
+          "insight",
+          "idealism",
+          "values-driven",
+          "empathy",
+          "inner depth",
+          "long-term thinking"
+        ],
+        "hero_summary_md": "You are like a quiet light pointing toward meaning: you tend to understand what matters beneath the surface and guide life or people toward more coherence. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Intuitive · Feeling · Judging · Turbulent | the “Quiet Idealist”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, INFJ-T personalities often bring depth, insight, and values-led long-range vision.\n\nYou feel most like yourself when your life points toward something meaningful and leaves room for depth, reflection, and integrity.\n\nFor you, life works best when you can understand what matters beneath the surface and guide life or people toward more coherence rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that combine insight, meaning, and long-term human impact.\n\nWhen values are repeatedly compromised or everything stays shallow and emotionally careless, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit INFJ-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Psychology, coaching, and guidance",
+                "description": "Roles that rely on insight and careful support.",
+                "examples": [
+                  "counseling and coaching",
+                  "student support and development work",
+                  "therapeutic or wellbeing-related roles"
+                ]
+              },
+              {
+                "group_title": "Education and thoughtful content",
+                "description": "Paths built around meaning and articulation.",
+                "examples": [
+                  "teaching and curriculum design",
+                  "writing, editorial, or reflective content",
+                  "research-backed communication or facilitation"
+                ]
+              },
+              {
+                "group_title": "Social impact and mission work",
+                "description": "Fields where ideals become real contributions.",
+                "examples": [
+                  "nonprofit or social impact programs",
+                  "advocacy or public-interest work",
+                  "community and mission-led initiatives"
+                ]
+              },
+              {
+                "group_title": "Research and strategy with a human lens",
+                "description": "Work that combines systems thinking and human sensitivity.",
+                "examples": [
+                  "user research and insights",
+                  "organizational development",
+                  "mission-led strategy roles"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into keeping too much inside and carrying hurt without naming it clearly enough.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Value alignment, depth, meaningful work, and helping people feel understood usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Value alignment, depth, meaningful work, and helping people feel understood usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Chronic value conflict, emotional noise without sincerity, and being the silent container for everyone else’s pain can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Chronic value conflict, emotional noise without sincerity, and being the silent container for everyone else’s pain can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be deep, sincere, and highly attentive to emotional truth.\n\nYour main challenge is keeping too much inside and carrying hurt without naming it clearly enough.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often offer insight, loyalty, tenderness, and a rare sense of being deeply understood.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often offer insight, loyalty, tenderness, and a rare sense of being deeply understood.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you stay silent too long about your own hurt or limits, closeness can quietly become one-sided.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you stay silent too long about your own hurt or limits, closeness can quietly become one-sided.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "INFJ-T Advocate",
+        "seo_description": "You are like a quiet light pointing toward meaning: you tend to understand what matters beneath the surface and guide life or people toward more coherence. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "INFJ-T Quiet Idealist",
+        "og_description": "You are like a quiet light pointing toward meaning: you tend to understand what matters beneath the surface and guide life or people toward more coherence. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "INFJ-T Quiet Idealist",
+        "twitter_description": "You are like a quiet light pointing toward meaning: you tend to understand what matters beneath the surface and guide life or people toward more coherence. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3319,26 +11131,460 @@
       "runtime_type_code": "INFP-A",
       "canonical_type_code": "INFP",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Mediator",
+        "nickname": "Steadfast Idealist",
+        "rarity_text": "Approx. 4–6%",
+        "keywords_json": [
+          "idealism",
+          "empathy",
+          "inner values",
+          "imagination",
+          "independent thinking",
+          "self-motivation"
+        ],
+        "hero_summary_md": "You are like a quiet flame protecting what matters: you tend to live in a way that feels emotionally true while creating meaning that reflects your inner values. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Intuitive · Feeling · Prospecting · Assertive | the “Steadfast Idealist”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, INFP-A personalities often bring inner values, sincerity, and imaginative emotional depth.\n\nYou feel most like yourself when there is space to imagine, create, care, and move at a humane pace.\n\nFor you, life works best when you can live in a way that feels emotionally true while creating meaning that reflects your inner values rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where sincerity, creativity, and value alignment matter.\n\nWhen the environment becomes cynical, shallow, or disconnected from meaning, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit INFP-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Writing, art, and creative expression",
+                "description": "Paths that turn imagination and feeling into meaningful work.",
+                "examples": [
+                  "writing, editing, or storytelling",
+                  "design, illustration, or visual communication",
+                  "creative strategy grounded in emotional resonance"
+                ]
+              },
+              {
+                "group_title": "Education and guidance",
+                "description": "Roles that help people grow without reducing them to metrics.",
+                "examples": [
+                  "teaching and learning support",
+                  "coaching or facilitation",
+                  "community and mentorship roles"
+                ]
+              },
+              {
+                "group_title": "Psychological and social support",
+                "description": "Fields that rely on empathy and patience.",
+                "examples": [
+                  "support and wellbeing roles",
+                  "social impact or nonprofit work",
+                  "care-centered service paths"
+                ]
+              },
+              {
+                "group_title": "Human-centered user or brand work",
+                "description": "Settings where empathy shapes the outcome.",
+                "examples": [
+                  "user research and community work",
+                  "customer experience roles",
+                  "mission-led brand or experience design"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into staying quiet about pain while hoping harmony or potential will fix what is wrong.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Creative freedom, emotional truth, values alignment, and work that feels genuinely humane usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Creative freedom, emotional truth, values alignment, and work that feels genuinely humane usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Cynical systems, shallow roles, and relationships that feed hope more than wellbeing can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Cynical systems, shallow roles, and relationships that feed hope more than wellbeing can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be tender, idealistic, and deeply oriented toward emotional authenticity.\n\nYour main challenge is staying quiet about pain while hoping harmony or potential will fix what is wrong.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring tenderness, imagination, and genuine emotional sincerity into connection.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring tenderness, imagination, and genuine emotional sincerity into connection.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you romanticize potential too long, you may stay loyal to what could be instead of what is.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you romanticize potential too long, you may stay loyal to what could be instead of what is.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "INFP-A Mediator",
+        "seo_description": "You are like a quiet flame protecting what matters: you tend to live in a way that feels emotionally true while creating meaning that reflects your inner values. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "INFP-A Steadfast Idealist",
+        "og_description": "You are like a quiet flame protecting what matters: you tend to live in a way that feels emotionally true while creating meaning that reflects your inner values. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "INFP-A Steadfast Idealist",
+        "twitter_description": "You are like a quiet flame protecting what matters: you tend to live in a way that feels emotionally true while creating meaning that reflects your inner values. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3348,26 +11594,460 @@
       "runtime_type_code": "INFP-T",
       "canonical_type_code": "INFP",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Mediator",
+        "nickname": "Gentle Dream Builder",
+        "rarity_text": "Approx. 4–7%",
+        "keywords_json": [
+          "idealism",
+          "empathic ability",
+          "inner values",
+          "imagination",
+          "sincerity",
+          "self-exploration"
+        ],
+        "hero_summary_md": "You are like a quiet flame protecting what matters: you tend to live in a way that feels emotionally true while creating meaning that reflects your inner values. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Intuitive · Feeling · Prospecting · Turbulent | the “Gentle Dream Builder”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, INFP-T personalities often bring inner values, sincerity, and imaginative emotional depth.\n\nYou feel most like yourself when there is space to imagine, create, care, and move at a humane pace.\n\nFor you, life works best when you can live in a way that feels emotionally true while creating meaning that reflects your inner values rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where sincerity, creativity, and value alignment matter.\n\nWhen the environment becomes cynical, shallow, or disconnected from meaning, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit INFP-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Writing, art, and creative expression",
+                "description": "Paths that turn imagination and feeling into meaningful work.",
+                "examples": [
+                  "writing, editing, or storytelling",
+                  "design, illustration, or visual communication",
+                  "creative strategy grounded in emotional resonance"
+                ]
+              },
+              {
+                "group_title": "Education and guidance",
+                "description": "Roles that help people grow without reducing them to metrics.",
+                "examples": [
+                  "teaching and learning support",
+                  "coaching or facilitation",
+                  "community and mentorship roles"
+                ]
+              },
+              {
+                "group_title": "Psychological and social support",
+                "description": "Fields that rely on empathy and patience.",
+                "examples": [
+                  "support and wellbeing roles",
+                  "social impact or nonprofit work",
+                  "care-centered service paths"
+                ]
+              },
+              {
+                "group_title": "Human-centered user or brand work",
+                "description": "Settings where empathy shapes the outcome.",
+                "examples": [
+                  "user research and community work",
+                  "customer experience roles",
+                  "mission-led brand or experience design"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into staying quiet about pain while hoping harmony or potential will fix what is wrong.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Creative freedom, emotional truth, values alignment, and work that feels genuinely humane usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Creative freedom, emotional truth, values alignment, and work that feels genuinely humane usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Cynical systems, shallow roles, and relationships that feed hope more than wellbeing can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Cynical systems, shallow roles, and relationships that feed hope more than wellbeing can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be tender, idealistic, and deeply oriented toward emotional authenticity.\n\nYour main challenge is staying quiet about pain while hoping harmony or potential will fix what is wrong.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring tenderness, imagination, and genuine emotional sincerity into connection.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring tenderness, imagination, and genuine emotional sincerity into connection.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you romanticize potential too long, you may stay loyal to what could be instead of what is.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you romanticize potential too long, you may stay loyal to what could be instead of what is.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "INFP-T Mediator",
+        "seo_description": "You are like a quiet flame protecting what matters: you tend to live in a way that feels emotionally true while creating meaning that reflects your inner values. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "INFP-T Gentle Dream Builder",
+        "og_description": "You are like a quiet flame protecting what matters: you tend to live in a way that feels emotionally true while creating meaning that reflects your inner values. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "INFP-T Gentle Dream Builder",
+        "twitter_description": "You are like a quiet flame protecting what matters: you tend to live in a way that feels emotionally true while creating meaning that reflects your inner values. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3377,26 +12057,460 @@
       "runtime_type_code": "INTJ-A",
       "canonical_type_code": "INTJ",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Architect",
+        "nickname": "Rational Visionary",
+        "rarity_text": "Approx. 1–4%",
+        "keywords_json": [
+          "strategic thinking",
+          "independent judgment",
+          "long-range planning",
+          "systems thinking",
+          "high standards",
+          "self-motivation"
+        ],
+        "hero_summary_md": "You are like an architect drawing long-range systems in silence: you tend to build more coherent systems and protect high-leverage progress from avoidable chaos. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Intuitive · Thinking · Judging · Assertive | the “Rational Visionary”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, INTJ-A personalities often bring strategic design, independence, and long-term optimization.\n\nYou feel most like yourself when there is room to think independently, solve a real problem, and pursue the most coherent path.\n\nFor you, life works best when you can build more coherent systems and protect high-leverage progress from avoidable chaos rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward strategy, depth, and system-level improvement.\n\nWhen the environment is irrational, politically noisy, or hostile to independent judgment, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit INTJ-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Strategy, planning, and optimization",
+                "description": "Roles that require long-range thinking and structural improvement.",
+                "examples": [
+                  "strategy and planning",
+                  "operations design and optimization",
+                  "high-level product or business architecture"
+                ]
+              },
+              {
+                "group_title": "Technical and analytical work",
+                "description": "Fields where logic and precision matter.",
+                "examples": [
+                  "engineering and architecture",
+                  "data or analytical roles",
+                  "technical product or systems design"
+                ]
+              },
+              {
+                "group_title": "Research and expert paths",
+                "description": "Work that rewards independent depth.",
+                "examples": [
+                  "research and analysis",
+                  "specialist consulting",
+                  "deep knowledge creation or interpretation"
+                ]
+              },
+              {
+                "group_title": "Leadership with structural responsibility",
+                "description": "Roles where decisions shape systems, not just tasks.",
+                "examples": [
+                  "program leadership",
+                  "business unit or technical leadership",
+                  "change and transformation roles"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into retreating into analysis or distance when emotional complexity rises.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Hard problems, conceptual clarity, visible improvement, and elegant long-term systems usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Hard problems, conceptual clarity, visible improvement, and elegant long-term systems usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Low-quality thinking, chronic irrationality, shallow politics, and empty busyness can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Low-quality thinking, chronic irrationality, shallow politics, and empty busyness can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be steady, selective, and serious about long-term viability.\n\nYour main challenge is retreating into analysis or distance when emotional complexity rises.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring honesty, steadiness, and a serious commitment to building something durable.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring honesty, steadiness, and a serious commitment to building something durable.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If emotion feels inefficient or hard to translate, you may go quiet precisely when closeness needs clearer language.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If emotion feels inefficient or hard to translate, you may go quiet precisely when closeness needs clearer language.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "INTJ-A Architect",
+        "seo_description": "You are like an architect drawing long-range systems in silence: you tend to build more coherent systems and protect high-leverage progress from avoidable chaos. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "INTJ-A Rational Visionary",
+        "og_description": "You are like an architect drawing long-range systems in silence: you tend to build more coherent systems and protect high-leverage progress from avoidable chaos. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "INTJ-A Rational Visionary",
+        "twitter_description": "You are like an architect drawing long-range systems in silence: you tend to build more coherent systems and protect high-leverage progress from avoidable chaos. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3406,26 +12520,460 @@
       "runtime_type_code": "INTJ-T",
       "canonical_type_code": "INTJ",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Architect",
+        "nickname": "Calm Strategist",
+        "rarity_text": "Approx. 1–3%",
+        "keywords_json": [
+          "strategic thinking",
+          "independent judgment",
+          "deep thinking",
+          "system planning",
+          "high self-demands",
+          "long-term thinking"
+        ],
+        "hero_summary_md": "You are like an architect drawing long-range systems in silence: you tend to build more coherent systems and protect high-leverage progress from avoidable chaos. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Intuitive · Thinking · Judging · Turbulent | the “Calm Strategist”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, INTJ-T personalities often bring strategic design, independence, and long-term optimization.\n\nYou feel most like yourself when there is room to think independently, solve a real problem, and pursue the most coherent path.\n\nFor you, life works best when you can build more coherent systems and protect high-leverage progress from avoidable chaos rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward strategy, depth, and system-level improvement.\n\nWhen the environment is irrational, politically noisy, or hostile to independent judgment, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit INTJ-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Strategy, planning, and optimization",
+                "description": "Roles that require long-range thinking and structural improvement.",
+                "examples": [
+                  "strategy and planning",
+                  "operations design and optimization",
+                  "high-level product or business architecture"
+                ]
+              },
+              {
+                "group_title": "Technical and analytical work",
+                "description": "Fields where logic and precision matter.",
+                "examples": [
+                  "engineering and architecture",
+                  "data or analytical roles",
+                  "technical product or systems design"
+                ]
+              },
+              {
+                "group_title": "Research and expert paths",
+                "description": "Work that rewards independent depth.",
+                "examples": [
+                  "research and analysis",
+                  "specialist consulting",
+                  "deep knowledge creation or interpretation"
+                ]
+              },
+              {
+                "group_title": "Leadership with structural responsibility",
+                "description": "Roles where decisions shape systems, not just tasks.",
+                "examples": [
+                  "program leadership",
+                  "business unit or technical leadership",
+                  "change and transformation roles"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into retreating into analysis or distance when emotional complexity rises.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Hard problems, conceptual clarity, visible improvement, and elegant long-term systems usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Hard problems, conceptual clarity, visible improvement, and elegant long-term systems usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Low-quality thinking, chronic irrationality, shallow politics, and empty busyness can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Low-quality thinking, chronic irrationality, shallow politics, and empty busyness can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be steady, selective, and serious about long-term viability.\n\nYour main challenge is retreating into analysis or distance when emotional complexity rises.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring honesty, steadiness, and a serious commitment to building something durable.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring honesty, steadiness, and a serious commitment to building something durable.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If emotion feels inefficient or hard to translate, you may go quiet precisely when closeness needs clearer language.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If emotion feels inefficient or hard to translate, you may go quiet precisely when closeness needs clearer language.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "INTJ-T Architect",
+        "seo_description": "You are like an architect drawing long-range systems in silence: you tend to build more coherent systems and protect high-leverage progress from avoidable chaos. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "INTJ-T Calm Strategist",
+        "og_description": "You are like an architect drawing long-range systems in silence: you tend to build more coherent systems and protect high-leverage progress from avoidable chaos. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "INTJ-T Calm Strategist",
+        "twitter_description": "You are like an architect drawing long-range systems in silence: you tend to build more coherent systems and protect high-leverage progress from avoidable chaos. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3435,26 +12983,460 @@
       "runtime_type_code": "INTP-A",
       "canonical_type_code": "INTP",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Logician",
+        "nickname": "Rational Deconstructor",
+        "rarity_text": "Approx. 2–4%",
+        "keywords_json": [
+          "independent thinking",
+          "analytical reasoning",
+          "curiosity",
+          "systems thinking",
+          "love of deconstruction",
+          "calm confidence"
+        ],
+        "hero_summary_md": "You are like a quiet engine of questions and models: you tend to understand how things work underneath the surface and build cleaner explanations or systems. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Intuitive · Thinking · Prospecting · Assertive | the “Rational Deconstructor”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, INTP-A personalities often bring curiosity, analytical depth, and conceptual freedom.\n\nYou feel most like yourself when there is room to think freely, explore deeply, and follow a question to its structural root.\n\nFor you, life works best when you can understand how things work underneath the surface and build cleaner explanations or systems rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward analysis, problem solving, and conceptual autonomy.\n\nWhen the environment is interruption-heavy, overstructured, or hostile to depth, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit INTP-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Analysis and research",
+                "description": "Roles centered on understanding and explanation.",
+                "examples": [
+                  "research and analysis",
+                  "quantitative or qualitative investigation",
+                  "specialist knowledge work"
+                ]
+              },
+              {
+                "group_title": "Technical problem-solving",
+                "description": "Fields where curiosity directly improves systems.",
+                "examples": [
+                  "software and technical roles",
+                  "data or modeling work",
+                  "engineering or systems analysis"
+                ]
+              },
+              {
+                "group_title": "Product and concept work",
+                "description": "Work built around structure and better design.",
+                "examples": [
+                  "product thinking and UX logic",
+                  "knowledge architecture",
+                  "tooling and process design"
+                ]
+              },
+              {
+                "group_title": "Independent expert paths",
+                "description": "Environments that reward unusual depth.",
+                "examples": [
+                  "consulting",
+                  "independent technical or analytical work",
+                  "educational or thoughtful content creation"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into staying too much in your head and under-translating warmth or emotional clarity.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Deep questions, elegant explanations, conceptual freedom, and real intellectual challenge usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Deep questions, elegant explanations, conceptual freedom, and real intellectual challenge usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Forced shallowness, constant interruption, and work that leaves no room for real thought can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Forced shallowness, constant interruption, and work that leaves no room for real thought can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be thoughtful, independent, and drawn to honest, low-drama depth.\n\nYour main challenge is staying too much in your head and under-translating warmth or emotional clarity.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring intelligence, calm perspective, and a refreshing respect for autonomy to relationships.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring intelligence, calm perspective, and a refreshing respect for autonomy to relationships.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you wait too long for perfect clarity before speaking, important emotional realities can remain underexplained.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you wait too long for perfect clarity before speaking, important emotional realities can remain underexplained.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "INTP-A Logician",
+        "seo_description": "You are like a quiet engine of questions and models: you tend to understand how things work underneath the surface and build cleaner explanations or systems. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "INTP-A Rational Deconstructor",
+        "og_description": "You are like a quiet engine of questions and models: you tend to understand how things work underneath the surface and build cleaner explanations or systems. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "INTP-A Rational Deconstructor",
+        "twitter_description": "You are like a quiet engine of questions and models: you tend to understand how things work underneath the surface and build cleaner explanations or systems. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3464,26 +13446,460 @@
       "runtime_type_code": "INTP-T",
       "canonical_type_code": "INTP",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Logician",
+        "nickname": "Curious Deconstructor",
+        "rarity_text": "Approx. 3–5%",
+        "keywords_json": [
+          "rationality",
+          "curiosity",
+          "deconstruction",
+          "independent thinking",
+          "free exploration",
+          "self-reflection"
+        ],
+        "hero_summary_md": "You are like a quiet engine of questions and models: you tend to understand how things work underneath the surface and build cleaner explanations or systems. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Intuitive · Thinking · Prospecting · Turbulent | the “Curious Deconstructor”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "N",
+                "title": "Intuition (N)",
+                "description": "You naturally look for patterns, implications, and what something could become. Meaning and possibility often matter to you as much as the immediate facts."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, INTP-T personalities often bring curiosity, analytical depth, and conceptual freedom.\n\nYou feel most like yourself when there is room to think freely, explore deeply, and follow a question to its structural root.\n\nFor you, life works best when you can understand how things work underneath the surface and build cleaner explanations or systems rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more intuitive and big-picture",
+                "description": "You tend to notice patterns, themes, and future possibilities quickly. Details make the most sense when they fit a larger meaning or direction."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that reward analysis, problem solving, and conceptual autonomy.\n\nWhen the environment is interruption-heavy, overstructured, or hostile to depth, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You spot patterns and future potential",
+                "body": "You naturally connect details to larger themes, which helps you identify leverage points, risks, and opportunities that others may miss."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may overlook practical constraints",
+                "body": "When the larger vision is compelling, details, logistics, and immediate limitations can start to feel smaller than they really are."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit INTP-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Analysis and research",
+                "description": "Roles centered on understanding and explanation.",
+                "examples": [
+                  "research and analysis",
+                  "quantitative or qualitative investigation",
+                  "specialist knowledge work"
+                ]
+              },
+              {
+                "group_title": "Technical problem-solving",
+                "description": "Fields where curiosity directly improves systems.",
+                "examples": [
+                  "software and technical roles",
+                  "data or modeling work",
+                  "engineering or systems analysis"
+                ]
+              },
+              {
+                "group_title": "Product and concept work",
+                "description": "Work built around structure and better design.",
+                "examples": [
+                  "product thinking and UX logic",
+                  "knowledge architecture",
+                  "tooling and process design"
+                ]
+              },
+              {
+                "group_title": "Independent expert paths",
+                "description": "Environments that reward unusual depth.",
+                "examples": [
+                  "consulting",
+                  "independent technical or analytical work",
+                  "educational or thoughtful content creation"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into staying too much in your head and under-translating warmth or emotional clarity.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You naturally think in patterns and possibilities",
+                "body": "Your mind often sees what could be improved, expanded, or reimagined."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may get stuck in possibilities",
+                "body": "A rich imagination can turn into overthinking if it loses contact with practical next steps."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Deep questions, elegant explanations, conceptual freedom, and real intellectual challenge usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Deep questions, elegant explanations, conceptual freedom, and real intellectual challenge usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Forced shallowness, constant interruption, and work that leaves no room for real thought can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Forced shallowness, constant interruption, and work that leaves no room for real thought can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be thoughtful, independent, and drawn to honest, low-drama depth.\n\nYour main challenge is staying too much in your head and under-translating warmth or emotional clarity.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You look for meaning in connection",
+                "body": "You often care about growth, depth, and what a relationship could become, not just how it appears on the surface."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may idealize potential",
+                "body": "You can sometimes stay attached to what the relationship could become while losing sight of what it is right now."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring intelligence, calm perspective, and a refreshing respect for autonomy to relationships.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring intelligence, calm perspective, and a refreshing respect for autonomy to relationships.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you wait too long for perfect clarity before speaking, important emotional realities can remain underexplained.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you wait too long for perfect clarity before speaking, important emotional realities can remain underexplained.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "INTP-T Logician",
+        "seo_description": "You are like a quiet engine of questions and models: you tend to understand how things work underneath the surface and build cleaner explanations or systems. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "INTP-T Curious Deconstructor",
+        "og_description": "You are like a quiet engine of questions and models: you tend to understand how things work underneath the surface and build cleaner explanations or systems. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "INTP-T Curious Deconstructor",
+        "twitter_description": "You are like a quiet engine of questions and models: you tend to understand how things work underneath the surface and build cleaner explanations or systems. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3493,26 +13909,460 @@
       "runtime_type_code": "ISFJ-A",
       "canonical_type_code": "ISFJ",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Defender",
+        "nickname": "Steady Caregiver",
+        "rarity_text": "Approx. 6–8%",
+        "keywords_json": [
+          "responsibility",
+          "sensitivity",
+          "protectiveness",
+          "practicality",
+          "stability",
+          "quiet devotion"
+        ],
+        "hero_summary_md": "You are like a steady pair of hands keeping life from fraying: you tend to protect stability, remember what matters, and support people in concrete ways. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Sensing · Feeling · Judging · Assertive | the “Steady Caregiver”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ISFJ-A personalities often bring care, responsibility, and quiet continuity.\n\nYou feel most like yourself when there is steadiness, clarity, and room to care for people practically.\n\nFor you, life works best when you can protect stability, remember what matters, and support people in concrete ways rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where care, consistency, and practical support are genuinely valued.\n\nWhen the environment is unstable, harsh, or dismissive of careful effort, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ISFJ-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Care and support",
+                "description": "Roles that rely on steadiness and practical help.",
+                "examples": [
+                  "caregiving and wellbeing roles",
+                  "student or community support",
+                  "support functions built around people"
+                ]
+              },
+              {
+                "group_title": "Education and administration",
+                "description": "Work that requires follow-through and thoughtful structure.",
+                "examples": [
+                  "education support and school administration",
+                  "office or program coordination",
+                  "administrative operations"
+                ]
+              },
+              {
+                "group_title": "Service and continuity",
+                "description": "Fields where reliability affects real people.",
+                "examples": [
+                  "customer care and client service",
+                  "healthcare support and coordination",
+                  "hospitality or daily operations roles"
+                ]
+              },
+              {
+                "group_title": "Steady team roles",
+                "description": "Settings that need dependable execution.",
+                "examples": [
+                  "team support roles",
+                  "process and documentation work",
+                  "operations assistance with a human touch"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into absorbing too much strain while minimizing your own needs.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Trust, appreciation, stable routines, and making a meaningful practical difference usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Trust, appreciation, stable routines, and making a meaningful practical difference usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Being taken for granted, chronic instability, and one-way responsibility can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Being taken for granted, chronic instability, and one-way responsibility can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be loyal, thoughtful, and quietly devoted.\n\nYour main challenge is absorbing too much strain while minimizing your own needs.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring steadiness, tenderness, and practical devotion that people can truly rely on.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring steadiness, tenderness, and practical devotion that people can truly rely on.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you keep quiet about your own limits, endurance can slowly replace mutual care.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you keep quiet about your own limits, endurance can slowly replace mutual care.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ISFJ-A Defender",
+        "seo_description": "You are like a steady pair of hands keeping life from fraying: you tend to protect stability, remember what matters, and support people in concrete ways. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ISFJ-A Steady Caregiver",
+        "og_description": "You are like a steady pair of hands keeping life from fraying: you tend to protect stability, remember what matters, and support people in concrete ways. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ISFJ-A Steady Caregiver",
+        "twitter_description": "You are like a steady pair of hands keeping life from fraying: you tend to protect stability, remember what matters, and support people in concrete ways. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3522,26 +14372,460 @@
       "runtime_type_code": "ISFJ-T",
       "canonical_type_code": "ISFJ",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Defender",
+        "nickname": "Gentle Watcher",
+        "rarity_text": "Approx. 6–9%",
+        "keywords_json": [
+          "responsibility",
+          "gentle attentiveness",
+          "steady reliability",
+          "quiet devotion",
+          "sense of order",
+          "high self-demands"
+        ],
+        "hero_summary_md": "You are like a steady pair of hands keeping life from fraying: you tend to protect stability, remember what matters, and support people in concrete ways. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Sensing · Feeling · Judging · Turbulent | the “Gentle Watcher”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ISFJ-T personalities often bring care, responsibility, and quiet continuity.\n\nYou feel most like yourself when there is steadiness, clarity, and room to care for people practically.\n\nFor you, life works best when you can protect stability, remember what matters, and support people in concrete ways rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where care, consistency, and practical support are genuinely valued.\n\nWhen the environment is unstable, harsh, or dismissive of careful effort, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ISFJ-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Care and support",
+                "description": "Roles that rely on steadiness and practical help.",
+                "examples": [
+                  "caregiving and wellbeing roles",
+                  "student or community support",
+                  "support functions built around people"
+                ]
+              },
+              {
+                "group_title": "Education and administration",
+                "description": "Work that requires follow-through and thoughtful structure.",
+                "examples": [
+                  "education support and school administration",
+                  "office or program coordination",
+                  "administrative operations"
+                ]
+              },
+              {
+                "group_title": "Service and continuity",
+                "description": "Fields where reliability affects real people.",
+                "examples": [
+                  "customer care and client service",
+                  "healthcare support and coordination",
+                  "hospitality or daily operations roles"
+                ]
+              },
+              {
+                "group_title": "Steady team roles",
+                "description": "Settings that need dependable execution.",
+                "examples": [
+                  "team support roles",
+                  "process and documentation work",
+                  "operations assistance with a human touch"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into absorbing too much strain while minimizing your own needs.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Trust, appreciation, stable routines, and making a meaningful practical difference usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Trust, appreciation, stable routines, and making a meaningful practical difference usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Being taken for granted, chronic instability, and one-way responsibility can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Being taken for granted, chronic instability, and one-way responsibility can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be loyal, thoughtful, and quietly devoted.\n\nYour main challenge is absorbing too much strain while minimizing your own needs.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring steadiness, tenderness, and practical devotion that people can truly rely on.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring steadiness, tenderness, and practical devotion that people can truly rely on.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you keep quiet about your own limits, endurance can slowly replace mutual care.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you keep quiet about your own limits, endurance can slowly replace mutual care.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ISFJ-T Defender",
+        "seo_description": "You are like a steady pair of hands keeping life from fraying: you tend to protect stability, remember what matters, and support people in concrete ways. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ISFJ-T Gentle Watcher",
+        "og_description": "You are like a steady pair of hands keeping life from fraying: you tend to protect stability, remember what matters, and support people in concrete ways. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ISFJ-T Gentle Watcher",
+        "twitter_description": "You are like a steady pair of hands keeping life from fraying: you tend to protect stability, remember what matters, and support people in concrete ways. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3551,26 +14835,460 @@
       "runtime_type_code": "ISFP-A",
       "canonical_type_code": "ISFP",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Adventurer",
+        "nickname": "Free-spirited Feeler",
+        "rarity_text": "Approx. 5–9%",
+        "keywords_json": [
+          "sensitivity",
+          "aesthetic sense",
+          "gentle resolve",
+          "living in the present",
+          "independence",
+          "expressing through action"
+        ],
+        "hero_summary_md": "You are like a gentle artist moving through the real world with feeling: you tend to protect what feels true, beautiful, and personally meaningful while moving at an honest pace. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Sensing · Feeling · Prospecting · Assertive | the “Free-spirited Feeler”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ISFP-A personalities often bring authenticity, aesthetic sensitivity, and quiet personal freedom.\n\nYou feel most like yourself when there is room to breathe, create, notice, and live without violating your inner harmony.\n\nFor you, life works best when you can protect what feels true, beautiful, and personally meaningful while moving at an honest pace rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that leave room for authenticity, aesthetic sensitivity, and practical creativity.\n\nWhen the environment feels controlling, performative, or emotionally rough, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ISFP-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Creative and aesthetic work",
+                "description": "Paths that turn feeling and taste into expression.",
+                "examples": [
+                  "design and visual expression",
+                  "photography, styling, or creative production",
+                  "hands-on artistic work"
+                ]
+              },
+              {
+                "group_title": "Personalized service and care",
+                "description": "Roles where sensitivity improves someone’s lived experience.",
+                "examples": [
+                  "wellbeing and care services",
+                  "personalized customer experience roles",
+                  "supportive one-to-one work"
+                ]
+              },
+              {
+                "group_title": "Nature, craft, and physical creation",
+                "description": "Work that is grounded, tangible, and skill-based.",
+                "examples": [
+                  "craft and making",
+                  "hands-on technical or aesthetic work",
+                  "environmental or outdoor roles"
+                ]
+              },
+              {
+                "group_title": "Independent or flexible paths",
+                "description": "Environments that respect individuality.",
+                "examples": [
+                  "freelance creative work",
+                  "small-team roles with autonomy",
+                  "portfolio careers"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into going silent under strain instead of making needs and boundaries explicit.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Beauty, sincerity, freedom, and the feeling that your life still sounds like your own inner voice usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Beauty, sincerity, freedom, and the feeling that your life still sounds like your own inner voice usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Control, emotional roughness, performative norms, and environments with no room for gentleness can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Control, emotional roughness, performative norms, and environments with no room for gentleness can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be soft, sincere, and respectful of individuality.\n\nYour main challenge is going silent under strain instead of making needs and boundaries explicit.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring warmth, authenticity, and a quietly respectful kind of affection to connection.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring warmth, authenticity, and a quietly respectful kind of affection to connection.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If conflict is avoided too long, you may withdraw inward and leave others guessing what hurt you.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If conflict is avoided too long, you may withdraw inward and leave others guessing what hurt you.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ISFP-A Adventurer",
+        "seo_description": "You are like a gentle artist moving through the real world with feeling: you tend to protect what feels true, beautiful, and personally meaningful while moving at an honest pace. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ISFP-A Free-spirited Feeler",
+        "og_description": "You are like a gentle artist moving through the real world with feeling: you tend to protect what feels true, beautiful, and personally meaningful while moving at an honest pace. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ISFP-A Free-spirited Feeler",
+        "twitter_description": "You are like a gentle artist moving through the real world with feeling: you tend to protect what feels true, beautiful, and personally meaningful while moving at an honest pace. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3580,26 +15298,460 @@
       "runtime_type_code": "ISFP-T",
       "canonical_type_code": "ISFP",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Adventurer",
+        "nickname": "Gentle Feeler",
+        "rarity_text": "Approx. 4–9%",
+        "keywords_json": [
+          "sensitivity",
+          "freedom",
+          "present-moment experience",
+          "aesthetic sense",
+          "empathy",
+          "spontaneity"
+        ],
+        "hero_summary_md": "You are like a gentle artist moving through the real world with feeling: you tend to protect what feels true, beautiful, and personally meaningful while moving at an honest pace. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Sensing · Feeling · Prospecting · Turbulent | the “Gentle Feeler”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "F",
+                "title": "Feeling (F)",
+                "description": "You tend to weigh values, emotional reality, and human impact when making decisions. You care not just about what gets done, but about how it affects people."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ISFP-T personalities often bring authenticity, aesthetic sensitivity, and quiet personal freedom.\n\nYou feel most like yourself when there is room to breathe, create, notice, and live without violating your inner harmony.\n\nFor you, life works best when you can protect what feels true, beautiful, and personally meaningful while moving at an honest pace rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more emotionally attuned",
+                "description": "You are usually sensitive to values, tone, and the human consequences of a choice. Emotional context matters to your decision process."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles that leave room for authenticity, aesthetic sensitivity, and practical creativity.\n\nWhen the environment feels controlling, performative, or emotionally rough, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You understand people and emotional context",
+                "body": "You often sense what others need, how the atmosphere is shifting, and how human dynamics affect the quality of the outcome."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may carry too much emotional weight",
+                "body": "Because people matter to you, you may soften difficult truths, personalize friction, or absorb more emotional labor than is healthy."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ISFP-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Creative and aesthetic work",
+                "description": "Paths that turn feeling and taste into expression.",
+                "examples": [
+                  "design and visual expression",
+                  "photography, styling, or creative production",
+                  "hands-on artistic work"
+                ]
+              },
+              {
+                "group_title": "Personalized service and care",
+                "description": "Roles where sensitivity improves someone’s lived experience.",
+                "examples": [
+                  "wellbeing and care services",
+                  "personalized customer experience roles",
+                  "supportive one-to-one work"
+                ]
+              },
+              {
+                "group_title": "Nature, craft, and physical creation",
+                "description": "Work that is grounded, tangible, and skill-based.",
+                "examples": [
+                  "craft and making",
+                  "hands-on technical or aesthetic work",
+                  "environmental or outdoor roles"
+                ]
+              },
+              {
+                "group_title": "Independent or flexible paths",
+                "description": "Environments that respect individuality.",
+                "examples": [
+                  "freelance creative work",
+                  "small-team roles with autonomy",
+                  "portfolio careers"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Care ≠ self-erasure",
+                "body": "Support becomes healthier when you state your limits clearly. Before helping, decide what is truly yours to carry and what belongs to someone else."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into going silent under strain instead of making needs and boundaries explicit.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You carry strong emotional intelligence",
+                "body": "You tend to understand motives, values, and emotional impact in ways that can deepen relationships and improve decisions."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may confuse kindness with self-erasure",
+                "body": "Caring deeply can make it harder to hold boundaries, tell hard truths, or protect your own energy in time."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Beauty, sincerity, freedom, and the feeling that your life still sounds like your own inner voice usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Beauty, sincerity, freedom, and the feeling that your life still sounds like your own inner voice usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Control, emotional roughness, performative norms, and environments with no room for gentleness can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Control, emotional roughness, performative norms, and environments with no room for gentleness can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be soft, sincere, and respectful of individuality.\n\nYour main challenge is going silent under strain instead of making needs and boundaries explicit.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You are emotionally attuned",
+                "body": "You often notice tone shifts, unspoken needs, and the emotional effect of what is happening between people."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may avoid conflict or over-accommodate",
+                "body": "Protecting harmony can become expensive if you keep softening difficult truths or downplaying your own needs."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring warmth, authenticity, and a quietly respectful kind of affection to connection.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring warmth, authenticity, and a quietly respectful kind of affection to connection.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If conflict is avoided too long, you may withdraw inward and leave others guessing what hurt you.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If conflict is avoided too long, you may withdraw inward and leave others guessing what hurt you.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ISFP-T Adventurer",
+        "seo_description": "You are like a gentle artist moving through the real world with feeling: you tend to protect what feels true, beautiful, and personally meaningful while moving at an honest pace. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ISFP-T Gentle Feeler",
+        "og_description": "You are like a gentle artist moving through the real world with feeling: you tend to protect what feels true, beautiful, and personally meaningful while moving at an honest pace. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ISFP-T Gentle Feeler",
+        "twitter_description": "You are like a gentle artist moving through the real world with feeling: you tend to protect what feels true, beautiful, and personally meaningful while moving at an honest pace. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3609,26 +15761,460 @@
       "runtime_type_code": "ISTJ-A",
       "canonical_type_code": "ISTJ",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Logistician",
+        "nickname": "Guardian of Order",
+        "rarity_text": "Approx. 10–14%",
+        "keywords_json": [
+          "responsibility",
+          "practicality",
+          "orderliness",
+          "respect for rules",
+          "reliability",
+          "long-term thinking"
+        ],
+        "hero_summary_md": "You are like a careful steward keeping the structure sound: you tend to build trust through clear standards, reliable systems, and disciplined follow-through. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Sensing · Thinking · Judging · Assertive | the “Guardian of Order”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ISTJ-A personalities often bring responsibility, accuracy, and dependable order.\n\nYou feel most like yourself when expectations are clear, reality is faced honestly, and good work actually matters.\n\nFor you, life works best when you can build trust through clear standards, reliable systems, and disciplined follow-through rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where precision, reliability, and long-term consistency matter.\n\nWhen the environment is disorderly, vague, or repeatedly irresponsible, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ISTJ-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Operations, logistics, and process",
+                "description": "Roles that depend on accuracy and continuity.",
+                "examples": [
+                  "operations and process roles",
+                  "project administration and coordination",
+                  "logistics and planning"
+                ]
+              },
+              {
+                "group_title": "Compliance, finance, and quality",
+                "description": "Fields where detail and standards matter.",
+                "examples": [
+                  "finance or accounting-related work",
+                  "audit, compliance, and quality roles",
+                  "documentation and control functions"
+                ]
+              },
+              {
+                "group_title": "Institutional and public-facing structure",
+                "description": "Settings where duty and order are central.",
+                "examples": [
+                  "public service and administration",
+                  "education or healthcare operations",
+                  "structured organizational support roles"
+                ]
+              },
+              {
+                "group_title": "Technical and dependable execution",
+                "description": "Work that rewards careful competence.",
+                "examples": [
+                  "technical support or implementation",
+                  "data and records management",
+                  "specialist operations roles"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into becoming dutiful but under-expressive when stress rises.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Clear expectations, stable systems, real competence, and the satisfaction of doing things well usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Clear expectations, stable systems, real competence, and the satisfaction of doing things well usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Disorder, vague standards, empty noise, and repeated irresponsibility can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Disorder, vague standards, empty noise, and repeated irresponsibility can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be steady, responsible, and more demonstrative through action than through display.\n\nYour main challenge is becoming dutiful but under-expressive when stress rises.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring loyalty, groundedness, and the quiet security of someone who means what they say.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring loyalty, groundedness, and the quiet security of someone who means what they say.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you keep emotion implicit for too long, others may feel the reliability without fully feeling the warmth.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you keep emotion implicit for too long, others may feel the reliability without fully feeling the warmth.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ISTJ-A Logistician",
+        "seo_description": "You are like a careful steward keeping the structure sound: you tend to build trust through clear standards, reliable systems, and disciplined follow-through. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ISTJ-A Guardian of Order",
+        "og_description": "You are like a careful steward keeping the structure sound: you tend to build trust through clear standards, reliable systems, and disciplined follow-through. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ISTJ-A Guardian of Order",
+        "twitter_description": "You are like a careful steward keeping the structure sound: you tend to build trust through clear standards, reliable systems, and disciplined follow-through. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3638,26 +16224,460 @@
       "runtime_type_code": "ISTJ-T",
       "canonical_type_code": "ISTJ",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Logistician",
+        "nickname": "Guardian of Order",
+        "rarity_text": "Approx. 10–13%",
+        "keywords_json": [
+          "practicality",
+          "responsibility",
+          "respect for rules",
+          "steady execution",
+          "reliability",
+          "self-discipline"
+        ],
+        "hero_summary_md": "You are like a careful steward keeping the structure sound: you tend to build trust through clear standards, reliable systems, and disciplined follow-through. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Sensing · Thinking · Judging · Turbulent | the “Guardian of Order”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "J",
+                "title": "Judging (J)",
+                "description": "You generally prefer clarity, structure, and a visible direction of travel. Plans, milestones, and defined expectations help you stay focused and effective."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ISTJ-T personalities often bring responsibility, accuracy, and dependable order.\n\nYou feel most like yourself when expectations are clear, reality is faced honestly, and good work actually matters.\n\nFor you, life works best when you can build trust through clear standards, reliable systems, and disciplined follow-through rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more planned and structured",
+                "description": "You generally feel better when the path is clear, the priorities are set, and the next step is defined. Structure tends to increase your sense of control."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where precision, reliability, and long-term consistency matter.\n\nWhen the environment is disorderly, vague, or repeatedly irresponsible, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You organize, prioritize, and follow through",
+                "body": "You naturally bring structure to complexity, define next steps, and help work move from intention to completion."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may become rigid under ambiguity",
+                "body": "When priorities keep changing or standards stay vague, you can feel unusually strained and may push too hard for closure."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ISTJ-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Operations, logistics, and process",
+                "description": "Roles that depend on accuracy and continuity.",
+                "examples": [
+                  "operations and process roles",
+                  "project administration and coordination",
+                  "logistics and planning"
+                ]
+              },
+              {
+                "group_title": "Compliance, finance, and quality",
+                "description": "Fields where detail and standards matter.",
+                "examples": [
+                  "finance or accounting-related work",
+                  "audit, compliance, and quality roles",
+                  "documentation and control functions"
+                ]
+              },
+              {
+                "group_title": "Institutional and public-facing structure",
+                "description": "Settings where duty and order are central.",
+                "examples": [
+                  "public service and administration",
+                  "education or healthcare operations",
+                  "structured organizational support roles"
+                ]
+              },
+              {
+                "group_title": "Technical and dependable execution",
+                "description": "Work that rewards careful competence.",
+                "examples": [
+                  "technical support or implementation",
+                  "data and records management",
+                  "specialist operations roles"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Structure works best when it can breathe",
+                "body": "Plans are valuable, but they become stronger when they leave room for new information. Build checkpoints, not cages."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into becoming dutiful but under-expressive when stress rises.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You can turn intentions into rhythm and structure",
+                "body": "You usually know how to create plans, milestones, and routines that keep life from drifting."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may put too much pressure on yourself to stay in control",
+                "body": "When life becomes messy, your instinct to manage everything can turn into hidden tension or burnout."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Clear expectations, stable systems, real competence, and the satisfaction of doing things well usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Clear expectations, stable systems, real competence, and the satisfaction of doing things well usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Disorder, vague standards, empty noise, and repeated irresponsibility can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Disorder, vague standards, empty noise, and repeated irresponsibility can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be steady, responsible, and more demonstrative through action than through display.\n\nYour main challenge is becoming dutiful but under-expressive when stress rises.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You value consistency and commitment",
+                "body": "You often take relationships seriously and try to build something stable rather than improvising forever."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may become too controlling around uncertainty",
+                "body": "When you want clarity badly, you may push for answers, commitment, or structure before the relationship is ready for that pace."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring loyalty, groundedness, and the quiet security of someone who means what they say.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring loyalty, groundedness, and the quiet security of someone who means what they say.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you keep emotion implicit for too long, others may feel the reliability without fully feeling the warmth.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you keep emotion implicit for too long, others may feel the reliability without fully feeling the warmth.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ISTJ-T Logistician",
+        "seo_description": "You are like a careful steward keeping the structure sound: you tend to build trust through clear standards, reliable systems, and disciplined follow-through. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ISTJ-T Guardian of Order",
+        "og_description": "You are like a careful steward keeping the structure sound: you tend to build trust through clear standards, reliable systems, and disciplined follow-through. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ISTJ-T Guardian of Order",
+        "twitter_description": "You are like a careful steward keeping the structure sound: you tend to build trust through clear standards, reliable systems, and disciplined follow-through. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3667,26 +16687,460 @@
       "runtime_type_code": "ISTP-A",
       "canonical_type_code": "ISTP",
       "variant_code": "A",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Virtuoso",
+        "nickname": "Calm Action-Taker",
+        "rarity_text": "Approx. 4–6%",
+        "keywords_json": [
+          "calmness",
+          "hands-on skill",
+          "problem solving",
+          "independence",
+          "flexibility",
+          "love of exploration"
+        ],
+        "hero_summary_md": "You are like a calm hand reaching for the right tool: you tend to understand how something works, fix what is broken, and move through reality with quiet precision. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Sensing · Thinking · Prospecting · Assertive | the “Calm Action-Taker”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "A",
+                "title": "Assertive (-A)",
+                "description": "The assertive side of you usually steadies your mood under pressure. You tend to recover faster from setbacks and trust yourself to course-correct as you go."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ISTP-A personalities often bring independence, practical intelligence, and hands-on problem solving.\n\nYou feel most like yourself when there is room to think independently, act practically, and learn by direct engagement.\n\nFor you, life works best when you can understand how something works, fix what is broken, and move through reality with quiet precision rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-assured",
+                "description": "You are not free of stress, but you usually return to center relatively quickly. You trust yourself to test, adapt, and keep moving."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where technical skill, autonomy, and practical problem solving matter.\n\nWhen the environment is overcontrolled, overly talkative, or disconnected from real-world feedback, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ISTP-A. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Technical troubleshooting and repair",
+                "description": "Roles built around diagnosis and practical fixes.",
+                "examples": [
+                  "technical repair and maintenance",
+                  "systems support and troubleshooting",
+                  "hands-on engineering or implementation"
+                ]
+              },
+              {
+                "group_title": "Field and operations work",
+                "description": "Settings that reward composure and adaptability.",
+                "examples": [
+                  "operations with real-time decision-making",
+                  "logistics or site roles",
+                  "frontline technical execution"
+                ]
+              },
+              {
+                "group_title": "Independent craft and skill",
+                "description": "Work where mastery grows through direct practice.",
+                "examples": [
+                  "craft, fabrication, or maker paths",
+                  "specialist freelance work",
+                  "skill-based independent roles"
+                ]
+              },
+              {
+                "group_title": "Applied analysis and problem solving",
+                "description": "Environments where clear thinking has a concrete outcome.",
+                "examples": [
+                  "testing and prototyping",
+                  "data-informed operational roles",
+                  "practical product or process improvement"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by how well confidence is matched with clear systems and sustainable pacing.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Confidence compounds through feedback loops",
+                "body": "Trust your instincts, but still review what works. Calm confidence becomes even stronger when it is paired with deliberate iteration."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into disappearing into self-sufficiency and leaving feelings underexplained.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Autonomy, competence, real-world challenge, and the chance to solve concrete problems usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Autonomy, competence, real-world challenge, and the chance to solve concrete problems usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Micromanagement, empty talk, emotional overexposure without movement, and impractical systems can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Micromanagement, empty talk, emotional overexposure without movement, and impractical systems can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be steady, low-drama, and more action-oriented than verbally demonstrative.\n\nYour main challenge is disappearing into self-sufficiency and leaving feelings underexplained.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring calm realism, skill, and grounded problem-solving that can make hard moments more manageable.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring calm realism, skill, and grounded problem-solving that can make hard moments more manageable.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you stay too private for too long, people may experience your calm as absence instead of stability.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you stay too private for too long, people may experience your calm as absence instead of stability.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ISTP-A Virtuoso",
+        "seo_description": "You are like a calm hand reaching for the right tool: you tend to understand how something works, fix what is broken, and move through reality with quiet precision. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ISTP-A Calm Action-Taker",
+        "og_description": "You are like a calm hand reaching for the right tool: you tend to understand how something works, fix what is broken, and move through reality with quiet precision. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ISTP-A Calm Action-Taker",
+        "twitter_description": "You are like a calm hand reaching for the right tool: you tend to understand how something works, fix what is broken, and move through reality with quiet precision. The -A side of you adds steadier self-trust and a faster return to center after setbacks.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null
@@ -3696,26 +17150,460 @@
       "runtime_type_code": "ISTP-T",
       "canonical_type_code": "ISTP",
       "variant_code": "T",
-      "is_published": false,
-      "published_at": null,
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
       "profile_overrides": {
-        "type_name": null,
-        "nickname": null,
-        "rarity_text": null,
-        "keywords_json": [],
-        "hero_summary_md": null,
+        "type_name": "Virtuoso",
+        "nickname": "Calm Problem-Solver",
+        "rarity_text": "Approx. 4–7%",
+        "keywords_json": [
+          "independence",
+          "hands-on skill",
+          "rational calm",
+          "realism",
+          "love of tinkering",
+          "on-the-spot reactions"
+        ],
+        "hero_summary_md": "You are like a calm hand reaching for the right tool: you tend to understand how something works, fix what is broken, and move through reality with quiet precision. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "hero_summary_html": null
       },
-      "section_overrides": [],
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "Introverted · Sensing · Thinking · Prospecting · Turbulent | the “Calm Problem-Solver”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "Introversion (I)",
+                "description": "You usually regain energy through solitude, reflection, and uninterrupted inner space. Depth and privacy help you think clearly and return to yourself."
+              },
+              {
+                "letter": "S",
+                "title": "Sensing (S)",
+                "description": "You naturally trust direct evidence, concrete detail, and practical usefulness. You often feel more grounded when ideas connect clearly to observable reality."
+              },
+              {
+                "letter": "T",
+                "title": "Thinking (T)",
+                "description": "You tend to prioritize logic, clarity, and effectiveness when making decisions. You usually want the reasoning to hold up, even when the situation is emotionally charged."
+              },
+              {
+                "letter": "P",
+                "title": "Prospecting (P)",
+                "description": "You generally prefer flexibility, openness, and the freedom to adjust as reality changes. You often work best when options can stay alive a little longer."
+              },
+              {
+                "letter": "T",
+                "title": "Turbulent (-T)",
+                "description": "The turbulent side of you usually increases self-awareness, self-questioning, and sensitivity to feedback. It can sharpen growth, but it can also turn into invisible internal pressure."
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "In Fermat Psychology’s model, ISTP-T personalities often bring independence, practical intelligence, and hands-on problem solving.\n\nYou feel most like yourself when there is room to think independently, act practically, and learn by direct engagement.\n\nFor you, life works best when you can understand how something works, fix what is broken, and move through reality with quiet precision rather than merely go through the motions.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+          "body_html": null,
+          "payload_json": {
+            "summary": "Recommended for use with the five dimension bars in the mini-program: Extraverted / Introverted | Intuitive / Practical | Feeling / Thinking | Planned / Flexible | More self-questioning / More self-assured.",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "Energy Orientation",
+                "label": "Energy Orientation",
+                "axis_left": "Extraverted",
+                "axis_right": "Introverted",
+                "summary": "Leans more introverted",
+                "description": "You usually need quiet space to think, recover, and reconnect with yourself. Solitude is often productive rather than empty for you."
+              },
+              {
+                "id": "SN",
+                "name": "Mental Style",
+                "label": "Mental Style",
+                "axis_left": "Intuitive / Big-picture",
+                "axis_right": "Sensing / Practical",
+                "summary": "Leans more sensing and practical",
+                "description": "You tend to trust what can be checked, observed, and used. Big ideas matter most when they become concrete and workable."
+              },
+              {
+                "id": "TF",
+                "name": "Decision Style",
+                "label": "Decision Style",
+                "axis_left": "Feeling / Human-centered",
+                "axis_right": "Thinking / Analytical",
+                "summary": "Leans more analytical",
+                "description": "You usually step back, separate variables, and look for the most coherent answer. Emotional reality still matters, but it often comes after logic in your first pass."
+              },
+              {
+                "id": "JP",
+                "name": "Response Pattern",
+                "label": "Response Pattern",
+                "axis_left": "Planned / Structured",
+                "axis_right": "Adaptive / Flexible",
+                "summary": "Leans more adaptive and open-ended",
+                "description": "You generally prefer room to adjust, improvise, and keep several possibilities available. Too much rigidity can make your energy drop quickly."
+              },
+              {
+                "id": "AT",
+                "name": "Identity Feature",
+                "label": "Identity Feature",
+                "axis_left": "More self-questioning",
+                "axis_right": "More self-assured",
+                "summary": "Slightly more self-questioning",
+                "description": "You quickly notice friction, missed opportunities, and places where things could be better. That awareness helps growth, but it can also feed overthinking."
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually do your best work in roles where technical skill, autonomy, and practical problem solving matter.\n\nWhen the environment is overcontrolled, overly talkative, or disconnected from real-world feedback, your motivation and stamina often drop much faster than outsiders expect.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You think deeply and work well independently",
+                "body": "You often produce your best work when you have room to process carefully, notice nuance, and develop something without constant noise."
+              },
+              {
+                "title": "You stay grounded in practical reality",
+                "body": "You notice what will actually work in the real world and often catch useful details that more abstract thinkers glide past."
+              },
+              {
+                "title": "You analyze problems clearly",
+                "body": "You can often separate signal from noise, evaluate tradeoffs, and move toward a coherent decision without drowning in emotional turbulence."
+              },
+              {
+                "title": "You adapt quickly when reality changes",
+                "body": "You often keep options available, learn from feedback fast, and remain useful even when the original plan stops fitting the situation."
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may stay too quiet for too long",
+                "body": "Your thinking can be valuable, but if you wait too long to speak, others may miss what you see or underestimate your contribution."
+              },
+              {
+                "title": "You may stay with the proven path too long",
+                "body": "Your respect for what works can make it harder to lean into untested possibilities even when the old approach is no longer enough."
+              },
+              {
+                "title": "You may sound blunter than you intend",
+                "body": "When you focus on logic or efficiency, others may experience your clarity as pressure or coldness unless you add more context."
+              },
+              {
+                "title": "You may delay closure or routine maintenance",
+                "body": "Open possibilities can feel more alive than finished systems, which can make final polish, repetition, or long-term consistency harder to sustain."
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "The paths below are not the only jobs that fit ISTP-T. They are simply directions that are more likely to make your strengths feel meaningful, natural, and sustainable.",
+            "groups": [
+              {
+                "group_title": "Technical troubleshooting and repair",
+                "description": "Roles built around diagnosis and practical fixes.",
+                "examples": [
+                  "technical repair and maintenance",
+                  "systems support and troubleshooting",
+                  "hands-on engineering or implementation"
+                ]
+              },
+              {
+                "group_title": "Field and operations work",
+                "description": "Settings that reward composure and adaptability.",
+                "examples": [
+                  "operations with real-time decision-making",
+                  "logistics or site roles",
+                  "frontline technical execution"
+                ]
+              },
+              {
+                "group_title": "Independent craft and skill",
+                "description": "Work where mastery grows through direct practice.",
+                "examples": [
+                  "craft, fabrication, or maker paths",
+                  "specialist freelance work",
+                  "skill-based independent roles"
+                ]
+              },
+              {
+                "group_title": "Applied analysis and problem solving",
+                "description": "Environments where clear thinking has a concrete outcome.",
+                "examples": [
+                  "testing and prototyping",
+                  "data-informed operational roles",
+                  "practical product or process improvement"
+                ]
+              }
+            ],
+            "outro": "What matters more than the job title is whether the work allows you to use your strengths in a way that feels meaningful, sustainable, and real."
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "For this type, career ceilings are rarely caused by a lack of talent. They are more often shaped by hidden self-pressure, overthinking, or weak boundaries around energy.\n\nThe ideas below are useful “small formulas” you can return to when you want more stable growth at work.",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Clarity ≠ coldness",
+                "body": "A strong point becomes more persuasive when people can feel the care behind it. Add context, timing, and emotional translation to your logic."
+              },
+              {
+                "title": "Freedom becomes power when it has a container",
+                "body": "Options are valuable, but your best ideas need deadlines, rituals, or simple systems to become real output."
+              },
+              {
+                "title": "Depth creates more value when it becomes visible",
+                "body": "Do not wait for perfect readiness before sharing what you see. Small moments of visibility often change your influence more than perfect private thinking."
+              },
+              {
+                "title": "Self-reflection works better with self-kindness",
+                "body": "Review your work carefully, but do not let reflection become self-attack. Growth accelerates when the inner voice stays honest and humane."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into disappearing into self-sufficiency and leaving feelings underexplained.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You have a rich inner processing space",
+                "body": "Solitude often helps you refine ideas, notice nuance, and return with clearer judgment."
+              },
+              {
+                "title": "You stay close to what is real",
+                "body": "You often know how to translate ideas into workable details and practical habits."
+              },
+              {
+                "title": "You can stay clear-headed under complexity",
+                "body": "You often know how to separate noise from structure and think your way through a difficult problem."
+              },
+              {
+                "title": "You stay open to emerging reality",
+                "body": "You can often adapt without over-defending the old plan and keep learning while in motion."
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may isolate when overloaded",
+                "body": "Solitude can restore you, but under pressure it can also become avoidance, making it harder for others to know when you need support."
+              },
+              {
+                "title": "You may hesitate to leave familiar ground",
+                "body": "When something has worked before, it can feel safer to optimize the known than to risk an uncertain but promising new path."
+              },
+              {
+                "title": "You may under-translate warmth",
+                "body": "Clear logic is a strength, but if feeling is left implicit too often, other people may experience distance where you meant steadiness."
+              },
+              {
+                "title": "You may resist the structures that would actually support you",
+                "body": "Freedom matters, but without some repetition or closure, your best ideas or intentions can remain more potential than reality."
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "Autonomy, competence, real-world challenge, and the chance to solve concrete problems usually strengthen your state and make your effort feel worth it.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Autonomy, competence, real-world challenge, and the chance to solve concrete problems usually strengthen your state and make your effort feel worth it.",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "Micromanagement, empty talk, emotional overexposure without movement, and impractical systems can quietly hollow out your energy if they last too long.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "Micromanagement, empty talk, emotional overexposure without movement, and impractical systems can quietly hollow out your energy if they last too long.",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "In relationships, you tend to be steady, low-drama, and more action-oriented than verbally demonstrative.\n\nYour main challenge is disappearing into self-sufficiency and leaving feelings underexplained.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You often offer depth and steadiness",
+                "body": "You may not be loud, but your attention can be sincere, thoughtful, and deeply loyal over time."
+              },
+              {
+                "title": "You show care in practical, grounded ways",
+                "body": "Your attention often shows up in what is remembered, prepared, fixed, or quietly maintained."
+              },
+              {
+                "title": "You bring honesty and clear thinking",
+                "body": "You can often help a relationship by naming what is true, practical, and structurally unsustainable."
+              },
+              {
+                "title": "You bring flexibility and openness",
+                "body": "You can often create space, reduce pressure, and help a relationship breathe when things get too rigid."
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "You may keep too much inside",
+                "body": "If your inner world stays private for too long, the other person may have to guess what matters, hurts, or changes."
+              },
+              {
+                "title": "You may over-rely on the familiar pattern",
+                "body": "If the routine feels stable, it can be easy to postpone deeper conversations or changes that the relationship genuinely needs."
+              },
+              {
+                "title": "You may sound distant or overly corrective",
+                "body": "When you focus on fixing the issue, the other person may miss the warmth or care behind your words."
+              },
+              {
+                "title": "You may delay difficult decisions",
+                "body": "Keeping options open can become avoidance if hard choices, boundaries, or commitments are repeatedly postponed."
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "You often bring calm realism, skill, and grounded problem-solving that can make hard moments more manageable.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "You often bring calm realism, skill, and grounded problem-solving that can make hard moments more manageable.",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "If you stay too private for too long, people may experience your calm as absence instead of stability.",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "If you stay too private for too long, people may experience your calm as absence instead of stability.",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
       "seo_overrides": {
-        "seo_title": null,
-        "seo_description": null,
+        "seo_title": "ISTP-T Virtuoso",
+        "seo_description": "You are like a calm hand reaching for the right tool: you tend to understand how something works, fix what is broken, and move through reality with quiet precision. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "canonical_url": null,
-        "og_title": null,
-        "og_description": null,
+        "og_title": "ISTP-T Calm Problem-Solver",
+        "og_description": "You are like a calm hand reaching for the right tool: you tend to understand how something works, fix what is broken, and move through reality with quiet precision. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "og_image_url": null,
-        "twitter_title": null,
-        "twitter_description": null,
+        "twitter_title": "ISTP-T Calm Problem-Solver",
+        "twitter_description": "You are like a calm hand reaching for the right tool: you tend to understand how something works, fix what is broken, and move through reality with quiet precision. The -T side of you adds more self-reflection, higher self-demands, and greater sensitivity to feedback.",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null


### PR DESCRIPTION
## Summary\n- publish full raw English 32-type MBTI variant authority into committed baseline\n- upgrade \ from placeholder variants to published variants\n- unblock PR-10B canonical cutover precheck for locale completeness\n\n## Tests\n- cd backend && php artisan personality:import-local-baseline --dry-run --locale=en --type=INTJ --upsert --status=published\n- cd backend && php artisan route:list | grep -Ei "personality|seo|sitemap"\n- cd backend && php artisan migrate\n- cd backend && php artisan personality:import-local-baseline --locale=en --type=INTJ --upsert --status=published\n- curl -s "http://127.0.0.1:8000/api/v0.5/personality/intj-a?locale=en"\n- curl -s "http://127.0.0.1:8000/api/v0.5/personality/intj-a/seo?locale=en"\n- cd backend && bash scripts/ci_verify_mbti.sh