### PR TITLE
[codex] allow x-region on checkout preflight

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -18,6 +18,7 @@ return [
         'X-Org-Id',
         'X-FM-Org-Id',
         'X-Anon-Id',
+        'X-Region',
         'X-Fap-Locale',
         'Idempotency-Key',
         'X-Request-Id',

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\V0_3;
 use App\Services\Commerce\Checkout\WechatPayCheckoutService;
 use Database\Seeders\Pr19CommerceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\TestResponse;
 use Mockery;
@@ -17,6 +18,27 @@ final class CommerceCheckoutPayActionTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
     use RefreshDatabase;
+
+    public function test_checkout_options_allows_x_region_header_for_browser_preflight(): void
+    {
+        $response = app()->handle(Request::create(
+            '/api/v0.3/orders/checkout',
+            'OPTIONS',
+            [],
+            [],
+            [],
+            [
+                'HTTP_ORIGIN' => 'https://fermatmind.com',
+                'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+                'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'content-type,x-region,x-fap-locale,idempotency-key,x-anon-id',
+            ]
+        ));
+
+        $this->assertContains($response->getStatusCode(), [200, 204]);
+
+        $allowedHeaders = strtolower((string) $response->headers->get('Access-Control-Allow-Headers', ''));
+        $this->assertStringContainsString('x-region', $allowedHeaders);
+    }
 
     public function test_checkout_lemonsqueezy_returns_pay_redirect_and_checkout_url(): void
     {


### PR DESCRIPTION
## Summary
This PR fixes the backend half of the MBTI checkout regression that surfaced on the result page as `Failed to fetch`. Users clicking the `¥1.99` unlock CTA never reached the checkout controller because the browser blocked the request during CORS preflight.

## Root Cause
The frontend sends `X-Region` with `POST /api/v0.3/orders/checkout` so mainland users can be routed through the configured CN payment priority. Because `X-Region` is a non-simple header, the browser performs an `OPTIONS` preflight before the checkout request. The backend CORS configuration did not include `X-Region` in `allowed_headers`, so the preflight response was missing that header and the browser refused to send the actual checkout request. That made the payment flow fail before provider selection, order creation, or WeChat QR generation could happen.

## Changes
This PR adds `X-Region` to the CORS allowlist in `backend/config/cors.php`. No checkout controller logic, provider routing, or WeChat/Alipay payment action behavior changes in this patch; the fix is intentionally scoped to restoring the request path that already exists.

The test suite now includes an explicit browser-style preflight assertion for `OPTIONS /api/v0.3/orders/checkout`, verifying that the response exposes `x-region` in `Access-Control-Allow-Headers`. Existing checkout pay-action coverage remains in place to confirm the CORS change does not alter `wechatpay`, `alipay`, `lemonsqueezy`, or legacy billing behavior.

## Validation
I ran:

- `php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`
