### PR TITLE
[codex] fix(api): route cn mainland checkout to configured wechatpay

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -10,6 +10,7 @@ use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Commerce\OrderManager;
 use App\Services\Commerce\SkuCatalog;
 use App\Services\Email\EmailCaptureService;
+use App\Services\Payments\PaymentProviderRegistry;
 use App\Services\Payments\PaymentRouter;
 use App\Services\Report\ReportAccess;
 use App\Support\OrgContext;
@@ -31,6 +32,7 @@ class CommerceController extends Controller
         private EmailCaptureService $emailCaptures,
         private SkuCatalog $skus,
         private PaymentRouter $paymentRouter,
+        private PaymentProviderRegistry $paymentProviders,
         private MbtiAccessHubBuilder $mbtiAccessHubBuilder,
         private LemonSqueezyCheckoutService $lemonSqueezyCheckout,
         private WechatPayCheckoutService $wechatPayCheckout,
@@ -1025,50 +1027,12 @@ class CommerceController extends Controller
 
     private function allowedProviders(): array
     {
-        $providers = [];
-        $configured = config('payments.providers', []);
-        if (is_array($configured)) {
-            foreach ($configured as $provider => $providerConfig) {
-                if (! is_string($provider)) {
-                    continue;
-                }
-
-                $provider = strtolower(trim($provider));
-                if ($provider === '') {
-                    continue;
-                }
-
-                $enabled = (bool) (is_array($providerConfig) ? ($providerConfig['enabled'] ?? false) : false);
-                if (! $enabled) {
-                    continue;
-                }
-
-                if ($provider === 'stub' && ! $this->isStubEnabled()) {
-                    continue;
-                }
-
-                $providers[] = $provider;
-            }
-        }
-
-        if ($providers === []) {
-            $providers = ['stripe', 'billing'];
-            if ($this->isStubEnabled()) {
-                $providers[] = 'stub';
-            }
-        }
-
-        return array_values(array_unique($providers));
+        return $this->paymentProviders->enabledProviders();
     }
 
     private function isProviderEnabled(string $provider): bool
     {
-        return in_array(strtolower(trim($provider)), $this->allowedProviders(), true);
-    }
-
-    private function isStubEnabled(): bool
-    {
-        return app()->environment(['local', 'testing']) && config('payments.allow_stub') === true;
+        return $this->paymentProviders->isEnabled($provider);
     }
 
     private function resolveRequestId(Request $request): string

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -4,6 +4,7 @@ namespace App\Services\Commerce;
 
 use App\Models\Order;
 use App\Services\Email\EmailOutboxService;
+use App\Services\Payments\PaymentProviderRegistry;
 use App\Services\Report\ReportAccess;
 use App\Services\Scale\ScaleIdentityWriteProjector;
 use Illuminate\Support\Facades\DB;
@@ -23,6 +24,7 @@ class OrderManager
         private ScaleIdentityWriteProjector $identityProjector,
         private EmailOutboxService $emailOutbox,
         private PaymentRecoveryToken $paymentRecoveryTokens,
