### PR TITLE
[codex] fix(api): allow payment recovery token in cors preflight

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -18,6 +18,7 @@ return [
         'X-Org-Id',
         'X-FM-Org-Id',
         'X-Anon-Id',
+        'X-Payment-Recovery-Token',
         'X-Region',
         'X-Fap-Locale',
         'Idempotency-Key',

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -44,6 +44,31 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $this->assertStringContainsString('x-region', $allowedHeaders);
     }
 
+    public function test_order_status_options_allows_payment_recovery_token_header_for_browser_preflight(): void
+    {
+        $response = app()->handle(Request::create(
+            '/api/v0.3/orders/ord_payment_recovery_preflight_1',
+            'OPTIONS',
+            [
+                'include_payment_action' => '1',
+                'payment_recovery_token' => 'token_payment_recovery_preflight_1',
+            ],
+            [],
+            [],
+            [
+                'HTTP_ORIGIN' => 'https://www.fermatmind.com',
+                'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET',
+                'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-payment-recovery-token,x-anon-id',
+            ]
+        ));
+
+        $this->assertContains($response->getStatusCode(), [200, 204]);
+
+        $allowedHeaders = strtolower((string) $response->headers->get('Access-Control-Allow-Headers', ''));
+        $this->assertStringContainsString('x-payment-recovery-token', $allowedHeaders);
+        $this->assertStringContainsString('x-anon-id', $allowedHeaders);
+    }
+
     public function test_checkout_lemonsqueezy_returns_pay_redirect_and_checkout_url(): void
     {
         $this->seedCommerce();


### PR DESCRIPTION
## Summary

This hotfix restores the token-based payment recovery flow by allowing the browser preflight for `X-Payment-Recovery-Token`.

The current production failure is not in the checkout, order recovery, or payment action business logic. The browser never reaches `GET /api/v0.3/orders/{orderNo}` because the cross-origin preflight is rejected before the request can hit Laravel. The frontend now sends the recovery token in both the query string and the `X-Payment-Recovery-Token` header, but the API CORS allowlist did not include that header.

## What Changed

- Added `X-Payment-Recovery-Token` to the API CORS `allowed_headers` list.
- Added a dedicated browser preflight regression test for `OPTIONS /api/v0.3/orders/{orderNo}` asserting that `x-payment-recovery-token` is allowed.

## Why This Fix

The backend already supports reading the payment recovery token from either the query string or the header. The token recovery path and order read logic are already implemented. The actual blocker in production is that the browser upgrades the recovery request into a preflighted CORS request because of the custom header, and the preflight response did not allow that header. This hotfix makes the existing recovery flow reachable.

## Validation

- `php -l backend/config/cors.php`
- `php -l backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`
- `php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`

## Post-deploy verification

1. Run a real preflight against production and confirm `Access-Control-Allow-Headers` includes `x-payment-recovery-token`.
2. Reload a `/pay/wait?...payment_recovery_token=...` page and verify the browser sends the real `GET /api/v0.3/orders/{orderNo}` request instead of failing in preflight.
