### PR TITLE
[codex] cache pending order payment actions

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -348,6 +348,18 @@ class CommerceController extends Controller
             }
         }
 
+        if ($order !== null) {
+            $this->persistOrderPaymentPayload(
+                $order,
+                $this->resolvePaymentActionScene((string) $request->userAgent()),
+                [
+                    'provider' => $provider,
+                    'pay' => $payPayload,
+                    'checkout_url' => $checkoutUrl,
+                ]
+            );
+        }
+
         return response()->json([
             'ok' => true,
             'order_no' => $orderNo !== '' ? $orderNo : ($created['order_no'] ?? null),
@@ -548,7 +560,7 @@ class CommerceController extends Controller
         }
 
         $normalizedProvider = $provider !== '' ? $provider : null;
-        if ($normalizedProvider === null || ! $this->isProviderEnabled($normalizedProvider)) {
+        if (! $includePaymentAction) {
             return [
                 'provider' => $normalizedProvider,
                 'pay' => null,
@@ -556,7 +568,13 @@ class CommerceController extends Controller
             ];
         }
 
-        if (! $includePaymentAction) {
+        $scene = $this->resolvePaymentActionScene((string) $request->userAgent());
+        $cached = $this->resolveCachedOrderPaymentPayload($order, $normalizedProvider, $scene);
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        if ($normalizedProvider === null || ! $this->isProviderEnabled($normalizedProvider)) {
             return [
                 'provider' => $normalizedProvider,
                 'pay' => null,
@@ -606,7 +624,10 @@ class CommerceController extends Controller
             ];
         }
 
-        return $this->presentCheckoutPayAction($normalizedProvider, $payAction);
+        $presented = $this->presentCheckoutPayAction($normalizedProvider, $payAction);
+        $this->persistOrderPaymentPayload($order, $scene, $presented);
+
+        return $presented;
     }
 
     /**
@@ -639,6 +660,129 @@ class CommerceController extends Controller
             ],
             'checkout_url' => $payType === 'redirect' ? $payValue : null,
         ];
+    }
+
+    /**
+     * @return array{
+     *     provider:?string,
+     *     pay:?array{type:string,value:string,provider:string},
+     *     checkout_url:?string
+     * }|null
+     */
+    private function resolveCachedOrderPaymentPayload(object $order, ?string $provider, string $scene): ?array
+    {
+        if ($provider === null || $scene === '') {
+            return null;
+        }
+
+        $meta = $this->decodeMeta($order->meta_json ?? null);
+        $scenes = $meta['payment_action_cache'][$provider] ?? null;
+        if (! is_array($scenes)) {
+            return null;
+        }
+
+        $payload = $scenes[$scene] ?? null;
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        $pay = $payload['pay'] ?? null;
+        if (! is_array($pay)) {
+            return null;
+        }
+
+        $payType = strtolower(trim((string) ($pay['type'] ?? '')));
+        $payValue = trim((string) ($pay['value'] ?? ''));
+        if ($payType === '' || $payValue === '') {
+            return null;
+        }
+
+        return [
+            'provider' => $provider,
+            'pay' => [
+                'type' => $payType,
+                'value' => $payValue,
+                'provider' => $provider,
+            ],
+            'checkout_url' => $payType === 'redirect'
+                ? ($payload['checkout_url'] ?? $payValue)
+                : ($payload['checkout_url'] ?? null),
+        ];
+    }
+
+    /**
+     * @param  array{
+     *     provider:?string,
+     *     pay:?array{type:string,value:string,provider:string},
+     *     checkout_url:?string
+     * }  $payload
+     */
+    private function persistOrderPaymentPayload(object $order, string $scene, array $payload): void
+    {
+        $provider = strtolower(trim((string) ($payload['provider'] ?? '')));
+        $pay = $payload['pay'] ?? null;
+        $orderNo = trim((string) ($order->order_no ?? ''));
+        $orgId = (int) ($order->org_id ?? 0);
+
+        if ($provider === '' || $scene === '' || $orderNo === '' || ! is_array($pay)) {
+            return;
+        }
+
+        $payType = strtolower(trim((string) ($pay['type'] ?? '')));
+        $payValue = trim((string) ($pay['value'] ?? ''));
+        if ($payType === '' || $payValue === '') {
+            return;
+        }
+
+        $meta = $this->decodeMeta($order->meta_json ?? null);
+        $cache = is_array($meta['payment_action_cache'] ?? null) ? $meta['payment_action_cache'] : [];
+        $providerCache = is_array($cache[$provider] ?? null) ? $cache[$provider] : [];
+        $providerCache[$scene] = [
+            'provider' => $provider,
+            'pay' => [
+                'type' => $payType,
+                'value' => $payValue,
+                'provider' => $provider,
+            ],
+            'checkout_url' => $payload['checkout_url'] ?? null,
+            'cached_at' => now()->toIso8601String(),
+        ];
+        $cache[$provider] = $providerCache;
+        $meta['payment_action_cache'] = $cache;
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->where('org_id', $orgId)
+            ->update([
+                'meta_json' => json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'updated_at' => now(),
+            ]);
+    }
+
+    private function resolvePaymentActionScene(string $userAgent): string
+    {
+        return preg_match('/android|iphone|ipad|ipod|mobile|micromessenger/i', $userAgent) === 1
+            ? 'mobile'
+            : 'desktop';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeMeta(mixed $meta): array
+    {
+        if (is_array($meta)) {
+            return $meta;
+        }
+
+        if (is_string($meta) && $meta !== '') {
+            $decoded = json_decode($meta, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
     }
 
     private function toHttpResponse(mixed $gatewayResponse): ?Response

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -301,6 +301,66 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('checkout_url', null);
     }
 
+    public function test_get_order_reuses_cached_payment_action_from_checkout_when_gateway_is_not_reinvoked(): void
+    {
+        $this->seedCommerce();
+
+        config([
+            'payments.providers.wechatpay.enabled' => true,
+        ]);
+
+        $anonId = 'anon_cached_payment_action_1';
+        $firstMock = Mockery::mock(WechatPayCheckoutService::class);
+        $firstMock->shouldReceive('createCheckoutAction')
+            ->once()
+            ->andReturn([
+                'ok' => true,
+                'type' => 'qr',
+                'value' => 'weixin://wxpay/bizpayurl?pr=cached_payment_action',
+            ]);
+        $this->app->instance(WechatPayCheckoutService::class, $firstMock);
+
+        $checkout = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        ])->postJson('/api/v0.3/orders/checkout', [
+            'sku' => 'MBTI_CREDIT',
+            'provider' => 'wechatpay',
+            'email' => 'cached@example.com',
+        ]);
+
+        $checkout->assertStatus(200);
+        $checkout->assertJsonPath('pay.type', 'qr');
+        $checkout->assertJsonPath('pay.value', 'weixin://wxpay/bizpayurl?pr=cached_payment_action');
+
+        $orderNo = (string) $checkout->json('order_no');
+        $order = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($order);
+        $meta = json_decode((string) ($order->meta_json ?? ''), true);
+        $this->assertIsArray($meta);
+        $this->assertSame(
+            'weixin://wxpay/bizpayurl?pr=cached_payment_action',
+            data_get($meta, 'payment_action_cache.wechatpay.desktop.pay.value')
+        );
+
+        $secondMock = Mockery::mock(WechatPayCheckoutService::class);
+        $secondMock->shouldReceive('createCheckoutAction')->never();
+        $this->app->instance(WechatPayCheckoutService::class, $secondMock);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        ])->getJson('/api/v0.3/orders/'.$orderNo.'?include_payment_action=1');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('order_no', $orderNo);
+        $response->assertJsonPath('status', 'pending');
+        $response->assertJsonPath('provider', 'wechatpay');
+        $response->assertJsonPath('pay.type', 'qr');
+        $response->assertJsonPath('pay.value', 'weixin://wxpay/bizpayurl?pr=cached_payment_action');
+        $response->assertJsonPath('checkout_url', null);
+    }
+
     private function seedCommerce(): void
     {
         (new Pr19CommerceSeeder)->run();


### PR DESCRIPTION
## Summary
Readable pending orders could still timeout on the order page even though the API supported `include_payment_action=1`. The failure mode was subtle: if the order page asked for a payment action and the backend could not reconstruct one at that moment, we returned `pending` with `pay: null`. The frontend's old behavior then stopped asking for payment actions, and the order eventually timed out.

That also meant the API had no stable replay path for already-generated payment actions. Even when checkout initially produced a QR code or launch URL, later order-page recovery depended on regenerating the payment action from scratch.

## Fix
This PR adds the smallest backend support needed to make pending payment recovery stable:

- Cache successful payment actions in `orders.meta_json` keyed by `provider` and request `scene` (`desktop` / `mobile`).
- Persist that cache both when checkout first creates a pending order payment action and when an order-status recovery call successfully regenerates one.
- When `GET /orders/{orderNo}?include_payment_action=1` or lookup recovery requests a payment action, prefer the cached payload before trying to regenerate it.
- Keep current ownership checks and public contracts intact.

## Validation
- `php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`
- `php -l backend/app/Http/Controllers/API/V0_3/CommerceController.php`

## Notes
This is intentionally a minimal compatibility fix. It does not redesign payment orchestration or add new tables. It simply gives order recovery a stable replay source so pending orders do not depend on every later request being able to reissue the payment action successfully.