+        private PaymentProviderRegistry $paymentProviders,
     ) {}
 
     public function createOrder(
@@ -1154,45 +1156,7 @@ class OrderManager
 
     private function allowedProviders(): array
     {
-        $providers = [];
-        $configured = config('payments.providers', []);
-        if (is_array($configured)) {
-            foreach ($configured as $provider => $providerConfig) {
-                if (! is_string($provider)) {
-                    continue;
-                }
-
-                $provider = strtolower(trim($provider));
-                if ($provider === '') {
-                    continue;
-                }
-
-                $enabled = (bool) (is_array($providerConfig) ? ($providerConfig['enabled'] ?? false) : false);
-                if (! $enabled) {
-                    continue;
-                }
-
-                if ($provider === 'stub' && ! $this->isStubEnabled()) {
-                    continue;
-                }
-
-                $providers[] = $provider;
-            }
-        }
-
-        if ($providers === []) {
-            $providers = ['stripe', 'billing'];
-            if ($this->isStubEnabled()) {
-                $providers[] = 'stub';
-            }
-        }
-
-        return array_values(array_unique($providers));
-    }
-
-    private function isStubEnabled(): bool
-    {
-        return app()->environment(['local', 'testing']) && config('payments.allow_stub') === true;
+        return $this->paymentProviders->enabledProviders();
     }
 
     /**

--- a/backend/app/Services/Payments/PaymentProviderRegistry.php
+++ b/backend/app/Services/Payments/PaymentProviderRegistry.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payments;
+
+use Yansongda\Pay\Pay;
+
+final class PaymentProviderRegistry
+{
+    /**
+     * @return array<int, string>
+     */
+    public function enabledProviders(): array
+    {
+        $providers = [];
+        $configured = config('payments.providers', []);
+        if (is_array($configured)) {
+            foreach ($configured as $provider => $providerConfig) {
+                if (! is_string($provider)) {
+                    continue;
+                }
+
+                $provider = strtolower(trim($provider));
+                if ($provider === '') {
+                    continue;
+                }
+
+                if ($provider === 'stub' && ! $this->isStubEnabled()) {
+                    continue;
+                }
+
+                if ($this->isEnabled($provider)) {
+                    $providers[] = $provider;
+                }
+            }
+        }
+
+        if ($providers === []) {
+            $providers = ['stripe', 'billing'];
+            if ($this->isStubEnabled()) {
+                $providers[] = 'stub';
+            }
+        }
+
+        return array_values(array_unique($providers));
+    }
+
+    public function isEnabled(string $provider): bool
+    {
+        $provider = strtolower(trim($provider));
+        if ($provider === '') {
+            return false;
+        }
+
+        $providerConfig = config('payments.providers.'.$provider, []);
+        $explicitEnabled = (bool) (is_array($providerConfig) ? ($providerConfig['enabled'] ?? false) : false);
+        if ($explicitEnabled) {
+            return $provider !== 'stub' || $this->isStubEnabled();
+        }
+
+        $autoEnable = (bool) (is_array($providerConfig) ? ($providerConfig['auto_enable_when_configured'] ?? false) : false);
+        if (! $autoEnable) {
+            return false;
+        }
+
+        return match ($provider) {
+            'wechatpay' => $this->isWechatPayConfigured(),
+            'alipay' => $this->isAlipayConfigured(),
+            default => false,
+        };
+    }
+
+    private function isWechatPayConfigured(): bool
+    {
+        if (! class_exists(Pay::class)) {
+            return false;
+        }
+
+        $wechat = config('pay.wechat.default', []);
+        if (! is_array($wechat)) {
+            return false;
+        }
+
+        $appId = trim((string) ($wechat['mp_app_id'] ?? ''));
+        if ($appId === '') {
+            $appId = trim((string) ($wechat['app_id'] ?? ''));
+        }
+        if ($appId === '') {
+            $appId = trim((string) ($wechat['mini_app_id'] ?? ''));
+        }
+
+        if ($appId === '') {
+            return false;
+        }
+
+        if (trim((string) ($wechat['mch_id'] ?? '')) === '') {
+            return false;
+        }
+
+        $mchSecretKey = trim((string) ($wechat['mch_secret_key'] ?? ''));
+        if ($mchSecretKey === '' || strlen($mchSecretKey) !== 32) {
+            return false;
+        }
+
+        return $this->isReadableCertInput($wechat['mch_secret_cert'] ?? null)
+            && $this->isReadableCertInput($wechat['mch_public_cert_path'] ?? null)
+            && $this->isReadableCertInput($wechat['wechat_public_cert_path'] ?? null);
+    }
+
+    private function isAlipayConfigured(): bool
+    {
+        if (! class_exists(Pay::class)) {
+            return false;
+        }
+
+        $alipay = config('pay.alipay.default', []);
+        if (! is_array($alipay)) {
+            return false;
+        }
+
+        if (trim((string) ($alipay['app_id'] ?? '')) === '') {
+            return false;
+        }
+
+        $hasMerchantPrivateKey = trim((string) ($alipay['merchant_private_key'] ?? '')) !== ''
+            || $this->isReadableCertInput($alipay['merchant_private_key_path'] ?? null);
+
+        if (! $hasMerchantPrivateKey) {
+            return false;
+        }
+
+        return $this->isReadableCertInput($alipay['app_public_cert_path'] ?? null)
+            && $this->isReadableCertInput($alipay['alipay_public_cert_path'] ?? null)
+            && $this->isReadableCertInput($alipay['alipay_root_cert_path'] ?? null);
+    }
+
+    private function isReadableCertInput(mixed $value): bool
+    {
+        if (is_array($value)) {
+            return $value !== [];
+        }
+
+        $raw = trim((string) $value);
+        if ($raw === '') {
+            return false;
+        }
+
+        if (str_starts_with($raw, '-----BEGIN')) {
+            return true;
+        }
+
+        $path = $this->resolvePath($raw);
+
+        return is_file($path) && is_readable($path) && filesize($path) > 0;
+    }
+
+    private function resolvePath(string $path): string
+    {
+        if (str_starts_with($path, '/')) {
+            return $path;
+        }
+
+        return base_path($path);
+    }
+
+    private function isStubEnabled(): bool
+    {
+        return app()->environment(['local', 'testing']) && config('payments.allow_stub') === true;
+    }
+}

