### PR TITLE
[codex] feat(api): add token-based payment recovery contract

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -123,36 +123,54 @@ class CommerceController extends Controller
         $orgId = $this->orgContext->orgId();
         $userId = $this->orgContext->userId();
         $anonId = $this->resolveAnonId($request);
-        $result = $this->orders->getOrder($orgId, $userId !== null ? (string) $userId : null, $anonId, $order_no, false);
+        $requestedPaymentRecoveryToken = $this->resolvePaymentRecoveryToken($request);
+        $result = $this->orders->getOrder(
+            $orgId,
+            $userId !== null ? (string) $userId : null,
+            $anonId,
+            $order_no,
+            false,
+            $requestedPaymentRecoveryToken
+        );
         if (! ($result['ok'] ?? false)) {
-            $status = $this->mapErrorStatus((string) data_get($result, 'error_code', data_get($result, 'error', '')));
+            $errorCode = (string) data_get($result, 'error_code', data_get($result, 'error', ''));
             $message = trim((string) ($result['message'] ?? ''));
+            if (in_array($errorCode, ['PAYMENT_RECOVERY_TOKEN_INVALID', 'PAYMENT_RECOVERY_TOKEN_EXPIRED'], true)) {
+                return response()->json([
+                    'ok' => false,
+                    'error_code' => $errorCode,
+                    'message' => $message !== '' ? $message : 'payment recovery token invalid.',
+                ], 403);
+            }
+
+            $status = $this->mapErrorStatus($errorCode);
             abort($status, $message !== '' ? $message : 'request failed.');
         }
 
         $order = $result['order'];
         $ownershipVerified = (bool) ($result['ownership_verified'] ?? true);
+        $paymentRecoveryVerified = (bool) ($result['payment_recovery_verified'] ?? false);
         $status = $this->normalizePublicOrderStatus((string) ($order->status ?? ''));
         $message = $this->publicOrderMessage((string) ($order->status ?? ''));
         $delivery = $this->buildOrderDelivery($order);
+        $paymentRecoveryToken = $paymentRecoveryVerified && $requestedPaymentRecoveryToken !== null
+            ? $requestedPaymentRecoveryToken
+            : $this->orders->issuePaymentRecoveryToken($order);
+        $recoveryUrls = $this->orders->presentPaymentRecoveryUrls(
+            $order,
+            $paymentRecoveryToken,
+            $this->resolveRequestedLocale($request)
+        );
         $payment = $this->buildOrderPaymentPayload(
             $request,
             $order,
-            $status === 'pending' && $request->boolean('include_payment_action')
+            $status === 'pending' && ($request->boolean('include_payment_action') || $paymentRecoveryVerified),
+            $paymentRecoveryToken
         );
-
-        if (! $ownershipVerified) {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'ORDER_NOT_FOUND',
-                'message' => 'order not found.',
-            ], 404);
-        }
 
         $payload = [
             'ok' => true,
-            'ownership_verified' => true,
-            'order' => $order,
+            'ownership_verified' => $ownershipVerified,
             'order_no' => $order->order_no ?? null,
             'attempt_id' => $delivery['attempt_id'],
             'status' => $status,
@@ -160,14 +178,20 @@ class CommerceController extends Controller
             'amount_cents' => $order->amount_cents ?? $order->amount_total ?? null,
             'currency' => $order->currency ?? null,
             'provider' => $payment['provider'],
+            'payment_recovery_token' => $paymentRecoveryToken,
+            'result_url' => $recoveryUrls['result_url'],
             'pay' => $payment['pay'],
             'checkout_url' => $payment['checkout_url'],
             'delivery' => $delivery['delivery'],
         ];
 
-        $mbtiAccessHub = $this->mbtiAccessHubBuilder->buildForOrderContext($order);
-        if ($mbtiAccessHub !== null) {
-            $payload[ReportAccess::ACCESS_HUB_KEY] = $mbtiAccessHub;
+        if ($ownershipVerified) {
+            $payload['order'] = $order;
+
+            $mbtiAccessHub = $this->mbtiAccessHubBuilder->buildForOrderContext($order);
+            if ($mbtiAccessHub !== null) {
+                $payload[ReportAccess::ACCESS_HUB_KEY] = $mbtiAccessHub;
+            }
         }
 
         return response()->json($payload);
@@ -242,10 +266,17 @@ class CommerceController extends Controller
                 if ($provider === '') {
                     $provider = (string) $this->paymentRouter->primaryProviderForRegion($this->regionContext->region());
                 }
+                $paymentRecoveryToken = $this->orders->issuePaymentRecoveryToken($order);
+                $recoveryUrls = $this->orders->presentPaymentRecoveryUrls(
+                    $order,
+                    $paymentRecoveryToken,
+                    $this->resolveRequestedLocale($request)
+                );
                 $payment = $this->buildOrderPaymentPayload(
                     $request,
                     $order,
-                    $this->normalizePublicOrderStatus((string) ($order->status ?? '')) === 'pending'
+                    $this->normalizePublicOrderStatus((string) ($order->status ?? '')) === 'pending',
+                    $paymentRecoveryToken
                 );
 
                 return response()->json([
@@ -255,6 +286,9 @@ class CommerceController extends Controller
                     'status' => $this->normalizePublicOrderStatus((string) ($order->status ?? '')),
                     'message' => $this->publicOrderMessage((string) ($order->status ?? '')),
                     'provider' => $payment['provider'] ?? $provider,
+                    'payment_recovery_token' => $paymentRecoveryToken,
+                    'wait_url' => $recoveryUrls['wait_url'],
+                    'result_url' => $recoveryUrls['result_url'],
                     'pay' => $payment['pay'],
                     'checkout_url' => $payment['checkout_url'],
                 ]);
@@ -360,6 +394,23 @@ class CommerceController extends Controller
             );
         }
 
