### PR TITLE
[codex] fix(payments): stop injecting default alipay mode into vendor config

### DIFF
--- a/backend/config/pay.php
+++ b/backend/config/pay.php
@@ -7,6 +7,7 @@ $alipayMerchantPrivateKeyPath = trim((string) env(
     'ALIPAY_MERCHANT_PRIVATE_KEY_PATH',
     storage_path('app/cert/alipay/app_private_key.pem')
 ));
+$alipayMode = trim((string) env('ALIPAY_MODE', ''));
 $resolvedAlipayPrivateKey = $alipayMerchantPrivateKey;
 
 if (
@@ -67,7 +68,7 @@ return [
             ),
             'notify_url' => env('ALIPAY_NOTIFY_URL', ''),
             'return_url' => env('ALIPAY_RETURN_URL', ''),
-            'mode' => env('ALIPAY_MODE', 'normal'),
+            ...($alipayMode !== '' ? ['mode' => $alipayMode] : []),
         ],
     ],
 ];

--- a/backend/tests/Unit/Config/PayConfigTest.php
+++ b/backend/tests/Unit/Config/PayConfigTest.php
@@ -21,6 +21,7 @@ final class PayConfigTest extends TestCase
         $snapshot = $this->snapshotEnv([
             'ALIPAY_MERCHANT_PRIVATE_KEY',
             'ALIPAY_MERCHANT_PRIVATE_KEY_PATH',
+            'ALIPAY_MODE',
         ]);
 
         try {
@@ -56,6 +57,7 @@ final class PayConfigTest extends TestCase
         $snapshot = $this->snapshotEnv([
             'ALIPAY_MERCHANT_PRIVATE_KEY',
             'ALIPAY_MERCHANT_PRIVATE_KEY_PATH',
+            'ALIPAY_MODE',
         ]);
 
         try {
@@ -69,6 +71,51 @@ final class PayConfigTest extends TestCase
         } finally {
             $this->restoreEnv($snapshot);
             @unlink($path);
+            config(['pay' => require base_path('config/pay.php')]);
+        }
+    }
+
+    public function test_alipay_mode_is_omitted_when_env_is_unset_or_blank(): void
+    {
+        $snapshot = $this->snapshotEnv([
+            'ALIPAY_MODE',
+        ]);
+
+        try {
+            $this->setEnvValue('ALIPAY_MODE', '');
+
+            config(['pay' => require base_path('config/pay.php')]);
+
+            $alipayConfig = config('pay.alipay.default', []);
+
+            $this->assertArrayNotHasKey('mode', $alipayConfig);
+            $this->assertArrayHasKey('app_secret_cert', $alipayConfig);
+            $this->assertArrayHasKey('merchant_private_key_path', $alipayConfig);
+        } finally {
+            $this->restoreEnv($snapshot);
+            config(['pay' => require base_path('config/pay.php')]);
+        }
+    }
+
+    public function test_alipay_mode_is_injected_only_when_explicitly_set(): void
+    {
+        $snapshot = $this->snapshotEnv([
+            'ALIPAY_MODE',
+        ]);
+
+        try {
+            $this->setEnvValue('ALIPAY_MODE', 'service');
+
+            config(['pay' => require base_path('config/pay.php')]);
+
+            $alipayConfig = config('pay.alipay.default', []);
+
+            $this->assertSame('service', $alipayConfig['mode'] ?? null);
+            $this->assertArrayHasKey('app_secret_cert', $alipayConfig);
+            $this->assertArrayHasKey('merchant_private_key_path', $alipayConfig);
+            $this->assertArrayHasKey('notify_url', $alipayConfig);
+        } finally {
+            $this->restoreEnv($snapshot);
             config(['pay' => require base_path('config/pay.php')]);
         }
     }


### PR DESCRIPTION
## Summary
This PR removes the default Alipay `mode=normal` injection from `config/pay.php` so the launch flow can proceed into the next real SDK/platform validation layer instead of failing locally with `Undefined array key "normal"`.

## Problem
After the earlier Alipay contract and return/recovery work landed, staging could already route CN mainland checkout into Alipay and reach the launch endpoint. The latest direct blocker was now:

- `ALIPAY_LAUNCH_FAILED`
- `Undefined array key "normal"`

That meant the request was still failing inside local backend config-to-SDK wiring before any meaningful platform-side response could be observed.

## User impact
From the user side, the flow stalled at:

- `checkout -> /pay/wait -> /pay/alipay -> 502`

So even though checkout, wait, and recovery were already closed, the actual payment launch still could not leave the backend because the vendor config was malformed.

## Root cause
Our Alipay config always injected:

- `'mode' => env('ALIPAY_MODE', 'normal')`

The installed `yansongda/pay` package already falls back to its own internal normal mode when `mode` is absent. By explicitly injecting the string `"normal"`, we passed a value that the vendor code later used as an array key and crashed on. The issue was not in `AlipayCheckoutService`, not in provider routing, and not in the frontend.

## Fix
This PR keeps the change strictly inside `config/pay.php`:

- read `ALIPAY_MODE` into a local trimmed variable
- only inject `mode` into `pay.alipay.default` when `ALIPAY_MODE` is explicitly non-empty
- leave all other Alipay keys unchanged, including:
  - `app_id`
  - `merchant_private_key`
  - `merchant_private_key_path`
  - `app_secret_cert`
  - `app_public_cert_path`
  - `alipay_public_cert_path`
  - `alipay_root_cert_path`
  - `notify_url`
  - `return_url`

The accompanying config tests lock two behaviors:

- when `ALIPAY_MODE` is unset or blank, `pay.alipay.default` does not contain `mode`
- when `ALIPAY_MODE` is explicitly set, that value is passed through without disturbing the other Alipay config keys

## Scope
- backend only
- no frontend changes
- no payment routing changes
- no service/controller changes
- no env contract redesign
- no attempt to guess a replacement Alipay mode value

## Validation
- `php artisan test tests/Unit/Config/PayConfigTest.php tests/Feature/V0_3/AlipayLaunchEndpointTest.php`
  - result: `6 passed (18 assertions)`
- local `php artisan tinker --execute='dump(config("pay.alipay.default"));'`
  - confirmed the default Alipay config no longer contains `mode => normal`

## Follow-up
This PR only removes the local config-level blocker. If staging then fails with a new Alipay platform-side error after deployment, that is expected next-layer behavior and should be handled separately.
