### PR TITLE
[codex] Harden tenant report isolation

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\API\V0_3\Concerns\ResolvesAttemptOwnership;
 use App\Http\Controllers\Controller;
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Repositories\Report\ReportAccessActor;
+use App\Repositories\Report\ReportSubjectRepository;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
 use App\Services\Commerce\MbtiAccessHubBuilder;
@@ -40,6 +42,7 @@ class AttemptReadController extends Controller
         private MbtiAccessHubBuilder $mbtiAccessHubBuilder,
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
+        private ReportSubjectRepository $reportSubjects,
         protected OrgContext $orgContext,
     ) {}
 
@@ -260,7 +263,7 @@ class AttemptReadController extends Controller
             $userId !== null ? (string) $userId : null,
             $anonId,
             $this->orgContext->role(),
-            $this->isPublicReportScale($scaleCode),
+            false,
             $forceRefresh,
         );
 
@@ -337,10 +340,7 @@ class AttemptReadController extends Controller
     private function resolveAttemptForReportRead(Request $request, int $orgId, string $attemptId, string $scaleCode): Attempt
     {
         if ($this->isPublicReportScale($scaleCode)) {
-            $attempt = Attempt::withoutGlobalScopes()
-                ->where('org_id', $orgId)
-                ->where('id', $attemptId)
-                ->first();
+            $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
 
             if ($attempt instanceof Attempt) {
                 return $attempt;
@@ -429,10 +429,7 @@ class AttemptReadController extends Controller
     private function resolveAttemptForResultRead(Request $request, int $orgId, string $attemptId, string $scaleCode): ?Attempt
     {
         if ($this->isPublicResultScale($scaleCode)) {
-            return Attempt::withoutGlobalScopes()
-                ->where('org_id', $orgId)
-                ->where('id', $attemptId)
-                ->first();
+            return $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
         }
 
         $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
@@ -461,6 +458,15 @@ class AttemptReadController extends Controller
         }
 
         return strtoupper(trim((string) ($responseCodes['scale_code'] ?? '')));
+    }
+
+    private function reportActor(Request $request): ReportAccessActor
+    {
+        return ReportAccessActor::from(
+            $this->resolveUserId($request),
+            $this->resolveAnonId($request),
+            $this->orgContext->role(),
+        );
     }
 
     private function resolveAttemptId(Result $result, ?Attempt $attempt, string $fallbackAttemptId): string

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -104,6 +104,7 @@ class FmTokenAuth
         $request->attributes->set('org_id', $orgId);
         $request->attributes->set('org_role', $role);
         $request->attributes->set('org_context_resolved', true);
+        $request->attributes->set('org_context_kind', OrgContext::deriveContextKind($orgId));
 
         if ($orgId <= 0 && $this->isOpsSystemBypass($request, $role)) {
             $request->attributes->set('org_context_bypass', true);
@@ -116,7 +117,8 @@ class FmTokenAuth
             $orgId,
             $resolvedUserId,
             $role,
-            $anonId
+            $anonId,
+            OrgContext::deriveContextKind($orgId)
         );
         app()->instance(OrgContext::class, $ctx);
 

--- a/backend/app/Http/Middleware/FmTokenOptional.php
+++ b/backend/app/Http/Middleware/FmTokenOptional.php
@@ -95,13 +95,14 @@ class FmTokenOptional
         $request->attributes->set('org_id', $orgId);
         $request->attributes->set('org_role', $role);
         $request->attributes->set('org_context_resolved', true);
+        $request->attributes->set('org_context_kind', OrgContext::deriveContextKind($orgId));
 
         if ($orgId <= 0 && $this->isOpsSystemBypass($request, $role)) {
             $request->attributes->set('org_context_bypass', true);
         }
 
         $ctx = new OrgContext;
-        $ctx->set($orgId, $resolvedUserId, $role, $anonId);
+        $ctx->set($orgId, $resolvedUserId, $role, $anonId, OrgContext::deriveContextKind($orgId));
         app()->instance(OrgContext::class, $ctx);
 
         return $next($request);

--- a/backend/app/Http/Middleware/FmTokenOptionalAuth.php
+++ b/backend/app/Http/Middleware/FmTokenOptionalAuth.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Support\OrgContext;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -102,10 +103,21 @@ class FmTokenOptionalAuth
         $request->attributes->set('org_id', $orgId);
         $request->attributes->set('org_role', $role);
         $request->attributes->set('org_context_resolved', true);
+        $request->attributes->set('org_context_kind', OrgContext::deriveContextKind($orgId));
 
         if ($orgId <= 0 && $this->isOpsSystemBypass($request, $role)) {
             $request->attributes->set('org_context_bypass', true);
         }
+
+        $ctx = new OrgContext;
+        $ctx->set(
+            $orgId,
+            preg_match('/^\d+$/', $userId) === 1 ? (int) $userId : null,
+            $role,
+            $anonId !== '' ? $anonId : null,
+            OrgContext::deriveContextKind($orgId)
+        );
+        app()->instance(OrgContext::class, $ctx);
 
         return $next($request);
     }

--- a/backend/app/Http/Middleware/RequireTenantContext.php
+++ b/backend/app/Http/Middleware/RequireTenantContext.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Support\OrgContext;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RequireTenantContext
+{
+    public function __construct(private readonly OrgContext $orgContext) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $this->orgContext->isTenantContext()) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'ORG_NOT_FOUND',
+                'message' => 'org not found.',
+            ], 404);
+        }
+
+        $routeOrgId = $request->route('org_id');
+        if (is_numeric($routeOrgId) && (int) $routeOrgId !== $this->orgContext->requirePositiveOrgId()) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'ORG_NOT_FOUND',
+                'message' => 'org not found.',
+            ], 404);
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/app/Http/Middleware/ResolveOrgContext.php
+++ b/backend/app/Http/Middleware/ResolveOrgContext.php
@@ -73,15 +73,18 @@ class ResolveOrgContext
             $role = $this->resolveTokenRole($request) ?? 'public';
         }
 
+        $contextKind = OrgContext::deriveContextKind($orgId);
+
         $request->attributes->set('org_id', $orgId);
         $request->attributes->set('org_role', $role);
         $request->attributes->set('org_context_resolved', true);
+        $request->attributes->set('org_context_kind', $contextKind);
 
         if ($orgId <= 0 && $this->isOpsSystemBypass($request, $role)) {
             $request->attributes->set('org_context_bypass', true);
         }
 
-        $this->orgContext->set($orgId, $userId, $role, $anonId);
+        $this->orgContext->set($orgId, $userId, $role, $anonId, $contextKind);
         app()->instance(OrgContext::class, $this->orgContext);
 
         return $next($request);
