### PR TITLE
[codex] return pending payment actions from order lookup

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -400,12 +400,21 @@ class CommerceController extends Controller
         }
 
         $delivery = $this->buildOrderDelivery($order);
+        $status = $this->normalizePublicOrderStatus((string) ($order->status ?? ''));
+        $payment = $this->buildOrderPaymentPayload(
+            $request,
+            $order,
+            $status === 'pending'
+        );
 
         $payload = [
             'ok' => true,
             'order_no' => $order->order_no ?? $orderNo,
-            'status' => $this->normalizePublicOrderStatus((string) ($order->status ?? '')),
+            'status' => $status,
             'attempt_id' => $delivery['attempt_id'],
+            'provider' => $payment['provider'],
+            'pay' => $payment['pay'],
+            'checkout_url' => $payment['checkout_url'],
             'delivery' => $delivery['delivery'],
         ];
 

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -265,6 +265,42 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('checkout_url', null);
     }
 
+    public function test_lookup_can_include_payment_action_for_pending_orders_after_email_match(): void
+    {
+        $this->seedCommerce();
+
+        config([
+            'payments.providers.wechatpay.enabled' => true,
+        ]);
+
+        $orderNo = 'ord_lookup_include_payment_action_1';
+        $anonId = 'anon_lookup_include_payment_action_1';
+        $this->insertPendingOrder($orderNo, 'wechatpay', $anonId, 'buyer@example.com');
+
+        $mock = Mockery::mock(WechatPayCheckoutService::class);
+        $mock->shouldReceive('createCheckoutAction')
+            ->once()
+            ->andReturn([
+                'ok' => true,
+                'type' => 'qr',
+                'value' => 'weixin://wxpay/bizpayurl?pr=lookup_include_payment_action',
+            ]);
+        $this->app->instance(WechatPayCheckoutService::class, $mock);
+
+        $response = $this->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => 'buyer@example.com',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('order_no', $orderNo);
+        $response->assertJsonPath('status', 'pending');
+        $response->assertJsonPath('provider', 'wechatpay');
+        $response->assertJsonPath('pay.type', 'qr');
+        $response->assertJsonPath('pay.value', 'weixin://wxpay/bizpayurl?pr=lookup_include_payment_action');
+        $response->assertJsonPath('checkout_url', null);
+    }
+
     private function seedCommerce(): void
     {
         (new Pr19CommerceSeeder)->run();
@@ -279,7 +315,7 @@ final class CommerceCheckoutPayActionTest extends TestCase
         return $this->withHeaders($headers)->postJson('/api/v0.3/orders/checkout', $payload);
     }
 
-    private function insertPendingOrder(string $orderNo, string $provider, string $anonId): void
+    private function insertPendingOrder(string $orderNo, string $provider, string $anonId, ?string $email = null): void
     {
         $now = now();
         $row = [
@@ -307,7 +343,7 @@ final class CommerceCheckoutPayActionTest extends TestCase
             'scale_code_v2' => null,
             'scale_uid' => null,
             'external_trade_no' => null,
-            'contact_email_hash' => null,
+            'contact_email_hash' => $email ? hash('sha256', mb_strtolower(trim($email), 'UTF-8')) : null,
             'metadata' => null,
             'meta_json' => null,
             'paid_at' => null,


### PR DESCRIPTION
## Summary
Production order pages were still getting stuck in a pending spinner for some users even after we restored payment actions for directly readable pending orders. The remaining failure mode was an ownership mismatch: the frontend called `GET /api/v0.3/orders/{orderNo}?include_payment_action=1`, but the API returned `404 NOT_FOUND` because the current browser identity did not own the order.

That behavior is correct and should remain in place. The real gap was that the email-based recovery endpoint did not return payment actions for pending orders, so the frontend had no choice but to redirect users back to the protected order page after lookup. For users on a different device or browser, that redirect immediately failed with the same ownership 404.

## Root cause
`POST /api/v0.3/orders/lookup` only returned delivery/access metadata. It did not return the pending order's public status or reconstructed payment action, even when the user had already proven possession with the correct order number and purchase email.

As a result, the frontend could not complete recovery on the lookup page and had to bounce users back into a route that was never meant to be publicly readable.

## Fix
This PR keeps the current ownership rules on `GET /orders/{orderNo}` unchanged and extends the lookup response so the recovery flow can finish without relaxing security:

- `CommerceController::lookup()` now normalizes and returns the public order `status`.
- For pending orders, lookup now reuses the existing payment payload builder and includes `provider`, `pay`, and `checkout_url` in the response.
- Wrong email or non-existent orders still return the existing blind 404 behavior and do not leak order existence.
- Existing protected-order behavior remains unchanged.

## Validation
- `php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`

## Notes
This keeps the strong ownership model intact. The lookup endpoint remains the explicit recovery surface, and it now has enough information for the frontend to resume pending payment flows after email verification without exposing `/orders/{orderNo}` to non-owners.
