### PR TITLE
[codex] restore pending order payment action and ops pending kpi

### DIFF
--- a/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
+++ b/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
@@ -25,6 +25,7 @@ class CommerceKpiWidget extends BaseWidget
         if ($orgId <= 0) {
             return [
                 Stat::make(__('ops.widgets.paid_orders_today'), '0')->description(__('ops.widgets.select_org_to_view_metrics')),
+                Stat::make(__('ops.widgets.pending_orders'), '0')->description(__('ops.widgets.no_org_selected')),
                 Stat::make(__('ops.widgets.revenue_today'), '0')->description(__('ops.widgets.no_org_selected')),
                 Stat::make(__('ops.widgets.unlock_rate'), '0%')->description(__('ops.widgets.no_org_selected')),
                 Stat::make(__('ops.widgets.refund_count'), '0')->description(__('ops.widgets.no_org_selected')),
@@ -45,6 +46,11 @@ class CommerceKpiWidget extends BaseWidget
             ->where('created_at', '>=', $start)
             ->where('created_at', '<', $end)
             ->sum(DB::raw('COALESCE(amount_cents, 0)'));
+
+        $pendingOrders = (int) DB::table('orders')
+            ->where('org_id', $orgId)
+            ->whereRaw("lower(coalesce(status, '')) in (?, ?)", ['created', 'pending'])
+            ->count();
 
         $refundCount = (int) DB::table('orders')
             ->where('org_id', $orgId)
@@ -77,6 +83,8 @@ class CommerceKpiWidget extends BaseWidget
 
         return [
             Stat::make(__('ops.widgets.paid_orders_today'), (string) $paidOrders),
+            Stat::make(__('ops.widgets.pending_orders'), (string) $pendingOrders)
+                ->color($pendingOrders > 0 ? 'warning' : 'success'),
             Stat::make(__('ops.widgets.revenue_today'), (string) $todayRevenue)->description(__('ops.widgets.cents')),
             Stat::make(__('ops.widgets.unlock_rate'), (string) $unlockRate . '%'),
             Stat::make(__('ops.widgets.refund_count'), (string) $refundCount)

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -135,6 +135,11 @@ class CommerceController extends Controller
         $status = $this->normalizePublicOrderStatus((string) ($order->status ?? ''));
         $message = $this->publicOrderMessage((string) ($order->status ?? ''));
         $delivery = $this->buildOrderDelivery($order);
+        $payment = $this->buildOrderPaymentPayload(
+            $request,
+            $order,
+            $status === 'pending' && $request->boolean('include_payment_action')
+        );
 
         if (! $ownershipVerified) {
             return response()->json([
@@ -154,6 +159,9 @@ class CommerceController extends Controller
             'message' => $message,
             'amount_cents' => $order->amount_cents ?? $order->amount_total ?? null,
             'currency' => $order->currency ?? null,
+            'provider' => $payment['provider'],
+            'pay' => $payment['pay'],
+            'checkout_url' => $payment['checkout_url'],
             'delivery' => $delivery['delivery'],
         ];
 
@@ -234,6 +242,11 @@ class CommerceController extends Controller
                 if ($provider === '') {
                     $provider = (string) $this->paymentRouter->primaryProviderForRegion($this->regionContext->region());
                 }
+                $payment = $this->buildOrderPaymentPayload(
+                    $request,
+                    $order,
+                    $this->normalizePublicOrderStatus((string) ($order->status ?? '')) === 'pending'
+                );
 
                 return response()->json([
                     'ok' => true,
@@ -241,9 +254,9 @@ class CommerceController extends Controller
                     'attempt_id' => $order->target_attempt_id ?? null,
                     'status' => $this->normalizePublicOrderStatus((string) ($order->status ?? '')),
                     'message' => $this->publicOrderMessage((string) ($order->status ?? '')),
-                    'provider' => $provider,
-                    'pay' => null,
-                    'checkout_url' => null,
+                    'provider' => $payment['provider'] ?? $provider,
+                    'pay' => $payment['pay'],
+                    'checkout_url' => $payment['checkout_url'],
                 ]);
             }
         }
@@ -509,6 +522,114 @@ class CommerceController extends Controller
             ),
             default => ['ok' => true],
         };
+    }
+
+    /**
+     * @return array{
+     *     provider:?string,
+     *     pay:?array{type:string,value:string,provider:string},
+     *     checkout_url:?string
+     * }
+     */
+    private function buildOrderPaymentPayload(Request $request, object $order, bool $includePaymentAction): array
+    {
+        $provider = strtolower(trim((string) ($order->provider ?? '')));
+        if ($provider === '') {
+            $provider = (string) $this->paymentRouter->primaryProviderForRegion($this->regionContext->region());
+        }
+
+        $normalizedProvider = $provider !== '' ? $provider : null;
+        if ($normalizedProvider === null || ! $this->isProviderEnabled($normalizedProvider)) {
+            return [
+                'provider' => $normalizedProvider,
+                'pay' => null,
+                'checkout_url' => null,
+            ];
+        }
+
+        if (! $includePaymentAction) {
+            return [
+                'provider' => $normalizedProvider,
+                'pay' => null,
+                'checkout_url' => null,
+            ];
+        }
+
+        $orderNo = trim((string) ($order->order_no ?? ''));
+        if ($orderNo === '') {
+            return [
+                'provider' => $normalizedProvider,
+                'pay' => null,
+                'checkout_url' => null,
+            ];
+        }
+
+        $amountCents = (int) ($order->amount_cents ?? $order->amount_total ?? 0);
+        $currency = strtoupper(trim((string) ($order->currency ?? 'USD')));
+        $description = strtoupper(trim((string) ($order->sku ?? '')));
+        if ($description === '') {
+            $description = 'FermatMind Order';
+        }
+
+        $payAction = $this->resolveCheckoutPayAction(
+            $normalizedProvider,
+            $orderNo,
+            $this->trimNullableString($order->target_attempt_id ?? null),
+            $amountCents,
+            $currency,
+            $description,
+            null,
+            (string) $request->userAgent()
+        );
+
+        if (($payAction['ok'] ?? true) !== true) {
+            Log::warning('ORDER_PAYMENT_ACTION_UNAVAILABLE', [
+                'order_no' => $orderNo,
+                'provider' => $normalizedProvider,
+                'status' => (string) ($order->status ?? ''),
+                'reason' => $payAction['error_code'] ?? $payAction['message'] ?? 'unknown',
+            ]);
+
+            return [
+                'provider' => $normalizedProvider,
+                'pay' => null,
+                'checkout_url' => null,
+            ];
+        }
+
+        return $this->presentCheckoutPayAction($normalizedProvider, $payAction);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payAction
+     * @return array{
+     *     provider:?string,
+     *     pay:?array{type:string,value:string,provider:string},
+     *     checkout_url:?string
+     * }
+     */
+    private function presentCheckoutPayAction(?string $provider, array $payAction): array
+    {
+        $payType = strtolower(trim((string) ($payAction['type'] ?? '')));
+        $payValue = trim((string) ($payAction['value'] ?? ''));
+
+        if ($payType === '' || $payValue === '') {
+            return [
+                'provider' => $provider,
+                'pay' => null,
+                'checkout_url' => null,
+            ];
+        }
+
+        return [
+            'provider' => $provider,
+            'pay' => [
+                'type' => $payType,
+                'value' => $payValue,
+                'provider' => $provider ?? '',
+            ],
+            'checkout_url' => $payType === 'redirect' ? $payValue : null,
+        ];
     }
 
     private function toHttpResponse(mixed $gatewayResponse): ?Response
@@ -779,6 +900,17 @@ class CommerceController extends Controller
         }
 
         return $email;
