### PR TITLE
[codex] feat(api): add MBTI career recommendation authority v1

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerRecommendationController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerRecommendationController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Cms;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Services\Cms\CareerRecommendationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+final class CareerRecommendationController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerRecommendationService $careerRecommendationService,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        return response()->json([
+            'items' => $this->careerRecommendationService->listPublicRecommendations(
+                $validated['org_id'],
+                $validated['locale'],
+            ),
+        ]);
+    }
+
+    public function show(Request $request, string $type): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $payload = $this->careerRecommendationService->getPublicRecommendationByType(
+            $type,
+            $validated['org_id'],
+            $validated['locale'],
+        );
+
+        if (! is_array($payload)) {
+            return $this->notFoundResponse('career recommendation not found.');
+        }
+
+        return response()->json($payload);
+    }
+
+    /**
+     * @return array{org_id:int,locale:string}|JsonResponse
+     */
+    private function validateReadQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'locale' => ['required', 'in:en,zh-CN'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'locale' => (string) $validated['locale'],
+        ];
+    }
+
+    private function invalidArgument(string $message): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'INVALID_ARGUMENT',
+            'message' => $message,
+        ], 422);
+    }
+}

--- a/backend/app/Services/Cms/CareerGuideService.php
+++ b/backend/app/Services/Cms/CareerGuideService.php
@@ -10,6 +10,7 @@ use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 final class CareerGuideService
 {
@@ -38,6 +39,65 @@ final class CareerGuideService
             ->forSlug($this->normalizeSlug($slug))
             ->with('seoMeta')
             ->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function findPublishedGuidesForMbtiGraph(string $graphTypeCode, string $locale, int $orgId = 0): array
+    {
+        $normalizedGraphTypeCode = strtoupper(trim($graphTypeCode));
+
+        if ($normalizedGraphTypeCode === '') {
+            return [];
+        }
+
+        return $this->basePublicQuery($orgId, $locale)
+            ->with([
+                'relatedPersonalityProfiles' => function (BelongsToMany $query) use ($orgId, $locale): void {
+                    $query->withoutGlobalScopes()
+                        ->where('personality_profiles.org_id', max(0, $orgId))
+                        ->where('personality_profiles.scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+                        ->whereIn('personality_profiles.type_code', PersonalityProfile::TYPE_CODES)
+                        ->where('personality_profiles.locale', $this->normalizeLocale($locale))
+                        ->where('personality_profiles.status', 'published')
+                        ->where('personality_profiles.is_public', true)
+                        ->where(static function (Builder $builder): void {
+                            $builder->whereNull('personality_profiles.published_at')
+                                ->orWhere('personality_profiles.published_at', '<=', now());
+                        })
+                        ->orderBy('career_guide_personality_map.sort_order')
+                        ->orderBy('personality_profiles.id');
+                },
+            ])
+            ->orderBy('sort_order')
+            ->orderByDesc('published_at')
+            ->orderBy('guide_code')
+            ->orderBy('id')
+            ->get()
+            ->map(function (CareerGuide $guide) use ($normalizedGraphTypeCode): ?array {
+                $fitPersonalityCodes = $guide->relatedPersonalityProfiles
+                    ->filter(static fn (mixed $profile): bool => $profile instanceof PersonalityProfile)
+                    ->map(static fn (PersonalityProfile $profile): string => strtoupper((string) $profile->type_code))
+                    ->filter(static fn (string $typeCode): bool => $typeCode !== '')
+                    ->unique()
+                    ->values()
+                    ->all();
+
+                if (! in_array($normalizedGraphTypeCode, $fitPersonalityCodes, true)) {
+                    return null;
+                }
+
+                return [
+                    'slug' => (string) $guide->slug,
+                    'title' => (string) $guide->title,
+                    'summary' => $this->fallbackText($guide->excerpt, $guide->title),
+                    'fit_personality_codes' => $fitPersonalityCodes,
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
     }
 
     /**
@@ -261,5 +321,21 @@ final class CareerGuideService
         $normalized = strtolower(trim($category));
 
         return $normalized !== '' ? $normalized : null;
+    }
+
+    private function fallbackText(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/app/Services/Cms/CareerJobService.php
+++ b/backend/app/Services/Cms/CareerJobService.php
@@ -42,6 +42,64 @@ final class CareerJobService
     /**
      * @return array<string, mixed>
      */
+    public function findPublishedJobsForMbtiGraph(string $graphTypeCode, string $locale, int $orgId = 0): array
+    {
+        $normalizedGraphTypeCode = strtoupper(trim($graphTypeCode));
+
+        if ($normalizedGraphTypeCode === '') {
+            return [];
+        }
+
+        $items = $this->basePublicQuery($orgId, $locale)
+            ->orderBy('sort_order')
+            ->orderBy('job_code')
+            ->orderBy('id')
+            ->get()
+            ->map(function (CareerJob $job) use ($normalizedGraphTypeCode): ?array {
+                $primaryCodes = $this->normalizeTypeCodes($job->mbti_primary_codes_json);
+                $secondaryCodes = $this->normalizeTypeCodes($job->mbti_secondary_codes_json);
+
+                if (in_array($normalizedGraphTypeCode, $primaryCodes, true)) {
+                    $fitBucket = 'primary';
+                } elseif (in_array($normalizedGraphTypeCode, $secondaryCodes, true)) {
+                    $fitBucket = 'secondary';
+                } else {
+                    return null;
+                }
+
+                return [
+                    '_fit_rank' => $fitBucket === 'primary' ? 0 : 1,
+                    '_sort_order' => (int) $job->sort_order,
+                    '_job_code' => (string) $job->job_code,
+                    '_id' => (int) $job->id,
+                    'slug' => (string) $job->slug,
+                    'title' => (string) $job->title,
+                    'summary' => $this->fallbackText($job->excerpt, $job->subtitle, $job->title),
+                    'fit_bucket' => $fitBucket,
+                    'fit_personality_codes' => $this->normalizeTypeCodes($job->fit_personality_codes_json),
+                    'mbti_primary_codes' => $primaryCodes,
+                    'mbti_secondary_codes' => $secondaryCodes,
+                ];
+            })
+            ->all();
+
+        $items = array_values(array_filter($items, static fn (mixed $item): bool => is_array($item)));
+
+        usort($items, static function (array $left, array $right): int {
+            return [(int) $left['_fit_rank'], (int) $left['_sort_order'], (string) $left['_job_code'], (int) $left['_id']]
+                <=> [(int) $right['_fit_rank'], (int) $right['_sort_order'], (string) $right['_job_code'], (int) $right['_id']];
+        });
+
+        return array_map(static function (array $item): array {
+            unset($item['_fit_rank'], $item['_sort_order'], $item['_job_code'], $item['_id']);
+
+            return $item;
+        }, $items);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     public function listPayload(CareerJob $job): array
     {
         return [
@@ -203,5 +261,48 @@ final class CareerJobService
     private function normalizeSlug(string $slug): string
     {
         return strtolower(trim($slug));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeTypeCodes(mixed $codes): array
+    {
+        if (! is_array($codes)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($codes as $code) {
+            if (! is_scalar($code)) {
+                continue;
+            }
+
+            $value = strtoupper(trim((string) $code));
+            if ($value === '') {
+                continue;
+            }
+
+            $normalized[$value] = $value;
+        }
+
+        return array_values($normalized);
+    }
+
+    private function fallbackText(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/app/Services/Cms/CareerRecommendationService.php
+++ b/backend/app/Services/Cms/CareerRecommendationService.php
@@ -1,0 +1,471 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class CareerRecommendationService
+{
+    private const AUTHORITY_SOURCE = 'career_recommendation_service.v1';
+
+    public function __construct(
+        private readonly PersonalityProfileService $personalityProfileService,
+        private readonly CareerJobService $careerJobService,
+        private readonly CareerGuideService $careerGuideService,
+    ) {}
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function listPublicRecommendations(int $orgId, string $locale): array
+    {
+        $items = [];
+
+        foreach ($this->listPublishedProfilesWithVariants($orgId, $locale) as $profile) {
+            if (! $profile instanceof PersonalityProfile) {
+                continue;
+            }
+
+            foreach ($profile->variants as $variant) {
+                if (! $variant instanceof PersonalityProfileVariant) {
+                    continue;
+                }
+
+                $projection = $this->personalityProfileService->buildPublicProjection($profile, $variant);
+
+                $items[] = [
+                    'runtime_type_code' => data_get($projection, 'runtime_type_code'),
+                    'canonical_type_code' => data_get($projection, 'canonical_type_code'),
+                    'display_type' => data_get($projection, 'display_type'),
+                    'variant_code' => data_get($projection, 'variant_code'),
+                    'public_route_slug' => $this->resolvePublicRouteSlug($profile, $variant),
+                    'type_name' => $this->fallbackText(
+                        data_get($projection, 'profile.type_name'),
+                        (string) $profile->type_name,
+                        (string) $profile->title
+                    ),
+                    'nickname' => $this->fallbackText(
+                        data_get($projection, 'profile.nickname'),
+                        (string) $profile->nickname
+                    ),
+                    'hero_summary' => $this->fallbackText(
+                        data_get($projection, 'profile.hero_summary'),
+                        data_get($projection, 'summary_card.summary'),
+                        (string) $profile->excerpt
+                    ),
+                ];
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getPublicRecommendationByType(string $typeLookup, int $orgId, string $locale): ?array
+    {
+        $routeProfile = $this->personalityProfileService->getPublicDetailRouteProfileByType(
+            $typeLookup,
+            $orgId,
+            PersonalityProfile::SCALE_CODE_MBTI,
+            $this->normalizeLocale($locale),
+        );
+
+        if (! is_array($routeProfile)) {
+            return null;
+        }
+
+        /** @var PersonalityProfile $profile */
+        $profile = $routeProfile['profile'];
+        /** @var PersonalityProfileVariant|null $variant */
+        $variant = $routeProfile['variant'];
+
+        if (! $variant instanceof PersonalityProfileVariant) {
+            $variant = $this->personalityProfileService->getDefaultPublishedVariantForCanonicalRoute($profile);
+        }
+
+        if (! $variant instanceof PersonalityProfileVariant) {
+            return null;
+        }
+
+        $projection = $this->personalityProfileService->buildPublicProjection($profile, $variant);
+        $canonicalTypeCode = strtoupper((string) data_get(
+            $projection,
+            'canonical_type_code',
+            (string) ($profile->canonical_type_code ?: $profile->type_code)
+        ));
+        $publicRouteSlug = $this->resolvePublicRouteSlug($profile, $variant);
+
+        if ($canonicalTypeCode === '' || $publicRouteSlug === '') {
+            return null;
+        }
+
+        return [
+            'runtime_type_code' => data_get($projection, 'runtime_type_code'),
+            'canonical_type_code' => $canonicalTypeCode,
+            'display_type' => data_get($projection, 'display_type'),
+            'variant_code' => data_get($projection, 'variant_code'),
+            'public_route_slug' => $publicRouteSlug,
+            'graph_type_code' => $canonicalTypeCode,
+            'type_name' => $this->fallbackText(
+                data_get($projection, 'profile.type_name'),
+                (string) $profile->type_name,
+                (string) $profile->title
+            ),
+            'nickname' => $this->fallbackText(
+                data_get($projection, 'profile.nickname'),
+                (string) $profile->nickname
+            ),
+            'hero_summary' => $this->fallbackText(
+                data_get($projection, 'profile.hero_summary'),
+                data_get($projection, 'summary_card.summary'),
+                (string) $profile->excerpt
+            ),
+            'keywords' => $this->stringList(data_get($projection, 'profile.keywords')),
+            'career' => [
+                'summary' => $this->summarySectionPayload($projection),
+                'advantages' => $this->bulletSectionPayload($projection, 'career.advantages', 'description'),
+                'weaknesses' => $this->bulletSectionPayload($projection, 'career.weaknesses', 'description'),
+                'preferred_roles' => $this->preferredRolesPayload($projection),
+                'upgrade_suggestions' => $this->upgradeSuggestionsPayload($projection),
+            ],
+            'matched_jobs' => $this->careerJobService->findPublishedJobsForMbtiGraph(
+                $canonicalTypeCode,
+                $locale,
+                $orgId,
+            ),
+            'matched_guides' => $this->careerGuideService->findPublishedGuidesForMbtiGraph(
+                $canonicalTypeCode,
+                $locale,
+                $orgId,
+            ),
+            'seo' => $this->seoPayload($projection, $locale, $publicRouteSlug),
+            '_meta' => [
+                'public_route_type' => '32-type',
+                'route_mode' => 'public_variant',
+                'authority_source' => self::AUTHORITY_SOURCE,
+            ],
+        ];
+    }
+
+    /**
+     * @return Collection<int, PersonalityProfile>
+     */
+    private function listPublishedProfilesWithVariants(int $orgId, string $locale): Collection
+    {
+        return PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', max(0, $orgId))
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->whereIn('type_code', PersonalityProfile::TYPE_CODES)
+            ->forLocale($this->normalizeLocale($locale))
+            ->publishedPublic()
+            ->where(static function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+                'variants' => static function (HasMany $query): void {
+                    $query->where('is_published', true)
+                        ->where(static function (Builder $builder): void {
+                            $builder->whereNull('published_at')
+                                ->orWhere('published_at', '<=', now());
+                        })
+                        ->with([
+                            'sections' => static function (HasMany $builder): void {
+                                $builder->orderBy('sort_order')
+                                    ->orderBy('id');
+                            },
+                            'seoMeta',
+                        ])
+                        ->orderByRaw("case when variant_code = 'A' then 0 when variant_code = 'T' then 1 else 9 end")
+                        ->orderBy('runtime_type_code')
+                        ->orderBy('id');
+                },
+            ])
+            ->orderBy('canonical_type_code')
+            ->orderBy('type_code')
+            ->orderBy('id')
+            ->get();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function summarySectionPayload(array $projection): array
+    {
+        $section = $this->sectionByKey($projection, 'career.summary');
+
+        return [
+            'title' => $this->nullableText($section['title'] ?? null),
+            'paragraphs' => $this->paragraphsFromMarkdown($section['body_md'] ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function bulletSectionPayload(array $projection, string $sectionKey, string $bodyField): array
+    {
+        $section = $this->sectionByKey($projection, $sectionKey);
+        $items = [];
+
+        foreach (data_get($section, 'payload.items', []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $items[] = array_filter([
+                'title' => $this->nullableText($item['title'] ?? null),
+                $bodyField => $this->nullableText($item['body'] ?? $item['description'] ?? null),
+            ], static fn (mixed $value): bool => $value !== null);
+        }
+
+        return [
+            'title' => $this->nullableText($section['title'] ?? null),
+            'items' => array_values($items),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function preferredRolesPayload(array $projection): array
+    {
+        $section = $this->sectionByKey($projection, 'career.preferred_roles');
+        $groups = [];
+
+        foreach (data_get($section, 'payload.groups', []) as $group) {
+            if (! is_array($group)) {
+                continue;
+            }
+
+            $groups[] = array_filter([
+                'group_title' => $this->nullableText($group['group_title'] ?? $group['title'] ?? null),
+                'description' => $this->nullableText($group['description'] ?? null),
+                'examples' => $this->stringList($group['examples'] ?? []),
+            ], static fn (mixed $value): bool => $value !== null);
+        }
+
+        return [
+            'title' => $this->nullableText($section['title'] ?? null),
+            'intro' => $this->nullableText(data_get($section, 'payload.intro')),
+            'groups' => $groups,
+            'outro' => $this->nullableText(data_get($section, 'payload.outro')),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function upgradeSuggestionsPayload(array $projection): array
+    {
+        $section = $this->sectionByKey($projection, 'career.upgrade_suggestions');
+        $bullets = [];
+
+        foreach (data_get($section, 'payload.items', []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $bullets[] = array_filter([
+                'label' => $this->nullableText($item['title'] ?? $item['label'] ?? null),
+                'content' => $this->nullableText($item['body'] ?? $item['content'] ?? null),
+            ], static fn (mixed $value): bool => $value !== null);
+        }
+
+        return [
+            'title' => $this->nullableText($section['title'] ?? null),
+            'paragraphs' => $this->paragraphsFromMarkdown($section['body_md'] ?? null),
+            'bullets' => array_values($bullets),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function seoPayload(array $projection, string $locale, string $publicRouteSlug): array
+    {
+        $displayType = $this->fallbackText(
+            $this->nullableText(data_get($projection, 'display_type')),
+            $this->nullableText(data_get($projection, 'runtime_type_code')),
+            $this->nullableText(data_get($projection, 'canonical_type_code'))
+        ) ?? $publicRouteSlug;
+        $typeName = $this->nullableText(data_get($projection, 'profile.type_name'));
+        $heroSummary = $this->fallbackText(
+            $this->nullableText(data_get($projection, 'profile.hero_summary')),
+            $this->nullableText(data_get($projection, 'summary_card.summary'))
+        );
+        $canonical = $this->careerRecommendationPath($locale, $publicRouteSlug);
+
+        return [
+            'title' => $this->fallbackText(
+                $this->nullableText(data_get($projection, 'seo.title')),
+                $this->localeCopy(
+                    $locale,
+                    trim($displayType.' Career Recommendations | FermatMind'),
+                    trim($displayType.' 职业推荐 | FermatMind'),
+                )
+            ),
+            'description' => $this->fallbackText(
+                $this->nullableText(data_get($projection, 'seo.description')),
+                $heroSummary,
+                $this->localeCopy(
+                    $locale,
+                    trim('Career recommendations, role fit, and growth paths for '.($typeName ?? $displayType).'.'),
+                    trim(($typeName ?? $displayType).' 的职业匹配、发展方向与成长建议。'),
+                )
+            ),
+            'canonical' => $canonical,
+            'alternates' => [
+                'en' => $this->careerRecommendationPath('en', $publicRouteSlug),
+                'zh-CN' => $this->careerRecommendationPath('zh-CN', $publicRouteSlug),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sectionByKey(array $projection, string $sectionKey): array
+    {
+        foreach (data_get($projection, 'sections', []) as $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+
+            if ((string) ($section['key'] ?? '') === $sectionKey) {
+                return $section;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function paragraphsFromMarkdown(mixed $bodyMd): array
+    {
+        if (! is_string($bodyMd)) {
+            return [];
+        }
+
+        $normalized = trim(str_replace("\r", '', $bodyMd));
+        if ($normalized === '') {
+            return [];
+        }
+
+        $parts = preg_split("/\n{2,}/", $normalized) ?: [];
+
+        return array_values(array_filter(array_map(static function (string $paragraph): string {
+            return trim(preg_replace("/\n+/", ' ', $paragraph) ?? $paragraph);
+        }, $parts), static fn (string $paragraph): bool => $paragraph !== ''));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $values): array
+    {
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($values as $value) {
+            if (! is_scalar($value)) {
+                continue;
+            }
+
+            $text = trim((string) $value);
+            if ($text === '') {
+                continue;
+            }
+
+            $normalized[] = $text;
+        }
+
+        return array_values($normalized);
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    private function careerRecommendationPath(string $locale, string $publicRouteSlug): string
+    {
+        return '/'
+            .$this->mapBackendLocaleToFrontendSegment($locale)
+            .'/career/recommendations/mbti/'
+            .rawurlencode(strtolower(trim($publicRouteSlug)));
+    }
+
+    private function resolvePublicRouteSlug(PersonalityProfile $profile, PersonalityProfileVariant $variant): string
+    {
+        $baseSlug = strtolower(trim((string) $profile->slug));
+        $variantCode = strtoupper(trim((string) $variant->variant_code));
+
+        if ($baseSlug === '') {
+            return '';
+        }
+
+        if (! in_array($variantCode, ['A', 'T'], true)) {
+            return $baseSlug;
+        }
+
+        return strtolower($baseSlug.'-'.$variantCode);
+    }
+
+    private function mapBackendLocaleToFrontendSegment(string $locale): string
+    {
+        return $this->normalizeLocale($locale) === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    private function localeCopy(string $locale, string $en, string $zhCn): string
+    {
+        return $this->normalizeLocale($locale) === 'zh-CN' ? $zhCn : $en;
+    }
+
+    private function nullableText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function fallbackText(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Cms/PersonalityProfileService.php
+++ b/backend/app/Services/Cms/PersonalityProfileService.php
@@ -159,25 +159,45 @@ final class PersonalityProfileService
         if ($profile->relationLoaded('variants')) {
             /** @var PersonalityProfileVariant|null $variant */
             $variant = $profile->variants
-                ->first(static fn (mixed $item): bool => $item instanceof PersonalityProfileVariant
-                    && $item->variant_code === 'A'
-                    && (bool) $item->is_published);
+                ->filter(static fn (mixed $item): bool => $item instanceof PersonalityProfileVariant
+                    && (bool) $item->is_published
+                    && ($item->published_at === null || $item->published_at->isPast()))
+                ->sortBy([
+                    static fn (PersonalityProfileVariant $item): int => $item->variant_code === 'A' ? 0 : 1,
+                    static fn (PersonalityProfileVariant $item): string => (string) $item->runtime_type_code,
+                    static fn (PersonalityProfileVariant $item): int => (int) $item->id,
+                ])
+                ->first();
 
             if ($variant instanceof PersonalityProfileVariant) {
-                $variant->loadMissing('seoMeta');
+                $variant->loadMissing([
+                    'sections' => static function (HasMany $query): void {
+                        $query->orderBy('sort_order')
+                            ->orderBy('id');
+                    },
+                    'seoMeta',
+                ]);
 
                 return $variant;
             }
         }
 
         return $profile->variants()
-            ->where('variant_code', 'A')
             ->where('is_published', true)
             ->where(static function (Builder $query): void {
                 $query->whereNull('published_at')
                     ->orWhere('published_at', '<=', now());
             })
-            ->with('seoMeta')
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+            ])
+            ->orderByRaw("case when variant_code = 'A' then 0 when variant_code = 'T' then 1 else 9 end")
+            ->orderBy('runtime_type_code')
+            ->orderBy('id')
             ->first();
     }
 

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1998,6 +1998,40 @@
                 ]
             }
         },
+        "/api/v0.5/career-recommendations/mbti": {
+            "get": {
+                "operationId": "get_api_v0_5_career_recommendations_mbti",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\CareerRecommendationController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/career-recommendations/mbti/{type}": {
+            "get": {
+                "operationId": "get_api_v0_5_career_recommendations_mbti_type_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\CareerRecommendationController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/cms/articles": {
             "post": {
                 "operationId": "post_api_v0_5_cms_articles",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -29,6 +29,7 @@ use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
 use App\Http\Controllers\API\V0_5\Cms\CareerGuideController;
 use App\Http\Controllers\API\V0_5\Cms\CareerJobController;
+use App\Http\Controllers\API\V0_5\Cms\CareerRecommendationController;
 use App\Http\Controllers\API\V0_5\Cms\PersonalityController;
 use App\Http\Controllers\API\V0_5\Cms\TopicController;
 use App\Http\Controllers\HealthzController;
@@ -344,6 +345,8 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career-jobs', [CareerJobController::class, 'index']);
     Route::get('/career-jobs/{slug}/seo', [CareerJobController::class, 'seo']);
     Route::get('/career-jobs/{slug}', [CareerJobController::class, 'show']);
+    Route::get('/career-recommendations/mbti', [CareerRecommendationController::class, 'index']);
+    Route::get('/career-recommendations/mbti/{type}', [CareerRecommendationController::class, 'show']);
     Route::get('/personality', [PersonalityController::class, 'index']);
     Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo']);
     Route::get('/personality/{type}', [PersonalityController::class, 'show']);

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -1078,6 +1078,7 @@ fi
 echo "[CI] personality full-32 authority gate"
 php artisan personality:import-local-baseline --dry-run --upsert --status=published
 php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml \
+  tests/Feature/V0_5/CareerRecommendationPublicApiTest.php \
   tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php \
   tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php \
   tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php \

--- a/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
@@ -1,0 +1,524 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\CareerGuide;
+use App\Models\CareerJob;
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerRecommendationPublicApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_list_returns_published_public_32_type_items_only(): void
+    {
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'type_name' => 'Architect',
+            'nickname' => 'Strategic Planner',
+            'hero_summary_md' => 'Architect hero summary.',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        $this->createVariant($profile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect',
+            'nickname' => 'Strategic Planner',
+            'hero_summary_md' => 'Assertive architect summary.',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariant($profile, [
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'type_name' => 'Architect',
+            'nickname' => 'Reflective Architect',
+            'hero_summary_md' => 'Turbulent architect summary.',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $hiddenProfile = $this->createProfile([
+            'type_code' => 'ENTP',
+            'slug' => 'entp',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($hiddenProfile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'ENTP-A',
+            'is_published' => false,
+            'published_at' => null,
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career-recommendations/mbti?locale=en');
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'items')
+            ->assertJsonPath('items.0.runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('items.0.public_route_slug', 'intj-a')
+            ->assertJsonPath('items.1.runtime_type_code', 'INTJ-T')
+            ->assertJsonPath('items.1.public_route_slug', 'intj-t');
+    }
+
+    public function test_detail_returns_variant_career_authority_jobs_guides_and_seo_for_en_and_zh_cn(): void
+    {
+        $enProfile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'type_name' => 'Architect',
+            'nickname' => 'Strategic Planner',
+            'hero_summary_md' => 'Architects map complexity into long-term plans.',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $enVariant = $this->createVariant($enProfile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect',
+            'nickname' => 'Strategic Planner',
+            'keywords_json' => ['strategy', 'systems'],
+            'hero_summary_md' => 'Assertive INTJs move fast once the model is clear.',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSection($enVariant, 'career.summary', 'Career Summary', 'rich_text', [
+            'body_md' => "Architects thrive in systems work.\n\nThey like long-range leverage.",
+        ]);
+        $this->createVariantSection($enVariant, 'career.advantages', 'Career Advantages', 'bullets', [
+            'payload_json' => [
+                'items' => [
+                    ['title' => 'Systems thinking', 'body' => 'They connect moving parts quickly.'],
+                ],
+            ],
+        ]);
+        $this->createVariantSection($enVariant, 'career.weaknesses', 'Career Weaknesses', 'bullets', [
+            'payload_json' => [
+                'items' => [
+                    ['title' => 'Patience', 'body' => 'They can move faster than group consensus.'],
+                ],
+            ],
+        ]);
+        $this->createVariantSection($enVariant, 'career.preferred_roles', 'Preferred Roles', 'preferred_role_list', [
+            'payload_json' => [
+                'intro' => 'Architects like strategic ownership.',
+                'groups' => [
+                    [
+                        'group_title' => 'Strategy',
+                        'description' => 'Roles with leverage and direction.',
+                        'examples' => ['Product Strategy', 'Research Lead'],
+                    ],
+                ],
+                'outro' => 'They usually want room to design systems.',
+            ],
+        ]);
+        $this->createVariantSection($enVariant, 'career.upgrade_suggestions', 'Upgrade Suggestions', 'bullets', [
+            'body_md' => "Work on translating complex reasoning.\n\nPractice stakeholder pacing.",
+            'payload_json' => [
+                'items' => [
+                    ['title' => 'Communication', 'body' => 'Explain the why before the conclusion.'],
+                ],
+            ],
+        ]);
+        $this->createVariant($enProfile, [
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'type_name' => 'Architect',
+            'is_published' => false,
+            'published_at' => null,
+        ]);
+
+        $this->createJob([
+            'job_code' => 'product-strategist',
+            'slug' => 'product-strategist',
+            'locale' => 'en',
+            'title' => 'Product Strategist',
+            'excerpt' => 'Shape product direction and operating decisions.',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'fit_personality_codes_json' => ['INTJ'],
+            'mbti_primary_codes_json' => ['INTJ'],
+            'mbti_secondary_codes_json' => [],
+            'sort_order' => 10,
+        ]);
+        $this->createJob([
+            'job_code' => 'business-analyst',
+            'slug' => 'business-analyst',
+            'locale' => 'en',
+            'title' => 'Business Analyst',
+            'excerpt' => 'Translate systems into decisions.',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'fit_personality_codes_json' => ['INTJ'],
+            'mbti_primary_codes_json' => ['ENTJ'],
+            'mbti_secondary_codes_json' => ['INTJ'],
+            'sort_order' => 20,
+        ]);
+        $this->createJob([
+            'job_code' => 'community-manager',
+            'slug' => 'community-manager',
+            'locale' => 'en',
+            'title' => 'Community Manager',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'fit_personality_codes_json' => ['ENFP'],
+            'mbti_primary_codes_json' => ['ENFP'],
+            'mbti_secondary_codes_json' => [],
+            'sort_order' => 30,
+        ]);
+
+        $guide = $this->createGuide([
+            'guide_code' => 'systems-career-playbook',
+            'slug' => 'systems-career-playbook',
+            'locale' => 'en',
+            'title' => 'Systems Career Playbook',
+            'excerpt' => 'How to choose roles with leverage and clarity.',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $guide->relatedPersonalityProfiles()->attach($enProfile->id, ['sort_order' => 10]);
+        $hiddenGuide = $this->createGuide([
+            'guide_code' => 'hidden-guide',
+            'slug' => 'hidden-guide',
+            'locale' => 'en',
+            'title' => 'Hidden Guide',
+            'status' => CareerGuide::STATUS_DRAFT,
+            'is_public' => true,
+        ]);
+        $hiddenGuide->relatedPersonalityProfiles()->attach($enProfile->id, ['sort_order' => 10]);
+
+        $zhProfile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'zh-CN',
+            'title' => 'INTJ 人格类型',
+            'type_name' => '建筑师',
+            'nickname' => '战略规划者',
+            'hero_summary_md' => 'INTJ 擅长把复杂问题拆成长期结构。',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $zhVariant = $this->createVariant($zhProfile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => '建筑师',
+            'nickname' => '战略规划者',
+            'keywords_json' => ['策略', '系统'],
+            'hero_summary_md' => 'INTJ-A 更愿意直接把判断推进成行动。',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSection($zhVariant, 'career.summary', '职业总结', 'rich_text', [
+            'body_md' => "他们适合系统型工作。\n\n也适合需要长期判断的岗位。",
+        ]);
+        $this->createVariantSection($zhVariant, 'career.advantages', '职业优势', 'bullets', [
+            'payload_json' => [
+                'items' => [
+                    ['title' => '结构化', 'body' => '能快速找到关键约束。'],
+                ],
+            ],
+        ]);
+        $this->createVariantSection($zhVariant, 'career.weaknesses', '职业短板', 'bullets', [
+            'payload_json' => [
+                'items' => [
+                    ['title' => '节奏', 'body' => '可能低估对齐成本。'],
+                ],
+            ],
+        ]);
+        $this->createVariantSection($zhVariant, 'career.preferred_roles', '偏好角色', 'preferred_role_list', [
+            'payload_json' => [
+                'intro' => '更适合有结构杠杆的角色。',
+                'groups' => [
+                    [
+                        'group_title' => '战略类',
+                        'description' => '强调推理和方向。',
+                        'examples' => ['战略分析', '产品策略'],
+                    ],
+                ],
+                'outro' => '最好有明确的目标与授权。',
+            ],
+        ]);
+        $this->createVariantSection($zhVariant, 'career.upgrade_suggestions', '升级建议', 'bullets', [
+            'body_md' => "训练对外解释能力。\n\n提前设计协作节奏。",
+            'payload_json' => [
+                'items' => [
+                    ['title' => '表达', 'body' => '先说问题框架，再说答案。'],
+                ],
+            ],
+        ]);
+        $this->createJob([
+            'job_code' => 'strategy-ops',
+            'slug' => 'strategy-ops',
+            'locale' => 'zh-CN',
+            'title' => '战略运营',
+            'excerpt' => '推动复杂项目落地。',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'fit_personality_codes_json' => ['INTJ'],
+            'mbti_primary_codes_json' => ['INTJ'],
+            'mbti_secondary_codes_json' => [],
+            'sort_order' => 10,
+        ]);
+        $zhGuide = $this->createGuide([
+            'guide_code' => 'career-structure-guide',
+            'slug' => 'career-structure-guide',
+            'locale' => 'zh-CN',
+            'title' => '职业结构指南',
+            'excerpt' => '如何把人格倾向转成岗位策略。',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $zhGuide->relatedPersonalityProfiles()->attach($zhProfile->id, ['sort_order' => 10]);
+
+        $enResponse = $this->getJson('/api/v0.5/career-recommendations/mbti/intj-a?locale=en');
+
+        $enResponse->assertOk()
+            ->assertJsonPath('runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('canonical_type_code', 'INTJ')
+            ->assertJsonPath('public_route_slug', 'intj-a')
+            ->assertJsonPath('graph_type_code', 'INTJ')
+            ->assertJsonPath('career.summary.title', 'Career summary')
+            ->assertJsonPath('career.summary.paragraphs.0', 'Architects thrive in systems work.')
+            ->assertJsonPath('career.advantages.items.0.title', 'Systems thinking')
+            ->assertJsonPath('career.advantages.items.0.description', 'They connect moving parts quickly.')
+            ->assertJsonPath('career.preferred_roles.groups.0.group_title', 'Strategy')
+            ->assertJsonPath('career.upgrade_suggestions.bullets.0.label', 'Communication')
+            ->assertJsonPath('matched_jobs.0.slug', 'product-strategist')
+            ->assertJsonPath('matched_jobs.0.fit_bucket', 'primary')
+            ->assertJsonPath('matched_jobs.1.slug', 'business-analyst')
+            ->assertJsonPath('matched_jobs.1.fit_bucket', 'secondary')
+            ->assertJsonPath('matched_guides.0.slug', 'systems-career-playbook')
+            ->assertJsonCount(1, 'matched_guides')
+            ->assertJsonPath('seo.canonical', '/en/career/recommendations/mbti/intj-a')
+            ->assertJsonPath('seo.alternates.en', '/en/career/recommendations/mbti/intj-a')
+            ->assertJsonPath('seo.alternates.zh-CN', '/zh/career/recommendations/mbti/intj-a')
+            ->assertJsonPath('_meta.public_route_type', '32-type')
+            ->assertJsonPath('_meta.route_mode', 'public_variant')
+            ->assertJsonPath('_meta.authority_source', 'career_recommendation_service.v1');
+
+        $zhResponse = $this->getJson('/api/v0.5/career-recommendations/mbti/intj-a?locale=zh-CN');
+
+        $zhResponse->assertOk()
+            ->assertJsonPath('runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('canonical_type_code', 'INTJ')
+            ->assertJsonPath('public_route_slug', 'intj-a')
+            ->assertJsonPath('graph_type_code', 'INTJ')
+            ->assertJsonPath('matched_jobs.0.slug', 'strategy-ops')
+            ->assertJsonPath('matched_jobs.0.fit_bucket', 'primary')
+            ->assertJsonPath('matched_guides.0.slug', 'career-structure-guide')
+            ->assertJsonPath('seo.canonical', '/zh/career/recommendations/mbti/intj-a')
+            ->assertJsonPath('seo.alternates.en', '/en/career/recommendations/mbti/intj-a')
+            ->assertJsonPath('seo.alternates.zh-CN', '/zh/career/recommendations/mbti/intj-a');
+    }
+
+    public function test_legacy_4_letter_route_resolves_to_default_published_variant_and_unpublished_alias_returns_not_found(): void
+    {
+        $intjProfile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($intjProfile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariant($intjProfile, [
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'is_published' => false,
+            'published_at' => null,
+        ]);
+
+        $entpProfile = $this->createProfile([
+            'type_code' => 'ENTP',
+            'slug' => 'entp',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($entpProfile, [
+            'variant_code' => 'T',
+            'runtime_type_code' => 'ENTP-T',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/career-recommendations/mbti/intj?locale=en')
+            ->assertOk()
+            ->assertJsonPath('public_route_slug', 'intj-a')
+            ->assertJsonPath('runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('graph_type_code', 'INTJ');
+
+        $this->getJson('/api/v0.5/career-recommendations/mbti/entp?locale=en')
+            ->assertOk()
+            ->assertJsonPath('public_route_slug', 'entp-t')
+            ->assertJsonPath('runtime_type_code', 'ENTP-T')
+            ->assertJsonPath('graph_type_code', 'ENTP');
+
+        $this->getJson('/api/v0.5/career-recommendations/mbti/intj-t?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createProfile(array $overrides = []): PersonalityProfile
+    {
+        /** @var PersonalityProfile */
+        return PersonalityProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ',
+            'type_name' => 'Architect',
+            'nickname' => 'Strategic Planner',
+            'subtitle' => 'Strategic and future-oriented',
+            'excerpt' => 'INTJs tend to value competence, systems, and long-range thinking.',
+            'hero_summary_md' => 'INTJ summary',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createVariant(PersonalityProfile $profile, array $overrides = []): PersonalityProfileVariant
+    {
+        /** @var PersonalityProfileVariant */
+        return PersonalityProfileVariant::query()->create(array_merge([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => (string) $profile->type_code,
+            'variant_code' => 'A',
+            'runtime_type_code' => ((string) $profile->type_code).'-A',
+            'type_name' => 'Variant type',
+            'nickname' => 'Variant nickname',
+            'rarity_text' => 'About 3%',
+            'keywords_json' => ['variant'],
+            'hero_summary_md' => 'Variant summary',
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createVariantSection(
+        PersonalityProfileVariant $variant,
+        string $sectionKey,
+        string $title,
+        string $renderVariant,
+        array $overrides = [],
+    ): PersonalityProfileVariantSection {
+        /** @var PersonalityProfileVariantSection */
+        return PersonalityProfileVariantSection::query()->create(array_merge([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'section_key' => $sectionKey,
+            'title' => $title,
+            'render_variant' => $renderVariant,
+            'body_md' => null,
+            'body_html' => null,
+            'payload_json' => null,
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createJob(array $overrides = []): CareerJob
+    {
+        /** @var CareerJob */
+        return CareerJob::query()->create(array_merge([
+            'org_id' => 0,
+            'job_code' => 'career-job',
+            'slug' => 'career-job',
+            'locale' => 'en',
+            'title' => 'Career job',
+            'subtitle' => 'Structured role profile',
+            'excerpt' => 'Career job excerpt.',
+            'industry_slug' => 'technology',
+            'industry_label' => 'Technology',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+            'fit_personality_codes_json' => ['INTJ'],
+            'mbti_primary_codes_json' => ['INTJ'],
+            'mbti_secondary_codes_json' => [],
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createGuide(array $overrides = []): CareerGuide
+    {
+        /** @var CareerGuide */
+        return CareerGuide::query()->create(array_merge([
+            'org_id' => 0,
+            'guide_code' => 'career-guide',
+            'slug' => 'career-guide',
+            'locale' => 'en',
+            'title' => 'Career guide',
+            'excerpt' => 'Career guide excerpt.',
+            'category_slug' => 'career-planning',
+            'body_md' => '# Career guide',
+            'body_html' => '<h1>Career guide</h1>',
+            'related_industry_slugs_json' => ['technology'],
+            'status' => CareerGuide::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => true,
+            'sort_order' => 0,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a backend-owned MBTI career recommendation authority layer for the public site.

Before this change, the frontend had to compose the career recommendation experience from multiple sources: MBTI personality authority from the public personality API, local `.velite` career recommendation profiles, and career jobs / guides from backend CMS endpoints. That left the public career recommendation page without a single backend owner for route identity, canonical graph matching, career narrative, and related content.

This PR introduces a new additive v0.5 API surface that resolves that split on the backend:

- `GET /api/v0.5/career-recommendations/mbti`
- `GET /api/v0.5/career-recommendations/mbti/{type}`

The new service composes published 32-type public personality authority with canonical 16-type graph matching for jobs and guides. It returns the public 32-type route slug, the canonical 16 graph key, the personality career narrative from existing personality authority, matched jobs, matched guides, and career-page SEO metadata in one response.

## Root Cause
The repo already had the necessary pieces, but they were split across different owners:

- personality public authority could resolve 32-type public routes
- career jobs already exposed MBTI fit arrays keyed by canonical 16-type codes
- career guides already linked to personality profiles through `career_guide_personality_map`

What was missing was a dedicated backend adapter that turned those pieces into one public career recommendation authority contract. As a result, the frontend still needed to do cross-source stitching on its own.

## What Changed
This PR adds a new backend authority owner and keeps all existing public contracts intact.

- Added `CareerRecommendationController` with `index()` and `show()` public endpoints.
- Added `CareerRecommendationService` as the single composition layer for:
  - published 32-type route identity
  - canonical 16-type graph matching
  - personality career narrative sourced from existing personality projection
  - matched jobs sourced from `CareerJobService`
  - matched guides sourced from `CareerGuideService`
  - career recommendation SEO payload for frontend consumers
- Extended `CareerJobService` with `findPublishedJobsForMbtiGraph()` without changing existing career-jobs list/detail contracts.
- Extended `CareerGuideService` with `findPublishedGuidesForMbtiGraph()` without changing existing career-guides contracts.
- Updated `PersonalityProfileService::getDefaultPublishedVariantForCanonicalRoute()` so legacy 4-letter compatibility requests resolve to `-A` first and otherwise fall back to the first published variant in the family.
- Added `CareerRecommendationPublicApiTest` covering:
  - 32-type route success
  - legacy 4-letter compatibility resolution
  - unpublished alias 404
  - graph key fallback to canonical 16
  - primary / secondary job fit buckets
  - published guide matching only
  - locale behavior for `en` and `zh-CN`
  - SEO canonical on the 32-type career recommendation route
- Added the new API test to `scripts/ci_verify_mbti.sh`.
- Regenerated `backend/docs/contracts/openapi.snapshot.json` for the new additive routes.

## Contract Notes
The new detail contract explicitly separates route identity from graph identity:

- `public_route_slug` is always the 32-type public route slug
- `graph_type_code` is always the canonical 16-type graph key used for jobs / guides matching

Legacy 4-letter requests remain compatibility inputs only. They never become the authority owner. A request like `/api/v0.5/career-recommendations/mbti/intj?locale=en` now resolves to the default published variant route slug (`intj-a` when available, otherwise the first published family variant).

## Validation
I ran:

- `php artisan route:list | grep -Ei "career|personality|seo|sitemap"`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/V0_5/CareerRecommendationPublicApiTest.php tests/Feature/V0_5/CareerJobPublicApiTest.php tests/Feature/V0_5/CareerGuidePublicApiTest.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`
- `bash scripts/ci_verify_mbti.sh`

## Guardrails Kept
This PR does not change:

- database or migrations
- personality baseline / importer files
- commerce / payment / orders / access hub
- frontend repo
- existing career-jobs list/detail contract
- existing career-guides list/detail contract
- v0.3 result / share / compare behavior
