### PR TITLE
[codex] fix(payments): map alipay private key into app_secret_cert for launch flow

### DIFF
--- a/backend/config/pay.php
+++ b/backend/config/pay.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+$alipayMerchantPrivateKey = trim((string) env('ALIPAY_MERCHANT_PRIVATE_KEY', ''));
+$alipayMerchantPrivateKeyPath = trim((string) env(
+    'ALIPAY_MERCHANT_PRIVATE_KEY_PATH',
+    storage_path('app/cert/alipay/app_private_key.pem')
+));
+$resolvedAlipayPrivateKey = $alipayMerchantPrivateKey;
+
+if (
+    $resolvedAlipayPrivateKey === ''
+    && $alipayMerchantPrivateKeyPath !== ''
+    && is_file($alipayMerchantPrivateKeyPath)
+    && is_readable($alipayMerchantPrivateKeyPath)
+) {
+    $loadedAlipayPrivateKey = file_get_contents($alipayMerchantPrivateKeyPath);
+    $resolvedAlipayPrivateKey = is_string($loadedAlipayPrivateKey)
+        ? trim($loadedAlipayPrivateKey)
+        : '';
+}
+
 return [
     'wechat' => [
         'default' => [
@@ -31,11 +50,9 @@ return [
     'alipay' => [
         'default' => [
             'app_id' => env('ALIPAY_APP_ID', ''),
-            'merchant_private_key' => env('ALIPAY_MERCHANT_PRIVATE_KEY', ''),
-            'merchant_private_key_path' => env(
-                'ALIPAY_MERCHANT_PRIVATE_KEY_PATH',
-                storage_path('app/cert/alipay/app_private_key.pem')
-            ),
+            'merchant_private_key' => $alipayMerchantPrivateKey,
+            'merchant_private_key_path' => $alipayMerchantPrivateKeyPath,
+            'app_secret_cert' => $resolvedAlipayPrivateKey,
             'app_public_cert_path' => env(
                 'ALIPAY_APP_PUBLIC_CERT',
                 storage_path('app/cert/alipay/appCertPublicKey.crt')

--- a/backend/tests/Unit/Config/PayConfigTest.php
+++ b/backend/tests/Unit/Config/PayConfigTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Config;
+
+use Tests\TestCase;
+
+final class PayConfigTest extends TestCase
+{
+    public function test_alipay_app_secret_cert_is_resolved_from_private_key_path_when_inline_key_is_blank(): void
+    {
+        $pem = "-----BEGIN PRIVATE KEY-----\nunit-test-key\n-----END PRIVATE KEY-----";
+        $path = tempnam(sys_get_temp_dir(), 'alipay_private_key_');
+
+        if (! is_string($path) || trim($path) === '') {
+            self::fail('failed to create temporary private key file.');
+        }
+
+        file_put_contents($path, $pem);
+        $snapshot = $this->snapshotEnv([
+            'ALIPAY_MERCHANT_PRIVATE_KEY',
+            'ALIPAY_MERCHANT_PRIVATE_KEY_PATH',
+        ]);
+
+        try {
+            $this->setEnvValue('ALIPAY_MERCHANT_PRIVATE_KEY', '');
+            $this->setEnvValue('ALIPAY_MERCHANT_PRIVATE_KEY_PATH', $path);
+
+            config(['pay' => require base_path('config/pay.php')]);
+
+            $appSecretCert = (string) config('pay.alipay.default.app_secret_cert');
+
+            $this->assertNotSame('', $appSecretCert);
+            $this->assertStringContainsString('BEGIN PRIVATE KEY', $appSecretCert);
+            $this->assertSame(trim($pem), $appSecretCert);
+            $this->assertSame($path, config('pay.alipay.default.merchant_private_key_path'));
+            $this->assertArrayHasKey('alipay_public_cert_path', config('pay.alipay.default', []));
+        } finally {
+            $this->restoreEnv($snapshot);
+            @unlink($path);
+            config(['pay' => require base_path('config/pay.php')]);
+        }
+    }
+
+    public function test_alipay_app_secret_cert_prefers_inline_private_key_over_private_key_path(): void
+    {
+        $inlinePem = "-----BEGIN PRIVATE KEY-----\ninline-test-key\n-----END PRIVATE KEY-----";
+        $path = tempnam(sys_get_temp_dir(), 'alipay_private_key_');
+
+        if (! is_string($path) || trim($path) === '') {
+            self::fail('failed to create temporary private key file.');
+        }
+
+        file_put_contents($path, "-----BEGIN PRIVATE KEY-----\npath-test-key\n-----END PRIVATE KEY-----");
+        $snapshot = $this->snapshotEnv([
+            'ALIPAY_MERCHANT_PRIVATE_KEY',
+            'ALIPAY_MERCHANT_PRIVATE_KEY_PATH',
+        ]);
+
+        try {
+            $this->setEnvValue('ALIPAY_MERCHANT_PRIVATE_KEY', $inlinePem);
+            $this->setEnvValue('ALIPAY_MERCHANT_PRIVATE_KEY_PATH', $path);
+
+            config(['pay' => require base_path('config/pay.php')]);
+
+            $this->assertSame(trim($inlinePem), config('pay.alipay.default.app_secret_cert'));
+            $this->assertSame(trim($inlinePem), config('pay.alipay.default.merchant_private_key'));
+        } finally {
+            $this->restoreEnv($snapshot);
+            @unlink($path);
+            config(['pay' => require base_path('config/pay.php')]);
+        }
+    }
+
+    /**
+     * @param  array<int, string>  $keys
+     * @return array<string, array{getenv: string|false, env: mixed, server: mixed}>
+     */
+    private function snapshotEnv(array $keys): array
+    {
+        $snapshot = [];
+
+        foreach ($keys as $key) {
+            $snapshot[$key] = [
+                'getenv' => getenv($key),
+                'env' => $_ENV[$key] ?? null,
+                'server' => $_SERVER[$key] ?? null,
+            ];
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * @param  array<string, array{getenv: string|false, env: mixed, server: mixed}>  $snapshot
+     */
+    private function restoreEnv(array $snapshot): void
+    {
+        foreach ($snapshot as $key => $values) {
+            $getenvValue = $values['getenv'];
+            if ($getenvValue === false) {
+                putenv($key);
+            } else {
+                putenv($key.'='.$getenvValue);
+            }
+
+            if ($values['env'] === null) {
+                unset($_ENV[$key]);
+            } else {
+                $_ENV[$key] = $values['env'];
+            }
+
+            if ($values['server'] === null) {
+                unset($_SERVER[$key]);
+            } else {
+                $_SERVER[$key] = $values['server'];
+            }
+        }
+    }
+
+    private function setEnvValue(string $key, ?string $value): void
+    {
+        if ($value === null) {
+            putenv($key);
+            unset($_ENV[$key], $_SERVER[$key]);
+
+            return;
+        }
+
+        putenv($key.'='.$value);
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes the immediate Alipay launch blocker in `config/pay.php` by mapping the existing merchant private key inputs into the SDK key that `yansongda/pay` actually reads: `app_secret_cert`.

## Problem
Alipay launch was already reaching the backend contract and provider routing layers, but failed before it could enter platform-side validation. The runtime error was:

`ALIPAY_LAUNCH_FAILED`
`配置异常: 缺少支付宝配置 -- [app_secret_cert]`

The blocking issue was not in the frontend, launch controller, payment router, or recovery flow. It was in the config bridge between our existing env values and the SDK's expected config shape.

## Root cause
`vendor/yansongda/pay/src/Plugin/Alipay/V2/AddPayloadSignaturePlugin.php` reads the private key from:

- `get_provider_config('alipay', $params)['app_secret_cert']`

Our `config/pay.php` exposed:

- `merchant_private_key`
- `merchant_private_key_path`

but it did not expose `app_secret_cert`, so the SDK threw an `InvalidConfigException` before signing the launch payload.

## Fix
The fix stays intentionally small and local to config:

- keep the existing env contract unchanged
- resolve the Alipay private key with this priority:
  1. `ALIPAY_MERCHANT_PRIVATE_KEY`
  2. file contents from `ALIPAY_MERCHANT_PRIVATE_KEY_PATH`
  3. empty string when the path is missing or unreadable
- map the resolved key into `pay.alipay.default.app_secret_cert`
- keep `merchant_private_key` and `merchant_private_key_path` in place for compatibility and existing diagnostics

## Scope
- backend only
- no frontend changes
- no payment routing changes
- no controller/service changes
- no deploy script changes
- no SDK replacement

## Validation
Targeted tests:

- `php artisan test tests/Unit/Config/PayConfigTest.php tests/Feature/V0_3/AlipayLaunchEndpointTest.php`
- `php artisan test tests/Feature/V0_3/PaymentWebhookCnCallbackTest.php tests/Unit/Ops/GoLiveGateServiceTest.php`

Local runtime smoke with a temporary PEM path:

- `app_secret_cert_present => true`
- `app_secret_cert_len => 76`

## Follow-up
This PR only removes the local config blocker. If staging launch proceeds past this point and Alipay then rejects the request because the app is still in a platform-side development or not-live state, that is the next layer and should be handled separately.