--- a/backend/app/Services/Payments/PaymentRouter.php
+++ b/backend/app/Services/Payments/PaymentRouter.php
@@ -6,10 +6,14 @@ namespace App\Services\Payments;
 
 final class PaymentRouter
 {
+    public function __construct(
+        private PaymentProviderRegistry $providers,
+    ) {}
+
     public function methodsForRegion(string $region): array
     {
         $region = $this->normalizeRegion($region);
-        $allowed = $this->allowedProviders();
+        $allowed = $this->providers->enabledProviders();
 
         $priority = config('payments.provider_priority', []);
         $methods = [];
@@ -59,46 +63,4 @@ final class PaymentRouter
         return $default !== '' ? $default : 'CN_MAINLAND';
     }
 
-    private function allowedProviders(): array
-    {
-        $providers = [];
-        $configured = config('payments.providers', []);
-        if (is_array($configured)) {
-            foreach ($configured as $provider => $providerConfig) {
-                if (! is_string($provider)) {
-                    continue;
-                }
-
-                $provider = strtolower(trim($provider));
-                if ($provider === '') {
-                    continue;
-                }
-
-                $enabled = (bool) (is_array($providerConfig) ? ($providerConfig['enabled'] ?? false) : false);
-                if (! $enabled) {
-                    continue;
-                }
-
-                if ($provider === 'stub' && ! $this->isStubEnabled()) {
-                    continue;
-                }
-
-                $providers[] = $provider;
-            }
-        }
-
-        if ($providers === []) {
-            $providers = ['stripe', 'billing'];
-            if ($this->isStubEnabled()) {
-                $providers[] = 'stub';
-            }
-        }
-
-        return array_values(array_unique($providers));
-    }
-
-    private function isStubEnabled(): bool
-    {
-        return app()->environment(['local', 'testing']) && config('payments.allow_stub') === true;
-    }
 }

--- a/backend/config/payments.php
+++ b/backend/config/payments.php
@@ -35,9 +35,11 @@ return [
         ],
         'wechatpay' => [
             'enabled' => (bool) env('PAYMENTS_PROVIDER_WECHATPAY_ENABLED', false),
+            'auto_enable_when_configured' => (bool) env('PAYMENTS_PROVIDER_WECHATPAY_AUTO_ENABLE_WHEN_CONFIGURED', true),
         ],
         'alipay' => [
             'enabled' => (bool) env('PAYMENTS_PROVIDER_ALIPAY_ENABLED', false),
+            'auto_enable_when_configured' => (bool) env('PAYMENTS_PROVIDER_ALIPAY_AUTO_ENABLE_WHEN_CONFIGURED', true),
         ],
         'stub' => [
             'enabled' => (bool) env('PAYMENTS_ALLOW_STUB', false),

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -182,6 +182,53 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('checkout_url', null);
     }
 
