### PR TITLE
[codex] fix(payment): harden unlock-to-pay and paid-to-result funnel

### DIFF
--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -359,10 +359,10 @@ class OrderManager
         $waitUrl = null;
         $normalizedPaymentRecoveryToken = $this->trimOrNull($paymentRecoveryToken);
         if ($orderNo !== null && $normalizedPaymentRecoveryToken !== null) {
-            $waitUrl = $base.'/'.$localeSegment.'/orders/'.urlencode($orderNo)
+            $waitUrl = $base.'/'.$localeSegment.'/pay/wait'
                 .'?'.http_build_query([
-                    'orderNo' => $orderNo,
-                    'paymentRecoveryToken' => $normalizedPaymentRecoveryToken,
+                    'order_no' => $orderNo,
+                    'payment_recovery_token' => $normalizedPaymentRecoveryToken,
                 ]);
         }
 

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -119,9 +119,9 @@ final class CommerceCheckoutPayActionTest extends TestCase
 
         $this->assertNotSame('', $orderNo);
         $this->assertNotSame('', $paymentRecoveryToken);
-        $this->assertStringContainsString('/en/orders/'.$orderNo, $waitUrl);
-        $this->assertStringContainsString('orderNo='.$orderNo, $waitUrl);
-        $this->assertStringContainsString('paymentRecoveryToken=', $waitUrl);
+        $this->assertStringContainsString('/en/pay/wait', $waitUrl);
+        $this->assertStringContainsString('order_no='.$orderNo, $waitUrl);
+        $this->assertStringContainsString('payment_recovery_token=', $waitUrl);
     }
 
     public function test_checkout_wechatpay_desktop_returns_qr_action(): void


### PR DESCRIPTION
## Summary
This PR hardens the payment funnel so checkout recovery, wait-page refresh, and provider return flows all converge on the same paid-to-result path.

## Scope
- make backend checkout wait_url point to the tokenized wait surface
- keep paid redirect authoritative on result_url
- keep naked order reads locked when owner and recovery token are both missing
- add focused payment funnel tests only

## Validation
- php artisan route:list | grep -Ei "orders|checkout|payment|result"
- php artisan migrate
- vendor/bin/phpunit tests/Feature/V0_3/CommerceCheckoutPayActionTest.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
- vendor/bin/phpunit tests/Feature/V0_3
- bash scripts/ci_verify_mbti.sh

## Notes
- The scoped payment tests are green.
- The full tests/Feature/V0_3 suite still contains one unrelated pre-existing failure in ReportErrorContractTest outside this PR's scope.