+        $paymentRecoveryToken = $order !== null ? $this->orders->issuePaymentRecoveryToken($order) : null;
+        $recoveryUrls = $order !== null
+            ? $this->orders->presentPaymentRecoveryUrls(
+                $order,
+                $paymentRecoveryToken,
+                $this->resolveRequestedLocale($request)
+            )
+            : ['wait_url' => null, 'result_url' => null];
+        $presentedPayment = $this->decoratePaymentPayloadForRecovery(
+            [
+                'provider' => $provider,
+                'pay' => $payPayload,
+                'checkout_url' => $checkoutUrl,
+            ],
+            $paymentRecoveryToken
+        );
+
         return response()->json([
             'ok' => true,
             'order_no' => $orderNo !== '' ? $orderNo : ($created['order_no'] ?? null),
@@ -367,8 +418,11 @@ class CommerceController extends Controller
             'provider' => $provider,
             'status' => 'pending',
             'message' => 'Order created, waiting for payment.',
-            'pay' => $payPayload,
-            'checkout_url' => $checkoutUrl,
+            'payment_recovery_token' => $paymentRecoveryToken,
+            'wait_url' => $recoveryUrls['wait_url'],
+            'result_url' => $recoveryUrls['result_url'],
+            'pay' => $presentedPayment['pay'],
+            'checkout_url' => $presentedPayment['checkout_url'],
         ]);
     }
 
@@ -473,8 +527,20 @@ class CommerceController extends Controller
         $orgId = $this->orgContext->orgId();
         $userId = $this->orgContext->userId();
         $anonId = $this->resolveAnonId($request);
-        $found = $this->orders->getOrder($orgId, $userId !== null ? (string) $userId : null, $anonId, $order_no);
+        $found = $this->orders->getOrder(
+            $orgId,
+            $userId !== null ? (string) $userId : null,
+            $anonId,
+            $order_no,
+            false,
+            $this->resolvePaymentRecoveryToken($request)
+        );
         if (! ($found['ok'] ?? false)) {
+            $errorCode = (string) data_get($found, 'error_code', data_get($found, 'error', ''));
+            if (in_array($errorCode, ['PAYMENT_RECOVERY_TOKEN_INVALID', 'PAYMENT_RECOVERY_TOKEN_EXPIRED'], true)) {
+                abort(403);
+            }
+
             abort(404);
         }
 
@@ -552,8 +618,12 @@ class CommerceController extends Controller
      *     checkout_url:?string
      * }
      */
