### PR TITLE
[codex] consolidate mbti full unlock backend

### DIFF
--- a/backend/app/Console/Commands/MbtiUpgradeLegacyPartialUnlocks.php
+++ b/backend/app/Console/Commands/MbtiUpgradeLegacyPartialUnlocks.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Commerce\EntitlementManager;
+use App\Services\Report\ReportAccess;
+use Illuminate\Console\Command;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class MbtiUpgradeLegacyPartialUnlocks extends Command
+{
+    private const FULL_BENEFIT_CODE = 'MBTI_REPORT_FULL';
+
+    private const LEGACY_PARTIAL_SKUS = [
+        'MBTI_CAREER_99',
+        'MBTI_RELATIONSHIP_99',
+    ];
+
+    private const LEGACY_PARTIAL_BENEFIT_CODES = [
+        'MBTI_CAREER',
+        'MBTI_RELATIONSHIP',
+        'MBTI_RELATIONSHIPS',
+    ];
+
+    protected $signature = 'commerce:mbti-upgrade-legacy-partials
+        {--org_id=0 : Organization id}
+        {--dry-run=0 : Preview without writing grants}
+        {--json=0 : Output json summary}';
+
+    protected $description = 'Upgrade legacy MBTI 0.99 partial unlocks to the 1.99 full-report entitlement.';
+
+    public function __construct(private readonly EntitlementManager $entitlements)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $orgId = max(0, (int) $this->option('org_id'));
+        $dryRun = $this->isTruthy($this->option('dry-run'));
+
+        $summary = [
+            'ok' => true,
+            'org_id' => $orgId,
+            'dry_run' => $dryRun,
+            'orders_scanned' => 0,
+            'grants_scanned' => 0,
+            'attempts_considered' => 0,
+            'upgraded' => 0,
+            'already_full' => 0,
+            'skipped' => 0,
+            'errors' => [],
+        ];
+
+        $seenAttempts = [];
+
+        foreach ($this->legacyPartialOrders($orgId) as $order) {
+            $summary['orders_scanned']++;
+            $this->processCandidate($orgId, $summary, $seenAttempts, $order, null, $dryRun);
+        }
+
+        foreach ($this->legacyPartialGrants($orgId) as $grant) {
+            $summary['grants_scanned']++;
+            $this->processCandidate($orgId, $summary, $seenAttempts, null, $grant, $dryRun);
+        }
+
+        if ($this->isTruthy($this->option('json'))) {
+            $this->line((string) json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line('MBTI legacy partial upgrade summary');
+            $this->line('org_id='.(string) $orgId.' dry_run='.($dryRun ? '1' : '0'));
+            $this->line('orders_scanned='.(string) $summary['orders_scanned']);
+            $this->line('grants_scanned='.(string) $summary['grants_scanned']);
+            $this->line('attempts_considered='.(string) $summary['attempts_considered']);
+            $this->line('upgraded='.(string) $summary['upgraded']);
+            $this->line('already_full='.(string) $summary['already_full']);
+            $this->line('skipped='.(string) $summary['skipped']);
+            $this->line('errors='.(string) count($summary['errors']));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return \Illuminate\Support\LazyCollection<int,object>
+     */
+    private function legacyPartialOrders(int $orgId)
+    {
+        if (! Schema::hasTable('orders')) {
+            return collect()->lazy();
+        }
+
+        $query = DB::table('orders')
+            ->where('org_id', $orgId)
+            ->whereNotNull('target_attempt_id')
+            ->where('target_attempt_id', '!=', '')
+            ->where(function (Builder $builder): void {
+                $builder->whereNotNull('paid_at')
+                    ->orWhereIn('status', ['paid', 'fulfilled', 'complete', 'completed']);
+            })
+            ->orderBy('created_at');
+
+        $skuColumns = array_values(array_filter([
+            Schema::hasColumn('orders', 'effective_sku') ? 'effective_sku' : null,
+            Schema::hasColumn('orders', 'requested_sku') ? 'requested_sku' : null,
+            Schema::hasColumn('orders', 'item_sku') ? 'item_sku' : null,
+            Schema::hasColumn('orders', 'sku') ? 'sku' : null,
+        ]));
+
+        if ($skuColumns === []) {
+            return collect()->lazy();
+        }
+
+        $query->where(function (Builder $builder) use ($skuColumns): void {
+            foreach ($skuColumns as $column) {
+                $builder->orWhereIn($column, self::LEGACY_PARTIAL_SKUS);
+            }
+        });
+
+        return $query->cursor();
+    }
+
+    /**
+     * @return \Illuminate\Support\LazyCollection<int,object>
+     */
+    private function legacyPartialGrants(int $orgId)
+    {
+        if (! Schema::hasTable('benefit_grants')) {
+            return collect()->lazy();
+        }
+
+        return DB::table('benefit_grants')
+            ->where('org_id', $orgId)
+            ->where('status', 'active')
+            ->whereIn('benefit_code', self::LEGACY_PARTIAL_BENEFIT_CODES)
+            ->whereNotNull('attempt_id')
+            ->where('attempt_id', '!=', '')
+            ->orderBy('created_at')
+            ->cursor();
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @param  array<string,bool>  $seenAttempts
+     */
+    private function processCandidate(
+        int $orgId,
+        array &$summary,
+        array &$seenAttempts,
+        ?object $order,
+        ?object $grant,
+        bool $dryRun
+    ): void {
+        $attemptId = trim((string) (($order->target_attempt_id ?? null) ?: ($grant->attempt_id ?? null) ?: ''));
+        if ($attemptId === '') {
+            $summary['skipped']++;
+
+            return;
+        }
+
+        if (isset($seenAttempts[$attemptId])) {
+            return;
+        }
+        $seenAttempts[$attemptId] = true;
+        $summary['attempts_considered']++;
+
+        if ($this->hasActiveFullGrant($orgId, $attemptId)) {
+            $summary['already_full']++;
+
+            return;
+        }
+
+        $userId = $this->trimOrNull(($order->user_id ?? null) ?: ($grant->user_id ?? null));
+        $anonId = $this->trimOrNull(($order->anon_id ?? null) ?: ($grant->benefit_ref ?? null));
+        $orderNo = $this->trimOrNull(($order->order_no ?? null) ?: ($grant->order_no ?? null));
+
+        if ($dryRun) {
+            $summary['upgraded']++;
+
+            return;
+        }
+
+        $result = $this->entitlements->grantAttemptUnlock(
+            $orgId,
+            $userId,
+            $anonId,
+            self::FULL_BENEFIT_CODE,
+            $attemptId,
+            $orderNo,
+            null,
+            null,
+            [
+                ReportAccess::MODULE_CORE_FULL,
+                ReportAccess::MODULE_CAREER,
+                ReportAccess::MODULE_RELATIONSHIPS,
+            ]
+        );
+
+        if (($result['ok'] ?? false) === true) {
+            $summary['upgraded']++;
+
+            return;
+        }
+
+        $summary['ok'] = false;
+        $summary['errors'][] = [
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'message' => (string) ($result['message'] ?? $result['error'] ?? 'grant failed'),
+        ];
+    }
+
+    private function hasActiveFullGrant(int $orgId, string $attemptId): bool
+    {
+        if (! Schema::hasTable('benefit_grants')) {
+            return false;
+        }
+
+        return DB::table('benefit_grants')
+            ->where('org_id', $orgId)
+            ->where('benefit_code', self::FULL_BENEFIT_CODE)
+            ->where('status', 'active')
+            ->where('attempt_id', $attemptId)
+            ->exists();
+    }
+
+    private function trimOrNull(mixed $value): ?string
+    {
+        $normalized = trim((string) ($value ?? ''));
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        return in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -20,6 +20,7 @@ use App\Console\Commands\FapSelfCheck;
 use App\Console\Commands\FapValidateReport;
 use App\Console\Commands\FapWeeklyReport;
 use App\Console\Commands\MetricsWeeklyValidity;
+use App\Console\Commands\MbtiUpgradeLegacyPartialUnlocks;
 use App\Console\Commands\NormsBig5BootstrapBuild;
 use App\Console\Commands\NormsBig5DriftCheck;
 use App\Console\Commands\NormsBig5MonthlyDriftCheck;
@@ -86,6 +87,7 @@ class Kernel extends ConsoleKernel
         FapValidateReport::class,
         FapWeeklyReport::class,
         MetricsWeeklyValidity::class,
+        MbtiUpgradeLegacyPartialUnlocks::class,
         AdminBootstrapOwner::class,
         OpsDeployEvent::class,
         OpsHealthzSnapshot::class,

--- a/backend/app/Services/Report/Resolvers/OfferResolver.php
+++ b/backend/app/Services/Report/Resolvers/OfferResolver.php
@@ -88,6 +88,7 @@ class OfferResolver
         if (count($offers) === 0) {
             $offers = $this->normalizeOffers($commercial['offers'] ?? null);
         }
+        $offers = $this->filterOffersForScale($scaleCode, $offers);
 
         return [
             'upgrade_sku' => $anchorSku,
@@ -279,6 +280,35 @@ class OfferResolver
         }
 
         return $offers;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $offers
+     * @return list<array<string,mixed>>
+     */
+    private function filterOffersForScale(string $scaleCode, array $offers): array
+    {
+        if ($scaleCode !== 'MBTI') {
+            return array_values($offers);
+        }
+
+        $filtered = array_values(array_filter($offers, fn (array $offer): bool => $this->isMbtiFullReportOffer($offer)));
+
+        return $filtered !== [] ? $filtered : array_values($offers);
+    }
+
+    /**
+     * @param  array<string,mixed>  $offer
+     */
+    private function isMbtiFullReportOffer(array $offer): bool
+    {
+        $sku = strtoupper(trim((string) ($offer['sku'] ?? $offer['sku_code'] ?? '')));
+        $benefitCode = strtoupper(trim((string) ($offer['benefit_code'] ?? '')));
+        $modulesIncluded = $this->normalizeModulesIncluded($offer['modules_included'] ?? null);
+
+        return $benefitCode === 'MBTI_REPORT_FULL'
+            || str_contains($sku, 'MBTI_REPORT_FULL')
+            || in_array(ReportAccess::MODULE_CORE_FULL, $modulesIncluded, true);
     }
 
     private function resolveCtaCopy(array $commercialSpec, ?string $anchorSku, ?string $effectiveSku): array

--- a/backend/database/migrations/2026_03_18_120000_consolidate_mbti_unlock_to_full_report.php
+++ b/backend/database/migrations/2026_03_18_120000_consolidate_mbti_unlock_to_full_report.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const SCALE_REGISTRY_TABLES = [
+        'scales_registry',
+        'scales_registry_v2',
+    ];
+
+    private const MBTI_EFFECTIVE_SKU = 'MBTI_REPORT_FULL_199';
+
+    private const MBTI_ANCHOR_SKU = 'MBTI_REPORT_FULL';
+
+    private const LEGACY_PARTIAL_SKUS = [
+        'MBTI_CAREER_99',
+        'MBTI_RELATIONSHIP_99',
+    ];
+
+    public function up(): void
+    {
+        $this->deactivateLegacyMbtiPartials();
+        $this->syncMbtiScaleRegistryCommerce();
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to avoid reopening deprecated partial SKUs.
+    }
+
+    private function deactivateLegacyMbtiPartials(): void
+    {
+        if (! Schema::hasTable('skus')) {
+            return;
+        }
+
+        $rows = DB::table('skus')
+            ->whereIn('sku', self::LEGACY_PARTIAL_SKUS)
+            ->get(['sku', 'meta_json']);
+
+        foreach ($rows as $row) {
+            $meta = $this->decodeJson($row->meta_json ?? null);
+            $meta['deprecated'] = true;
+            $meta['offer'] = false;
+
+            DB::table('skus')
+                ->where('sku', (string) ($row->sku ?? ''))
+                ->update([
+                    'is_active' => false,
+                    'meta_json' => json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'updated_at' => now(),
+                ]);
+        }
+    }
+
+    private function syncMbtiScaleRegistryCommerce(): void
+    {
+        foreach (self::SCALE_REGISTRY_TABLES as $table) {
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+
+            $rows = DB::table($table)
+                ->where('code', 'MBTI')
+                ->get(['org_id', 'code', 'commercial_json', 'view_policy_json']);
+
+            foreach ($rows as $row) {
+                $commercial = $this->decodeJson($row->commercial_json ?? null);
+                $viewPolicy = $this->decodeJson($row->view_policy_json ?? null);
+
+                $commercial['report_unlock_sku'] = self::MBTI_EFFECTIVE_SKU;
+                $commercial['upgrade_sku_anchor'] = self::MBTI_ANCHOR_SKU;
+                $commercial['offers'] = array_values(array_filter(
+                    is_array($commercial['offers'] ?? null) ? $commercial['offers'] : [],
+                    fn (mixed $offer): bool => is_array($offer) && $this->isMbtiFullOffer($offer)
+                ));
+
+                $viewPolicy['upgrade_sku'] = self::MBTI_EFFECTIVE_SKU;
+
+                DB::table($table)
+                    ->where('org_id', (int) ($row->org_id ?? 0))
+                    ->where('code', (string) ($row->code ?? ''))
+                    ->update([
+                        'commercial_json' => json_encode($commercial, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                        'view_policy_json' => json_encode($viewPolicy, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                        'updated_at' => now(),
+                    ]);
+            }
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJson(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $offer
+     */
+    private function isMbtiFullOffer(array $offer): bool
+    {
+        $sku = strtoupper(trim((string) ($offer['sku'] ?? $offer['sku_code'] ?? '')));
+        $benefitCode = strtoupper(trim((string) ($offer['benefit_code'] ?? '')));
+
+        return $sku === self::MBTI_EFFECTIVE_SKU
+            || $sku === self::MBTI_ANCHOR_SKU
+            || $benefitCode === self::MBTI_ANCHOR_SKU;
+    }
+};

--- a/backend/database/seed_data/skus_mbti.json
+++ b/backend/database/seed_data/skus_mbti.json
@@ -64,12 +64,14 @@
     "price_cents": 99,
     "currency": "CNY",
     "title": "MBTI Career Module",
-    "is_active": true,
+    "is_active": false,
     "metadata_json": {
       "label": "MBTI career module",
+      "deprecated": true,
       "grant_type": "report_unlock",
       "grant_qty": 1,
       "entitlement_id": "report_career",
+      "offer": false,
       "modules_included": [
         "career"
       ]
@@ -86,12 +88,14 @@
     "price_cents": 99,
     "currency": "CNY",
     "title": "MBTI Relationship Module",
-    "is_active": true,
+    "is_active": false,
     "metadata_json": {
       "label": "MBTI relationship module",
+      "deprecated": true,
       "grant_type": "report_unlock",
       "grant_qty": 1,
       "entitlement_id": "report_relationships",
+      "offer": false,
       "modules_included": [
         "relationships"
       ]

--- a/backend/tests/Feature/Commerce/MbtiCommerceConsolidationTest.php
+++ b/backend/tests/Feature/Commerce/MbtiCommerceConsolidationTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Commerce\SkuCatalog;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiCommerceConsolidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mbti_catalog_and_sku_endpoint_hide_legacy_partial_skus(): void
+    {
+        $this->seedScales();
+
+        /** @var SkuCatalog $catalog */
+        $catalog = app(SkuCatalog::class);
+        $catalogSkus = collect($catalog->listActiveSkus('MBTI'))
+            ->pluck('sku')
+            ->filter(fn ($sku): bool => is_string($sku) && $sku !== '')
+            ->values()
+            ->all();
+
+        $this->assertContains('MBTI_REPORT_FULL_199', $catalogSkus);
+        $this->assertNotContains('MBTI_CAREER_99', $catalogSkus);
+        $this->assertNotContains('MBTI_RELATIONSHIP_99', $catalogSkus);
+
+        $response = $this->getJson('/api/v0.3/skus?scale=MBTI');
+        $response->assertOk()->assertJsonPath('ok', true);
+
+        $apiSkus = collect((array) $response->json('items'))
+            ->map(fn (mixed $item): string => is_array($item) ? (string) ($item['sku'] ?? '') : '')
+            ->filter()
+            ->values()
+            ->all();
+
+        $this->assertContains('MBTI_REPORT_FULL_199', $apiSkus);
+        $this->assertNotContains('MBTI_CAREER_99', $apiSkus);
+        $this->assertNotContains('MBTI_RELATIONSHIP_99', $apiSkus);
+    }
+
+    public function test_mbti_report_paywall_only_returns_the_full_report_offer(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_mbti_consolidated_offers';
+        $attemptId = $this->createAttemptWithResult($anonId);
+        $token = $this->issueAnonToken($anonId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('locked', true)
+            ->assertJsonPath('upgrade_sku', 'MBTI_REPORT_FULL')
+            ->assertJsonPath('upgrade_sku_effective', 'MBTI_REPORT_FULL_199')
+            ->assertJsonPath('cta.target_sku', 'MBTI_REPORT_FULL')
+            ->assertJsonPath('cta.target_sku_effective', 'MBTI_REPORT_FULL_199')
+            ->assertJsonCount(1, 'offers')
+            ->assertJsonPath('offers.0.sku', 'MBTI_REPORT_FULL_199');
+
+        $offerSkus = collect((array) $response->json('offers'))
+            ->map(fn (mixed $item): string => is_array($item) ? (string) ($item['sku'] ?? '') : '')
+            ->filter()
+            ->values()
+            ->all();
+
+        $this->assertSame(['MBTI_REPORT_FULL_199'], $offerSkus);
+        $this->assertNotContains('MBTI_CAREER_99', $offerSkus);
+        $this->assertNotContains('MBTI_RELATIONSHIP_99', $offerSkus);
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $packId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => ['EI' => 50, 'SN' => 50, 'TF' => 50, 'JP' => 50, 'AT' => 50],
+            'axis_states' => ['EI' => 'clear', 'SN' => 'clear', 'TF' => 'clear', 'JP' => 'clear', 'AT' => 'clear'],
+            'content_package_version' => 'v0.3',
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+}

--- a/backend/tests/Feature/Commerce/MbtiUpgradeLegacyPartialUnlocksCommandTest.php
+++ b/backend/tests/Feature/Commerce/MbtiUpgradeLegacyPartialUnlocksCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Services\Commerce\EntitlementManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiUpgradeLegacyPartialUnlocksCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_upgrades_legacy_partial_orders_and_grants_without_duplication(): void
+    {
+        $attemptFromOrder = (string) Str::uuid();
+        $attemptFromGrant = (string) Str::uuid();
+
+        $this->insertLegacyOrder('ord_mbti_legacy_order', $attemptFromOrder, 'anon_mbti_legacy_order', 'MBTI_CAREER_99');
+
+        /** @var EntitlementManager $entitlements */
+        $entitlements = app(EntitlementManager::class);
+        $partialGrant = $entitlements->grantAttemptUnlock(
+            0,
+            null,
+            'anon_mbti_legacy_grant',
+            'MBTI_RELATIONSHIP',
+            $attemptFromGrant,
+            'ord_mbti_legacy_grant',
+            'attempt',
+            null,
+            ['relationships']
+        );
+        $this->assertTrue((bool) ($partialGrant['ok'] ?? false));
+
+        $this->artisan('commerce:mbti-upgrade-legacy-partials', [
+            '--org_id' => 0,
+            '--json' => 1,
+        ])->expectsOutputToContain('"upgraded":2')
+            ->assertExitCode(0);
+
+        $fullGrants = DB::table('benefit_grants')
+            ->where('org_id', 0)
+            ->where('benefit_code', 'MBTI_REPORT_FULL')
+            ->where('status', 'active')
+            ->whereIn('attempt_id', [$attemptFromOrder, $attemptFromGrant])
+            ->orderBy('attempt_id')
+            ->get();
+
+        $this->assertCount(2, $fullGrants);
+
+        foreach ($fullGrants as $grant) {
+            $meta = json_decode((string) ($grant->meta_json ?? '[]'), true);
+            $meta = is_array($meta) ? $meta : [];
+            $modules = is_array($meta['modules'] ?? null) ? $meta['modules'] : [];
+
+            $this->assertContains('core_full', $modules);
+            $this->assertContains('career', $modules);
+            $this->assertContains('relationships', $modules);
+        }
+
+        $this->artisan('commerce:mbti-upgrade-legacy-partials', [
+            '--org_id' => 0,
+            '--json' => 1,
+        ])->expectsOutputToContain('"upgraded":0')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            2,
+            DB::table('benefit_grants')
+                ->where('org_id', 0)
+                ->where('benefit_code', 'MBTI_REPORT_FULL')
+                ->where('status', 'active')
+                ->whereIn('attempt_id', [$attemptFromOrder, $attemptFromGrant])
+                ->count()
+        );
+    }
+
+    private function insertLegacyOrder(string $orderNo, string $attemptId, string $anonId, string $sku): void
+    {
+        $now = now();
+        $row = [
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'sku' => $sku,
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 99,
+            'currency' => 'CNY',
+            'status' => 'paid',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $row['item_sku'] = $sku;
+        }
+        if (Schema::hasColumn('orders', 'requested_sku')) {
+            $row['requested_sku'] = $sku;
+        }
+        if (Schema::hasColumn('orders', 'effective_sku')) {
+            $row['effective_sku'] = $sku;
+        }
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $row['amount_total'] = 99;
+        }
+        if (Schema::hasColumn('orders', 'amount_refunded')) {
+            $row['amount_refunded'] = 0;
+        }
+        if (Schema::hasColumn('orders', 'provider_order_id')) {
+            $row['provider_order_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'device_id')) {
+            $row['device_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'request_id')) {
+            $row['request_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'created_ip')) {
+            $row['created_ip'] = null;
+        }
+        if (Schema::hasColumn('orders', 'fulfilled_at')) {
+            $row['fulfilled_at'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refunded_at')) {
+            $row['refunded_at'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refund_amount_cents')) {
+            $row['refund_amount_cents'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refund_reason')) {
+            $row['refund_reason'] = null;
+        }
+
+        DB::table('orders')->insert($row);
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/commercial_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/commercial_spec.json
@@ -15,10 +15,7 @@
     }
   },
   "offer_order": [
-    "MBTI_REPORT_FULL_199",
-    "MBTI_PRO_MONTH_599",
-    "MBTI_PRO_YEAR_1999",
-    "MBTI_GIFT_PACK_2990"
+    "MBTI_REPORT_FULL_199"
   ],
   "offers": [
     {
@@ -112,10 +109,7 @@
       "upgrade_sku_anchor": "MBTI_REPORT_FULL",
       "upgrade_sku": "MBTI_REPORT_FULL_199",
       "offer_order": [
-        "MBTI_REPORT_FULL_199",
-        "MBTI_PRO_MONTH_599",
-        "MBTI_PRO_YEAR_1999",
-        "MBTI_GIFT_PACK_2990"
+        "MBTI_REPORT_FULL_199"
       ],
       "view_policy": {
         "free_sections": [
@@ -161,13 +155,13 @@
       },
       "cta_copy": {
         "title": "解锁完整 MBTI 报告",
-        "subtitle": "查看更完整的人格层、成长路线、关系洞察与推荐阅读。",
+        "subtitle": "一次支付 ¥1.99，解锁完整人格、成长、职业与关系内容。",
         "primary_label": "解锁完整报告",
         "secondary_label": "先看免费版",
         "benefit_bullets": [
-          "获得四大正式模块的完整正文与更深的分析视角",
-          "查看稳定输出的推荐阅读与更完整的人格层内容",
-          "继续沿用当前结果，无需重新测试即可解锁"
+          "一次解锁完整人格、成长、职业与关系模块",
+          "保留当前结果，无需重新测试即可继续解锁",
+          "所有章节入口都会回到这一个完整报告方案"
         ],
         "badge": "完整版"
       }

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3/commercial_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3/commercial_spec.json
@@ -1,164 +1,170 @@
 {
-    "schema": "fap.report.rules.v1",
-    "schema_version": "v1",
-    "version": "v0.3",
-    "scale_code": "MBTI",
-    "currency": "CNY",
-    "sku_hint": {
-        "upgrade_sku_anchor": "MBTI_REPORT_FULL",
-        "effective_default": "MBTI_REPORT_FULL_199",
-        "legacy_to_effective": {
-            "MBTI_REPORT_FULL": "MBTI_REPORT_FULL_199"
-        },
-        "effective_to_legacy": {
-            "MBTI_REPORT_FULL_199": "MBTI_REPORT_FULL"
-        }
+  "schema": "fap.report.rules.v1",
+  "schema_version": "v1",
+  "version": "v0.3",
+  "scale_code": "MBTI",
+  "currency": "CNY",
+  "sku_hint": {
+    "upgrade_sku_anchor": "MBTI_REPORT_FULL",
+    "effective_default": "MBTI_REPORT_FULL_199",
+    "legacy_to_effective": {
+      "MBTI_REPORT_FULL": "MBTI_REPORT_FULL_199"
     },
-    "offer_order": [
-        "MBTI_REPORT_FULL_199",
-        "MBTI_PRO_MONTH_599",
-        "MBTI_PRO_YEAR_1999",
-        "MBTI_GIFT_PACK_2990"
-    ],
-    "offers": [
+    "effective_to_legacy": {
+      "MBTI_REPORT_FULL_199": "MBTI_REPORT_FULL"
+    }
+  },
+  "offer_order": [
+    "MBTI_REPORT_FULL_199"
+  ],
+  "offers": [
+    {
+      "sku": "MBTI_REPORT_FULL_199",
+      "title": "MBTI 完整报告（单次解锁）",
+      "price_cents": 199,
+      "currency": "CNY",
+      "entitlement_id": "MBTI_REPORT_FULL_ACCESS",
+      "grant": {
+        "type": "report_full",
+        "qty": 1,
+        "period_days": null
+      },
+      "meta": {
+        "kind": "one_time",
+        "scope": "mbti_report",
+        "tags": [
+          "b2c",
+          "report"
+        ]
+      }
+    },
+    {
+      "sku": "MBTI_PRO_MONTH_599",
+      "title": "MBTI Pro 月卡（不限次数）",
+      "price_cents": 599,
+      "currency": "CNY",
+      "entitlement_id": "MBTI_PRO_ACCESS",
+      "grant": {
+        "type": "pro_membership",
+        "qty": 1,
+        "period_days": 30
+      },
+      "meta": {
+        "kind": "subscription",
+        "scope": "mbti",
+        "tags": [
+          "b2c",
+          "subscription",
+          "pro"
+        ]
+      }
+    },
+    {
+      "sku": "MBTI_PRO_YEAR_1999",
+      "title": "MBTI Pro 年卡（不限次数）",
+      "price_cents": 1999,
+      "currency": "CNY",
+      "entitlement_id": "MBTI_PRO_ACCESS",
+      "grant": {
+        "type": "pro_membership",
+        "qty": 1,
+        "period_days": 365
+      },
+      "meta": {
+        "kind": "subscription",
+        "scope": "mbti",
+        "tags": [
+          "b2c",
+          "subscription",
+          "pro"
+        ]
+      }
+    },
+    {
+      "sku": "MBTI_GIFT_PACK_2990",
+      "title": "MBTI 赠送包（2 次解锁）",
+      "price_cents": 2990,
+      "currency": "CNY",
+      "entitlement_id": "MBTI_GIFT_CREDITS",
+      "grant": {
+        "type": "report_full_credits",
+        "qty": 2,
+        "period_days": null
+      },
+      "meta": {
+        "kind": "consumable",
+        "scope": "mbti_report",
+        "tags": [
+          "b2c",
+          "gift",
+          "credits"
+        ]
+      }
+    }
+  ],
+  "variants": [
+    {
+      "variant_id": "mbti_report_paywall_default_v1",
+      "default": true,
+      "upgrade_sku_anchor": "MBTI_REPORT_FULL",
+      "upgrade_sku": "MBTI_REPORT_FULL_199",
+      "offer_order": [
+        "MBTI_REPORT_FULL_199"
+      ],
+      "view_policy": {
+        "free_sections": [
+          "overview",
+          "type_snapshot",
+          "dimension_summary",
+          "highlights_free"
+        ],
+        "full_sections": [
+          "overview",
+          "type_snapshot",
+          "dimension_summary",
+          "highlights_full",
+          "traits",
+          "growth",
+          "relationships",
+          "stress_recovery",
+          "career",
+          "recommended_reads",
+          "borderline_notes"
+        ],
+        "blur_others": true,
+        "teaser_percent": 0.3,
+        "upgrade_sku": "MBTI_REPORT_FULL_199"
+      },
+      "unlock_paths": [
         {
-            "sku": "MBTI_REPORT_FULL_199",
-            "title": "MBTI 完整报告（单次解锁）",
-            "price_cents": 199,
-            "currency": "CNY",
-            "entitlement_id": "MBTI_REPORT_FULL_ACCESS",
-            "grant": {
-                "type": "report_full",
-                "qty": 1,
-                "period_days": null
-            },
-            "meta": {
-                "kind": "one_time",
-                "scope": "mbti_report",
-                "tags": [
-                    "b2c",
-                    "report"
-                ]
-            }
+          "access_level": "full",
+          "entitlements_any": [
+            "MBTI_REPORT_FULL_ACCESS",
+            "MBTI_PRO_ACCESS"
+          ]
         },
         {
-            "sku": "MBTI_PRO_MONTH_599",
-            "title": "MBTI Pro 月卡（不限次数）",
-            "price_cents": 599,
-            "currency": "CNY",
-            "entitlement_id": "MBTI_PRO_ACCESS",
-            "grant": {
-                "type": "pro_membership",
-                "qty": 1,
-                "period_days": 30
-            },
-            "meta": {
-                "kind": "subscription",
-                "scope": "mbti",
-                "tags": [
-                    "b2c",
-                    "subscription",
-                    "pro"
-                ]
-            }
-        },
-        {
-            "sku": "MBTI_PRO_YEAR_1999",
-            "title": "MBTI Pro 年卡（不限次数）",
-            "price_cents": 1999,
-            "currency": "CNY",
-            "entitlement_id": "MBTI_PRO_ACCESS",
-            "grant": {
-                "type": "pro_membership",
-                "qty": 1,
-                "period_days": 365
-            },
-            "meta": {
-                "kind": "subscription",
-                "scope": "mbti",
-                "tags": [
-                    "b2c",
-                    "subscription",
-                    "pro"
-                ]
-            }
-        },
-        {
-            "sku": "MBTI_GIFT_PACK_2990",
-            "title": "MBTI 赠送包（2 次解锁）",
-            "price_cents": 2990,
-            "currency": "CNY",
-            "entitlement_id": "MBTI_GIFT_CREDITS",
-            "grant": {
-                "type": "report_full_credits",
-                "qty": 2,
-                "period_days": null
-            },
-            "meta": {
-                "kind": "consumable",
-                "scope": "mbti_report",
-                "tags": [
-                    "b2c",
-                    "gift",
-                    "credits"
-                ]
-            }
+          "access_level": "free",
+          "entitlements_any": []
         }
-    ],
-    "variants": [
-        {
-            "variant_id": "mbti_report_paywall_default_v1",
-            "default": true,
-            "upgrade_sku_anchor": "MBTI_REPORT_FULL",
-            "upgrade_sku": "MBTI_REPORT_FULL_199",
-            "offer_order": [
-                "MBTI_REPORT_FULL_199",
-                "MBTI_PRO_MONTH_599",
-                "MBTI_PRO_YEAR_1999",
-                "MBTI_GIFT_PACK_2990"
-            ],
-            "view_policy": {
-                "free_sections": [
-                    "overview",
-                    "type_snapshot",
-                    "dimension_summary",
-                    "highlights_free"
-                ],
-                "full_sections": [
-                    "overview",
-                    "type_snapshot",
-                    "dimension_summary",
-                    "highlights_full",
-                    "traits",
-                    "growth",
-                    "relationships",
-                    "stress_recovery",
-                    "career",
-                    "recommended_reads",
-                    "borderline_notes"
-                ],
-                "blur_others": true,
-                "teaser_percent": 0.3,
-                "upgrade_sku": "MBTI_REPORT_FULL_199"
-            },
-            "unlock_paths": [
-                {
-                    "access_level": "full",
-                    "entitlements_any": [
-                        "MBTI_REPORT_FULL_ACCESS",
-                        "MBTI_PRO_ACCESS"
-                    ]
-                },
-                {
-                    "access_level": "free",
-                    "entitlements_any": []
-                }
-            ],
-            "analytics": {
-                "paywall_variant": "mbti_report_paywall_default_v1",
-                "sku_anchor": "MBTI_REPORT_FULL",
-                "sku_effective_default": "MBTI_REPORT_FULL_199"
-            }
-        }
-    ]
+      ],
+      "analytics": {
+        "paywall_variant": "mbti_report_paywall_default_v1",
+        "sku_anchor": "MBTI_REPORT_FULL",
+        "sku_effective_default": "MBTI_REPORT_FULL_199"
+      },
+      "cta_copy": {
+        "title": "解锁完整 MBTI 报告",
+        "subtitle": "一次支付 ¥1.99，解锁完整人格、成长、职业与关系内容。",
+        "primary_label": "解锁完整报告",
+        "secondary_label": "先看免费版",
+        "benefit_bullets": [
+          "一次解锁完整人格、成长、职业与关系模块",
+          "保留当前结果，无需重新测试即可继续解锁",
+          "所有章节入口都会回到这一个完整报告方案"
+        ],
+        "badge": "完整版"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This change consolidates MBTI commerce and entitlements around a single full-report unlock sku.

The intended user-facing rule is simple: one `¥1.99` payment should unlock the complete MBTI report, including core full content, career, and relationship modules. In practice, the backend still exposed the legacy `MBTI_CAREER_99` and `MBTI_RELATIONSHIP_99` skus as active offers, which meant `/api/v0.3/skus`, paywall payloads, and report contracts could continue to surface partial-purchase paths long after the product direction had shifted to a single full-report funnel.

The root cause was split across multiple layers. The sku seed data still marked the partial skus as active, MBTI commercial specs still retained broader offer ordering, and paywall offer assembly treated every active MBTI sku as a valid report offer. In addition, historical customers who had already bought a `0.99` partial unlock did not automatically receive the final full-report entitlement that the new pricing model requires.

This PR closes those gaps across the catalog, paywall, and entitlements layers. It deactivates the legacy partial skus in seed data, marks them deprecated and non-offerable, narrows MBTI commercial specs to `MBTI_REPORT_FULL_199`, and filters MBTI paywall offers so locked result pages only emit the full-report offer. It also adds a forward migration that synchronizes both `scales_registry` and `scales_registry_v2` to the new MBTI commerce contract, plus a one-off Artisan command that upgrades historical partial MBTI purchases to an active `MBTI_REPORT_FULL` grant with `core_full`, `career`, and `relationships` modules. The command is idempotent and is explicitly registered in the console kernel.

The effect on users and downstream clients is that new MBTI report traffic only sees the full-report unlock sku, report payloads consistently return `MBTI_REPORT_FULL_199` as the effective target, and legacy `0.99` customers can be upgraded to the full entitlement without destructive changes to old grant rows.

Validation on this branch covered both new and existing backend contracts:

- `php artisan test tests/Feature/Commerce/MbtiCommerceConsolidationTest.php tests/Feature/Commerce/MbtiUpgradeLegacyPartialUnlocksCommandTest.php`
- `php artisan test tests/Feature/V0_3/ReportPaywallTeaserTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/Commerce/OfferModulesContractTest.php`

These checks validate sku visibility, MBTI paywall offer filtering, report envelope contracts, and idempotent upgrade behavior for historical partial unlocks.