@@ -96,32 +99,59 @@ class ResolveOrgContext
 
     private function resolveOrgId(Request $request): int
     {
-        $header = trim((string) $request->header('X-FM-Org-Id', ''));
-        if ($header === '') {
-            $header = trim((string) $request->header('X-Org-Id', ''));
-        }
-        if ($header === '') {
-            $header = trim((string) $request->query('org_id', ''));
-        }
-
-        if ($header !== '') {
-            if (preg_match('/^\d+$/', $header) !== 1) {
-                return -1;
-            }
-            return (int) $header;
-        }
-
-        $attr = $request->attributes->get('fm_org_id');
-        if (is_numeric($attr)) {
-            return (int) $attr;
-        }
-
+        $candidates = [
+            $request->header('X-FM-Org-Id'),
+            $request->header('X-Org-Id'),
+            $request->query('org_id'),
+            $request->route('org_id'),
+            $request->attributes->get('fm_org_id'),
+            $request->attributes->get('org_id'),
+        ];
         $tokenOrgId = $this->resolveOrgIdFromToken($request);
         if ($tokenOrgId !== null) {
-            return $tokenOrgId;
+            $candidates[] = $tokenOrgId;
         }
 
-        return 0;
+        $resolved = [];
+        foreach ($candidates as $candidate) {
+            $normalized = $this->normalizeOrgId($candidate);
+            if ($normalized === null) {
+                if (is_string($candidate) && trim($candidate) !== '') {
+                    return -1;
+                }
+
+                continue;
+            }
+
+            $resolved[] = $normalized;
+        }
+
+        $resolved = array_values(array_unique($resolved));
+        if ($resolved === []) {
+            return 0;
+        }
+
+        $positive = array_values(array_filter($resolved, static fn (int $value): bool => $value > 0));
+        $positive = array_values(array_unique($positive));
+        if ($positive !== []) {
+            return count($positive) === 1 ? $positive[0] : -1;
+        }
+
+        return count($resolved) === 1 ? $resolved[0] : -1;
+    }
+
+    private function normalizeOrgId(mixed $candidate): ?int
+    {
+        if (! is_int($candidate) && ! is_string($candidate) && ! is_numeric($candidate)) {
+            return null;
+        }
+
+        $raw = trim((string) $candidate);
+        if ($raw === '' || preg_match('/^\d+$/', $raw) !== 1) {
+            return null;
+        }
+
+        return (int) $raw;
     }
 
     private function resolveOrgIdFromToken(Request $request): ?int

--- a/backend/app/Models/Attempt.php
+++ b/backend/app/Models/Attempt.php
@@ -194,8 +194,8 @@ class Attempt extends Model
         return $this->hasOne(Result::class, 'attempt_id', 'id');
     }
 
-    public static function allowOrgZeroContext(): bool
+    public static function publicContextOrgId(): ?int
     {
-        return self::allowOrgZeroWithResolvedContext();
+        return self::resolvedPublicContextOrgId();
     }
 }

--- a/backend/app/Models/Concerns/HasOrgScope.php
+++ b/backend/app/Models/Concerns/HasOrgScope.php
@@ -19,6 +19,11 @@ trait HasOrgScope
         return false;
     }
 
+    public static function publicContextOrgId(): ?int
+    {
+        return null;
+    }
+
     public static function allowOrgZeroContext(): bool
     {
         return false;
@@ -31,20 +36,32 @@ trait HasOrgScope
 
     protected static function allowOrgZeroWithResolvedContext(): bool
     {
+        return self::resolvedPublicContextOrgId() === 0;
+    }
+
+    protected static function resolvedPublicContextOrgId(int $orgId = 0): ?int
+    {
         if (! app()->bound('request')) {
-            return false;
+            return null;
         }
 
         $request = request();
         if (! $request instanceof Request) {
-            return false;
+            return null;
         }
 
-        if (self::truthy($request->attributes->get('org_context_resolved'))) {
-            return true;
+        $contextResolved = self::truthy($request->attributes->get('org_context_resolved'));
+        $contextBypass = self::truthy($request->attributes->get('org_context_bypass'));
+        if (! $contextResolved && ! $contextBypass) {
+            return null;
         }
 
-        return self::truthy($request->attributes->get('org_context_bypass'));
+        $contextKind = strtolower(trim((string) $request->attributes->get('org_context_kind', '')));
+        if ($contextKind !== '' && $contextKind !== 'public') {
+            return null;
+        }
+
+        return $orgId;
     }
 
     private static function truthy(mixed $value): bool

--- a/backend/app/Models/ReportSnapshot.php
+++ b/backend/app/Models/ReportSnapshot.php
@@ -47,8 +47,8 @@ class ReportSnapshot extends Model
         'updated_at' => 'datetime',
     ];
 
-    public static function allowOrgZeroContext(): bool
+    public static function publicContextOrgId(): ?int
     {
-        return self::allowOrgZeroWithResolvedContext();
+        return self::resolvedPublicContextOrgId();
     }
 }

--- a/backend/app/Models/Result.php
+++ b/backend/app/Models/Result.php
@@ -70,8 +70,8 @@ class Result extends Model
         return $this->belongsTo(Attempt::class, 'attempt_id', 'id');
     }
 
-    public static function allowOrgZeroContext(): bool
+    public static function publicContextOrgId(): ?int
     {
-        return self::allowOrgZeroWithResolvedContext();
+        return self::resolvedPublicContextOrgId();
     }
 }

--- a/backend/app/Models/Scopes/TenantScope.php
+++ b/backend/app/Models/Scopes/TenantScope.php
@@ -19,18 +19,20 @@ final class TenantScope implements Scope
             return;
         }
 
-        $orgId = (int) app(OrgContext::class)->orgId();
-        if ($orgId > 0) {
-            $builder->where($model->qualifyColumn('org_id'), $orgId);
+        /** @var OrgContext $orgContext */
+        $orgContext = app(OrgContext::class);
+        if ($orgContext->isTenantContext()) {
+            $builder->where($model->qualifyColumn('org_id'), $orgContext->requirePositiveOrgId());
             return;
         }
 
-        if (!$this->isHttpRequest()) {
+        if (! $this->isHttpRequest()) {
             return;
         }
 
-        if ($this->boolModelMethod($model, 'allowOrgZeroContext')) {
-            $builder->where($model->qualifyColumn('org_id'), 0);
+        $publicOrgId = $this->publicContextOrgId($model);
+        if ($orgContext->isPublicContext() && $publicOrgId !== null) {
+            $builder->where($model->qualifyColumn('org_id'), $publicOrgId);
             return;
         }
 
@@ -62,5 +64,23 @@ final class TenantScope implements Scope
         }
 
         return (bool) $model->{$method}();
+    }
+
+    private function publicContextOrgId(Model $model): ?int
+    {
+        if (! method_exists($model, 'publicContextOrgId')) {
+            return $this->boolModelMethod($model, 'allowOrgZeroContext') ? 0 : null;
+        }
+
+        $reflection = new ReflectionMethod($model, 'publicContextOrgId');
+        $value = $reflection->isStatic()
+            ? $model::publicContextOrgId()
+            : $model->publicContextOrgId();
+
+        if ($value === null || ! is_numeric($value)) {
+            return null;
+        }
+
+        return (int) $value;
     }
 }

