### PR TITLE
[codex] HOTFIX-PROD-001: shorten personality variant authority migration identifiers

### DIFF
--- a/backend/database/migrations/2026_03_16_000110_create_personality_profile_variant_authority_tables.php
+++ b/backend/database/migrations/2026_03_16_000110_create_personality_profile_variant_authority_tables.php
@@ -15,9 +15,7 @@ return new class extends Migration
     {
         Schema::create('personality_profile_variants', function (Blueprint $table): void {
             $table->id();
-            $table->foreignId('personality_profile_id')
-                ->constrained('personality_profiles')
-                ->cascadeOnDelete();
+            $table->unsignedBigInteger('personality_profile_id');
             $table->string('canonical_type_code', 4);
             $table->char('variant_code', 1);
             $table->string('runtime_type_code', 8);
@@ -40,14 +38,17 @@ return new class extends Migration
                 ['personality_profile_id', 'runtime_type_code'],
                 'personality_profile_variants_profile_runtime_unique'
             );
+            $table->index('personality_profile_id', 'pp_variants_profile_idx');
             $table->index('canonical_type_code', 'personality_profile_variants_canonical_idx');
+            $table->foreign('personality_profile_id', 'pp_variants_profile_fk')
+                ->references('id')
+                ->on('personality_profiles')
+                ->cascadeOnDelete();
         });
 
         Schema::create('personality_profile_variant_sections', function (Blueprint $table): void {
             $table->id();
-            $table->foreignId('personality_profile_variant_id')
-                ->constrained('personality_profile_variants')
-                ->cascadeOnDelete();
+            $table->unsignedBigInteger('personality_profile_variant_id');
             $table->string('section_key', 100);
             $table->string('render_variant', 100);
             $table->longText('body_md')->nullable();
@@ -61,13 +62,16 @@ return new class extends Migration
                 ['personality_profile_variant_id', 'section_key'],
                 'personality_profile_variant_sections_variant_section_unique'
             );
+            $table->index('personality_profile_variant_id', 'pp_variant_sections_variant_idx');
+            $table->foreign('personality_profile_variant_id', 'pp_variant_sections_variant_fk')
+                ->references('id')
+                ->on('personality_profile_variants')
+                ->cascadeOnDelete();
         });
 
         Schema::create('personality_profile_variant_seo_meta', function (Blueprint $table): void {
             $table->id();
-            $table->foreignId('personality_profile_variant_id')
-                ->constrained('personality_profile_variants')
-                ->cascadeOnDelete();
+            $table->unsignedBigInteger('personality_profile_variant_id');
             $table->string('seo_title', 255)->nullable();
             $table->text('seo_description')->nullable();
             $table->string('canonical_url', 2048)->nullable();
@@ -85,18 +89,27 @@ return new class extends Migration
                 ['personality_profile_variant_id'],
                 'personality_profile_variant_seo_meta_variant_unique'
             );
+            $table->index('personality_profile_variant_id', 'pp_variant_seo_variant_idx');
+            $table->foreign('personality_profile_variant_id', 'pp_variant_seo_variant_fk')
+                ->references('id')
+                ->on('personality_profile_variants')
+                ->cascadeOnDelete();
         });
 
         Schema::create('personality_profile_variant_revisions', function (Blueprint $table): void {
             $table->id();
-            $table->foreignId('personality_profile_variant_id')
-                ->constrained('personality_profile_variants')
-                ->cascadeOnDelete();
+            $table->unsignedBigInteger('personality_profile_variant_id');
             $table->unsignedInteger('revision_no');
             $table->json('snapshot_json');
             $table->string('note', 255)->nullable();
             $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
             $table->timestamp('created_at')->useCurrent();
+
+            $table->index('personality_profile_variant_id', 'pp_variant_revisions_variant_idx');
+            $table->foreign('personality_profile_variant_id', 'pp_variant_revisions_variant_fk')
+                ->references('id')
+                ->on('personality_profile_variants')
+                ->cascadeOnDelete();
         });
     }
 
@@ -106,6 +119,6 @@ return new class extends Migration
     public function down(): void
     {
         // Intentionally non-destructive: rollback does not remove authority tables.
-        return;
+
     }
 };


### PR DESCRIPTION
## Summary
Production deploys on Node3 are blocked by `2026_03_16_000110_create_personality_profile_variant_authority_tables`, which can fail on MySQL because Laravel generates foreign key identifiers that exceed MySQL's 64-character identifier limit for the new `personality_profile_variant*` tables.

## User impact
This blocks the API deploy before the new personality variant authority schema finishes migrating. In the failure mode we saw, `2026_03_16_000100` had already run, while `000110` failed partway through, which means production may be left with partial `personality_profile_variant*` tables but without a successful migration record for `000110`.

## Root cause
The migration relied on default constraint naming from `foreignId(...)->constrained(...)` on long table and column names such as `personality_profile_variant_sections.personality_profile_variant_id`. MySQL rejects the generated names like `personality_profile_variant_sections_personality_profile_variant_id_foreign` because they exceed the identifier length limit.

## Fix
This PR keeps the schema semantics unchanged and only hardens the migration by replacing the auto-generated foreign key names with explicit short names throughout the same migration. It does this for every foreign key in `2026_03_16_000110_create_personality_profile_variant_authority_tables` so the migration no longer has mixed naming behavior or leftover identifier-length risks.

The resulting schema shape, foreign key targets, cascade behavior, and application code paths are unchanged. No routes, controllers, services, frontend code, or Team / Pro work are touched.

## Validation
I ran the minimal backend validation set for this hotfix:

- `php -l backend/database/migrations/2026_03_16_000110_create_personality_profile_variant_authority_tables.php`
- `cd backend && ./vendor/bin/pint database/migrations/2026_03_16_000110_create_personality_profile_variant_authority_tables.php`
- `cd backend && php artisan migrate`
- `cd backend && php artisan migrate:status | rg '2026_03_16_00010|2026_03_16_000110'`
- `cd backend && php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php`
- `cd backend && php artisan route:list | grep -Ei 'personality|seo|sitemap'`

## Production recovery note
Before rerunning `deploy-api` in production, we should first verify whether `000110` was recorded in `migrations`. If it was not recorded and any `personality_profile_variant*` tables already exist, those partial tables should be dropped child-first before rerunning the deploy so the fixed migration can recreate them cleanly.
