### PR TITLE
[codex] feat(web+api): cut over MBTI public canonical, hreflang, llms, and sitemap to 32-type routes

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -206,7 +206,7 @@ class PersonalityController extends Controller
         $meta = [
             'seo_title' => $seoMeta?->seo_title,
             'seo_description' => $seoMeta?->seo_description,
-            'canonical_url' => $this->personalityProfileSeoService->buildCanonicalUrl($profile, (string) $profile->locale),
+            'canonical_url' => $this->personalityProfileSeoService->buildCanonicalUrl($profile, (string) $profile->locale, $variant),
             'og_title' => $seoMeta?->og_title,
             'og_description' => $seoMeta?->og_description,
             'og_image_url' => $seoMeta?->og_image_url,

--- a/backend/app/Services/Cms/PersonalityProfileSeoService.php
+++ b/backend/app/Services/Cms/PersonalityProfileSeoService.php
@@ -19,6 +19,9 @@ final class PersonalityProfileSeoService
     public function buildMeta(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
     {
         $projection = $this->personalityProfileService->buildPublicProjection($profile, $variant);
+        $canonicalVariant = $variant instanceof PersonalityProfileVariant
+            ? $variant
+            : $this->personalityProfileService->getDefaultPublishedVariantForCanonicalRoute($profile);
         $title = $this->fallbackText(
             data_get($projection, 'seo.title'),
             data_get($projection, 'summary_card.title'),
@@ -32,8 +35,8 @@ final class PersonalityProfileSeoService
             (string) ($profile->subtitle ?? null)
         );
         $canonical = $this->fallbackText(
-            data_get($projection, 'seo.canonical_url'),
-            $this->buildCanonicalUrl($profile, (string) $profile->locale)
+            $this->buildCanonicalUrl($profile, (string) $profile->locale, $canonicalVariant),
+            data_get($projection, 'seo.canonical_url')
         );
         $robots = $this->fallbackText(
             data_get($projection, 'seo.robots')
@@ -43,6 +46,7 @@ final class PersonalityProfileSeoService
             'title' => $title,
             'description' => $description,
             'canonical' => $canonical,
+            'alternates' => $this->buildAlternates($profile, $canonicalVariant),
             'og' => [
                 'title' => $this->fallbackText(data_get($projection, 'seo.og_title'), $title),
                 'description' => $this->fallbackText(data_get($projection, 'seo.og_description'), $description),
@@ -100,10 +104,13 @@ final class PersonalityProfileSeoService
         return $jsonLd;
     }
 
-    public function buildCanonicalUrl(PersonalityProfile $profile, string $locale): ?string
-    {
+    public function buildCanonicalUrl(
+        PersonalityProfile $profile,
+        string $locale,
+        ?PersonalityProfileVariant $variant = null
+    ): ?string {
         $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
-        $slug = $this->publicRouteSlug($profile);
+        $slug = $this->publicRouteSlug($profile, $variant);
 
         if ($baseUrl === '' || $slug === '') {
             return null;
@@ -115,14 +122,39 @@ final class PersonalityProfileSeoService
             .rawurlencode($slug);
     }
 
+    /**
+     * @return array{en:?string,zh-CN:?string}
+     */
+    public function buildAlternates(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
+    {
+        return [
+            'en' => $this->buildCanonicalUrl($profile, 'en', $variant),
+            'zh-CN' => $this->buildCanonicalUrl($profile, 'zh-CN', $variant),
+        ];
+    }
+
     public function mapBackendLocaleToFrontendSegment(string $locale): string
     {
         return trim($locale) === 'zh-CN' ? 'zh' : 'en';
     }
 
-    private function publicRouteSlug(PersonalityProfile $profile): string
+    private function publicRouteSlug(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): string
     {
-        return trim((string) $profile->slug);
+        $baseSlug = trim((string) $profile->slug);
+        if ($baseSlug === '') {
+            return '';
+        }
+
+        if (! $variant instanceof PersonalityProfileVariant) {
+            return $baseSlug;
+        }
+
+        $variantCode = strtoupper(trim((string) $variant->variant_code));
+        if (! in_array($variantCode, ['A', 'T'], true)) {
+            return $baseSlug;
+        }
+
+        return strtolower($baseSlug.'-'.$variantCode);
     }
 
     private function fallbackText(?string ...$candidates): ?string

--- a/backend/app/Services/Cms/PersonalityProfileService.php
+++ b/backend/app/Services/Cms/PersonalityProfileService.php
@@ -137,10 +137,48 @@ final class PersonalityProfileService
                         ->orderBy('sort_order')
                         ->orderBy('id');
                 },
+                'variants' => static function (HasMany $query): void {
+                    $query->where('is_published', true)
+                        ->where(static function (Builder $nested): void {
+                            $nested->whereNull('published_at')
+                                ->orWhere('published_at', '<=', now());
+                        })
+                        ->with('seoMeta')
+                        ->orderByRaw("case when variant_code = 'A' then 0 when variant_code = 'T' then 1 else 9 end")
+                        ->orderBy('runtime_type_code')
+                        ->orderBy('id');
+                },
             ])
             ->orderBy('locale')
             ->orderBy('slug')
             ->get();
+    }
+
+    public function getDefaultPublishedVariantForCanonicalRoute(PersonalityProfile $profile): ?PersonalityProfileVariant
+    {
+        if ($profile->relationLoaded('variants')) {
+            /** @var PersonalityProfileVariant|null $variant */
+            $variant = $profile->variants
+                ->first(static fn (mixed $item): bool => $item instanceof PersonalityProfileVariant
+                    && $item->variant_code === 'A'
+                    && (bool) $item->is_published);
+
+            if ($variant instanceof PersonalityProfileVariant) {
+                $variant->loadMissing('seoMeta');
+
+                return $variant;
+            }
+        }
+
+        return $profile->variants()
+            ->where('variant_code', 'A')
+            ->where('is_published', true)
+            ->where(static function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->with('seoMeta')
+            ->first();
     }
 
     /**
@@ -181,7 +219,11 @@ final class PersonalityProfileService
      */
     public function buildPublicProjection(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
     {
-        return $this->mbtiPublicProjectionService->buildForPublicPersonalityRoute($profile, $variant);
+        return $this->mbtiPublicProjectionService->buildForPublicPersonalityRoute(
+            $profile,
+            $variant,
+            $variant instanceof PersonalityProfileVariant ? 'public_variant' : 'base'
+        );
     }
 
     private function basePublicQuery(int $orgId, string $scaleCode, string $locale): Builder

--- a/backend/app/Services/Mbti/MbtiPublicProjectionService.php
+++ b/backend/app/Services/Mbti/MbtiPublicProjectionService.php
@@ -117,7 +117,8 @@ final class MbtiPublicProjectionService
      */
     public function buildForPublicPersonalityRoute(
         PersonalityProfile $profile,
-        ?PersonalityProfileVariant $variant = null
+        ?PersonalityProfileVariant $variant = null,
+        string $routeMode = ''
     ): array {
         $profile->loadMissing([
             'sections' => static function (HasMany $query): void {
@@ -133,18 +134,20 @@ final class MbtiPublicProjectionService
 
         $runtimeTypeCode = $this->nullableText($authority['runtime_type_code'] ?? null);
         $canonicalTypeCode = strtoupper(trim((string) ($profile->canonical_type_code ?: $profile->type_code)));
+        $publicRouteSlug = $this->resolvePublicRouteSlug($profile, $variant);
 
         $authority['runtime_type_code'] = $runtimeTypeCode;
         $authority['display_type'] = $runtimeTypeCode ?? $canonicalTypeCode;
         $authority['variant_code'] = $this->nullableText($authority['variant_code'] ?? null);
+        $authority['public_route_slug'] = $publicRouteSlug;
         $authority['dimensions'] = [];
         $authority['offer_set'] = [];
         $authority['_meta'] = array_merge(
             is_array($authority['_meta'] ?? null) ? $authority['_meta'] : [],
             [
                 'authority_source' => 'personality_cms_v2',
-                'route_mode' => $variant instanceof PersonalityProfileVariant ? 'public_alias' : 'base',
-                'public_route_type' => '16-type',
+                'route_mode' => trim($routeMode) !== '' ? trim($routeMode) : ($variant instanceof PersonalityProfileVariant ? 'public_variant' : 'base'),
+                'public_route_type' => $variant instanceof PersonalityProfileVariant ? '32-type' : '16-type',
                 'schema_version' => (string) ($profile->schema_version ?: PersonalityProfile::SCHEMA_VERSION_V2),
             ],
         );
@@ -440,7 +443,8 @@ final class MbtiPublicProjectionService
         );
 
         $canonicalUrl = $this->buildCanonicalUrl(
-            $this->nullableText($authority['slug'] ?? null),
+            $this->nullableText($authority['public_route_slug'] ?? null)
+                ?? $this->nullableText($authority['slug'] ?? null),
             (string) ($authority['locale'] ?? 'en')
         );
 
@@ -483,6 +487,27 @@ final class MbtiPublicProjectionService
             : [];
 
         return $projection;
+    }
+
+    private function resolvePublicRouteSlug(
+        PersonalityProfile $profile,
+        ?PersonalityProfileVariant $variant = null
+    ): ?string {
+        $baseSlug = $this->nullableText($profile->slug);
+        if ($baseSlug === null) {
+            return null;
+        }
+
+        if (! $variant instanceof PersonalityProfileVariant) {
+            return $baseSlug;
+        }
+
+        $variantCode = strtoupper(trim((string) $variant->variant_code));
+        if (! in_array($variantCode, ['A', 'T'], true)) {
+            return $baseSlug;
+        }
+
+        return strtolower($baseSlug.'-'.$variantCode);
     }
 
     /**

--- a/backend/app/Services/SEO/SitemapCache.php
+++ b/backend/app/Services/SEO/SitemapCache.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Facades\Cache;
 
 class SitemapCache
 {
-    public const XML_CACHE_KEY = 'seo:sitemap:xml:v4';
+    public const XML_CACHE_KEY = 'seo:sitemap:xml:v5';
 
-    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v4';
+    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v5';
 
     public const TTL_SECONDS = 86400;
 

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -5,6 +5,7 @@ namespace App\Services\SEO;
 use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
+use App\Models\PersonalityProfileVariant;
 use App\Models\TopicProfile;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerGuideSeoService;
@@ -225,30 +226,42 @@ class SitemapGenerator
 
         foreach ($rows as $row) {
             $locale = trim((string) $row->locale);
-            $canonical = trim((string) data_get(
-                $this->personalityProfileSeoService->buildMeta($row),
-                'canonical',
-                ''
-            ));
-
-            if ($canonical === '' || $locale === '') {
+            $segment = $this->personalityProfileSeoService->mapBackendLocaleToFrontendSegment($locale);
+            if ($locale === '') {
                 continue;
             }
 
-            $segment = $this->personalityProfileSeoService->mapBackendLocaleToFrontendSegment($locale);
-            $lastmod = $row->updated_at
-                ?? $row->published_at
-                ?? now();
+            foreach ($row->variants as $variant) {
+                if (! $variant instanceof PersonalityProfileVariant) {
+                    continue;
+                }
 
-            $urls[] = [
-                'loc' => $canonical,
-                'lastmod' => $lastmod->toAtomString(),
-                'slug' => 'personality:'.$segment.':'.trim((string) $row->slug),
-                'updated_at' => $lastmod->toDateTimeString(),
-            ];
+                $canonical = trim((string) data_get(
+                    $this->personalityProfileSeoService->buildMeta($row, $variant),
+                    'canonical',
+                    ''
+                ));
 
-            if (! isset($listLastModified[$segment]) || $lastmod->gt($listLastModified[$segment])) {
-                $listLastModified[$segment] = $lastmod;
+                if ($canonical === '') {
+                    continue;
+                }
+
+                $lastmod = $variant->updated_at
+                    ?? $variant->published_at
+                    ?? $row->updated_at
+                    ?? $row->published_at
+                    ?? now();
+
+                $urls[] = [
+                    'loc' => $canonical,
+                    'lastmod' => $lastmod->toAtomString(),
+                    'slug' => 'personality:'.$segment.':'.strtolower((string) $variant->runtime_type_code),
+                    'updated_at' => $lastmod->toDateTimeString(),
+                ];
+
+                if (! isset($listLastModified[$segment]) || $lastmod->gt($listLastModified[$segment])) {
+                    $listLastModified[$segment] = $lastmod;
+                }
             }
         }
 

--- a/backend/tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php
@@ -15,7 +15,7 @@ final class PersonalityVariantAuthorityTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_imported_variant_authority_rows_can_resolve_published_public_aliases_while_canonical_stays_base_only(): void
+    public function test_imported_variant_authority_rows_can_resolve_published_public_variants_after_public_cutover(): void
     {
         $this->artisan('personality:import-local-baseline', [
             '--locale' => ['en'],
@@ -67,7 +67,7 @@ final class PersonalityVariantAuthorityTest extends TestCase
             ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', 'ENFP-T')
             ->assertJsonPath('mbti_public_projection_v1.display_type', 'ENFP-T')
             ->assertJsonPath('mbti_public_projection_v1.variant_code', 'T')
-            ->assertJsonPath('mbti_public_projection_v1._meta.public_route_type', '16-type');
+            ->assertJsonPath('mbti_public_projection_v1._meta.public_route_type', '32-type');
 
         $this->getJson('/api/v0.5/personality/enfp-a?locale=en')
             ->assertStatus(404);

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -312,10 +312,10 @@ class SitemapGeneratorTest extends TestCase
 
         $this->assertStringContainsString('https://staging.fermatmind.com/en/personality', $xml);
         $this->assertStringContainsString('https://staging.fermatmind.com/zh/personality', $xml);
-        $this->assertStringContainsString('https://staging.fermatmind.com/en/personality/intj', $xml);
-        $this->assertStringContainsString('https://staging.fermatmind.com/zh/personality/intj', $xml);
-        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/intj-a', $xml);
-        $this->assertStringNotContainsString('https://staging.fermatmind.com/zh/personality/intj-a', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/en/personality/intj-a', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/zh/personality/intj-t', $xml);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/personality/intj</loc>', $xml);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/personality/intj</loc>', $xml);
 
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/entj', $xml);
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/entp', $xml);
@@ -327,16 +327,16 @@ class SitemapGeneratorTest extends TestCase
         $seoService = app(PersonalityProfileSeoService::class);
 
         $this->assertSame(
-            data_get($seoService->buildMeta($eligibleEn), 'canonical'),
-            data_get($seoService->buildJsonLd($eligibleEn), 'mainEntityOfPage')
+            data_get($seoService->buildMeta($eligibleEn, $eligibleEnVariant), 'canonical'),
+            data_get($seoService->buildJsonLd($eligibleEn, $eligibleEnVariant), 'mainEntityOfPage')
         );
         $this->assertSame(
-            data_get($seoService->buildMeta($eligibleZh), 'canonical'),
-            data_get($seoService->buildJsonLd($eligibleZh), 'mainEntityOfPage')
+            data_get($seoService->buildMeta($eligibleZh, $eligibleZhVariant), 'canonical'),
+            data_get($seoService->buildJsonLd($eligibleZh, $eligibleZhVariant), 'mainEntityOfPage')
         );
-        $this->assertSame('AboutPage', data_get($seoService->buildJsonLd($eligibleEn), '@type'));
-        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleEn), 'canonical'), $xml);
-        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh), 'canonical'), $xml);
+        $this->assertSame('AboutPage', data_get($seoService->buildJsonLd($eligibleEn, $eligibleEnVariant), '@type'));
+        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleEn, $eligibleEnVariant), 'canonical'), $xml);
+        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh, $eligibleZhVariant), 'canonical'), $xml);
     }
 
     public function test_generate_includes_only_indexable_global_topic_urls_with_locale_aware_paths(): void

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -450,10 +450,10 @@ class SitemapXmlTest extends TestCase
         $this->assertStringNotContainsString('<loc>'.$prefix.'hidden-alt</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/personality</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality</loc>', $body);
-        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/personality/intj</loc>', $body);
-        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality/intj</loc>', $body);
-        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/personality/intj-a</loc>', $body);
-        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/personality/intj-a</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/personality/intj-a</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality/intj-t</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/personality/intj</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/personality/intj</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/topics</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/topics</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/topics/mbti</loc>', $body);

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -325,11 +325,13 @@ final class PersonalityPublicApiTest extends TestCase
         $enResponse->assertOk()
             ->assertJsonPath('meta.title', 'INTJ-A Personality Type: Traits, Careers, and Growth | FermatMind')
             ->assertJsonPath('meta.description', 'Explore INTJ-A traits, strengths, blind spots, work style, relationships, and growth advice.')
-            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/personality/intj')
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/personality/intj-a')
+            ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/personality/intj-a')
+            ->assertJsonPath('meta.alternates.zh-CN', 'https://staging.fermatmind.com/zh/personality/intj-a')
             ->assertJsonPath('meta.robots', 'index,follow');
         self::assertSame('AboutPage', data_get($enResponse->json(), 'jsonld.@type'));
         self::assertSame(
-            'https://staging.fermatmind.com/en/personality/intj',
+            'https://staging.fermatmind.com/en/personality/intj-a',
             data_get($enResponse->json(), 'jsonld.mainEntityOfPage')
         );
 
@@ -337,15 +339,17 @@ final class PersonalityPublicApiTest extends TestCase
         $zhResponse->assertOk()
             ->assertJsonPath('meta.title', 'INTJ-T 人格类型：特质、职业与成长 | FermatMind')
             ->assertJsonPath('meta.description', '探索 INTJ-T 的特质、优势、关系模式与成长建议。')
-            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/personality/intj')
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/personality/intj-t')
+            ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/personality/intj-t')
+            ->assertJsonPath('meta.alternates.zh-CN', 'https://staging.fermatmind.com/zh/personality/intj-t')
             ->assertJsonPath('meta.robots', 'noindex,follow');
         self::assertSame(
-            'https://staging.fermatmind.com/zh/personality/intj',
+            'https://staging.fermatmind.com/zh/personality/intj-t',
             data_get($zhResponse->json(), 'jsonld.mainEntityOfPage')
         );
     }
 
-    public function test_detail_accepts_published_public_aliases_while_base_canonical_stays_frozen(): void
+    public function test_detail_accepts_published_public_variants_after_canonical_cutover(): void
     {
         config(['app.frontend_url' => 'https://staging.fermatmind.com']);
 
@@ -429,13 +433,13 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('sections.0.section_key', 'overview')
             ->assertJsonPath('sections.0.body_md', 'Variant overview')
             ->assertJsonPath('seo_meta.seo_title', 'Variant INTJ-A title')
-            ->assertJsonPath('seo_meta.canonical_url', 'https://staging.fermatmind.com/en/personality/intj')
+            ->assertJsonPath('seo_meta.canonical_url', 'https://staging.fermatmind.com/en/personality/intj-a')
             ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', 'INTJ-A')
             ->assertJsonPath('mbti_public_projection_v1.display_type', 'INTJ-A')
             ->assertJsonPath('mbti_public_projection_v1.variant_code', 'A')
-            ->assertJsonPath('mbti_public_projection_v1._meta.route_mode', 'public_alias')
-            ->assertJsonPath('mbti_public_projection_v1._meta.public_route_type', '16-type')
-            ->assertJsonPath('mbti_public_projection_v1.seo.canonical_url', 'https://staging.fermatmind.com/en/personality/intj');
+            ->assertJsonPath('mbti_public_projection_v1._meta.route_mode', 'public_variant')
+            ->assertJsonPath('mbti_public_projection_v1._meta.public_route_type', '32-type')
+            ->assertJsonPath('mbti_public_projection_v1.seo.canonical_url', 'https://staging.fermatmind.com/en/personality/intj-a');
 
         $this->getJson('/api/v0.5/personality/intj-t?locale=en')
             ->assertStatus(404)

--- a/backend/tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php
@@ -114,9 +114,9 @@ final class MbtiPublicProjectionServiceTest extends TestCase
         $this->assertSame('Assertive strategist', data_get($projection, 'profile.nickname'));
         $this->assertSame('Variant overview', data_get($projection, 'sections.0.body_md'));
         $this->assertSame('Variant SEO title', data_get($projection, 'seo.title'));
-        $this->assertSame('https://staging.fermatmind.com/en/personality/intj', data_get($projection, 'seo.canonical_url'));
-        $this->assertSame('public_alias', data_get($projection, '_meta.route_mode'));
-        $this->assertSame('16-type', data_get($projection, '_meta.public_route_type'));
+        $this->assertSame('https://staging.fermatmind.com/en/personality/intj-a', data_get($projection, 'seo.canonical_url'));
+        $this->assertSame('public_variant', data_get($projection, '_meta.route_mode'));
+        $this->assertSame('32-type', data_get($projection, '_meta.public_route_type'));
     }
 
     public function test_it_merges_runtime_identity_report_fallback_and_cms_variant_authority_for_share_projection(): void


### PR DESCRIPTION
## Summary
This backend PR completes the PR-10B canonical cutover on the API side.

It promotes published 32-type MBTI variant routes to the canonical public personality detail surface, updates public SEO metadata and JSON-LD to point at variant URLs, and switches personality sitemap detail URLs from 16-type base pages to published 32-type variant pages.

## What changed
- public personality projection now marks published variant detail routes as `32-type` canonical public pages
- `/api/v0.5/personality/{type}` and `/api/v0.5/personality/{type}/seo` continue resolving published aliases and now emit variant canonical URLs
- sitemap personality detail URLs now emit published `-a` / `-t` routes instead of 4-letter base routes
- sitemap cache key was bumped so deploys do not keep serving stale 16-type XML after cutover
- v0.3 runtime/report/share/compare contracts remain unchanged

## Validation
- `php artisan route:list | grep -Ei "personality|seo|sitemap"`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`
- `vendor/bin/phpunit tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php`
- `bash scripts/ci_verify_mbti.sh`