-    private function buildOrderPaymentPayload(Request $request, object $order, bool $includePaymentAction): array
-    {
+    private function buildOrderPaymentPayload(
+        Request $request,
+        object $order,
+        bool $includePaymentAction,
+        ?string $paymentRecoveryToken = null
+    ): array {
         $provider = strtolower(trim((string) ($order->provider ?? '')));
         if ($provider === '') {
             $provider = (string) $this->paymentRouter->primaryProviderForRegion($this->regionContext->region());
@@ -571,7 +641,7 @@ class CommerceController extends Controller
         $scene = $this->resolvePaymentActionScene((string) $request->userAgent());
         $cached = $this->resolveCachedOrderPaymentPayload($order, $normalizedProvider, $scene);
         if ($cached !== null) {
-            return $cached;
+            return $this->decoratePaymentPayloadForRecovery($cached, $paymentRecoveryToken);
         }
 
         if ($normalizedProvider === null || ! $this->isProviderEnabled($normalizedProvider)) {
@@ -627,7 +697,7 @@ class CommerceController extends Controller
         $presented = $this->presentCheckoutPayAction($normalizedProvider, $payAction);
         $this->persistOrderPaymentPayload($order, $scene, $presented);
 
-        return $presented;
+        return $this->decoratePaymentPayloadForRecovery($presented, $paymentRecoveryToken);
     }
 
     /**
@@ -873,6 +943,39 @@ class CommerceController extends Controller
         return null;
     }
 
+    private function resolvePaymentRecoveryToken(Request $request): ?string
+    {
+        foreach ([
+            $request->query('payment_recovery_token'),
+            $request->query('paymentRecoveryToken'),
+            $request->header('X-Payment-Recovery-Token', ''),
+        ] as $candidate) {
+            $normalized = $this->trimNullableString($candidate);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveRequestedLocale(Request $request): ?string
+    {
+        foreach ([
+            $request->query('locale'),
+            $request->header('X-Fap-Locale', ''),
+            $request->header('X-Locale', ''),
+            $request->getLocale(),
+        ] as $candidate) {
+            $normalized = $this->trimNullableString($candidate);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
     private function resolveIdempotencyKey(Request $request, array $payload): ?string
     {
         $header = trim((string) $request->header('Idempotency-Key', ''));
@@ -1096,6 +1199,53 @@ class CommerceController extends Controller
             'refunded' => 'Order refunded.',
             default => 'Confirming your payment...',
         };
+    }
+
+    /**
+     * @param  array{
+     *     provider:?string,
+     *     pay:?array{type:string,value:string,provider:string},
+     *     checkout_url:?string
+     * }  $payload
+     * @return array{
+     *     provider:?string,
+     *     pay:?array{type:string,value:string,provider:string},
+     *     checkout_url:?string
+     * }
+     */
+    private function decoratePaymentPayloadForRecovery(array $payload, ?string $paymentRecoveryToken): array
+    {
+        $normalizedToken = $this->trimNullableString($paymentRecoveryToken);
+        $provider = strtolower(trim((string) ($payload['provider'] ?? '')));
+        if ($normalizedToken === null || $provider !== 'alipay') {
+            return $payload;
+        }
+
+        $pay = $payload['pay'] ?? null;
+        if (is_array($pay)) {
+            $payValue = $this->trimNullableString($pay['value'] ?? null);
+            if ($payValue !== null) {
+                $payload['pay']['value'] = $this->appendPaymentRecoveryTokenToUrl($payValue, $normalizedToken);
+            }
+        }
+
+        $checkoutUrl = $this->trimNullableString($payload['checkout_url'] ?? null);
+        if ($checkoutUrl !== null) {
+            $payload['checkout_url'] = $this->appendPaymentRecoveryTokenToUrl($checkoutUrl, $normalizedToken);
+        }
+
+        return $payload;
+    }
+
+    private function appendPaymentRecoveryTokenToUrl(string $url, string $paymentRecoveryToken): string
+    {
+        if (str_contains($url, 'paymentRecoveryToken=')) {
+            return $url;
+        }
+
+        $separator = str_contains($url, '?') ? '&' : '?';
+
+        return $url.$separator.'paymentRecoveryToken='.rawurlencode($paymentRecoveryToken);
     }
 
     /**

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -11,6 +11,10 @@ class Order extends Model
 {
     use HasOrgScope;
 
+    public const PAYMENT_RECOVERY_PURPOSE = 'payment_recovery';
+
+    public const PAYMENT_RECOVERY_TOKEN_TTL_SECONDS = 2592000;
+
     protected $table = 'orders';
 
     public $incrementing = false;

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Commerce;
 
+use App\Models\Order;
 use App\Services\Email\EmailOutboxService;
 use App\Services\Report\ReportAccess;
 use App\Services\Scale\ScaleIdentityWriteProjector;
@@ -21,6 +22,7 @@ class OrderManager
         private SkuCatalog $skus,
         private ScaleIdentityWriteProjector $identityProjector,
         private EmailOutboxService $emailOutbox,
+        private PaymentRecoveryToken $paymentRecoveryTokens,
     ) {}
 
     public function createOrder(
@@ -256,7 +258,8 @@ class OrderManager
         ?string $userId,
         ?string $anonId,
         string $orderNo,
-        bool $allowAnonymousFallback = false
+        bool $allowAnonymousFallback = false,
+        ?string $paymentRecoveryToken = null
     ): array {
         $orderNo = trim($orderNo);
         if ($orderNo === '') {
@@ -278,23 +281,96 @@ class OrderManager
         $ownedByUser = $uid !== null && $uid === $this->trimOrNull($order->user_id ?? null);
         $ownedByAnon = $aid !== null && $aid === $this->trimOrNull($order->anon_id ?? null);
         $ownershipVerified = $ownedByUser || $ownedByAnon;
+        $paymentRecoveryVerified = false;
+        $paymentRecoveryFailure = null;
 
-        if (! $ownershipVerified && $uid === null && $aid === null && $allowAnonymousFallback) {
+        $normalizedPaymentRecoveryToken = $this->trimOrNull($paymentRecoveryToken);
+        if (! $ownershipVerified && $normalizedPaymentRecoveryToken !== null) {
+            $verified = $this->paymentRecoveryTokens->verify($normalizedPaymentRecoveryToken, $orderNo);
+            if (($verified['ok'] ?? false) === true) {
+                $paymentRecoveryVerified = true;
+            } else {
+                $paymentRecoveryFailure = [
+                    'ok' => false,
+                    'error' => (string) ($verified['error'] ?? 'PAYMENT_RECOVERY_TOKEN_INVALID'),
+                    'message' => (string) ($verified['message'] ?? 'payment recovery token invalid.'),
+                ];
+            }
+        }
+
+        if (! $ownershipVerified && ! $paymentRecoveryVerified && $uid === null && $aid === null && $allowAnonymousFallback) {
             return [
                 'ok' => true,
                 'order' => $order,
                 'ownership_verified' => false,
+                'payment_recovery_verified' => false,
             ];
         }
 
-        if (! $ownershipVerified) {
+        if (! $ownershipVerified && $paymentRecoveryFailure !== null) {
+            return $paymentRecoveryFailure;
+        }
+
+        if (! $ownershipVerified && ! $paymentRecoveryVerified) {
             return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
         }
 
         return [
             'ok' => true,
             'order' => $order,
-            'ownership_verified' => true,
+            'ownership_verified' => $ownershipVerified,
+            'payment_recovery_verified' => $paymentRecoveryVerified,
+        ];
+    }
+
+    public function issuePaymentRecoveryToken(object $order): ?string
+    {
+        $orderNo = $this->trimOrNull((string) ($order->order_no ?? ''));
+        if ($orderNo === null) {
+            return null;
+        }
+
+        return $this->paymentRecoveryTokens->issue($orderNo);
+    }
+
+    /**
+     * @return array{wait_url:?string,result_url:?string}
+     */
+    public function presentPaymentRecoveryUrls(
+        object $order,
+        ?string $paymentRecoveryToken = null,
+        ?string $fallbackLocale = null
+    ): array {
+        $base = $this->frontendBaseUrl();
+        if ($base === null) {
+            return [
+                'wait_url' => null,
+                'result_url' => null,
+            ];
+        }
+
+        $orderNo = $this->trimOrNull((string) ($order->order_no ?? ''));
+        $orgId = (int) ($order->org_id ?? 0);
+        $attemptId = $this->resolveKnownAttemptId($orgId, $order->target_attempt_id ?? null);
+        $localeSegment = $this->frontendLocaleSegment(
+            $this->resolveOrderLocale($orgId, $attemptId, $fallbackLocale)
+        );
+
+        $waitUrl = null;
+        $normalizedPaymentRecoveryToken = $this->trimOrNull($paymentRecoveryToken);
+        if ($orderNo !== null && $normalizedPaymentRecoveryToken !== null) {
+            $waitUrl = $base.'/'.$localeSegment.'/orders/'.urlencode($orderNo)
+                .'?'.http_build_query([
+                    'orderNo' => $orderNo,
+                    'paymentRecoveryToken' => $normalizedPaymentRecoveryToken,
+                ]);
+        }
+
+        return [
+            'wait_url' => $waitUrl,
+            'result_url' => $attemptId !== null
+                ? $base.'/'.$localeSegment.'/result/'.urlencode($attemptId)
+                : null,
         ];
     }
 
@@ -859,6 +935,36 @@ class OrderManager
             ->exists();
 
         return $exists ? $attemptId : null;
+    }
+
+    private function frontendBaseUrl(): ?string
+    {
+        $base = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+
+        return $base !== '' ? $base : null;
+    }
+
+    private function frontendLocaleSegment(string $locale): string
+    {
+        return str_starts_with(mb_strtolower(trim($locale), 'UTF-8'), 'zh') ? 'zh' : 'en';
+    }
+
+    private function resolveOrderLocale(int $orgId, ?string $attemptId, ?string $fallbackLocale = null): string
+    {
+        if ($attemptId !== null) {
+            $locale = DB::table('attempts')
+                ->where('id', $attemptId)
+                ->where('org_id', $orgId)
+                ->value('locale');
+            $normalized = $this->trimOrNull(is_string($locale) ? $locale : null);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        $fallback = $this->trimOrNull($fallbackLocale);
+
+        return $fallback ?? 'en';
     }
 
     private function isDeliveryEligibleStatus(string $status): bool

--- a/backend/app/Services/Commerce/PaymentRecoveryToken.php
+++ b/backend/app/Services/Commerce/PaymentRecoveryToken.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Commerce;
+
+use App\Models\Order;
+use RuntimeException;
+
+final class PaymentRecoveryToken
+{
+    /**
+     * @return array{ok:bool,payload?:array{order_no:string,purpose:string,exp:int},error?:string,message?:string}
+     */
+    public function verify(string $token, string $expectedOrderNo): array
+    {
+        $normalizedToken = trim($token);
+        $normalizedOrderNo = trim($expectedOrderNo);
+        if ($normalizedToken === '' || $normalizedOrderNo === '') {
+            return [
+                'ok' => false,
+                'error' => 'PAYMENT_RECOVERY_TOKEN_INVALID',
+                'message' => 'payment recovery token invalid.',
+            ];
+        }
+
+        $segments = explode('.', $normalizedToken);
+        if (count($segments) !== 2) {
+            return [
+                'ok' => false,
+                'error' => 'PAYMENT_RECOVERY_TOKEN_INVALID',
+                'message' => 'payment recovery token invalid.',
+            ];
+        }
+
+        [$payloadSegment, $signatureSegment] = $segments;
+
+        $payloadJson = $this->base64UrlDecode($payloadSegment);
+        $signature = $this->base64UrlDecode($signatureSegment);
+        if ($payloadJson === null || $signature === null) {
+            return [
+                'ok' => false,
+                'error' => 'PAYMENT_RECOVERY_TOKEN_INVALID',
+                'message' => 'payment recovery token invalid.',
+            ];
+        }
+
+        $expectedSignature = hash_hmac('sha256', $payloadSegment, $this->signingKey(), true);
+        if (! hash_equals($expectedSignature, $signature)) {
+            return [
+                'ok' => false,
+                'error' => 'PAYMENT_RECOVERY_TOKEN_INVALID',
+                'message' => 'payment recovery token invalid.',
+            ];
+        }
+
+        $payload = json_decode($payloadJson, true);
+        if (! is_array($payload)) {
+            return [
+                'ok' => false,
+                'error' => 'PAYMENT_RECOVERY_TOKEN_INVALID',
+                'message' => 'payment recovery token invalid.',
+            ];
+        }
+
+        $orderNo = trim((string) ($payload['order_no'] ?? ''));
+        $purpose = trim((string) ($payload['purpose'] ?? ''));
+        $exp = (int) ($payload['exp'] ?? 0);
+
+        if (
+            $orderNo === ''
+            || $purpose !== Order::PAYMENT_RECOVERY_PURPOSE
+            || $exp <= 0
+            || ! hash_equals($normalizedOrderNo, $orderNo)
+        ) {
+            return [
+                'ok' => false,
+                'error' => 'PAYMENT_RECOVERY_TOKEN_INVALID',
+                'message' => 'payment recovery token invalid.',
+            ];
+        }
+
+        if ($exp < time()) {
+            return [
+                'ok' => false,
+                'error' => 'PAYMENT_RECOVERY_TOKEN_EXPIRED',
+                'message' => 'payment recovery token expired.',
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'payload' => [
+                'order_no' => $orderNo,
+                'purpose' => $purpose,
+                'exp' => $exp,
+            ],
+        ];
+    }
+
+    public function issue(string $orderNo, ?int $ttlSeconds = null): string
+    {
+        $normalizedOrderNo = trim($orderNo);
+        if ($normalizedOrderNo === '') {
+            throw new RuntimeException('payment recovery token requires order_no.');
+        }
+
+        $ttl = max(60, (int) ($ttlSeconds ?? Order::PAYMENT_RECOVERY_TOKEN_TTL_SECONDS));
+        $payload = [
+            'order_no' => $normalizedOrderNo,
+            'purpose' => Order::PAYMENT_RECOVERY_PURPOSE,
+            'exp' => time() + $ttl,
+        ];
+
+        $payloadSegment = $this->base64UrlEncode((string) json_encode(
+            $payload,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+        ));
+        $signature = hash_hmac('sha256', $payloadSegment, $this->signingKey(), true);
+
+        return $payloadSegment.'.'.$this->base64UrlEncode($signature);
+    }
+
+    private function signingKey(): string
+    {
+        $key = trim((string) config('app.key', ''));
+        if ($key === '') {
+            throw new RuntimeException('app.key is required for payment recovery token signing.');
+        }
+
+        if (str_starts_with($key, 'base64:')) {
+            $decoded = base64_decode(substr($key, 7), true);
+            if (is_string($decoded) && $decoded !== '') {
+                return $decoded;
+            }
+
+            throw new RuntimeException('app.key base64 decode failed for payment recovery token signing.');
+        }
+
+        return $key;
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private function base64UrlDecode(string $value): ?string
+    {
+        $normalized = strtr($value, '-_', '+/');
+        $remainder = strlen($normalized) % 4;
+        if ($remainder > 0) {
+            $normalized .= str_repeat('=', 4 - $remainder);
+        }
+
+        $decoded = base64_decode($normalized, true);
+
+        return is_string($decoded) ? $decoded : null;
+    }
+}

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_3;
 
 use App\Services\Commerce\Checkout\WechatPayCheckoutService;
+use App\Services\Commerce\PaymentRecoveryToken;
 use Database\Seeders\Pr19CommerceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
@@ -88,6 +89,41 @@ final class CommerceCheckoutPayActionTest extends TestCase
         });
     }
 
+    public function test_checkout_response_includes_payment_recovery_contract_fields(): void
+    {
+        $this->seedCommerce();
+
+        config([
+            'app.frontend_url' => 'https://web.example.test',
+            'payments.providers.billing.enabled' => true,
+        ]);
+
+        $attemptId = 'attempt_checkout_recovery_contract_1';
+        $this->insertAttempt($attemptId, 'anon_checkout_recovery_contract_1', 'en');
+
+        $response = $this->checkout([
+            'sku' => 'MBTI_CREDIT',
+            'provider' => 'billing',
+            'email' => 'checkout-contract@example.com',
+            'attempt_id' => $attemptId,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('provider', 'billing');
+        $response->assertJsonPath('status', 'pending');
+        $response->assertJsonPath('result_url', 'https://web.example.test/en/result/'.$attemptId);
+
+        $orderNo = (string) $response->json('order_no');
+        $paymentRecoveryToken = (string) $response->json('payment_recovery_token');
+        $waitUrl = (string) $response->json('wait_url');
+
+        $this->assertNotSame('', $orderNo);
+        $this->assertNotSame('', $paymentRecoveryToken);
+        $this->assertStringContainsString('/en/orders/'.$orderNo, $waitUrl);
+        $this->assertStringContainsString('orderNo='.$orderNo, $waitUrl);
+        $this->assertStringContainsString('paymentRecoveryToken=', $waitUrl);
+    }
+
     public function test_checkout_wechatpay_desktop_returns_qr_action(): void
     {
         $this->seedCommerce();
@@ -144,6 +180,8 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('checkout_url', null);
         $this->assertStringContainsString('/api/v0.3/orders/', (string) $response->json('pay.value'));
         $this->assertStringContainsString('/pay/alipay?scene=desktop', (string) $response->json('pay.value'));
+        $this->assertNotSame('', (string) $response->json('payment_recovery_token'));
+        $this->assertStringContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
     }
 
     public function test_checkout_alipay_mobile_returns_redirect_and_checkout_url(): void
@@ -168,6 +206,8 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('pay.type', 'redirect');
         $response->assertJsonPath('checkout_url', $response->json('pay.value'));
         $this->assertStringContainsString('/pay/alipay?scene=mobile', (string) $response->json('pay.value'));
+        $this->assertNotSame('', (string) $response->json('payment_recovery_token'));
+        $this->assertStringContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
     }
 
     public function test_checkout_legacy_billing_remains_compatible_without_pay_action(): void
@@ -361,6 +401,32 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('checkout_url', null);
     }
 
+    public function test_alipay_launch_accepts_payment_recovery_token_without_owner_identity(): void
+    {
+        $this->seedCommerce();
+
+        config([
+            'payments.providers.alipay.enabled' => true,
+        ]);
+
+        $orderNo = 'ord_alipay_recovery_checkout_1';
+        $this->insertPendingOrder($orderNo, 'alipay', 'anon_alipay_recovery_checkout_1');
+
+        $service = Mockery::mock(\App\Services\Commerce\Checkout\AlipayCheckoutService::class);
+        $service->shouldReceive('launch')
+            ->once()
+            ->with(Mockery::type('array'), 'desktop')
+            ->andReturn('<html>pay</html>');
+        $this->app->instance(\App\Services\Commerce\Checkout\AlipayCheckoutService::class, $service);
+
+        $token = app(PaymentRecoveryToken::class)->issue($orderNo);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop&paymentRecoveryToken='.urlencode($token));
+
+        $response->assertStatus(200);
+        $response->assertSee('pay');
+    }
+
     private function seedCommerce(): void
     {
         (new Pr19CommerceSeeder)->run();
@@ -432,5 +498,33 @@ final class CommerceCheckoutPayActionTest extends TestCase
         }
 
         DB::table('orders')->insert($row);
+    }
+
+    private function insertAttempt(string $attemptId, string $anonId, string $locale = 'zh-CN'): void
+    {
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 93,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'mbti_spec_2026Q1_v1',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 }

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\V0_3;
 
+use App\Services\Commerce\PaymentRecoveryToken;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -45,9 +46,11 @@ final class CommerceOrderReadFallbackTest extends TestCase
 
     public function test_matching_token_identity_returns_full_payload(): void
     {
+        config(['app.frontend_url' => 'https://web.example.test']);
+
         $orderNo = 'ord_fallback_'.Str::lower(Str::random(10));
         $attemptId = (string) Str::uuid();
-        $this->insertAttempt($attemptId, self::ANON_OWNER);
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'BIG5_OCEAN', 'en');
         $this->insertOrderForOwner($orderNo, $attemptId, 'paid');
 
         $token = $this->issueAnonToken(self::ANON_OWNER);
@@ -64,11 +67,14 @@ final class CommerceOrderReadFallbackTest extends TestCase
             ->assertJsonPath('amount_cents', 1990)
             ->assertJsonPath('currency', 'USD')
             ->assertJsonPath('order.anon_id', self::ANON_OWNER)
+            ->assertJsonPath('result_url', "https://web.example.test/en/result/{$attemptId}")
             ->assertJsonPath('delivery.can_view_report', true)
             ->assertJsonPath('delivery.report_url', "/api/v0.3/attempts/{$attemptId}/report")
             ->assertJsonPath('delivery.can_download_pdf', true)
             ->assertJsonPath('delivery.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
             ->assertJsonPath('delivery.can_resend', false);
+
+        $this->assertNotSame('', (string) $response->json('payment_recovery_token'));
     }
 
     public function test_matching_token_identity_returns_mbti_access_hub_for_mbti_attempt(): void
@@ -100,6 +106,91 @@ final class CommerceOrderReadFallbackTest extends TestCase
             ->assertJsonPath('mbti_access_hub_v1.workspace_lite.has_entry', true)
             ->assertJsonPath('mbti_access_hub_v1.workspace_lite.entry_kind', 'mbti_history')
             ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId);