+    public function test_checkout_cn_mainland_prefers_configured_wechatpay_even_when_enabled_flag_is_false(): void
+    {
+        $this->seedCommerce();
+
+        $certFiles = $this->createTempCertFiles(3);
+
+        try {
+            config([
+                'payments.providers.wechatpay.enabled' => false,
+                'payments.providers.wechatpay.auto_enable_when_configured' => true,
+                'payments.providers.billing.enabled' => true,
+                'pay.wechat.default.app_id' => 'wx_auto_enabled_001',
+                'pay.wechat.default.mch_id' => '1900000109',
+                'pay.wechat.default.mch_secret_key' => '12345678901234567890123456789012',
+                'pay.wechat.default.mch_secret_cert' => $certFiles[0],
+                'pay.wechat.default.mch_public_cert_path' => $certFiles[1],
+                'pay.wechat.default.wechat_public_cert_path' => ['wechatpay_cert_001' => $certFiles[2]],
+            ]);
+
+            $mock = Mockery::mock(WechatPayCheckoutService::class);
+            $mock->shouldReceive('createCheckoutAction')
+                ->once()
+                ->andReturn([
+                    'ok' => true,
+                    'type' => 'qr',
+                    'value' => 'weixin://wxpay/bizpayurl?pr=auto_enabled_wechatpay',
+                ]);
+            $this->app->instance(WechatPayCheckoutService::class, $mock);
+
+            $response = $this->checkout([
+                'sku' => 'MBTI_CREDIT',
+                'email' => 'wechat-auto-enabled@example.com',
+                'attempt_id' => 'attempt_wechat_auto_enabled_001',
+            ], [
+                'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+                'X-Region' => 'CN_MAINLAND',
+            ]);
+
+            $response->assertStatus(200);
+            $response->assertJsonPath('provider', 'wechatpay');
+            $response->assertJsonPath('pay.type', 'qr');
+            $response->assertJsonPath('pay.value', 'weixin://wxpay/bizpayurl?pr=auto_enabled_wechatpay');
+        } finally {
+            $this->cleanupTempFiles($certFiles);
+        }
+    }
+
     public function test_checkout_alipay_desktop_returns_html_action_with_launch_url(): void
     {
         $this->seedCommerce();
@@ -551,5 +598,36 @@ final class CommerceCheckoutPayActionTest extends TestCase
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function createTempCertFiles(int $count): array
+    {
+        $files = [];
+        for ($index = 0; $index < $count; $index++) {
+            $path = tempnam(sys_get_temp_dir(), 'commerce_pay_cert_');
+            if (! is_string($path) || trim($path) === '') {
+                self::fail('failed to create temporary cert file.');
+            }
+
+            file_put_contents($path, 'dummy-cert-'.$index);
+            $files[] = $path;
+        }
+
+        return $files;
+    }
+
+    /**
+     * @param  array<int, string>  $files
+     */
+    private function cleanupTempFiles(array $files): void
+    {
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make CN_MAINLAND checkout route to WeChat Pay when runtime WeChat config is complete, even if the legacy enabled flag is still false
- unify provider availability checks across PaymentRouter, CommerceController, and OrderManager so checkout, order reads, and provider guards all use the same decision
- add a regression test locking the production failure mode: billing enabled, wechatpay flag false, but valid WeChat config should still produce provider=wechatpay with a QR pay action

## Why
Production checkout is currently falling back to `billing`, which returns `pay=null` and leaves `/pay/wait` stuck in pending. The actual issue is provider selection, not token recovery or webhook flow.

## Validation
- php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
- php artisan test tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
- php artisan test tests/Feature/V0_3/AlipayLaunchEndpointTest.php
- php artisan test tests/Unit/Ops/GoLiveGateServiceTest.php