### PR TITLE
[codex] feat(content): publish MBTI career authority baselines v1

### DIFF
--- a/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
@@ -387,6 +387,60 @@ final class CareerGuidePublicApiTest extends TestCase
             ->assertJsonPath('error', 'not found');
     }
 
+    public function test_imported_local_baseline_publishes_family_guides_with_personality_maps(): void
+    {
+        $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 18, 8, 0, 0, 'UTC'),
+        ]);
+        $this->createProfile([
+            'type_code' => 'ESFP',
+            'slug' => 'esfp',
+            'locale' => 'zh-CN',
+            'title' => 'ESFP 人格类型',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 18, 8, 5, 0, 'UTC'),
+        ]);
+
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en', 'zh-CN'],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--guide' => ['intj-career-playbook'],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['zh-CN'],
+            '--guide' => ['esfp-career-playbook'],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $this->getJson('/api/v0.5/career-guides/intj-career-playbook?locale=en')
+            ->assertOk()
+            ->assertJsonPath('guide.guide_code', 'intj-career-playbook')
+            ->assertJsonPath('guide.locale', 'en')
+            ->assertJsonPath('related_personality_profiles.0.type_code', 'INTJ');
+
+        $this->getJson('/api/v0.5/career-guides/esfp-career-playbook?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('guide.guide_code', 'esfp-career-playbook')
+            ->assertJsonPath('guide.locale', 'zh-CN')
+            ->assertJsonPath('related_personality_profiles.0.type_code', 'ESFP');
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */

--- a/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
@@ -302,6 +302,34 @@ final class CareerJobPublicApiTest extends TestCase
             ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
+    public function test_imported_local_baseline_publishes_family_jobs_for_en_and_zh_cn(): void
+    {
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en', 'zh-CN'],
+            '--job' => [
+                'innovation-consultant',
+                'event-experience-producer',
+            ],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $this->getJson('/api/v0.5/career-jobs/innovation-consultant?locale=en')
+            ->assertOk()
+            ->assertJsonPath('job.job_code', 'innovation-consultant')
+            ->assertJsonPath('job.locale', 'en')
+            ->assertJsonPath('job.fit_personality_codes.0', 'ENTJ')
+            ->assertJsonPath('job.mbti_primary_codes.0', 'ENTP')
+            ->assertJsonPath('job.mbti_secondary_codes.0', 'INTJ');
+
+        $this->getJson('/api/v0.5/career-jobs/event-experience-producer?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('job.job_code', 'event-experience-producer')
+            ->assertJsonPath('job.locale', 'zh-CN')
+            ->assertJsonPath('job.mbti_primary_codes.0', 'ESFP')
+            ->assertJsonPath('job.mbti_secondary_codes.0', 'ENFJ');
+    }
+
     public function test_detail_defaults_to_global_content_and_only_uses_requested_org_scope(): void
     {
         $this->createJob([

--- a/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
@@ -336,6 +336,138 @@ final class CareerRecommendationPublicApiTest extends TestCase
             ->assertJsonPath('seo.alternates.zh-CN', '/zh/career/recommendations/mbti/intj-a');
     }
 
+    public function test_imported_local_baselines_make_representative_32_type_routes_non_empty(): void
+    {
+        $intjProfile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($intjProfile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $enfpProfile = $this->createProfile([
+            'type_code' => 'ENFP',
+            'slug' => 'enfp',
+            'locale' => 'en',
+            'title' => 'ENFP Personality Type',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($enfpProfile, [
+            'variant_code' => 'T',
+            'runtime_type_code' => 'ENFP-T',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $istjProfile = $this->createProfile([
+            'type_code' => 'ISTJ',
+            'slug' => 'istj',
+            'locale' => 'zh-CN',
+            'title' => 'ISTJ 人格类型',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($istjProfile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'ISTJ-A',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $esfpProfile = $this->createProfile([
+            'type_code' => 'ESFP',
+            'slug' => 'esfp',
+            'locale' => 'zh-CN',
+            'title' => 'ESFP 人格类型',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($esfpProfile, [
+            'variant_code' => 'T',
+            'runtime_type_code' => 'ESFP-T',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en', 'zh-CN'],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--guide' => [
+                'intj-career-playbook',
+                'enfp-career-playbook',
+            ],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['zh-CN'],
+            '--guide' => [
+                'istj-career-playbook',
+                'esfp-career-playbook',
+            ],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $intjA = $this->getJson('/api/v0.5/career-recommendations/mbti/intj-a?locale=en');
+        $intjA->assertOk()
+            ->assertJsonPath('public_route_slug', 'intj-a')
+            ->assertJsonPath('graph_type_code', 'INTJ');
+        $this->assertGreaterThan(0, count((array) $intjA->json('matched_jobs')));
+        $this->assertGreaterThan(0, count((array) $intjA->json('matched_guides')));
+
+        $enfpT = $this->getJson('/api/v0.5/career-recommendations/mbti/enfp-t?locale=en');
+        $enfpT->assertOk()
+            ->assertJsonPath('public_route_slug', 'enfp-t')
+            ->assertJsonPath('graph_type_code', 'ENFP');
+        $this->assertGreaterThan(0, count((array) $enfpT->json('matched_jobs')));
+        $this->assertGreaterThan(0, count((array) $enfpT->json('matched_guides')));
+
+        $istjA = $this->getJson('/api/v0.5/career-recommendations/mbti/istj-a?locale=zh-CN');
+        $istjA->assertOk()
+            ->assertJsonPath('public_route_slug', 'istj-a')
+            ->assertJsonPath('graph_type_code', 'ISTJ');
+        $this->assertGreaterThan(0, count((array) $istjA->json('matched_jobs')));
+        $this->assertGreaterThan(0, count((array) $istjA->json('matched_guides')));
+
+        $esfpT = $this->getJson('/api/v0.5/career-recommendations/mbti/esfp-t?locale=zh-CN');
+        $esfpT->assertOk()
+            ->assertJsonPath('public_route_slug', 'esfp-t')
+            ->assertJsonPath('graph_type_code', 'ESFP');
+        $this->assertGreaterThan(0, count((array) $esfpT->json('matched_jobs')));
+        $this->assertGreaterThan(0, count((array) $esfpT->json('matched_guides')));
+
+        $legacy = $this->getJson('/api/v0.5/career-recommendations/mbti/intj?locale=en');
+        $legacy->assertOk()
+            ->assertJsonPath('public_route_slug', 'intj-a')
+            ->assertJsonPath('graph_type_code', 'INTJ');
+        $this->assertGreaterThan(0, count((array) $legacy->json('matched_jobs')));
+        $this->assertGreaterThan(0, count((array) $legacy->json('matched_guides')));
+    }
+
     public function test_legacy_4_letter_route_resolves_to_default_published_variant_and_unpublished_alias_returns_not_found(): void
     {
         $intjProfile = $this->createProfile([

--- a/content_baselines/career_guides/career_guides.en.json
+++ b/content_baselines/career_guides/career_guides.en.json
@@ -465,20 +465,7 @@
           "slug": "mbti-narrative-portrait"
         }
       ],
-      "related_personality_profiles": [
-        {
-          "type_code": "INTJ"
-        },
-        {
-          "type_code": "ENFP"
-        },
-        {
-          "type_code": "ISTJ"
-        },
-        {
-          "type_code": "ENTP"
-        }
-      ],
+      "related_personality_profiles": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -971,6 +958,806 @@
       "published_at": "2026-03-05",
       "scheduled_at": null,
       "sort_order": 0
+    },
+    {
+      "guide_code": "intj-career-playbook",
+      "slug": "intj-career-playbook",
+      "locale": "en",
+      "title": "INTJ Career Playbook: Turn Strategic Judgment Into Trusted Influence",
+      "excerpt": "For INTJs who already think in systems and need a clearer path from private judgment to visible, trusted career leverage.",
+      "category_slug": "career-planning",
+      "body_md": "# INTJ Career Playbook\n\n## Why this guide fits INTJ\nINTJs usually do not lack judgment. The real bottleneck is making strong thinking easier for other people to understand, trust, and act on.\n\n## Where INTJs usually win\n- Long-range planning and system design\n- Complex tradeoff judgment under ambiguity\n- Building structures that keep working after the first launch\n\n## Next-step moves\n1. Explain the frame before the conclusion in high-stakes conversations.\n2. Publish one visible artifact each quarter: memo, roadmap, architecture note, or decision model.\n3. Pair deep-work blocks with a repeatable stakeholder alignment rhythm.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "cloud-architect"
+        },
+        {
+          "job_code": "policy-analyst"
+        },
+        {
+          "job_code": "innovation-consultant"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "INTJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 100
+    },
+    {
+      "guide_code": "intp-career-playbook",
+      "slug": "intp-career-playbook",
+      "locale": "en",
+      "title": "INTP Career Playbook: Let Depth Travel All the Way to Execution",
+      "excerpt": "For INTPs who think deeply and need a better bridge from elegant models to shipped work, influence, and real-world feedback.",
+      "category_slug": "career-planning",
+      "body_md": "# INTP Career Playbook\n\n## Why this guide fits INTP\nINTPs often see the model before others do. Career growth accelerates when that depth reaches a usable recommendation, tool, prototype, or published point of view.\n\n## Where INTPs usually win\n- Abstract reasoning and model building\n- Pattern detection across messy information\n- Improving methods, frameworks, and systems\n\n## Next-step moves\n1. Convert one core idea into a prototype, memo, or test every cycle.\n2. Share unfinished thinking with a small review loop before it becomes too private.\n3. Practice closing with a recommendation, not only an analysis.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "research"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "researcher"
+        },
+        {
+          "job_code": "data-scientist"
+        },
+        {
+          "job_code": "product-experimentation-lead"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "INTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 101
+    },
+    {
+      "guide_code": "entj-career-playbook",
+      "slug": "entj-career-playbook",
+      "locale": "en",
+      "title": "ENTJ Career Playbook: Scale Leadership Beyond Personal Output",
+      "excerpt": "For ENTJs who already move fast and need to turn strong personal execution into systems, delegation, and sustainable team trust.",
+      "category_slug": "career-planning",
+      "body_md": "# ENTJ Career Playbook\n\n## Why this guide fits ENTJ\nENTJs usually do not struggle with ambition. The bigger question is whether leadership is still running through personal willpower or has started to scale through people and systems.\n\n## Where ENTJs usually win\n- Direction setting and decision clarity\n- Resource coordination under pressure\n- Translating goals into execution structures\n\n## Next-step moves\n1. Define what only you should own and what should become delegated process.\n2. Review whether team pace is sustainable, not only whether targets are moving.\n3. Build a stronger feedback loop with peers and direct reports before friction becomes attrition.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "management-consultant"
+        },
+        {
+          "job_code": "product-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ENTJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 102
+    },
+    {
+      "guide_code": "entp-career-playbook",
+      "slug": "entp-career-playbook",
+      "locale": "en",
+      "title": "ENTP Career Playbook: Turn Idea Density Into Shippable Momentum",
+      "excerpt": "For ENTPs who generate options fast and need a stronger habit of turning sharp ideas into trusted experiments, results, and reputation.",
+      "category_slug": "career-planning",
+      "body_md": "# ENTP Career Playbook\n\n## Why this guide fits ENTP\nENTPs often have more ideas than any single quarter can hold. Career leverage grows when curiosity is paired with enough delivery discipline to make the best ideas real.\n\n## Where ENTPs usually win\n- Reframing stale problems from a fresh angle\n- Connecting strategy, communication, and experimentation\n- Challenging assumptions without losing speed\n\n## Next-step moves\n1. Choose fewer ideas and take more of them to a visible end state.\n2. Pair your exploratory energy with a reliable finisher or review loop.\n3. Soften delivery, not logic, when you need others to stay with you.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "innovation-consultant"
+        },
+        {
+          "job_code": "product-experimentation-lead"
+        },
+        {
+          "job_code": "management-consultant"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ENTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 103
+    },
+    {
+      "guide_code": "infj-career-playbook",
+      "slug": "infj-career-playbook",
+      "locale": "en",
+      "title": "INFJ Career Playbook: Protect Meaning While Building Real Influence",
+      "excerpt": "For INFJs who care about depth, people, and direction, and need a steadier way to turn insight into visible professional impact.",
+      "category_slug": "career-planning",
+      "body_md": "# INFJ Career Playbook\n\n## Why this guide fits INFJ\nINFJs often know what matters before they know how to say it. Career growth becomes easier when inner clarity is translated into a role, boundary, and contribution that others can actually see.\n\n## Where INFJs usually win\n- Reading deeper patterns in people and systems\n- Connecting values with long-range direction\n- Creating thoughtful support, guidance, and trust\n\n## Next-step moves\n1. Name the kind of impact you want instead of waiting for the right title to appear.\n2. Build boundaries around emotional labor before it becomes invisible over-responsibility.\n3. Practice sharing unfinished insight earlier in the process.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "healthcare"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "psychological-counselor"
+        },
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "nurse"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "INFJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 104
+    },
+    {
+      "guide_code": "infp-career-playbook",
+      "slug": "infp-career-playbook",
+      "locale": "en",
+      "title": "INFP Career Playbook: Keep Values and Craft on the Same Side",
+      "excerpt": "For INFPs who want work to feel honest, meaningful, and creatively alive without losing structure, income, or momentum.",
+      "category_slug": "career-planning",
+      "body_md": "# INFP Career Playbook\n\n## Why this guide fits INFP\nINFPs usually thrive when work feels aligned with both inner values and personal craft. Motivation collapses when output becomes empty performance or constant external pressure.\n\n## Where INFPs usually win\n- Meaningful storytelling and creative interpretation\n- Quiet empathy and one-to-one understanding\n- Work that improves experience, care, or expression\n\n## Next-step moves\n1. Define your non-negotiables for meaning before choosing the next role.\n2. Build a simple execution rhythm so inspiration has somewhere to land.\n3. Let your portfolio show what you care about, not only what you can do.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "media",
+        "education"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "content-strategist"
+        },
+        {
+          "job_code": "brand-manager"
+        },
+        {
+          "job_code": "psychological-counselor"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "INFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 105
+    },
+    {
+      "guide_code": "enfj-career-playbook",
+      "slug": "enfj-career-playbook",
+      "locale": "en",
+      "title": "ENFJ Career Playbook: Lead People Without Carrying Everyone",
+      "excerpt": "For ENFJs who energize people naturally and need better boundaries, pacing, and role clarity so care does not turn into overload.",
+      "category_slug": "career-planning",
+      "body_md": "# ENFJ Career Playbook\n\n## Why this guide fits ENFJ\nENFJs often become the emotional center of a team before anyone formally asks them to. Career growth becomes more sustainable when care is paired with boundaries, structure, and role clarity.\n\n## Where ENFJs usually win\n- Creating trust and momentum in groups\n- Turning values into communication and direction\n- Coaching, coordination, and people-facing leadership\n\n## Next-step moves\n1. Separate support from over-responsibility in every key relationship.\n2. Make people-development work visible instead of letting it stay invisible labor.\n3. Protect recovery time as part of performance, not as an optional reward.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "hospitality"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "hr-business-partner"
+        },
+        {
+          "job_code": "guest-experience-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ENFJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 106
+    },
+    {
+      "guide_code": "enfp-career-playbook",
+      "slug": "enfp-career-playbook",
+      "locale": "en",
+      "title": "ENFP Career Playbook: Keep Freedom While Protecting Delivery",
+      "excerpt": "For ENFPs who create energy, ideas, and connection easily but need a stronger closed-loop rhythm to turn momentum into career capital.",
+      "category_slug": "career-planning",
+      "body_md": "# ENFP Career Playbook\n\n## Why this guide fits ENFP\nENFPs usually do not need help generating motion. The more useful upgrade is learning how to focus that motion long enough to create visible work, trust, and repeat opportunity.\n\n## Where ENFPs usually win\n- Creative expression and idea generation\n- Connecting people, stories, and possibilities\n- Energizing new communities, products, or initiatives\n\n## Next-step moves\n1. Limit active priorities so your best energy reaches the finish line.\n2. Protect exploratory time by anchoring it to one stable output rhythm.\n3. Build a personal archive of shipped work, not only inspiring conversations.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "media",
+        "events"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "content-strategist"
+        },
+        {
+          "job_code": "event-experience-producer"
+        },
+        {
+          "job_code": "brand-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ENFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 107
+    },
+    {
+      "guide_code": "istj-career-playbook",
+      "slug": "istj-career-playbook",
+      "locale": "en",
+      "title": "ISTJ Career Playbook: Stay Reliable Without Getting Stuck",
+      "excerpt": "For ISTJs who already deliver steady value and need more visibility, flexibility, and role expansion without losing their standards.",
+      "category_slug": "career-planning",
+      "body_md": "# ISTJ Career Playbook\n\n## Why this guide fits ISTJ\nISTJs are often trusted because they do what they say and keep systems stable. The next upgrade is making that reliability more visible and adaptable as scope grows.\n\n## Where ISTJs usually win\n- Process discipline and dependable execution\n- Quality control, compliance, and operational follow-through\n- Building routines people can count on\n\n## Next-step moves\n1. Explain the value of your work before others assume it is just maintenance.\n2. Practice small flexibility in low-risk situations so change feels less disruptive.\n3. Link accuracy to business impact when you communicate upward.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "finance",
+        "operations"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "financial-planner"
+        },
+        {
+          "job_code": "lawyer"
+        },
+        {
+          "job_code": "supply-chain-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ISTJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 108
+    },
+    {
+      "guide_code": "isfj-career-playbook",
+      "slug": "isfj-career-playbook",
+      "locale": "en",
+      "title": "ISFJ Career Playbook: Protect Care With Better Boundaries",
+      "excerpt": "For ISFJs who support people steadily and need clearer boundaries so reliability remains a strength instead of a hidden drain.",
+      "category_slug": "career-planning",
+      "body_md": "# ISFJ Career Playbook\n\n## Why this guide fits ISFJ\nISFJs often become indispensable because they notice what others need before anyone asks. Career growth becomes healthier when care is paired with explicit boundaries and role recognition.\n\n## Where ISFJs usually win\n- Consistent support and follow-through\n- Thoughtful service and people care\n- Detail-sensitive execution in stable systems\n\n## Next-step moves\n1. Name which support tasks are truly part of your role.\n2. Track invisible contributions so they can be recognized in reviews.\n3. Build recovery habits before helpfulness turns into exhaustion.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "healthcare",
+        "education"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "nurse"
+        },
+        {
+          "job_code": "pharmacist"
+        },
+        {
+          "job_code": "teacher"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ISFJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 109
+    },
+    {
+      "guide_code": "estj-career-playbook",
+      "slug": "estj-career-playbook",
+      "locale": "en",
+      "title": "ESTJ Career Playbook: Upgrade Strong Execution Into Durable Leadership",
+      "excerpt": "For ESTJs who already deliver hard results and need a better balance of authority, flexibility, and team sustainability.",
+      "category_slug": "career-planning",
+      "body_md": "# ESTJ Career Playbook\n\n## Why this guide fits ESTJ\nESTJs usually know how to create order and get results. The next level is learning when to push harder, when to adapt, and how to keep standards high without over-controlling the system.\n\n## Where ESTJs usually win\n- Clear structure, accountability, and pace\n- Operational consistency and decision speed\n- Protecting execution quality under pressure\n\n## Next-step moves\n1. Separate essential standards from personal preferences.\n2. Build room for feedback before problems become resistance.\n3. Train successors and systems so performance does not depend on your constant intervention.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "operations",
+        "finance"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "financial-planner"
+        },
+        {
+          "job_code": "supply-chain-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ESTJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 110
+    },
+    {
+      "guide_code": "esfj-career-playbook",
+      "slug": "esfj-career-playbook",
+      "locale": "en",
+      "title": "ESFJ Career Playbook: Turn Care Into Professional Influence",
+      "excerpt": "For ESFJs who support teams and customers generously and need clearer boundaries so warmth becomes recognized professional value.",
+      "category_slug": "career-planning",
+      "body_md": "# ESFJ Career Playbook\n\n## Why this guide fits ESFJ\nESFJs are often the people others trust first. Career growth becomes stronger when care, reliability, and service are treated as professional capabilities rather than assumed emotional labor.\n\n## Where ESFJs usually win\n- Relationship maintenance and practical support\n- Service quality and team coordination\n- Building trust through consistency and responsiveness\n\n## Next-step moves\n1. Name the operational value behind your people work.\n2. Stop rescuing every process gap by yourself.\n3. Protect a few non-negotiable boundaries around energy and time.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "hospitality"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "hr-business-partner"
+        },
+        {
+          "job_code": "guest-experience-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ESFJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 111
+    },
+    {
+      "guide_code": "istp-career-playbook",
+      "slug": "istp-career-playbook",
+      "locale": "en",
+      "title": "ISTP Career Playbook: Make Technical Strength More Visible and Durable",
+      "excerpt": "For ISTPs who solve real problems well and need a stronger way to make skill, judgment, and long-term direction more visible.",
+      "category_slug": "career-planning",
+      "body_md": "# ISTP Career Playbook\n\n## Why this guide fits ISTP\nISTPs often gain trust by fixing what other people cannot. Career ceilings rise when technical skill is paired with stronger visibility, collaboration, and a more deliberate map for what comes next.\n\n## Where ISTPs usually win\n- Hands-on troubleshooting and calm decision making\n- Rapid learning through direct experimentation\n- Independent work with clear technical feedback\n\n## Next-step moves\n1. Describe the value behind your technical fixes, not only the fix itself.\n2. Build enough relationship trust that autonomy does not look like disengagement.\n3. Choose one future-facing capability to deepen before urgency chooses it for you.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "engineering",
+        "design"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "field-service-engineer"
+        },
+        {
+          "job_code": "industrial-designer"
+        },
+        {
+          "job_code": "cybersecurity-analyst"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ISTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 112
+    },
+    {
+      "guide_code": "isfp-career-playbook",
+      "slug": "isfp-career-playbook",
+      "locale": "en",
+      "title": "ISFP Career Playbook: Let Your Work Be Seen Without Losing Your Tone",
+      "excerpt": "For ISFPs who create with sincerity and taste, and need a gentler way to make work visible, valued, and sustainable over time.",
+      "category_slug": "career-planning",
+      "body_md": "# ISFP Career Playbook\n\n## Why this guide fits ISFP\nISFPs often do their best work quietly, through craft, atmosphere, and care. Career momentum grows when that quality is made easier to notice without forcing a louder identity than feels true.\n\n## Where ISFPs usually win\n- Taste, feeling, and experience sensitivity\n- Creating work that is gentle, usable, and human\n- Craft that improves everyday life in tangible ways\n\n## Next-step moves\n1. Help your work get seen before assuming it will speak entirely for itself.\n2. Protect creative energy with firmer boundaries around requests.\n3. Add a light long-term plan so freedom does not become drift.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "design",
+        "media"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "industrial-designer"
+        },
+        {
+          "job_code": "ui-ux-designer"
+        },
+        {
+          "job_code": "content-strategist"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ISFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 113
+    },
+    {
+      "guide_code": "estp-career-playbook",
+      "slug": "estp-career-playbook",
+      "locale": "en",
+      "title": "ESTP Career Playbook: Pair Fast Action With Better Risk Framing",
+      "excerpt": "For ESTPs who move quickly in the real world and need a stronger habit of turning instinct, momentum, and nerve into durable judgment.",
+      "category_slug": "career-planning",
+      "body_md": "# ESTP Career Playbook\n\n## Why this guide fits ESTP\nESTPs often create opportunity by acting while others are still hesitating. Career growth gets stronger when speed is paired with enough framing to reduce avoidable risk and make wins repeatable.\n\n## Where ESTPs usually win\n- Fast action in uncertain real-world settings\n- Reading people, pressure, and timing in the moment\n- Closing gaps between intention and execution\n\n## Next-step moves\n1. Slow down just enough to define the risk before the jump.\n2. Capture what is working so instinct becomes repeatable playbook.\n3. Pair adrenaline-heavy work with one longer-term capability build.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "sales",
+        "operations"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "sales-manager"
+        },
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "field-service-engineer"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ESTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 114
+    },
+    {
+      "guide_code": "esfp-career-playbook",
+      "slug": "esfp-career-playbook",
+      "locale": "en",
+      "title": "ESFP Career Playbook: Keep Energy High While Building Lasting Skill",
+      "excerpt": "For ESFPs who thrive in live, people-rich environments and want to turn presence, warmth, and improvisation into durable career growth.",
+      "category_slug": "career-planning",
+      "body_md": "# ESFP Career Playbook\n\n## Why this guide fits ESFP\nESFPs often shine where there is energy, immediacy, and real human response. Career growth becomes stronger when that live strength is paired with a little more planning, boundary, and skill accumulation.\n\n## Where ESFPs usually win\n- Creating atmosphere and human connection in the moment\n- Responding fluidly to changing situations\n- Turning service, performance, or experience into real loyalty\n\n## Next-step moves\n1. Keep the spontaneity, but anchor it to one simple planning habit.\n2. Decide what you will and will not absorb from other people’s moods.\n3. Build one durable skill behind the visible charisma.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "events",
+        "hospitality"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "event-experience-producer"
+        },
+        {
+          "job_code": "guest-experience-manager"
+        },
+        {
+          "job_code": "brand-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ESFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 115
     }
   ]
 }

--- a/content_baselines/career_guides/career_guides.zh-CN.json
+++ b/content_baselines/career_guides/career_guides.zh-CN.json
@@ -465,20 +465,7 @@
           "slug": "mbti-narrative-portrait"
         }
       ],
-      "related_personality_profiles": [
-        {
-          "type_code": "INTJ"
-        },
-        {
-          "type_code": "ENFP"
-        },
-        {
-          "type_code": "ISTJ"
-        },
-        {
-          "type_code": "ENTP"
-        }
-      ],
+      "related_personality_profiles": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -971,6 +958,806 @@
       "published_at": "2026-03-05",
       "scheduled_at": null,
       "sort_order": 0
+    },
+    {
+      "guide_code": "intj-career-playbook",
+      "slug": "intj-career-playbook",
+      "locale": "zh-CN",
+      "title": "INTJ 职业行动指南：把判断力变成可被信任的影响力",
+      "excerpt": "写给已经很会做系统判断、但还需要把私人结论变成公开影响力与合作信任的 INTJ。",
+      "category_slug": "career-planning",
+      "body_md": "# INTJ 职业行动指南\n\n## 为什么这篇指南适合 INTJ\nINTJ 真正的瓶颈，往往不是判断力不够，而是如何让高质量判断被更多人理解、信任并愿意一起执行。\n\n## INTJ 常见的职业优势\n- 长线规划与系统搭建\n- 在复杂约束里做冷静取舍\n- 把一次性成果升级成长期结构\n\n## 下一步动作\n1. 在高风险沟通里先讲框架，再讲结论。\n2. 每个季度留下一个可见成果：路线图、备忘录、架构说明或判断模型。\n3. 给深度工作配一套固定的对齐节奏，别只在脑内完成闭环。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "cloud-architect"
+        },
+        {
+          "job_code": "policy-analyst"
+        },
+        {
+          "job_code": "innovation-consultant"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "INTJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 100
+    },
+    {
+      "guide_code": "intp-career-playbook",
+      "slug": "intp-career-playbook",
+      "locale": "zh-CN",
+      "title": "INTP 职业行动指南：让深度思考走到落地",
+      "excerpt": "写给擅长建模和抽象思考、但需要把洞见更快转成作品、建议和真实反馈的 INTP。",
+      "category_slug": "career-planning",
+      "body_md": "# INTP 职业行动指南\n\n## 为什么这篇指南适合 INTP\nINTP 并不缺想法，真正拉开差距的，是你能不能把高质量思考送到原型、结论、工具或被采用的方法论。\n\n## INTP 常见的职业优势\n- 抽象推理与模型搭建\n- 在复杂信息里发现规律\n- 优化方法、流程和系统结构\n\n## 下一步动作\n1. 每个阶段至少把一个核心想法做成原型、备忘录或小实验。\n2. 别等完全想明白再交流，先建立一个小范围反馈回路。\n3. 练习用“建议是什么”收尾，而不是只停在分析本身。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "research"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "researcher"
+        },
+        {
+          "job_code": "data-scientist"
+        },
+        {
+          "job_code": "product-experimentation-lead"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "INTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 101
+    },
+    {
+      "guide_code": "entj-career-playbook",
+      "slug": "entj-career-playbook",
+      "locale": "zh-CN",
+      "title": "ENTJ 职业行动指南：把领导力从亲力亲为升级成系统放大",
+      "excerpt": "写给已经很能冲结果、但需要把个人强执行升级为系统协同、授权与团队信任的 ENTJ。",
+      "category_slug": "career-planning",
+      "body_md": "# ENTJ 职业行动指南\n\n## 为什么这篇指南适合 ENTJ\nENTJ 往往不缺目标感，真正的升级点在于：你的领导力是否还主要靠个人推动，还是已经开始通过团队、机制与授权持续放大。\n\n## ENTJ 常见的职业优势\n- 定方向、做决策、压节奏\n- 在压力下整合资源\n- 把目标拆成可执行结构\n\n## 下一步动作\n1. 明确哪些事情必须你亲自做，哪些应该被流程化和授权出去。\n2. 定期检查团队节奏是否可持续，而不是只看目标有没有推进。\n3. 提前建立来自平级与下属的反馈回路，别等磨损变成人员流失。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "management-consultant"
+        },
+        {
+          "job_code": "product-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ENTJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 102
+    },
+    {
+      "guide_code": "entp-career-playbook",
+      "slug": "entp-career-playbook",
+      "locale": "zh-CN",
+      "title": "ENTP 职业行动指南：把点子密度变成可交付结果",
+      "excerpt": "写给点子很多、判断很快，但需要把创造力更稳定地压成实验、作品与职业口碑的 ENTP。",
+      "category_slug": "career-planning",
+      "body_md": "# ENTP 职业行动指南\n\n## 为什么这篇指南适合 ENTP\nENTP 常常不是缺灵感，而是容易让太多可能性同时展开。职业成长真正拉开差距的，是你能把多少好点子真正送到终点。\n\n## ENTP 常见的职业优势\n- 用新角度重构老问题\n- 把策略、表达与试验串起来\n- 在高变化环境里持续发现机会\n\n## 下一步动作\n1. 少开几个新题，多把已选方向推进到可见结果。\n2. 给自己配一个稳定的收尾机制或靠谱搭档。\n3. 不用降低逻辑，只要把表达方式再柔和一点。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "innovation-consultant"
+        },
+        {
+          "job_code": "product-experimentation-lead"
+        },
+        {
+          "job_code": "management-consultant"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ENTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 103
+    },
+    {
+      "guide_code": "infj-career-playbook",
+      "slug": "infj-career-playbook",
+      "locale": "zh-CN",
+      "title": "INFJ 职业行动指南：守住意义感，也要建立现实影响力",
+      "excerpt": "写给很重视深度、价值和人，但还需要把内在洞察变成清晰职业路径与可见贡献的 INFJ。",
+      "category_slug": "career-planning",
+      "body_md": "# INFJ 职业行动指南\n\n## 为什么这篇指南适合 INFJ\nINFJ 往往很早就知道什么重要，却不一定立刻知道该怎样把这种判断讲清、做实、被看见。职业成长会在“内在清晰”变成“外部角色”后明显提速。\n\n## INFJ 常见的职业优势\n- 看见人和系统里的深层模式\n- 把价值感与长期方向连接起来\n- 提供高质量的支持、引导与信任感\n\n## 下一步动作\n1. 主动命名你想创造的影响，而不是只等待一个完美职位。\n2. 提前给情绪劳动设边界，别把过度负责当成责任感。\n3. 更早分享半成型洞察，让外部反馈帮助你落地。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "healthcare"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "psychological-counselor"
+        },
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "nurse"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "INFJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 104
+    },
+    {
+      "guide_code": "infp-career-playbook",
+      "slug": "infp-career-playbook",
+      "locale": "zh-CN",
+      "title": "INFP 职业行动指南：让价值感和作品感同时成立",
+      "excerpt": "写给想让工作既真诚、有意义，又能稳定产出并持续推进的 INFP。",
+      "category_slug": "career-planning",
+      "body_md": "# INFP 职业行动指南\n\n## 为什么这篇指南适合 INFP\nINFP 往往只有在工作既符合内在价值、又允许表达个人作品感时，才会真正进入高投入状态。空洞表演和持续外压会很快抽空动力。\n\n## INFP 常见的职业优势\n- 有温度的叙事与表达\n- 一对一理解人的能力\n- 改善体验、关怀与表达品质的敏感度\n\n## 下一步动作\n1. 先定义你在工作里不能妥协的价值底线。\n2. 给灵感配一个轻量执行节奏，别只停在感受里。\n3. 让作品集同时呈现能力和你真正关心的主题。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "media",
+        "education"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "content-strategist"
+        },
+        {
+          "job_code": "brand-manager"
+        },
+        {
+          "job_code": "psychological-counselor"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "INFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 105
+    },
+    {
+      "guide_code": "enfj-career-playbook",
+      "slug": "enfj-career-playbook",
+      "locale": "zh-CN",
+      "title": "ENFJ 职业行动指南：带团队，不等于替所有人扛情绪",
+      "excerpt": "写给很会点燃团队、支持别人，但也容易因为边界不清而过度透支的 ENFJ。",
+      "category_slug": "career-planning",
+      "body_md": "# ENFJ 职业行动指南\n\n## 为什么这篇指南适合 ENFJ\nENFJ 常常在没有被正式任命之前，就已经成为团队的情绪中心和推动者。真正可持续的成长，是在关心别人时也保住自己的边界、节奏和角色清晰度。\n\n## ENFJ 常见的职业优势\n- 搭建信任与群体 momentum\n- 把价值感翻成沟通与方向\n- 人本领导、协调与培养他人\n\n## 下一步动作\n1. 在每段重要合作里区分“支持”与“过度负责”。\n2. 把培养人、稳氛围这类贡献明确呈现出来。\n3. 把恢复精力当成职业表现的一部分，而不是额外奖励。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "hospitality"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "hr-business-partner"
+        },
+        {
+          "job_code": "guest-experience-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ENFJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 106
+    },
+    {
+      "guide_code": "enfp-career-playbook",
+      "slug": "enfp-career-playbook",
+      "locale": "zh-CN",
+      "title": "ENFP 职业行动指南：保留自由度，也要守住闭环率",
+      "excerpt": "写给创意、热情和连接力都很强，但需要把动能更稳定地沉淀成结果与职业资本的 ENFP。",
+      "category_slug": "career-planning",
+      "body_md": "# ENFP 职业行动指南\n\n## 为什么这篇指南适合 ENFP\nENFP 往往并不缺行动力和灵感，真正有价值的升级，是把这些能量集中在少数重要项目上，让它们真的走到结果端。\n\n## ENFP 常见的职业优势\n- 创意表达与点子生成\n- 连接人、故事与可能性\n- 给新项目、新社区带来活力\n\n## 下一步动作\n1. 缩少同时展开的重点，让好状态真正触达终点。\n2. 给探索时间配一个稳定产出节奏。\n3. 建立自己的作品档案，而不是只留下很多精彩聊天。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "media",
+        "events"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "content-strategist"
+        },
+        {
+          "job_code": "event-experience-producer"
+        },
+        {
+          "job_code": "brand-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ENFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 107
+    },
+    {
+      "guide_code": "istj-career-playbook",
+      "slug": "istj-career-playbook",
+      "locale": "zh-CN",
+      "title": "ISTJ 职业行动指南：在可靠之外，增加一点表达和弹性",
+      "excerpt": "写给已经很稳、很可靠，但需要让价值更可见、角色更上一个台阶的 ISTJ。",
+      "category_slug": "career-planning",
+      "body_md": "# ISTJ 职业行动指南\n\n## 为什么这篇指南适合 ISTJ\nISTJ 很容易因为稳定、负责而被依赖，但职业升级真正需要的，是在保持标准的同时，让这种价值更可见、也更能适应范围扩张。\n\n## ISTJ 常见的职业优势\n- 流程纪律与稳定执行\n- 质量、规范与收尾能力\n- 搭建别人可以长期依赖的例行系统\n\n## 下一步动作\n1. 主动解释你的工作为什么重要，别让价值被默认为日常维护。\n2. 在低风险场景里练习一点弹性，降低对变化的排斥。\n3. 向上沟通时，把准确性翻成业务影响。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "finance",
+        "operations"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "financial-planner"
+        },
+        {
+          "job_code": "lawyer"
+        },
+        {
+          "job_code": "supply-chain-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ISTJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 108
+    },
+    {
+      "guide_code": "isfj-career-playbook",
+      "slug": "isfj-career-playbook",
+      "locale": "zh-CN",
+      "title": "ISFJ 职业行动指南：照顾别人之前，先保住自己的边界",
+      "excerpt": "写给总能照顾细节、支持他人，但也容易把责任越扛越多的 ISFJ。",
+      "category_slug": "career-planning",
+      "body_md": "# ISFJ 职业行动指南\n\n## 为什么这篇指南适合 ISFJ\nISFJ 很容易因为“总能补位”和“很会照顾人”而变得不可替代，但如果没有边界，这种优势也会慢慢变成看不见的消耗。\n\n## ISFJ 常见的职业优势\n- 稳定支持与高质量收尾\n- 细腻服务与照顾人的能力\n- 在相对稳定体系里的执行可靠度\n\n## 下一步动作\n1. 先说清哪些支持工作属于你的职责。\n2. 把隐形贡献记录下来，别等别人自动看见。\n3. 在乐于助人之前，先建立自己的恢复节奏。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "healthcare",
+        "education"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "nurse"
+        },
+        {
+          "job_code": "pharmacist"
+        },
+        {
+          "job_code": "teacher"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ISFJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 109
+    },
+    {
+      "guide_code": "estj-career-playbook",
+      "slug": "estj-career-playbook",
+      "locale": "zh-CN",
+      "title": "ESTJ 职业行动指南：把强执行升级成可持续领导力",
+      "excerpt": "写给很会扛结果、带节奏，但需要在权威、弹性和团队可持续之间找到更好平衡的 ESTJ。",
+      "category_slug": "career-planning",
+      "body_md": "# ESTJ 职业行动指南\n\n## 为什么这篇指南适合 ESTJ\nESTJ 通常知道怎样建立秩序、推进目标、压住执行质量。下一步更关键的是：什么时候该加压，什么时候该调节，以及如何避免所有结果都靠你亲自盯住。\n\n## ESTJ 常见的职业优势\n- 清晰结构、责任感和推进节奏\n- 在压力下保持运营稳定\n- 让团队知道什么是标准和交付要求\n\n## 下一步动作\n1. 区分哪些是核心标准，哪些只是个人偏好。\n2. 提前建立反馈空间，别等阻力升级才处理。\n3. 培养接班人与流程，让结果不再只依赖你一直盯着。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "operations",
+        "finance"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "financial-planner"
+        },
+        {
+          "job_code": "supply-chain-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ESTJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 110
+    },
+    {
+      "guide_code": "esfj-career-playbook",
+      "slug": "esfj-career-playbook",
+      "locale": "zh-CN",
+      "title": "ESFJ 职业行动指南：让照顾力成为专业影响力，而不是情绪负担",
+      "excerpt": "写给很会照顾团队和客户、也容易把温暖当成理所当然职责的 ESFJ。",
+      "category_slug": "career-planning",
+      "body_md": "# ESFJ 职业行动指南\n\n## 为什么这篇指南适合 ESFJ\nESFJ 很容易成为团队里最先被信任的人，但职业升级真正需要的，是把这种温暖、稳定和响应力翻成专业价值，而不是默默承担所有情绪劳动。\n\n## ESFJ 常见的职业优势\n- 关系维护与务实支持\n- 服务质量与团队协调\n- 用稳定回应建立长期信任\n\n## 下一步动作\n1. 主动说清你在人与流程之间创造了什么价值。\n2. 不要再独自补所有系统漏洞。\n3. 给时间和精力设几个真正不能退让的边界。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "hospitality"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "hr-business-partner"
+        },
+        {
+          "job_code": "guest-experience-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ESFJ"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 111
+    },
+    {
+      "guide_code": "istp-career-playbook",
+      "slug": "istp-career-playbook",
+      "locale": "zh-CN",
+      "title": "ISTP 职业行动指南：把技术力变成可见的长期筹码",
+      "excerpt": "写给很能解决真实问题，但还需要让能力更可见、协作更顺、长期路径更清晰的 ISTP。",
+      "category_slug": "career-planning",
+      "body_md": "# ISTP 职业行动指南\n\n## 为什么这篇指南适合 ISTP\nISTP 很容易因为“能解决问题”而被依赖，但职业上限会在你学会把技术价值讲清楚、建立必要协作信任、并提前规划下一步时继续上升。\n\n## ISTP 常见的职业优势\n- 动手排障与冷静判断\n- 在真实试错里快速学习\n- 喜欢有直接技术反馈的独立工作\n\n## 下一步动作\n1. 讲清楚你做的不只是修好问题，而是降低了什么风险。\n2. 让必要的协作存在，别让自主看起来像抽离。\n3. 先主动选一个未来能力深化，而不是总等着被任务推着走。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "engineering",
+        "design"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "field-service-engineer"
+        },
+        {
+          "job_code": "industrial-designer"
+        },
+        {
+          "job_code": "cybersecurity-analyst"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ISTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 112
+    },
+    {
+      "guide_code": "isfp-career-playbook",
+      "slug": "isfp-career-playbook",
+      "locale": "zh-CN",
+      "title": "ISFP 职业行动指南：作品会说话，但你也要帮它被看到",
+      "excerpt": "写给有审美、有感受力、做事真诚，但需要让作品更可见、价值更稳定沉淀下来的 ISFP。",
+      "category_slug": "career-planning",
+      "body_md": "# ISFP 职业行动指南\n\n## 为什么这篇指南适合 ISFP\nISFP 很多时候是安静地把作品做好，再慢慢改变别人对一个空间、一个产品、一次体验的感受。职业 momentum 的关键，是让这种质量更容易被看见，而不是逼自己变成完全不同的人。\n\n## ISFP 常见的职业优势\n- 对审美、氛围与体验的敏感度\n- 做出温柔、好用、有人味的作品\n- 用具体成果改善日常生活质感\n\n## 下一步动作\n1. 主动为作品争取被看见的机会，别只靠结果自己发声。\n2. 给需求设边界，保护创作与恢复空间。\n3. 加一点长期规划，让自由不再等于漂着走。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "design",
+        "media"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "industrial-designer"
+        },
+        {
+          "job_code": "ui-ux-designer"
+        },
+        {
+          "job_code": "content-strategist"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ISFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 113
+    },
+    {
+      "guide_code": "estp-career-playbook",
+      "slug": "estp-career-playbook",
+      "locale": "zh-CN",
+      "title": "ESTP 职业行动指南：把行动力变成更稳的判断力",
+      "excerpt": "写给很会抓现场机会、推进现实结果，但需要把速度再升级成可复制判断与长期筹码的 ESTP。",
+      "category_slug": "career-planning",
+      "body_md": "# ESTP 职业行动指南\n\n## 为什么这篇指南适合 ESTP\nESTP 很擅长在别人还犹豫的时候先动起来。真正的职业升级，是让这种速度多一点风险框架、多一点复盘，让胜利不只是偶然状态，而是可复制能力。\n\n## ESTP 常见的职业优势\n- 在真实场景里快速行动\n- 读懂人、压力和时机\n- 缩短想法与执行之间的距离\n\n## 下一步动作\n1. 出手前多花一点时间定义风险边界。\n2. 把直觉型成功沉淀成可重复的方法。\n3. 在高刺激工作之外，也给自己留一个长期能力建设项。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "sales",
+        "operations"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "sales-manager"
+        },
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "field-service-engineer"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ESTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 114
+    },
+    {
+      "guide_code": "esfp-career-playbook",
+      "slug": "esfp-career-playbook",
+      "locale": "zh-CN",
+      "title": "ESFP 职业行动指南：保留现场感染力，也要沉淀长期能力",
+      "excerpt": "写给很会带动现场、和人建立真实连接，但也想把热情沉淀成更稳定职业成长的 ESFP。",
+      "category_slug": "career-planning",
+      "body_md": "# ESFP 职业行动指南\n\n## 为什么这篇指南适合 ESFP\nESFP 最擅长的，往往是现场感、互动感和真实回应。职业升级真正需要补的一点点，是简单计划、边界感，以及能长期积累下来的能力资产。\n\n## ESFP 常见的职业优势\n- 在当下营造氛围与连接感\n- 灵活应对变化中的人和情境\n- 把服务、内容或体验做得有记忆点\n\n## 下一步动作\n1. 保留即兴，但给自己配一个最简单的计划习惯。\n2. 区分哪些情绪该共情，哪些情绪不必全盘接住。\n3. 在可见魅力背后，持续沉淀一个硬能力。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "events",
+        "hospitality"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "event-experience-producer"
+        },
+        {
+          "job_code": "guest-experience-manager"
+        },
+        {
+          "job_code": "brand-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [
+        {
+          "type_code": "ESFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 115
     }
   ]
 }

--- a/content_baselines/career_jobs/career_jobs.en.json
+++ b/content_baselines/career_jobs/career_jobs.en.json
@@ -34,9 +34,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -52,7 +50,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -114,9 +119,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -159,9 +162,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -177,7 +178,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFP",
+        "ENTP",
+        "ESFP",
+        "INFJ",
+        "INFP",
+        "ISFP"
+      ],
       "mbti_primary_codes_json": [
         "INFP",
         "ENFP",
@@ -239,9 +247,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -284,9 +290,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -302,7 +306,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -364,9 +375,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -409,9 +418,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -427,7 +434,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -489,9 +503,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -534,9 +546,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -552,7 +562,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFP",
+        "ENTP",
+        "ESFP",
+        "INFJ",
+        "INFP",
+        "ISFP"
+      ],
       "mbti_primary_codes_json": [
         "INFP",
         "ENFP",
@@ -614,9 +631,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -659,9 +674,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -677,7 +690,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -739,9 +759,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -784,9 +802,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -802,7 +818,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -864,9 +887,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -909,9 +930,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -927,7 +946,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -989,9 +1015,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1034,9 +1058,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1052,7 +1074,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -1114,9 +1143,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1159,9 +1186,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1177,7 +1202,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ESFJ",
+        "ESTJ",
+        "ESTP",
+        "ISFJ",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "ESTJ",
         "ISTJ",
@@ -1239,9 +1271,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1284,9 +1314,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1302,7 +1330,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -1364,9 +1399,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1409,9 +1442,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1427,7 +1458,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -1489,9 +1527,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1534,9 +1570,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1552,7 +1586,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -1614,9 +1655,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1659,9 +1698,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1677,7 +1714,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -1739,9 +1783,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1784,9 +1826,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1802,7 +1842,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ESFJ",
+        "ESTJ",
+        "ESTP",
+        "ISFJ",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "ESTJ",
         "ISTJ",
@@ -1864,9 +1911,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1909,9 +1954,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1927,7 +1970,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -1989,9 +2039,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2034,9 +2082,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2052,7 +2098,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -2114,9 +2167,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2159,9 +2210,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2177,7 +2226,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -2239,9 +2295,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2284,9 +2338,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2302,7 +2354,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -2364,9 +2423,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2409,9 +2466,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2427,7 +2482,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -2489,9 +2551,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2534,9 +2594,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2552,7 +2610,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -2614,9 +2679,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2659,9 +2722,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2677,7 +2738,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -2739,9 +2807,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2784,9 +2850,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2802,7 +2866,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -2864,9 +2935,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2909,9 +2978,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2927,7 +2994,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -2989,9 +3063,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3034,9 +3106,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3052,7 +3122,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -3114,9 +3191,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3159,9 +3234,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3177,7 +3250,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -3239,9 +3319,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3284,9 +3362,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3302,7 +3378,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -3364,9 +3447,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3409,9 +3490,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3427,7 +3506,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -3489,9 +3575,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3534,9 +3618,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3552,7 +3634,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -3614,9 +3703,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3659,9 +3746,7 @@
           "Data-informed decision making",
           "Continuous learning"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3677,7 +3762,14 @@
           "5+ years: move toward specialist leadership or managerial scope."
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFP",
+        "ENTP",
+        "ESFP",
+        "INFJ",
+        "INFP",
+        "ISFP"
+      ],
       "mbti_primary_codes_json": [
         "INFP",
         "ENFP",
@@ -3739,9 +3831,757 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "innovation-consultant",
+      "slug": "innovation-consultant",
+      "locale": "en",
+      "title": "Innovation Consultant",
+      "subtitle": null,
+      "excerpt": "Help teams frame ambiguous problems, test fresh solutions, and turn early-stage ideas into practical business options.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": "Consulting",
+      "body_md": "# Innovation Consultant\n\n## Role Overview\nInnovation Consultants help organizations turn uncertain opportunities into testable strategic choices. The work rewards people who enjoy reframing problems, spotting leverage, and moving ideas from debate into decisions.\n\n## Core Work Scope\n- Clarify the business question behind noisy requests.\n- Design experiments, workshops, and decision frameworks.\n- Translate qualitative signals into an actionable recommendation.\n\n## Career Development Advice\nBuild a portfolio of problem-framing memos, experiment designs, and recommendation decks. The faster you can show both creativity and structure, the more trust you earn in high-ambiguity work.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$70,000 - $190,000 (varies by market, firm, and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand is strongest in consulting, innovation labs, and transformation teams that need structured experimentation."
+      },
+      "skills_json": {
+        "core": [
+          "Problem framing",
+          "Workshop design",
+          "Strategic communication",
+          "Experiment planning",
+          "Stakeholder synthesis"
+        ],
+        "supporting": [
+          "Market research",
+          "Deck writing"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Diagnose why a growth or product problem is stuck.",
+          "Run structured discovery sessions with leaders and operators.",
+          "Turn competing ideas into a roadmap, pilot, or decision memo."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: learn discovery and synthesis discipline.",
+          "3-5 years: own workstreams and guide decision workshops.",
+          "5+ years: lead transformation programs or specialized innovation practices."
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INTJ"
       ],
+      "mbti_primary_codes_json": [
+        "ENTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "INTJ"
+      ],
+      "riasec_profile_json": {
+        "R": 28,
+        "I": 79,
+        "A": 74,
+        "S": 45,
+        "E": 71,
+        "C": 42
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 65,
+            "max": 100
+          },
+          "conscientiousness": {
+            "min": 45,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 45,
+            "max": 95
+          },
+          "agreeableness": {
+            "min": 30,
+            "max": 80
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 60
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 48,
+          "max": 92
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 100,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "product-experimentation-lead",
+      "slug": "product-experimentation-lead",
+      "locale": "en",
+      "title": "Product Experimentation Lead",
+      "subtitle": null,
+      "excerpt": "Design rapid product tests, learn from imperfect signals, and turn curiosity into repeatable growth decisions.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": "Technology",
+      "body_md": "# Product Experimentation Lead\n\n## Role Overview\nProduct Experimentation Leads sit between strategy, product, and growth. They turn strong hypotheses into fast tests, then decide what deserves another round of investment.\n\n## Core Work Scope\n- Translate opportunity ideas into measurable experiments.\n- Coordinate design, product, and data partners around a tight learning loop.\n- Separate signal from noise fast enough to keep momentum.\n\n## Career Development Advice\nTreat every launch as a learning asset. The strongest people in this role build a visible record of what they tested, what they learned, and how those lessons changed the roadmap.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$80,000 - $210,000 (varies by market, product scope, and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Growth-stage product teams continue to hire for fast experimentation and evidence-based iteration."
+      },
+      "skills_json": {
+        "core": [
+          "Experiment design",
+          "Product judgment",
+          "Decision writing",
+          "Cross-functional alignment",
+          "Learning velocity"
+        ],
+        "supporting": [
+          "Analytics interpretation",
+          "User research"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Prioritize which hypotheses deserve a live test.",
+          "Define metrics, success thresholds, and guardrails.",
+          "Convert experiment outcomes into product or growth decisions."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build testing fluency and product intuition.",
+          "3-5 years: lead multi-team experiment programs.",
+          "5+ years: move into product strategy, growth leadership, or new-venture incubation."
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ENTP",
+        "INTP",
+        "ISTP"
+      ],
+      "mbti_primary_codes_json": [
+        "ENTP",
+        "INTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISTP"
+      ],
+      "riasec_profile_json": {
+        "R": 30,
+        "I": 81,
+        "A": 66,
+        "S": 38,
+        "E": 67,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 70,
+            "max": 100
+          },
+          "conscientiousness": {
+            "min": 45,
+            "max": 85
+          },
+          "extraversion": {
+            "min": 30,
+            "max": 85
+          },
+          "agreeableness": {
+            "min": 25,
+            "max": 78
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 58
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 66,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 42,
+          "max": 88
+        }
+      },
+      "market_demand_json": {
+        "raw": 81
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 101,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "field-service-engineer",
+      "slug": "field-service-engineer",
+      "locale": "en",
+      "title": "Field Service Engineer",
+      "subtitle": null,
+      "excerpt": "Solve real equipment or systems problems on site, where calm diagnosis and hands-on judgment matter more than abstract theory alone.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "engineering",
+      "industry_label": "Engineering",
+      "body_md": "# Field Service Engineer\n\n## Role Overview\nField Service Engineers step into live environments, identify what is actually broken, and restore reliable performance with limited time and imperfect information.\n\n## Core Work Scope\n- Diagnose mechanical, electrical, or system failures on site.\n- Stabilize urgent issues without losing safety and quality standards.\n- Explain root causes and preventive fixes to customers or internal teams.\n\n## Career Development Advice\nDocument your troubleshooting logic, not just the fix. The engineers who grow fastest can teach others how they noticed patterns under pressure.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$60,000 - $170,000 (varies by industry, region, and travel requirements)"
+      },
+      "outlook_json": {
+        "summary": "Demand stays resilient in industrial systems, infrastructure, medical devices, and enterprise hardware support."
+      },
+      "skills_json": {
+        "core": [
+          "Troubleshooting",
+          "Hands-on repair",
+          "Root-cause analysis",
+          "Safety discipline",
+          "Customer communication"
+        ],
+        "supporting": [
+          "Documentation",
+          "Preventive maintenance planning"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Inspect systems in real operating conditions.",
+          "Diagnose the most likely failure point under time pressure.",
+          "Recommend repairs, replacements, or process changes that reduce repeat incidents."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build diagnostic confidence and field discipline.",
+          "3-5 years: own complex site issues and customer relationships.",
+          "5+ years: move into technical specialist, reliability, or regional operations leadership roles."
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ESTP",
+        "INTJ",
+        "ISTP"
+      ],
+      "mbti_primary_codes_json": [
+        "ISTP",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INTJ"
+      ],
+      "riasec_profile_json": {
+        "R": 88,
+        "I": 72,
+        "A": 34,
+        "S": 28,
+        "E": 46,
+        "C": 62
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 35,
+            "max": 85
+          },
+          "conscientiousness": {
+            "min": 55,
+            "max": 95
+          },
+          "extraversion": {
+            "min": 20,
+            "max": 75
+          },
+          "agreeableness": {
+            "min": 25,
+            "max": 78
+          },
+          "neuroticism": {
+            "min": 8,
+            "max": 52
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 58,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 35,
+          "max": 82
+        }
+      },
+      "market_demand_json": {
+        "raw": 76
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 102,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "industrial-designer",
+      "slug": "industrial-designer",
+      "locale": "en",
+      "title": "Industrial Designer",
+      "subtitle": null,
+      "excerpt": "Turn user needs, material constraints, and form into products that feel intuitive, useful, and well made in the real world.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": "Design",
+      "body_md": "# Industrial Designer\n\n## Role Overview\nIndustrial Designers translate human use, physical constraints, and aesthetic direction into products people want to touch, keep, and return to.\n\n## Core Work Scope\n- Explore concepts through sketching, prototyping, and user feedback.\n- Balance form, function, cost, and manufacturability.\n- Work with engineering and brand teams to protect both usability and quality.\n\n## Career Development Advice\nShow the thinking behind your portfolio, not only final renders. Strong designers prove how they moved from observation to iteration to a better experience.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $165,000 (varies by market, product category, and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand is strongest where physical products, consumer experience, and prototyping speed all matter."
+      },
+      "skills_json": {
+        "core": [
+          "User observation",
+          "Prototyping",
+          "Form exploration",
+          "Design critique",
+          "Cross-functional collaboration"
+        ],
+        "supporting": [
+          "CAD tools",
+          "Material knowledge"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Translate fuzzy user needs into concept directions.",
+          "Prototype physical or digital touchpoints and learn from feedback.",
+          "Refine designs so they are both expressive and manufacturable."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build craft range and user sensitivity.",
+          "3-5 years: own product categories and prototyping strategy.",
+          "5+ years: move into design leadership, creative direction, or specialist product innovation."
+        ]
+      },
+      "fit_personality_codes_json": [
+        "INTP",
+        "ISFP",
+        "ISTP"
+      ],
+      "mbti_primary_codes_json": [
+        "ISTP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INTP"
+      ],
+      "riasec_profile_json": {
+        "R": 64,
+        "I": 58,
+        "A": 92,
+        "S": 36,
+        "E": 40,
+        "C": 46
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 68,
+            "max": 100
+          },
+          "conscientiousness": {
+            "min": 40,
+            "max": 85
+          },
+          "extraversion": {
+            "min": 20,
+            "max": 75
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 82
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 60
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 55,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 73
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 103,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "event-experience-producer",
+      "slug": "event-experience-producer",
+      "locale": "en",
+      "title": "Event Experience Producer",
+      "subtitle": null,
+      "excerpt": "Design live moments that feel energetic, well paced, and emotionally memorable for guests, audiences, and partners.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "events",
+      "industry_label": "Events",
+      "body_md": "# Event Experience Producer\n\n## Role Overview\nEvent Experience Producers turn a loose idea into a real atmosphere people can feel. They coordinate story, logistics, timing, and audience energy so an event lands with clarity and momentum.\n\n## Core Work Scope\n- Shape a live experience from concept to run-of-show.\n- Coordinate vendors, speakers, performers, and venue details.\n- Make real-time adjustments when the room or schedule changes.\n\n## Career Development Advice\nKeep a portfolio of live programs you have shaped, including how you solved last-minute changes. In experience work, the quality of your judgment under motion becomes your reputation.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$48,000 - $145,000 (varies by market, venue scale, and brand scope)"
+      },
+      "outlook_json": {
+        "summary": "Demand remains healthy in brand experiences, hospitality, destination marketing, and live community events."
+      },
+      "skills_json": {
+        "core": [
+          "Audience sense",
+          "Run-of-show planning",
+          "Live coordination",
+          "Creative briefing",
+          "Vendor management"
+        ],
+        "supporting": [
+          "Budget tracking",
+          "Stage communication"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Translate a brand or program idea into a live audience journey.",
+          "Coordinate dozens of moving parts without flattening the atmosphere.",
+          "Read the room and adjust timing, energy, or sequencing in real time."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: learn production discipline and live problem solving.",
+          "3-5 years: own flagship events or touring programs.",
+          "5+ years: move into experience direction, hospitality leadership, or creative operations."
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFP"
+      ],
+      "mbti_primary_codes_json": [
+        "ESFP",
+        "ENFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 30,
+        "I": 38,
+        "A": 84,
+        "S": 68,
+        "E": 87,
+        "C": 40
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 60,
+            "max": 100
+          },
+          "conscientiousness": {
+            "min": 40,
+            "max": 86
+          },
+          "extraversion": {
+            "min": 60,
+            "max": 100
+          },
+          "agreeableness": {
+            "min": 42,
+            "max": 90
+          },
+          "neuroticism": {
+            "min": 12,
+            "max": 62
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 92
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 69
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 104,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "guest-experience-manager",
+      "slug": "guest-experience-manager",
+      "locale": "en",
+      "title": "Guest Experience Manager",
+      "subtitle": null,
+      "excerpt": "Lead frontline service quality, team warmth, and recovery moments that make guests feel genuinely seen and well cared for.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "hospitality",
+      "industry_label": "Hospitality",
+      "body_md": "# Guest Experience Manager\n\n## Role Overview\nGuest Experience Managers shape how a service environment feels in real life. They protect service standards, coach teams on tone and recovery, and turn small details into repeat trust.\n\n## Core Work Scope\n- Define what good service should feel like, not just how it should look on paper.\n- Coach frontline teams through difficult or emotional customer moments.\n- Improve the service system based on recurring friction signals.\n\n## Career Development Advice\nTrack the patterns behind compliments and complaints. The strongest operators in service environments can turn emotional feedback into better systems without losing warmth.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$45,000 - $135,000 (varies by market, property type, and operating scale)"
+      },
+      "outlook_json": {
+        "summary": "Demand is stable across hospitality, premium retail, education services, and customer-experience-led businesses."
+      },
+      "skills_json": {
+        "core": [
+          "Service recovery",
+          "Frontline coaching",
+          "Quality standards",
+          "Customer empathy",
+          "Operational follow-through"
+        ],
+        "supporting": [
+          "Scheduling",
+          "Escalation handling"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Coach teams on how to deliver a consistent service tone.",
+          "Resolve sensitive guest issues without losing trust.",
+          "Translate service feedback into staffing, training, or process improvements."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build service judgment and team coaching habits.",
+          "3-5 years: own multi-site quality or customer success operations.",
+          "5+ years: move into hospitality leadership, experience strategy, or service training systems."
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ESFJ",
+        "ESFP",
+        "ISFP"
+      ],
+      "mbti_primary_codes_json": [
+        "ESFP",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFP"
+      ],
+      "riasec_profile_json": {
+        "R": 24,
+        "I": 30,
+        "A": 58,
+        "S": 82,
+        "E": 79,
+        "C": 55
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 35,
+            "max": 86
+          },
+          "conscientiousness": {
+            "min": 48,
+            "max": 92
+          },
+          "extraversion": {
+            "min": 55,
+            "max": 100
+          },
+          "agreeableness": {
+            "min": 55,
+            "max": 100
+          },
+          "neuroticism": {
+            "min": 12,
+            "max": 60
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 42,
+          "max": 88
+        },
+        "eq_range": {
+          "min": 68,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 71
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 105,
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,

--- a/content_baselines/career_jobs/career_jobs.zh-CN.json
+++ b/content_baselines/career_jobs/career_jobs.zh-CN.json
@@ -34,9 +34,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -52,7 +50,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -114,9 +119,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -159,9 +162,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -177,7 +178,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFP",
+        "ENTP",
+        "ESFP",
+        "INFJ",
+        "INFP",
+        "ISFP"
+      ],
       "mbti_primary_codes_json": [
         "INFP",
         "ENFP",
@@ -239,9 +247,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -284,9 +290,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -302,7 +306,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -364,9 +375,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -409,9 +418,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -427,7 +434,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -489,9 +503,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -534,9 +546,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -552,7 +562,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFP",
+        "ENTP",
+        "ESFP",
+        "INFJ",
+        "INFP",
+        "ISFP"
+      ],
       "mbti_primary_codes_json": [
         "INFP",
         "ENFP",
@@ -614,9 +631,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -659,9 +674,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -677,7 +690,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -739,9 +759,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -784,9 +802,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -802,7 +818,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -864,9 +887,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -909,9 +930,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -927,7 +946,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -989,9 +1015,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1034,9 +1058,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1052,7 +1074,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -1114,9 +1143,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1159,9 +1186,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1177,7 +1202,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ESFJ",
+        "ESTJ",
+        "ESTP",
+        "ISFJ",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "ESTJ",
         "ISTJ",
@@ -1239,9 +1271,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1284,9 +1314,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1302,7 +1330,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -1364,9 +1399,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1409,9 +1442,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1427,7 +1458,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -1489,9 +1527,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1534,9 +1570,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1552,7 +1586,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -1614,9 +1655,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1659,9 +1698,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1677,7 +1714,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -1739,9 +1783,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1784,9 +1826,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1802,7 +1842,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ESFJ",
+        "ESTJ",
+        "ESTP",
+        "ISFJ",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "ESTJ",
         "ISTJ",
@@ -1864,9 +1911,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -1909,9 +1954,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -1927,7 +1970,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -1989,9 +2039,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2034,9 +2082,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2052,7 +2098,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -2114,9 +2167,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2159,9 +2210,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2177,7 +2226,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -2239,9 +2295,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2284,9 +2338,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2302,7 +2354,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -2364,9 +2423,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2409,9 +2466,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2427,7 +2482,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -2489,9 +2551,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2534,9 +2594,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2552,7 +2610,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -2614,9 +2679,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2659,9 +2722,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2677,7 +2738,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -2739,9 +2807,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2784,9 +2850,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2802,7 +2866,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -2864,9 +2935,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -2909,9 +2978,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -2927,7 +2994,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -2989,9 +3063,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3034,9 +3106,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3052,7 +3122,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -3114,9 +3191,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3159,9 +3234,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3177,7 +3250,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -3239,9 +3319,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3284,9 +3362,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3302,7 +3378,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INFJ",
+        "INTJ",
+        "INTP",
+        "ISTJ"
+      ],
       "mbti_primary_codes_json": [
         "INTJ",
         "INTP",
@@ -3364,9 +3447,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3409,9 +3490,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3427,7 +3506,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ENTJ",
+        "ENTP",
+        "ESTJ",
+        "ESTP"
+      ],
       "mbti_primary_codes_json": [
         "ENTJ",
         "ENFJ",
@@ -3489,9 +3575,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3534,9 +3618,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3552,7 +3634,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFJ",
+        "INFJ",
+        "INFP",
+        "ISFJ"
+      ],
       "mbti_primary_codes_json": [
         "ENFJ",
         "ISFJ",
@@ -3614,9 +3703,7 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
-      ],
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,
@@ -3659,9 +3746,7 @@
           "数据驱动决策",
           "持续学习能力"
         ],
-        "supporting": [
-
-        ]
+        "supporting": []
       },
       "work_contents_json": {
         "items": [
@@ -3677,7 +3762,14 @@
           "5 年以上：走向专家型负责人或管理型角色。"
         ]
       },
-      "fit_personality_codes_json": null,
+      "fit_personality_codes_json": [
+        "ENFP",
+        "ENTP",
+        "ESFP",
+        "INFJ",
+        "INFP",
+        "ISFP"
+      ],
       "mbti_primary_codes_json": [
         "INFP",
         "ENFP",
@@ -3739,9 +3831,757 @@
       "published_at": null,
       "scheduled_at": null,
       "sort_order": 0,
-      "sections": [
-
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "innovation-consultant",
+      "slug": "innovation-consultant",
+      "locale": "zh-CN",
+      "title": "创新咨询顾问",
+      "subtitle": null,
+      "excerpt": "把模糊机会拆成可验证的问题、方案与试点，适合需要在不确定里找方向的组织。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": "咨询",
+      "body_md": "# 创新咨询顾问\n\n## 岗位概览\n创新咨询顾问的核心价值，不是替客户“想一个新点子”，而是把混乱问题重新定义成可以判断、可以试验、可以推进的业务选择。\n\n## 核心工作内容\n- 从噪音里找出真正值得回答的问题。\n- 设计访谈、工作坊、试点与决策框架。\n- 把模糊想法沉淀成管理层能直接使用的建议。\n\n## 成长建议\n尽量积累一套“问题重构 + 试点设计 + 结论表达”的作品证据。别人越能看见你的结构化思路，越愿意把高不确定项目交给你。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "¥180,000 - ¥600,000（视城市、公司与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "在咨询、创新实验室、战略转型团队与新业务孵化场景中需求更稳定。"
+      },
+      "skills_json": {
+        "core": [
+          "问题定义",
+          "工作坊设计",
+          "战略表达",
+          "试点规划",
+          "多方信息整合"
+        ],
+        "supporting": [
+          "市场研究",
+          "汇报写作"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "诊断一个增长或产品问题为什么一直卡住。",
+          "组织关键人共识会议与探索访谈。",
+          "把分散想法沉淀成路线图、试点方案或决策备忘录。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立调研、拆题与整合能力。",
+          "3-5 年：独立带工作流并主持决策讨论。",
+          "5 年以上：进入转型项目、创新负责人或专业咨询合伙路径。"
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ENTJ",
+        "ENTP",
+        "INTJ"
       ],
+      "mbti_primary_codes_json": [
+        "ENTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "INTJ"
+      ],
+      "riasec_profile_json": {
+        "R": 28,
+        "I": 79,
+        "A": 74,
+        "S": 45,
+        "E": 71,
+        "C": 42
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 65,
+            "max": 100
+          },
+          "conscientiousness": {
+            "min": 45,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 45,
+            "max": 95
+          },
+          "agreeableness": {
+            "min": 30,
+            "max": 80
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 60
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 48,
+          "max": 92
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 100,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "product-experimentation-lead",
+      "slug": "product-experimentation-lead",
+      "locale": "zh-CN",
+      "title": "产品实验负责人",
+      "subtitle": null,
+      "excerpt": "把好奇心和产品判断变成快速试验，让团队用真实反馈决定什么值得继续投入。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": "科技",
+      "body_md": "# 产品实验负责人\n\n## 岗位概览\n产品实验负责人站在策略、产品与增长的交叉点，把“也许可行”的方向压成能快速验证的小实验，再根据证据决定下一步。\n\n## 核心工作内容\n- 把机会猜想翻译成明确的实验问题。\n- 协调产品、设计、数据等角色一起跑学习闭环。\n- 从不完美反馈里提炼真正有价值的信号。\n\n## 成长建议\n把每次试验留下的结论沉淀成文档和案例。你越能证明“我不仅点子多，还能用证据推进决策”，职业杠杆就越高。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "¥220,000 - ¥700,000（视城市、业务体量与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "在增长型产品团队、创新业务与高迭代组织中仍有持续需求。"
+      },
+      "skills_json": {
+        "core": [
+          "实验设计",
+          "产品判断",
+          "结论表达",
+          "跨团队协同",
+          "学习速度"
+        ],
+        "supporting": [
+          "数据解读",
+          "用户研究"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "筛选哪些假设值得先做真实测试。",
+          "定义指标、成功阈值与风险边界。",
+          "把实验结果转成产品或增长决策。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立测试思维与产品直觉。",
+          "3-5 年：负责跨团队实验项目。",
+          "5 年以上：走向产品策略、增长负责人或新业务孵化。"
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ENTP",
+        "INTP",
+        "ISTP"
+      ],
+      "mbti_primary_codes_json": [
+        "ENTP",
+        "INTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISTP"
+      ],
+      "riasec_profile_json": {
+        "R": 30,
+        "I": 81,
+        "A": 66,
+        "S": 38,
+        "E": 67,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 70,
+            "max": 100
+          },
+          "conscientiousness": {
+            "min": 45,
+            "max": 85
+          },
+          "extraversion": {
+            "min": 30,
+            "max": 85
+          },
+          "agreeableness": {
+            "min": 25,
+            "max": 78
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 58
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 66,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 42,
+          "max": 88
+        }
+      },
+      "market_demand_json": {
+        "raw": 81
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 101,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "field-service-engineer",
+      "slug": "field-service-engineer",
+      "locale": "zh-CN",
+      "title": "现场服务工程师",
+      "subtitle": null,
+      "excerpt": "在真实环境里排查系统或设备故障，靠冷静判断和动手能力把问题尽快恢复到稳定状态。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "engineering",
+      "industry_label": "工程",
+      "body_md": "# 现场服务工程师\n\n## 岗位概览\n现场服务工程师会直接进入真实系统和现场条件中解决问题。它不只看技术，更看你在时间压力下能否迅速判断、稳住节奏、把系统拉回正常。\n\n## 核心工作内容\n- 在现场诊断机械、电气或系统类故障。\n- 在有限时间内做出安全且有效的修复判断。\n- 向客户或内部团队解释原因与后续预防方案。\n\n## 成长建议\n不要只记录“修好了什么”，更要记录“你是怎么判断出来的”。能把诊断逻辑讲清楚的人，成长速度会明显更快。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "¥160,000 - ¥500,000（视行业、地区与出差频率而定）"
+      },
+      "outlook_json": {
+        "summary": "在工业系统、基础设施、医疗设备与企业硬件支持中需求稳定。"
+      },
+      "skills_json": {
+        "core": [
+          "故障排查",
+          "动手维修",
+          "根因分析",
+          "安全规范",
+          "客户沟通"
+        ],
+        "supporting": [
+          "文档记录",
+          "预防性维护"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "在真实运行场景里检查系统状态。",
+          "在压力下快速定位最可能的故障点。",
+          "提出修复、替换或流程改进方案，减少重复故障。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立现场判断与执行纪律。",
+          "3-5 年：接手复杂故障与核心客户场景。",
+          "5 年以上：走向技术专家、可靠性负责人或区域运营管理。"
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ESTP",
+        "INTJ",
+        "ISTP"
+      ],
+      "mbti_primary_codes_json": [
+        "ISTP",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INTJ"
+      ],
+      "riasec_profile_json": {
+        "R": 88,
+        "I": 72,
+        "A": 34,
+        "S": 28,
+        "E": 46,
+        "C": 62
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 35,
+            "max": 85
+          },
+          "conscientiousness": {
+            "min": 55,
+            "max": 95
+          },
+          "extraversion": {
+            "min": 20,
+            "max": 75
+          },
+          "agreeableness": {
+            "min": 25,
+            "max": 78
+          },
+          "neuroticism": {
+            "min": 8,
+            "max": 52
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 58,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 35,
+          "max": 82
+        }
+      },
+      "market_demand_json": {
+        "raw": 76
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 102,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "industrial-designer",
+      "slug": "industrial-designer",
+      "locale": "zh-CN",
+      "title": "工业设计师",
+      "subtitle": null,
+      "excerpt": "把用户感受、材料约束与产品形态揉进同一个方案里，做出真正好用也好看的作品。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": "设计",
+      "body_md": "# 工业设计师\n\n## 岗位概览\n工业设计师需要把人的使用体验、现实制造条件和产品表达整合在一起。它适合既重感受，又愿意反复推敲细节的人。\n\n## 核心工作内容\n- 从观察与访谈中提炼真正的使用痛点。\n- 通过草图、模型和样机不断迭代方案。\n- 在审美、功能、成本和可制造性之间找到平衡。\n\n## 成长建议\n作品集不要只放最后的漂亮结果，更要展示你如何从观察、试错走到更好的设计判断。别人越看得见你的思路，越容易信任你的能力。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "¥150,000 - ¥480,000（视行业、公司与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "在消费产品、智能硬件、家居、医疗器械与体验创新场景中需求更明显。"
+      },
+      "skills_json": {
+        "core": [
+          "用户观察",
+          "原型制作",
+          "形态探索",
+          "设计评审",
+          "跨团队协作"
+        ],
+        "supporting": [
+          "CAD 工具",
+          "材料知识"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "把模糊需求转成可讨论的概念方向。",
+          "通过原型与反馈快速验证使用体验。",
+          "持续优化细节，让方案既有表达也能落地生产。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立设计手感与用户敏感度。",
+          "3-5 年：开始独立负责产品线与原型策略。",
+          "5 年以上：走向设计负责人、创意总监或专业创新岗位。"
+        ]
+      },
+      "fit_personality_codes_json": [
+        "INTP",
+        "ISFP",
+        "ISTP"
+      ],
+      "mbti_primary_codes_json": [
+        "ISTP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INTP"
+      ],
+      "riasec_profile_json": {
+        "R": 64,
+        "I": 58,
+        "A": 92,
+        "S": 36,
+        "E": 40,
+        "C": 46
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 68,
+            "max": 100
+          },
+          "conscientiousness": {
+            "min": 40,
+            "max": 85
+          },
+          "extraversion": {
+            "min": 20,
+            "max": 75
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 82
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 60
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 55,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 73
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 103,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "event-experience-producer",
+      "slug": "event-experience-producer",
+      "locale": "zh-CN",
+      "title": "活动体验制作人",
+      "subtitle": null,
+      "excerpt": "把一个点子做成有现场感、有节奏、有情绪记忆的活动体验，适合擅长带动氛围和统筹临场变化的人。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "events",
+      "industry_label": "活动",
+      "body_md": "# 活动体验制作人\n\n## 岗位概览\n活动体验制作人的价值，不只是把流程跑完，而是让现场真正“有感觉”。它要求你同时盯住叙事、节奏、细节与真实氛围。\n\n## 核心工作内容\n- 从概念出发设计完整的现场体验路径。\n- 协调场地、供应商、嘉宾与执行团队。\n- 在活动过程中根据现场变化即时调整节奏。\n\n## 成长建议\n建立自己的项目作品库，尤其要记录那些你在现场临时处理问题的判断。体验类岗位最能拉开差距的，往往就是临场感与收尾力。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "¥140,000 - ¥420,000（视城市、品牌与项目体量而定）"
+      },
+      "outlook_json": {
+        "summary": "在品牌活动、文旅、社区体验、会展与线下内容场景中持续有需求。"
+      },
+      "skills_json": {
+        "core": [
+          "氛围感知",
+          "流程统筹",
+          "现场协调",
+          "创意 briefing",
+          "供应商管理"
+        ],
+        "supporting": [
+          "预算控制",
+          "舞台沟通"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "把品牌或项目诉求翻译成观众能感受到的体验路径。",
+          "协调多方资源，保证活动节奏与现场感同时成立。",
+          "根据人流、反馈与突发情况即时调节方案。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立活动执行纪律和现场判断。",
+          "3-5 年：负责大型项目或连续性活动 IP。",
+          "5 年以上：走向体验总监、创意运营负责人或文旅 / 品牌体验管理。"
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ENFJ",
+        "ENFP",
+        "ESFP"
+      ],
+      "mbti_primary_codes_json": [
+        "ESFP",
+        "ENFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 30,
+        "I": 38,
+        "A": 84,
+        "S": 68,
+        "E": 87,
+        "C": 40
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 60,
+            "max": 100
+          },
+          "conscientiousness": {
+            "min": 40,
+            "max": 86
+          },
+          "extraversion": {
+            "min": 60,
+            "max": 100
+          },
+          "agreeableness": {
+            "min": 42,
+            "max": 90
+          },
+          "neuroticism": {
+            "min": 12,
+            "max": 62
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 92
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 69
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 104,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "guest-experience-manager",
+      "slug": "guest-experience-manager",
+      "locale": "zh-CN",
+      "title": "客户体验经理",
+      "subtitle": null,
+      "excerpt": "通过服务标准、团队训练与问题修复，让客户在真实接触点上感到被看见、被重视、被妥善照顾。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "hospitality",
+      "industry_label": "服务业",
+      "body_md": "# 客户体验经理\n\n## 岗位概览\n客户体验经理负责把“好服务”从一句口号变成真实体验。它看重你是否能在标准化和人情味之间找到平衡，并带着团队长期稳定地执行。\n\n## 核心工作内容\n- 定义什么才算真正让客户感到舒服和被尊重。\n- 训练一线团队处理高情绪或复杂反馈。\n- 从投诉、表扬和服务摩擦里反推系统改进。\n\n## 成长建议\n不要只看满意度分数，更要看背后的模式。能把情绪信号转成培训、排班和流程优化的人，才会真正拉开差距。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "¥130,000 - ¥400,000（视行业、城市与管理范围而定）"
+      },
+      "outlook_json": {
+        "summary": "在酒店、教育服务、精品零售、健康管理与高体验要求业务中需求稳定。"
+      },
+      "skills_json": {
+        "core": [
+          "服务修复",
+          "一线辅导",
+          "标准制定",
+          "客户共情",
+          "运营跟进"
+        ],
+        "supporting": [
+          "排班管理",
+          "升级投诉处理"
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "定义并训练团队执行一致的服务体验。",
+          "处理棘手客户场景，稳住关系与口碑。",
+          "把一线反馈转成流程、培训或人员配置优化。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立服务判断与团队指导能力。",
+          "3-5 年：负责多门店、多团队或更复杂客户旅程。",
+          "5 年以上：走向体验策略、服务体系负责人或区域运营管理。"
+        ]
+      },
+      "fit_personality_codes_json": [
+        "ESFJ",
+        "ESFP",
+        "ISFP"
+      ],
+      "mbti_primary_codes_json": [
+        "ESFP",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFP"
+      ],
+      "riasec_profile_json": {
+        "R": 24,
+        "I": 30,
+        "A": 58,
+        "S": 82,
+        "E": 79,
+        "C": 55
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 35,
+            "max": 86
+          },
+          "conscientiousness": {
+            "min": 48,
+            "max": 92
+          },
+          "extraversion": {
+            "min": 55,
+            "max": 100
+          },
+          "agreeableness": {
+            "min": 55,
+            "max": 100
+          },
+          "neuroticism": {
+            "min": 12,
+            "max": 60
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 42,
+          "max": 88
+        },
+        "eq_range": {
+          "min": 68,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 71
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-18",
+      "scheduled_at": null,
+      "sort_order": 105,
+      "sections": [],
       "seo_meta": {
         "seo_title": null,
         "seo_description": null,


### PR DESCRIPTION
## Summary
This PR publishes the MBTI career authority v1 content baselines needed for public recommendation detail routes to return non-empty `matched_jobs` and `matched_guides` through the existing matcher and service chain.

## Scope
- publish bilingual career job baseline coverage for the 16 canonical MBTI families
- add 16 canonical family career guides in `en` and `zh-CN`
- update the public API tests to assert representative 32-type routes and legacy 4-letter compatibility now resolve non-empty matches
- keep routes, controllers, services, matcher rules, migrations, and frontend behavior unchanged

## Validation
- `php artisan route:list | grep -Ei "career|personality|seo|sitemap"`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/V0_5/CareerRecommendationPublicApiTest.php tests/Feature/V0_5/CareerJobPublicApiTest.php tests/Feature/V0_5/CareerGuidePublicApiTest.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`
- `php artisan personality:import-local-baseline --locale=en --locale=zh-CN --upsert --status=published`
- `php artisan career-jobs:import-local-baseline --locale=en --locale=zh-CN --upsert --status=published`
- `php artisan career-guides:import-local-baseline --locale=en --locale=zh-CN --guide=intj-career-playbook --guide=intp-career-playbook --guide=entj-career-playbook --guide=entp-career-playbook --guide=infj-career-playbook --guide=infp-career-playbook --guide=enfj-career-playbook --guide=enfp-career-playbook --guide=istj-career-playbook --guide=isfj-career-playbook --guide=estj-career-playbook --guide=esfj-career-playbook --guide=istp-career-playbook --guide=isfp-career-playbook --guide=estp-career-playbook --guide=esfp-career-playbook --upsert --status=published`
- `curl -s "http://127.0.0.1:8000/api/v0.5/career-recommendations/mbti/intj-a?locale=en" | jq '{slug:.public_route_slug, graph:.graph_type_code, jobs:(.matched_jobs|length), guides:(.matched_guides|length)}'`
- `curl -s "http://127.0.0.1:8000/api/v0.5/career-recommendations/mbti/enfp-t?locale=en" | jq '{slug:.public_route_slug, graph:.graph_type_code, jobs:(.matched_jobs|length), guides:(.matched_guides|length)}'`
- `curl -s "http://127.0.0.1:8000/api/v0.5/career-recommendations/mbti/istj-a?locale=zh-CN" | jq '{slug:.public_route_slug, graph:.graph_type_code, jobs:(.matched_jobs|length), guides:(.matched_guides|length)}'`
- `curl -s "http://127.0.0.1:8000/api/v0.5/career-recommendations/mbti/esfp-t?locale=zh-CN" | jq '{slug:.public_route_slug, graph:.graph_type_code, jobs:(.matched_jobs|length), guides:(.matched_guides|length)}'`
- `curl -s "http://127.0.0.1:8000/api/v0.5/career-recommendations/mbti/intj?locale=en" | jq '{slug:.public_route_slug, graph:.graph_type_code, jobs:(.matched_jobs|length), guides:(.matched_guides|length)}'`
- `bash scripts/ci_verify_mbti.sh`

## Non-goals
- no matcher rule changes
- no route/controller/service changes
- no migrations
- no frontend changes