+    }
+
+    public function test_valid_payment_recovery_token_reads_pending_order_without_owner_identity(): void
+    {
+        config([
+            'app.frontend_url' => 'https://web.example.test',
+            'app.url' => 'http://localhost:8000',
+            'payments.providers.alipay.enabled' => true,
+        ]);
+
+        $orderNo = 'ord_recovery_pending_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'BIG5_OCEAN', 'en');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'created', 'alipay');
+
+        $token = app(PaymentRecoveryToken::class)->issue($orderNo);
+        $response = $this->getJson('/api/v0.3/orders/'.$orderNo.'?payment_recovery_token='.urlencode($token));
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('ownership_verified', false)
+            ->assertJsonPath('order_no', $orderNo)
+            ->assertJsonPath('status', 'pending')
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('payment_recovery_token', $token)
+            ->assertJsonPath('result_url', "https://web.example.test/en/result/{$attemptId}")
+            ->assertJsonPath('provider', 'alipay')
+            ->assertJsonPath('pay.type', 'html')
+            ->assertJsonPath('checkout_url', null)
+            ->assertJsonMissingPath('order');
+
+        $this->assertStringContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
+    }
+
+    public function test_valid_payment_recovery_token_reads_paid_order_without_owner_identity(): void
+    {
+        config(['app.frontend_url' => 'https://web.example.test']);
+
+        $orderNo = 'ord_recovery_paid_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'BIG5_OCEAN', 'zh-CN');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'fulfilled');
+
+        $token = app(PaymentRecoveryToken::class)->issue($orderNo);
+        $response = $this->withHeaders([
+            'X-Payment-Recovery-Token' => $token,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('ownership_verified', false)
+            ->assertJsonPath('order_no', $orderNo)
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('payment_recovery_token', $token)
+            ->assertJsonPath('result_url', "https://web.example.test/zh/result/{$attemptId}")
+            ->assertJsonPath('pay', null)
+            ->assertJsonPath('checkout_url', null)
+            ->assertJsonMissingPath('order');
+    }
+
+    public function test_expired_payment_recovery_token_is_rejected(): void
+    {
+        $orderNo = 'ord_recovery_expired_'.Str::lower(Str::random(10));
+        $this->insertOrderForOwner($orderNo);
+
+        $token = $this->issuePaymentRecoveryToken($orderNo, time() - 60);
+        $response = $this->getJson('/api/v0.3/orders/'.$orderNo.'?payment_recovery_token='.urlencode($token));
+
+        $response->assertStatus(403)
+            ->assertJsonPath('error_code', 'PAYMENT_RECOVERY_TOKEN_EXPIRED');
+    }
+
+    public function test_tampered_payment_recovery_token_is_rejected(): void
+    {
+        $orderNo = 'ord_recovery_tampered_'.Str::lower(Str::random(10));
+        $this->insertOrderForOwner($orderNo);
+
+        $token = app(PaymentRecoveryToken::class)->issue($orderNo);
+        $tampered = substr($token, 0, -1).(str_ends_with($token, 'a') ? 'b' : 'a');
+
+        $response = $this->getJson('/api/v0.3/orders/'.$orderNo.'?payment_recovery_token='.urlencode($tampered));
+
+        $response->assertStatus(403)
+            ->assertJsonPath('error_code', 'PAYMENT_RECOVERY_TOKEN_INVALID');
     }
 
     private function issueAnonToken(string $anonId): string
@@ -137,8 +228,12 @@ final class CommerceOrderReadFallbackTest extends TestCase
         return $token;
     }
 
-    private function insertAttempt(string $attemptId, string $anonId, string $scaleCode = 'BIG5_OCEAN'): void
-    {
+    private function insertAttempt(
+        string $attemptId,
+        string $anonId,
+        string $scaleCode = 'BIG5_OCEAN',
+        string $locale = 'zh-CN'
+    ): void {
         DB::table('attempts')->insert([
             'id' => $attemptId,
             'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
@@ -148,7 +243,7 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'scale_code' => $scaleCode,
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
-            'locale' => 'zh-CN',
+            'locale' => $locale,
             'question_count' => 120,
             'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'client_platform' => 'test',
@@ -165,8 +260,12 @@ final class CommerceOrderReadFallbackTest extends TestCase
         ]);
     }
 
-    private function insertOrderForOwner(string $orderNo, ?string $attemptId = null, string $status = 'created'): void
-    {
+    private function insertOrderForOwner(
+        string $orderNo,
+        ?string $attemptId = null,
+        string $status = 'created',
+        string $provider = 'billing'
+    ): void {
         $now = now();
         $row = [
             'id' => (string) Str::uuid(),
@@ -180,7 +279,7 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'amount_cents' => 1990,
             'currency' => 'USD',
             'status' => $status,
-            'provider' => 'billing',
+            'provider' => $provider,
             'external_trade_no' => null,
             'paid_at' => $status === 'paid' ? $now : null,
             'created_at' => $now,
@@ -222,5 +321,40 @@ final class CommerceOrderReadFallbackTest extends TestCase
         }
 
         DB::table('orders')->insert($row);
+    }
+
+    private function issuePaymentRecoveryToken(string $orderNo, int $exp): string
+    {
+        $payload = [
+            'order_no' => $orderNo,
+            'purpose' => \App\Models\Order::PAYMENT_RECOVERY_PURPOSE,
+            'exp' => $exp,
+        ];
+
+        $payloadSegment = $this->base64UrlEncode((string) json_encode(
+            $payload,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+        ));
+        $signature = hash_hmac('sha256', $payloadSegment, $this->paymentRecoverySigningKey(), true);
+
+        return $payloadSegment.'.'.$this->base64UrlEncode($signature);
+    }
+
+    private function paymentRecoverySigningKey(): string
+    {
+        $key = (string) config('app.key', '');
+        if (str_starts_with($key, 'base64:')) {
+            $decoded = base64_decode(substr($key, 7), true);
+            if (is_string($decoded) && $decoded !== '') {
+                return $decoded;
+            }
+        }
+
+        return $key;
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a token-based payment recovery contract for the v0.3 commerce funnel so order recovery no longer depends on ambient browser identity (`user_id` / `anon_id`).

## Scope
- add stateless signed `payment_recovery_token` issuance and verification using `app.key`
- extend checkout responses with `payment_recovery_token`, `wait_url`, and `result_url`
- extend `GET /api/v0.3/orders/{order_no}` to support recovery reads via query/header token while preserving legacy owner reads
- allow the Alipay launch endpoint to accept the same recovery token so cached/local pay actions remain usable after identity loss
- keep routes, migrations, payment cache persistence semantics, provider logic, and non-payment surfaces unchanged

## Contract changes
- checkout response now includes:
  - `payment_recovery_token`
  - `wait_url`
  - `result_url`
- order status response now includes:
  - `payment_recovery_token`
  - `result_url`
- `/api/v0.3/orders/{order_no}` now accepts:
  - query `payment_recovery_token`
  - header `X-Payment-Recovery-Token`
- valid recovery tokens allow read-only payment recovery for:
  - status
  - attempt_id
  - result_url
  - pay / checkout_url
  - simplified delivery
- invalid or expired recovery tokens are rejected
- owner reads and no-owner/no-token behavior remain unchanged

## Validation
- `cd backend && php artisan route:list | grep -Ei "orders|checkout|payment|result"`
- `cd backend && php artisan migrate`
- `cd backend && vendor/bin/phpunit tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`
- `cd backend && vendor/bin/phpunit tests/Feature/V0_3/CommerceOrderReadFallbackTest.php`
- `cd backend && vendor/bin/phpunit tests/Feature/V0_3/*Commerce* tests/Feature/V0_3/*Order* tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`
- `cd backend && bash scripts/export_openapi.sh`
- `cd backend && bash scripts/ci_verify_mbti.sh`

## Notes
- `backend/docs/contracts/openapi.snapshot.json` was re-exported and remained unchanged because the current snapshot is route-list based and does not encode response-body field schema changes.