+    }
+
+    private function trimNullableString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
     }
 
     /**

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -62,6 +62,7 @@ return [
         'healthz_status' => 'Healthz Status',
         'funnel_7d' => 'Funnel (7d)',
         'paid_orders_today' => 'Paid Orders Today',
+        'pending_orders' => 'Pending Orders',
         'revenue_today' => 'Revenue Today',
         'unlock_rate' => 'Unlock Rate',
         'refund_count' => 'Refund Count',

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -62,6 +62,7 @@ return [
         'healthz_status' => '健康状态',
         'funnel_7d' => '漏斗（7天）',
         'paid_orders_today' => '今日已支付订单',
+        'pending_orders' => '待支付订单',
         'revenue_today' => '今日收入',
         'unlock_rate' => '解锁率',
         'refund_count' => '退款数量',

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -8,7 +8,10 @@ use App\Services\Commerce\Checkout\WechatPayCheckoutService;
 use Database\Seeders\Pr19CommerceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -188,6 +191,80 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $this->assertNotSame('', (string) $response->json('order_no'));
     }
 
+    public function test_checkout_reuses_pending_order_and_returns_pay_action_for_existing_pending_order(): void
+    {
+        $this->seedCommerce();
+
+        config([
+            'payments.providers.wechatpay.enabled' => true,
+        ]);
+
+        $orderNo = 'ord_existing_pending_checkout_1';
+        $anonId = 'anon_existing_pending_checkout_1';
+        $this->insertPendingOrder($orderNo, 'wechatpay', $anonId);
+
+        $mock = Mockery::mock(WechatPayCheckoutService::class);
+        $mock->shouldReceive('createCheckoutAction')
+            ->once()
+            ->andReturn([
+                'ok' => true,
+                'type' => 'qr',
+                'value' => 'weixin://wxpay/bizpayurl?pr=existing_pending_checkout',
+            ]);
+        $this->app->instance(WechatPayCheckoutService::class, $mock);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        ])->postJson('/api/v0.3/orders/checkout', [
+            'order_no' => $orderNo,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('order_no', $orderNo);
+        $response->assertJsonPath('status', 'pending');
+        $response->assertJsonPath('provider', 'wechatpay');
+        $response->assertJsonPath('pay.type', 'qr');
+        $response->assertJsonPath('pay.value', 'weixin://wxpay/bizpayurl?pr=existing_pending_checkout');
+        $response->assertJsonPath('checkout_url', null);
+    }
+
+    public function test_get_order_can_include_payment_action_for_pending_orders(): void
+    {
+        $this->seedCommerce();
+
+        config([
+            'payments.providers.wechatpay.enabled' => true,
+        ]);
+
+        $orderNo = 'ord_include_payment_action_1';
+        $anonId = 'anon_include_payment_action_1';
+        $this->insertPendingOrder($orderNo, 'wechatpay', $anonId);
+
+        $mock = Mockery::mock(WechatPayCheckoutService::class);
+        $mock->shouldReceive('createCheckoutAction')
+            ->once()
+            ->andReturn([
+                'ok' => true,
+                'type' => 'qr',
+                'value' => 'weixin://wxpay/bizpayurl?pr=include_payment_action',
+            ]);
+        $this->app->instance(WechatPayCheckoutService::class, $mock);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        ])->getJson('/api/v0.3/orders/'.$orderNo.'?include_payment_action=1');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('order_no', $orderNo);
+        $response->assertJsonPath('status', 'pending');
+        $response->assertJsonPath('provider', 'wechatpay');
+        $response->assertJsonPath('pay.type', 'qr');
+        $response->assertJsonPath('pay.value', 'weixin://wxpay/bizpayurl?pr=include_payment_action');
+        $response->assertJsonPath('checkout_url', null);
+    }
+
     private function seedCommerce(): void
     {
         (new Pr19CommerceSeeder)->run();
@@ -200,5 +277,64 @@ final class CommerceCheckoutPayActionTest extends TestCase
     private function checkout(array $payload, array $headers = []): TestResponse
     {
         return $this->withHeaders($headers)->postJson('/api/v0.3/orders/checkout', $payload);
+    }
+
+    private function insertPendingOrder(string $orderNo, string $provider, string $anonId): void
+    {
+        $now = now();
+        $row = [
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'sku' => 'MBTI_CREDIT',
+            'item_sku' => 'MBTI_CREDIT',
+            'requested_sku' => 'MBTI_CREDIT',
+            'effective_sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'amount_total' => 199,
+            'amount_cents' => 199,
+            'amount_refunded' => 0,
+            'currency' => 'CNY',
+            'status' => 'created',
+            'provider' => $provider,
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => 'req_'.$orderNo,
+            'created_ip' => null,
+            'target_attempt_id' => 'attempt_'.$orderNo,
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'external_trade_no' => null,
+            'contact_email_hash' => null,
+            'metadata' => null,
+            'meta_json' => null,
+            'paid_at' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+            'refund_amount_cents' => null,
+            'refund_reason' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+
+        foreach ([
+            'requested_sku',
+            'effective_sku',
+            'scale_code_v2',
+            'scale_uid',
+            'contact_email_hash',
+            'metadata',
+            'meta_json',
+            'refund_amount_cents',
+            'refund_reason',
+        ] as $column) {
+            if (! Schema::hasColumn('orders', $column)) {
+                unset($row[$column]);
+            }
+        }
+
+        DB::table('orders')->insert($row);
     }
 }


### PR DESCRIPTION
## Summary
Two issues were affecting commerce recovery flows. First, reusing an existing pending order returned no `pay` payload, and the order status endpoint also could not return a pending payment action, which left the web order screen spinning without a QR code or launch button. Second, the Ops dashboard did not expose any pending-order KPI, so the CMS/Ops shell could not show the number of unpaid orders at all.

## Root Cause
`POST /api/v0.3/orders/checkout` dropped `pay` and `checkout_url` when an existing pending order was reused, and `GET /api/v0.3/orders/{orderNo}` only returned delivery/status data. That meant pending orders could be looked up, but not resumed. Separately, the commerce KPI widget only counted paid orders, revenue, refunds, unlock rate, and webhook failures; there was no pending-order metric in the widget.

## Fix
- add a reusable payment-payload builder in `CommerceController` so pending orders can resolve provider actions consistently
- return `provider/pay/checkout_url` when checkout reuses an existing pending order
- allow `GET /api/v0.3/orders/{orderNo}?include_payment_action=1` to include the payment action for pending orders, while leaving paid/failed/refunded payloads unchanged
- add a pending-orders KPI card to the Ops commerce widget using `created/pending` order states
- add zh/en widget copy for the new pending-orders card
- extend the checkout pay-action feature test to cover both existing-pending-order reuse and order-status payment recovery

## Validation
- `php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`
- `php -l backend/app/Http/Controllers/API/V0_3/CommerceController.php`
- `php -l backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php`