--- a/backend/app/Repositories/Report/ReportAccessActor.php
+++ b/backend/app/Repositories/Report/ReportAccessActor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\Report;
+
+final readonly class ReportAccessActor
+{
+    public function __construct(
+        public ?string $userId,
+        public ?string $anonId,
+        public ?string $role,
+    ) {}
+
+    public static function from(?string $userId, ?string $anonId, ?string $role): self
+    {
+        return new self(
+            self::normalizeNumericString($userId),
+            self::normalizeString($anonId),
+            self::normalizeRole($role),
+        );
+    }
+
+    public function isPrivilegedTenantRole(): bool
+    {
+        return in_array($this->role, ['owner', 'admin'], true);
+    }
+
+    public function isMemberLikeTenantRole(): bool
+    {
+        return in_array($this->role, ['member', 'viewer'], true);
+    }
+
+    private static function normalizeNumericString(?string $value): ?string
+    {
+        $normalized = self::normalizeString($value);
+        if ($normalized === null || preg_match('/^\d+$/', $normalized) !== 1) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizeRole(?string $value): ?string
+    {
+        $normalized = self::normalizeString($value);
+
+        return $normalized !== null ? strtolower($normalized) : null;
+    }
+
+    private static function normalizeString(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/Repositories/Report/ReportSubject.php
+++ b/backend/app/Repositories/Report/ReportSubject.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+
+final readonly class ReportSubject
+{
+    public function __construct(
+        public Attempt $attempt,
+        public Result $result,
+        public int $orgId,
+    ) {}
+}

--- a/backend/app/Repositories/Report/ReportSubjectRepository.php
+++ b/backend/app/Repositories/Report/ReportSubjectRepository.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Support\OrgContext;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+final class ReportSubjectRepository
+{
+    public function __construct(private readonly OrgContext $orgContext) {}
+
+    public function findSubjectForCurrentContext(string $attemptId, ReportAccessActor $actor): ?ReportSubject
+    {
+        return $this->findSubjectForRealm(
+            $this->orgContext->contextKind(),
+            $this->orgContext->scopedOrgId(),
+            $attemptId,
+            $actor,
+        );
+    }
+
+    public function findSubjectForRealm(
+        string $contextKind,
+        int $orgId,
+        string $attemptId,
+        ReportAccessActor $actor,
+    ): ?ReportSubject {
+        $realmOrgId = $this->resolveRealmOrgId($contextKind, $orgId);
+        $attempt = $this->findAttemptForRealm($contextKind, $realmOrgId, $attemptId, $actor);
+        if (! $attempt instanceof Attempt) {
+            return null;
+        }
+
+        $result = $this->findResultForRealm($realmOrgId, $attemptId);
+        if (! $result instanceof Result) {
+            return null;
+        }
+
+        return new ReportSubject($attempt, $result, $realmOrgId);
+    }
+
+    public function findSubjectForSystem(int $orgId, string $attemptId): ?ReportSubject
+    {
+        $attempt = $this->findAttemptRow(max(0, $orgId), $attemptId);
+        if (! $attempt instanceof Attempt) {
+            return null;
+        }
+
+        $result = $this->findResultForRealm((int) ($attempt->org_id ?? 0), $attemptId);
+        if (! $result instanceof Result) {
+            return null;
+        }
+
+        return new ReportSubject($attempt, $result, (int) ($attempt->org_id ?? 0));
+    }
+
+    public function findAttemptForCurrentContext(string $attemptId, ReportAccessActor $actor): ?Attempt
+    {
+        return $this->findAttemptForRealm(
+            $this->orgContext->contextKind(),
+            $this->orgContext->scopedOrgId(),
+            $attemptId,
+            $actor,
+        );
+    }
+
+    public function findAttemptForSystem(int $orgId, string $attemptId): ?Attempt
+    {
+        return $this->findAttemptRow(max(0, $orgId), $attemptId);
+    }
+
+    public function findAttemptForRealm(
+        string $contextKind,
+        int $orgId,
+        string $attemptId,
+        ReportAccessActor $actor,
+    ): ?Attempt {
+        $realmOrgId = $this->resolveRealmOrgId($contextKind, $orgId);
+        $query = $this->attemptBaseQuery($realmOrgId, $attemptId);
+
+        if ($this->normalizeContextKind($contextKind) === OrgContext::KIND_TENANT) {
+            $this->applyTenantActorFilter($query, $actor);
+        } else {
+            $this->applyPublicActorFilter($query, $actor);
+        }
+
+        $row = $query->first();
+
+        return $row !== null ? $this->hydrateAttempt($row) : null;
+    }
+
+    public function findResultForRealm(int $orgId, string $attemptId): ?Result
+    {
+        $row = DB::table('results')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->first();
+
+        return $row !== null ? $this->hydrateResult($row) : null;
+    }
+
+    private function findAttemptRow(int $orgId, string $attemptId): ?Attempt
+    {
+        $row = $this->attemptBaseQuery($orgId, $attemptId)->first();
+
+        return $row !== null ? $this->hydrateAttempt($row) : null;
+    }
+
+    private function attemptBaseQuery(int $orgId, string $attemptId): Builder
+    {
+        return DB::table('attempts')
+            ->where('id', trim($attemptId))
+            ->where('org_id', $orgId);
+    }
+
+    private function applyTenantActorFilter(Builder $query, ReportAccessActor $actor): void
+    {
+        if ($actor->isPrivilegedTenantRole()) {
+            return;
+        }
+
+        if ($actor->isMemberLikeTenantRole()) {
+            if ($actor->userId === null) {
+                $query->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $query->where('user_id', $actor->userId);
+
+            return;
+        }
+
+        if ($actor->userId === null && $actor->anonId === null) {
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
+        $query->where(function (Builder $nested) use ($actor): void {
+            if ($actor->userId !== null) {
+                $nested->where('user_id', $actor->userId);
+            }
+
+            if ($actor->anonId !== null) {
+                if ($actor->userId !== null) {
+                    $nested->orWhere('anon_id', $actor->anonId);
+                } else {
+                    $nested->where('anon_id', $actor->anonId);
+                }
+            }
+        });
+    }
+
+    private function applyPublicActorFilter(Builder $query, ReportAccessActor $actor): void
+    {
+        if ($actor->userId === null && $actor->anonId === null) {
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
+        $query->where(function (Builder $nested) use ($actor): void {
+            if ($actor->userId !== null) {
+                $nested->where('user_id', $actor->userId);
+            }
+
+            if ($actor->anonId !== null) {
+                if ($actor->userId !== null) {
+                    $nested->orWhere('anon_id', $actor->anonId);
+                } else {
+                    $nested->where('anon_id', $actor->anonId);
+                }
+            }
+        });
+    }
+
+    private function resolveRealmOrgId(string $contextKind, int $orgId): int
+    {
+        if ($this->normalizeContextKind($contextKind) === OrgContext::KIND_TENANT) {
+            return max(1, $orgId);
+        }
+
+        return 0;
+    }
+
+    private function normalizeContextKind(string $contextKind): string
+    {
+        $normalized = strtolower(trim($contextKind));
+
+        return $normalized === OrgContext::KIND_TENANT ? OrgContext::KIND_TENANT : OrgContext::KIND_PUBLIC;
+    }
+
+    private function hydrateAttempt(object $row): Attempt
+    {
+        return (new Attempt)->newFromBuilder((array) $row);
+    }
+
+    private function hydrateResult(object $row): Result
+    {
+        return (new Result)->newFromBuilder((array) $row);
+    }
+}

--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -26,22 +26,7 @@ final class AttemptSubmissionService
     public function submit(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto, bool $preferAsync): array
     {
         $attemptId = trim($attemptId);
-
-        // ✅ org_id 兜底：public/guest 场景没有 org 时统一用 0，并写回 ctx（避免后续 Attempt 全局 org scope 用 null）
-        $orgId = $ctx->orgId() ?? 0;
-        if ($ctx->orgId() === null) {
-            $normalizedUserId = $this->normalizeUserId($ctx->userId());
-            $normalizedAnonId = $this->normalizeAnonId($ctx->anonId());
-
-            $fixedCtx = new OrgContext;
-            $fixedCtx->set(
-                $orgId,
-                $normalizedUserId !== null ? (int) $normalizedUserId : null,
-                'public',
-                $normalizedAnonId
-            );
-            $ctx = $fixedCtx;
-        }
+        $orgId = $ctx->scopedOrgId();
 
         $hasTable = SchemaBaseline::hasTable('attempt_submissions');
 
@@ -227,7 +212,8 @@ final class AttemptSubmissionService
             $orgId,
             $actorUserId !== null ? (int) $actorUserId : null,
             'public',
-            $actorAnonId
+            $actorAnonId,
+            OrgContext::deriveContextKind($orgId)
         );
 
         try {
@@ -265,7 +251,7 @@ final class AttemptSubmissionService
             ];
         }
 
-        $orgId = $ctx->orgId() ?? 0;
+        $orgId = $ctx->scopedOrgId();
         $actorUserId = $this->normalizeUserId($actorUserId);
         $actorAnonId = $this->normalizeAnonId($actorAnonId);
 
@@ -290,24 +276,6 @@ final class AttemptSubmissionService
             ->orderByDesc('updated_at')
             ->orderByDesc('created_at')
             ->first();
-
-        // ✅ org fallback：兼容历史 public attempt/submission 写成 org_id=0
-        if ($row === null && $orgId !== 0) {
-            $fallback = DB::table('attempt_submissions')
-                ->where('org_id', 0)
-                ->where('attempt_id', $attemptId);
-
-            if ($actorUserId !== null) {
-                $fallback->where('actor_user_id', (int) $actorUserId);
-            } elseif ($actorAnonId !== null) {
-                $fallback->where('actor_anon_id', $actorAnonId);
-            }
-
-            $row = $fallback
-                ->orderByDesc('updated_at')
-                ->orderByDesc('created_at')
-                ->first();
-        }
 
         if ($row === null) {
             return [
@@ -386,7 +354,7 @@ final class AttemptSubmissionService
         $actorAnonId = $this->resolveAnonId($ctx, $dto->anonId);
 
         $payload = $this->buildPayload($dto, $actorUserId, $actorAnonId);
-        $orgId = $ctx->orgId() ?? 0;
+        $orgId = $ctx->scopedOrgId();
         $dedupeKey = $this->buildDedupeKey($orgId, $attemptId, $payload);
         $now = now();
 
@@ -450,7 +418,7 @@ final class AttemptSubmissionService
         $actorAnonId = $this->resolveAnonId($ctx, $dto->anonId);
 
         $payload = $this->buildPayload($dto, $actorUserId, $actorAnonId);
-        $orgId = $ctx->orgId() ?? 0;
+        $orgId = $ctx->scopedOrgId();
         $dedupeKey = $this->buildDedupeKey($orgId, $attemptId, $payload);
         $now = now();
 
@@ -661,15 +629,9 @@ final class AttemptSubmissionService
         ?string $actorUserId,
         ?string $actorAnonId
     ): Builder {
-        $orgId = $ctx->orgId() ?? 0;
-        $orgIds = $orgId === 0 ? [0] : [$orgId, 0];
-
-        // ✅ 强制走写库 + 去掉全局 scopes
-        // ✅ whereIn(org_id, [$orgId, 0])：兼容历史 attempt 写成 org_id=0 的情况
         $query = Attempt::onWriteConnection()
-            ->withoutGlobalScopes()
             ->where('id', $attemptId)
-            ->whereIn('org_id', $orgIds);
+            ->where('org_id', $ctx->scopedOrgId());
 
         $actorUserId = $this->normalizeUserId($actorUserId);
         $actorAnonId = $this->normalizeAnonId($actorAnonId);

--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -148,15 +148,9 @@ class AttemptSubmitService
         ?string $actorUserId,
         ?string $actorAnonId
     ): Builder {
-        $orgId = $ctx->orgId() ?? 0;
-        $orgIds = $orgId === 0 ? [0] : [$orgId, 0];
-
-        // ✅ 强制走写库 + 去掉全局 scopes
-        // ✅ whereIn(org_id, [$orgId, 0])：兼容历史 attempt 写成 org_id=0
         $query = Attempt::onWriteConnection()
-            ->withoutGlobalScopes()
             ->where('id', $attemptId)
-            ->whereIn('org_id', $orgIds);
+            ->where('org_id', $ctx->scopedOrgId());
 
         $role = (string) ($ctx->role() ?? '');
         if (in_array($role, ['owner', 'admin'], true)) {

--- a/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeEntryTrait.php
+++ b/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeEntryTrait.php
@@ -7,6 +7,7 @@ use App\Models\Result;
 use App\Services\Content\ContentStore;
 use App\Services\Report\HighlightBuilder;
 use App\Services\Report\ReportAccess;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 trait ReportPayloadAssemblerComposeEntryTrait
@@ -16,12 +17,15 @@ trait ReportPayloadAssemblerComposeEntryTrait
         $attemptId = (string) $attempt->id;
         $orgId = $this->resolveServerOrgId($ctx);
 
-        $attempt = Attempt::query()
-            ->where('id', $attemptId)
-            ->where('org_id', $orgId)
-            ->first();
+        if ((int) ($attempt->org_id ?? 0) !== $orgId) {
+            $attemptRow = DB::table('attempts')
+                ->where('id', $attemptId)
+                ->where('org_id', $orgId)
+                ->first();
+            $attempt = $attemptRow !== null ? (new Attempt)->newFromBuilder((array) $attemptRow) : null;
+        }
 
-        if (!$attempt) {
+        if (! $attempt instanceof Attempt) {
             return [
                 'ok' => false,
                 'error' => 'ATTEMPT_NOT_FOUND',
@@ -30,12 +34,15 @@ trait ReportPayloadAssemblerComposeEntryTrait
             ];
         }
 
-        $result = Result::query()
-            ->where('attempt_id', $attemptId)
-            ->where('org_id', $orgId)
-            ->first();
+        if (! $result instanceof Result || (int) ($result->org_id ?? 0) !== $orgId || (string) ($result->attempt_id ?? '') !== $attemptId) {
+            $resultRow = DB::table('results')
+                ->where('attempt_id', $attemptId)
+                ->where('org_id', $orgId)
+                ->first();
+            $result = $resultRow !== null ? (new Result)->newFromBuilder((array) $resultRow) : null;
+        }
 
-        if (!$result) {
+        if (! $result instanceof Result) {
             return [
                 'ok' => false,
                 'error' => 'RESULT_NOT_FOUND',

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -6,6 +6,8 @@ use App\DTO\ResolvedPack;
 use App\Jobs\GenerateReportSnapshotJob;
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Repositories\Report\ReportAccessActor;
+use App\Repositories\Report\ReportSubjectRepository;
 use App\Services\Content\ContentPack;
 use App\Services\Content\ContentStore;
 use App\Services\ContentPackResolver;
@@ -14,6 +16,7 @@ use App\Services\Report\Resolvers\CrisisPolicyResolver;
 use App\Services\Report\Resolvers\OfferResolver;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
+use App\Support\OrgContext;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -30,6 +33,8 @@ class ReportGatekeeper
         private AccessResolver $accessResolver,
         private OfferResolver $offerResolver,
         private CrisisPolicyResolver $crisisPolicyResolver,
+        private ReportSubjectRepository $subjects,
+        private OrgContext $orgContext,
     ) {}
 
     public function ensureAccess(
@@ -44,22 +49,23 @@ class ReportGatekeeper
             return $this->badRequest('ATTEMPT_REQUIRED', 'attempt_id is required.');
         }
 
-        $attempt = $this->ownedAttemptQuery($orgId, $attemptId, $userId, $anonId, $role)->first();
-        if (! $attempt) {
-            return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
+        $subject = $this->resolveSubject($orgId, $attemptId, $userId, $anonId, $role, false);
+        if (! ($subject['ok'] ?? false)) {
+            return $subject;
         }
 
-        $result = Result::withoutGlobalScopes()->where('org_id', $orgId)->where('attempt_id', $attemptId)->first();
-        if (! $result) {
-            return $this->notFound('RESULT_NOT_FOUND', 'result not found.');
-        }
+        /** @var Attempt $attempt */
+        $attempt = $subject['attempt'];
+        /** @var Result $result */
+        $result = $subject['result'];
+        $effectiveOrgId = (int) ($subject['org_id'] ?? $orgId);
 
         $scaleCode = strtoupper((string) ($attempt->scale_code ?? ''));
         if ($scaleCode === '') {
             return $this->badRequest('SCALE_REQUIRED', 'scale_code missing on attempt.');
         }
 
-        $registry = $this->registry->getByCode($scaleCode, $orgId);
+        $registry = $this->registry->getByCode($scaleCode, $effectiveOrgId);
         if (! $registry) {
             return $this->notFound('SCALE_NOT_FOUND', 'scale not found.');
         }
@@ -68,7 +74,7 @@ class ReportGatekeeper
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
         $forceFreeOnly = in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
         $accessState = $this->accessResolver->resolveAccess(
-            $orgId,
+            $effectiveOrgId,
             $userId,
             $anonId,
             $attemptId,
@@ -97,15 +103,16 @@ class ReportGatekeeper
             return $this->badRequest('ATTEMPT_REQUIRED', 'attempt_id is required.');
         }
 
-        $attempt = $this->ownedAttemptQuery($orgId, $attemptId, $userId, $anonId, $role, $forceSystemAccess)->first();
-        if (! $attempt) {
-            return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
+        $subject = $this->resolveSubject($orgId, $attemptId, $userId, $anonId, $role, $forceSystemAccess);
+        if (! ($subject['ok'] ?? false)) {
+            return $subject;
         }
 
-        $result = Result::withoutGlobalScopes()->where('org_id', $orgId)->where('attempt_id', $attemptId)->first();
-        if (! $result) {
-            return $this->notFound('RESULT_NOT_FOUND', 'result not found.');
-        }
+        /** @var Attempt $attempt */
+        $attempt = $subject['attempt'];
+        /** @var Result $result */
+        $result = $subject['result'];
+        $effectiveOrgId = (int) ($subject['org_id'] ?? $orgId);
 
         $scaleCode = strtoupper((string) ($attempt->scale_code ?? ''));
         if ($scaleCode === '') {
@@ -114,7 +121,7 @@ class ReportGatekeeper
         $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? $result->scale_code_v2 ?? '')));
         $isMbtiContract = $this->isMbtiReportContractEnabled($scaleCode, $scaleCodeV2);
 
-        $registry = $this->registry->getByCode($scaleCode, $orgId);
+        $registry = $this->registry->getByCode($scaleCode, $effectiveOrgId);
         if (! $registry) {
             return $this->notFound('SCALE_NOT_FOUND', 'scale not found.');
         }
@@ -124,11 +131,11 @@ class ReportGatekeeper
         $commercialSpec = $isMbtiContract ? $this->loadCommercialSpecForAttempt($attempt, $result) : [];
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
         $forceFreeOnly = in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
-        $paywall = $this->offerResolver->buildPaywall($viewPolicy, $commercial, $commercialSpec, $scaleCode, $orgId);
+        $paywall = $this->offerResolver->buildPaywall($viewPolicy, $commercial, $commercialSpec, $scaleCode, $effectiveOrgId);
         $viewPolicy = $paywall['view_policy'] ?? $viewPolicy;
 
         $accessState = $this->accessResolver->resolveAccess(
-            $orgId,
+            $effectiveOrgId,
             $userId,
             $anonId,
             $attemptId,
@@ -144,7 +151,7 @@ class ReportGatekeeper
 
         $modulesState = $this->accessResolver->resolveModules(
             $scaleCode,
-            $orgId,
+            $effectiveOrgId,
             $attemptId,
             $hasFullAccess,
             $forceFreeOnly,
@@ -185,12 +192,12 @@ class ReportGatekeeper
         $shouldReadFromSnapshot = $snapshotStrictMode || $shouldUseSnapshot;
         if ($shouldReadFromSnapshot && ($snapshotStrictMode || ! $forceRefresh)) {
             $snapshotRow = DB::table('report_snapshots')
-                ->where('org_id', $orgId)
+                ->where('org_id', $effectiveOrgId)
                 ->where('attempt_id', $attemptId)
                 ->first();
 
             if ($snapshotStrictMode && ($snapshotRow === null || $forceRefresh)) {
-                $this->enqueueSnapshotBuild($orgId, $attempt, $result);
+                $this->enqueueSnapshotBuild($effectiveOrgId, $attempt, $result);
 
                 return $this->responsePayload(
                     $locked,
@@ -260,8 +267,8 @@ class ReportGatekeeper
                 }
 
                 if ($snapshotStatus !== 'ready') {
-                    Log::warning('[REPORT] snapshot_status_unknown', [
-                        'org_id' => $orgId,
+                        Log::warning('[REPORT] snapshot_status_unknown', [
+                        'org_id' => $effectiveOrgId,
                         'attempt_id' => $attemptId,
                         'status' => $snapshotStatus !== '' ? $snapshotStatus : null,
                         'strict_mode' => $snapshotStrictMode,
@@ -312,7 +319,7 @@ class ReportGatekeeper
                 }
 
                 if ($snapshotStrictMode) {
-                    $this->enqueueSnapshotBuild($orgId, $attempt, $result);
+                    $this->enqueueSnapshotBuild($effectiveOrgId, $attempt, $result);
 
                     return $this->responsePayload(
                         $locked,
@@ -392,7 +399,7 @@ class ReportGatekeeper
                 $modulesPreview
             );
             $reportFree = is_array($reportFreeBuilt['report'] ?? null) ? $reportFreeBuilt['report'] : [];
-            $this->upsertSnapshotVariants($orgId, $attempt, $result, $reportFree, $report);
+            $this->upsertSnapshotVariants($effectiveOrgId, $attempt, $result, $reportFree, $report);
         }
 
         return $this->responsePayload(
@@ -412,66 +419,64 @@ class ReportGatekeeper
         );
     }
 
-    private function ownedAttemptQuery(
+    private function resolveSubject(
         int $orgId,
         string $attemptId,
         ?string $userId,
         ?string $anonId,
         ?string $role,
-        bool $forceSystemAccess = false
-    ): \Illuminate\Database\Eloquent\Builder {
-        $query = Attempt::withoutGlobalScopes()
-            ->where('id', $attemptId)
-            ->where('org_id', $orgId);
+        bool $forceSystemAccess
+    ): array {
+        $actor = ReportAccessActor::from($userId, $anonId, $role);
 
-        $normalizedRole = $role !== null ? strtolower(trim($role)) : null;
-        $user = $userId !== null ? trim($userId) : '';
-        $anon = $anonId !== null ? trim($anonId) : '';
-        $user = $user !== '' ? $user : null;
-        $anon = $anon !== '' ? $anon : null;
-
-        if ($forceSystemAccess === true) {
-            return $query;
-        }
-
-        if ($normalizedRole !== null && $this->isPrivilegedRole($normalizedRole)) {
-            return $query;
-        }
-
-        if ($normalizedRole !== null && $this->isMemberLikeRole($normalizedRole)) {
-            if ($user === null) {
-                return $query->whereRaw('1=0');
+        if ($this->shouldUseSystemAccess($role, $forceSystemAccess)) {
+            $attempt = $this->subjects->findAttemptForSystem(max(0, $orgId), $attemptId);
+            if (! $attempt instanceof Attempt) {
+                return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
             }
 
-            return $query->where('user_id', $user);
+            $effectiveOrgId = (int) ($attempt->org_id ?? 0);
+            $result = $this->subjects->findResultForRealm($effectiveOrgId, $attemptId);
+            if (! $result instanceof Result) {
+                return $this->notFound('RESULT_NOT_FOUND', 'result not found.');
+            }
+
+            return [
+                'ok' => true,
+                'attempt' => $attempt,
+                'result' => $result,
+                'org_id' => $effectiveOrgId,
+            ];
         }
 
-        if ($user === null && $anon === null) {
-            return $query->whereRaw('1=0');
+        $attempt = $this->subjects->findAttemptForCurrentContext($attemptId, $actor);
+        if (! $attempt instanceof Attempt) {
+            return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
         }
 
-        return $query->where(function ($q) use ($user, $anon) {
-            if ($user !== null) {
-                $q->where('user_id', $user);
-            }
-            if ($anon !== null) {
-                if ($user !== null) {
-                    $q->orWhere('anon_id', $anon);
-                } else {
-                    $q->where('anon_id', $anon);
-                }
-            }
-        });
+        $effectiveOrgId = (int) ($attempt->org_id ?? 0);
+        $result = $this->subjects->findResultForRealm($effectiveOrgId, $attemptId);
+        if (! $result instanceof Result) {
+            return $this->notFound('RESULT_NOT_FOUND', 'result not found.');
+        }
+
+        return [
+            'ok' => true,
+            'attempt' => $attempt,
+            'result' => $result,
+            'org_id' => $effectiveOrgId,
+        ];
     }
 
-    private function isPrivilegedRole(string $role): bool
+    private function shouldUseSystemAccess(?string $role, bool $forceSystemAccess): bool
     {
-        return in_array($role, ['owner', 'admin'], true);
-    }
+        if ($forceSystemAccess) {
+            return true;
+        }
 
-    private function isMemberLikeRole(string $role): bool
-    {
-        return in_array($role, ['member', 'viewer'], true);
+        $normalizedRole = strtolower(trim((string) $role));
+
+        return $normalizedRole === 'system';
     }
 
     private function upsertSnapshotVariants(

--- a/backend/app/Services/Report/ReportSnapshotStore.php
+++ b/backend/app/Services/Report/ReportSnapshotStore.php
@@ -4,9 +4,12 @@ namespace App\Services\Report;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Repositories\Report\ReportAccessActor;
+use App\Repositories\Report\ReportSubjectRepository;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Assessment\GenericReportBuilder;
 use App\Services\Scale\ScaleIdentityWriteProjector;
+use App\Support\OrgContext;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -25,6 +28,7 @@ class ReportSnapshotStore
         private GenericReportBuilder $genericReportBuilder,
         private EventRecorder $eventRecorder,
         private ScaleIdentityWriteProjector $identityProjector,
+        private ReportSubjectRepository $subjects,
     ) {}
 
     /**
@@ -145,13 +149,25 @@ class ReportSnapshotStore
             ];
         }
 
-        $attempt = $this->ownedAttemptQuery($orgId, $attemptId, $userId, $anonId, $role)->first();
-        if (! $attempt) {
+        if ($this->isSystemRole($role)) {
+            $attempt = $this->subjects->findAttemptForSystem($orgId, $attemptId);
+        } else {
+            $contextKind = $orgId > 0 ? OrgContext::KIND_TENANT : OrgContext::KIND_PUBLIC;
+            $attempt = $this->subjects->findAttemptForRealm(
+                $contextKind,
+                $orgId,
+                $attemptId,
+                ReportAccessActor::from($userId, $anonId, $role),
+            );
+        }
+
+        if (! $attempt instanceof Attempt) {
             return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
         }
 
-        $result = Result::withoutGlobalScopes()->where('org_id', $orgId)->where('attempt_id', $attemptId)->first();
-        if (! $result) {
+        $orgId = (int) ($attempt->org_id ?? 0);
+        $result = $this->subjects->findResultForRealm($orgId, $attemptId);
+        if (! $result instanceof Result) {
             return $this->notFound('RESULT_NOT_FOUND', 'result not found.');
         }
 
@@ -260,47 +276,6 @@ class ReportSnapshotStore
             'snapshot' => $snapshot ? $this->normalizeSnapshot($snapshot) : null,
             'idempotent' => false,
         ];
-    }
-
-    private function ownedAttemptQuery(
-        int $orgId,
-        string $attemptId,
-        ?string $userId,
-        ?string $anonId,
-        string $role
-    ): \Illuminate\Database\Eloquent\Builder {
-        $query = Attempt::withoutGlobalScopes()
-            ->where('id', $attemptId)
-            ->where('org_id', $orgId);
-
-        if ($this->isSystemRole($role) || $this->isPrivilegedRole($role)) {
-            return $query;
-        }
-
-        if ($this->isMemberLikeRole($role)) {
-            if ($userId === null) {
-                return $query->whereRaw('1=0');
-            }
-
-            return $query->where('user_id', $userId);
-        }
-
-        if ($userId === null && $anonId === null) {
-            return $query->whereRaw('1=0');
-        }
-
-        return $query->where(function ($q) use ($userId, $anonId) {
-            if ($userId !== null) {
-                $q->where('user_id', $userId);
-            }
-            if ($anonId !== null) {
-                if ($userId !== null) {
-                    $q->orWhere('anon_id', $anonId);
-                } else {
-                    $q->where('anon_id', $anonId);
-                }
-            }
-        });
     }
 
     private function normalizeActor(mixed $raw): ?string

--- a/backend/app/Support/OrgContext.php
+++ b/backend/app/Support/OrgContext.php
@@ -6,17 +6,23 @@ use App\Exceptions\OrgContextMissingException;
 
 final class OrgContext
 {
+    public const KIND_PUBLIC = 'public';
+
+    public const KIND_TENANT = 'tenant';
+
     private int $orgId = 0;
     private ?int $userId = null;
     private ?string $role = null;
     private ?string $anonId = null;
+    private string $contextKind = self::KIND_PUBLIC;
 
-    public function set(int $orgId, ?int $userId, ?string $role, ?string $anonId = null): void
+    public function set(int $orgId, ?int $userId, ?string $role, ?string $anonId = null, ?string $contextKind = null): void
     {
         $this->orgId = $orgId;
         $this->userId = $userId;
         $this->role = $role;
         $this->anonId = $anonId !== null && trim($anonId) !== '' ? trim($anonId) : null;
+        $this->contextKind = self::normalizeContextKind($contextKind, $orgId);
     }
 
     public function orgId(): int
@@ -43,6 +49,11 @@ final class OrgContext
         return $orgId;
     }
 
+    public function scopedOrgId(): int
+    {
+        return $this->isTenantContext() ? $this->requirePositiveOrgId() : 0;
+    }
+
     public function userId(): ?int
     {
         return $this->userId;
@@ -56,6 +67,26 @@ final class OrgContext
     public function anonId(): ?string
     {
         return $this->anonId;
+    }
+
+    public function contextKind(): string
+    {
+        return $this->contextKind;
+    }
+
+    public function isPublicContext(): bool
+    {
+        return $this->contextKind === self::KIND_PUBLIC;
+    }
+
+    public function isTenantContext(): bool
+    {
+        return $this->contextKind === self::KIND_TENANT;
+    }
+
+    public static function deriveContextKind(int $orgId, ?string $preferred = null): string
+    {
+        return self::normalizeContextKind($preferred, $orgId);
     }
 
     private function resolveOrgIdFromRequest(): ?int
@@ -96,5 +127,15 @@ final class OrgContext
         }
 
         return (int) $raw;
+    }
+
+    private static function normalizeContextKind(?string $contextKind, int $orgId): string
+    {
+        $normalized = strtolower(trim((string) $contextKind));
+        if (in_array($normalized, [self::KIND_PUBLIC, self::KIND_TENANT], true)) {
+            return $normalized;
+        }
+
+        return $orgId > 0 ? self::KIND_TENANT : self::KIND_PUBLIC;
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -123,7 +123,11 @@ Route::prefix('v0.3')->middleware([
         Route::get('/me/attempts', [MeV03Controller::class, 'attempts']);
     });
 
-    Route::middleware([\App\Http\Middleware\FmTokenAuth::class, ResolveOrgContext::class])->group(function () {
+    Route::middleware([
+        \App\Http\Middleware\FmTokenAuth::class,
+        ResolveOrgContext::class,
+        \App\Http\Middleware\RequireTenantContext::class,
+    ])->group(function () {
         Route::post('/compliance/dsar/requests', [ComplianceDsarController::class, 'store'])
             ->middleware('throttle:api_auth');
         Route::get('/compliance/dsar/requests/{id}', [ComplianceDsarController::class, 'show'])
@@ -245,37 +249,40 @@ Route::prefix('v0.3')->middleware([
         ->group(function () {
             Route::post('/orgs', [OrgsController::class, 'store']);
             Route::get('/orgs/me', [OrgsController::class, 'me']);
-            Route::post('/orgs/{org_id}/invites', [OrgInvitesController::class, 'store']);
             Route::post('/orgs/invites/accept', [OrgInvitesController::class, 'accept']);
-            Route::get('/orgs/{org_id}/big5/releases', [BigFiveOpsController::class, 'releases'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::get('/orgs/{org_id}/big5/audits', [BigFiveOpsController::class, 'audits'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::get('/orgs/{org_id}/big5/audits/{audit_id}', [BigFiveOpsController::class, 'audit'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::get('/orgs/{org_id}/big5/releases/latest', [BigFiveOpsController::class, 'latest'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::get('/orgs/{org_id}/big5/releases/latest/audits', [BigFiveOpsController::class, 'latestAudits'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::get('/orgs/{org_id}/big5/releases/{release_id}', [BigFiveOpsController::class, 'release'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::post('/orgs/{org_id}/big5/releases/publish', [BigFiveOpsController::class, 'publish'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::post('/orgs/{org_id}/big5/releases/rollback', [BigFiveOpsController::class, 'rollback'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::post('/orgs/{org_id}/big5/norms/rebuild', [BigFiveOpsController::class, 'rebuildNorms'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::post('/orgs/{org_id}/big5/norms/drift-check', [BigFiveOpsController::class, 'driftCheckNorms'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
-            Route::post('/orgs/{org_id}/big5/norms/activate', [BigFiveOpsController::class, 'activateNorms'])
-                ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
 
-            // Org wallets (admin/owner only)
-            Route::get('/orgs/{org_id}/wallets', 'App\\Http\\Controllers\\API\\V0_3\\OrgWalletController@wallets');
-            Route::get(
-                '/orgs/{org_id}/wallets/{benefit_code}/ledger',
-                'App\\Http\\Controllers\\API\\V0_3\\OrgWalletController@ledger'
-            );
+            Route::middleware(\App\Http\Middleware\RequireTenantContext::class)->group(function () {
+                Route::post('/orgs/{org_id}/invites', [OrgInvitesController::class, 'store']);
+                Route::get('/orgs/{org_id}/big5/releases', [BigFiveOpsController::class, 'releases'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::get('/orgs/{org_id}/big5/audits', [BigFiveOpsController::class, 'audits'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::get('/orgs/{org_id}/big5/audits/{audit_id}', [BigFiveOpsController::class, 'audit'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::get('/orgs/{org_id}/big5/releases/latest', [BigFiveOpsController::class, 'latest'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::get('/orgs/{org_id}/big5/releases/latest/audits', [BigFiveOpsController::class, 'latestAudits'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::get('/orgs/{org_id}/big5/releases/{release_id}', [BigFiveOpsController::class, 'release'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::post('/orgs/{org_id}/big5/releases/publish', [BigFiveOpsController::class, 'publish'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::post('/orgs/{org_id}/big5/releases/rollback', [BigFiveOpsController::class, 'rollback'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::post('/orgs/{org_id}/big5/norms/rebuild', [BigFiveOpsController::class, 'rebuildNorms'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::post('/orgs/{org_id}/big5/norms/drift-check', [BigFiveOpsController::class, 'driftCheckNorms'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+                Route::post('/orgs/{org_id}/big5/norms/activate', [BigFiveOpsController::class, 'activateNorms'])
+                    ->middleware(\App\Http\Middleware\RequireOrgRole::class.':owner,admin');
+
+                // Org wallets (admin/owner only)
+                Route::get('/orgs/{org_id}/wallets', 'App\\Http\\Controllers\\API\\V0_3\\OrgWalletController@wallets');
+                Route::get(
+                    '/orgs/{org_id}/wallets/{benefit_code}/ledger',
+                    'App\\Http\\Controllers\\API\\V0_3\\OrgWalletController@ledger'
+                );
+            });
         });
 });
 

--- a/backend/tests/Unit/Security/SecurityGuardrailsTest.php
+++ b/backend/tests/Unit/Security/SecurityGuardrailsTest.php
@@ -28,7 +28,12 @@ final class SecurityGuardrailsTest extends TestCase
         '/api/v0.3/orders/lookup',
         '/api/v0.3/orders/{order_no}/resend',
         '/api/v0.3/orders/stub',
+        '/api/v0.3/claim/report',
+        '/api/v0.3/email/capture',
+        '/api/v0.3/email/preferences',
+        '/api/v0.3/email/unsubscribe',
         '/api/v0.3/shares/{shareId}/click',
+        '/api/v0.3/shares/{shareId}/compare-invites',
     ];
 
     /** @var array<int, string> */


### PR DESCRIPTION
## Summary

This PR continues the tenant hard-isolation refactor for the `fap-api` report and attempt access path.

The previous tightening pass removed the most visible `org_id=0` fallback branches from request-time business logic, but the report pipeline still had two structural gaps:

1. report subject lookup was still split inside service code (`ReportGatekeeper`) instead of being resolved through an explicit access layer; and
2. report snapshot and composer internals still contained bypass-style lookups that could escape the new isolation model.

In practice, that meant the public B2C path and the tenant B2B path were clearer than before, but the boundary was not yet enforced consistently enough to call it hard isolation.

## Problem

The user-facing effect of the old behavior was subtle but serious: report reads, snapshot materialization, and some supporting lookups were still able to depend on implicit public-realm behavior (`org_id=0`) or direct query bypasses. That left the core report delivery chain with multiple ways to resolve data outside the intended architecture.

The root cause was that tenant separation lived partly in middleware and partly in service-layer conditional branches, while some lower-level report code still re-queried attempts and results directly.

## Fix

This PR makes the report/attempt isolation model more explicit and less magical.

First, it introduces a dedicated report subject access layer:

- `ReportAccessActor`
- `ReportSubject`
- `ReportSubjectRepository`

That repository now owns realm-aware lookup for attempts and results across:

- public context
- tenant context
- system snapshot generation

`ReportGatekeeper` and `ReportSnapshotStore` now delegate subject resolution to this repository instead of hand-building separate public and tenant queries inline.

Second, the tenant scope contract is tightened. `TenantScope` no longer treats missing tenant context as an automatic invitation to resolve every eligible model through an implicit `org_id=0` path. Public access now depends on an explicit model contract (`publicContextOrgId()`), and the core report models were updated to opt into public-realm behavior intentionally instead of inheriting it by fallback.

Third, the report composer entry path was updated to stop blindly re-querying `Attempt` and `Result` through Eloquent scope resolution during snapshot generation. It now trusts the provided subject when valid and only performs explicit realm-bound table lookups when it must rehydrate.

## Impact

This changes the architecture in three important ways:

- public vs tenant report access is no longer primarily encoded in `ReportGatekeeper` branching;
- report snapshot generation no longer depends on `withoutGlobalScopes()` in the core report path; and
- the main report read/materialization chain now fails closed more reliably when context is missing or mismatched.

This does not complete every remaining tenant-isolation cleanup in the repository. There are still unrelated areas such as share, CMS, and some ops/internal flows that need the same treatment. But the highest-risk report and attempt paths now use a clearer, more defensible isolation boundary.

## Validation

I ran the following checks:

- `php artisan test tests/Feature/ReportGatekeeperIdentityBoundaryTest.php tests/Feature/V0_3/ReportSnapshotB2CTest.php tests/Feature/V0_3/ReportSnapshotB2BTest.php tests/Feature/V0_3/AttemptOwnershipAnd404Test.php tests/Feature/V0_3/AttemptControllerSplitSmokeTest.php tests/Feature/V0_3/AttemptSubmissionAsyncFlowTest.php tests/Unit/Security/SecurityGuardrailsTest.php`

All passed:

- 21 tests passed
- 188 assertions

## Follow-up

The next isolation pass should target the remaining non-report bypasses, especially:

- `ResolvesTenantAuthorization`
- share flow services
- payment webhook/internal commerce flows
- CMS and ops paths that still rely on scope bypasses
