### PR TITLE
[codex] strengthen storage inventory, logging compatibility, and hygiene

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,13 @@
+# backend/storage runtime noise
+backend/storage/logs/**
+backend/storage/framework/**
+backend/storage/app/private/reports/**
+backend/storage/app/private/artifacts/**
+backend/storage/app/private/content_releases/**
+backend/storage/app/private/content_packs_cache/**
+backend/storage/app/private/migration_plans/**
+backend/storage/app/private/packs_v2/**
+backend/storage/app/private/private/**
+backend/storage/app/private/prune_plans/**
+backend/storage/app/content_packs_v2/**
+backend/storage/app/archives/**

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,13 @@ backend/storage/logs/
 backend/storage/framework/
 backend/storage/app/private/reports/
 backend/storage/app/private/artifacts/
+backend/storage/app/private/content_releases/
+backend/storage/app/private/content_packs_cache/
+backend/storage/app/private/migration_plans/
 backend/storage/app/private/packs_v2/
+backend/storage/app/private/private/
 backend/storage/app/private/prune_plans/
+backend/storage/app/content_packs_v2/
 backend/storage/app/archives/
 
 # SEC/SRE-000 release package hygiene

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,13 @@
+# backend/storage runtime noise
+backend/storage/logs/**
+backend/storage/framework/**
+backend/storage/app/private/reports/**
+backend/storage/app/private/artifacts/**
+backend/storage/app/private/content_releases/**
+backend/storage/app/private/content_packs_cache/**
+backend/storage/app/private/migration_plans/**
+backend/storage/app/private/packs_v2/**
+backend/storage/app/private/private/**
+backend/storage/app/private/prune_plans/**
+backend/storage/app/content_packs_v2/**
+backend/storage/app/archives/**

--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,13 @@
+# backend/storage runtime noise
+backend/storage/logs/**
+backend/storage/framework/**
+backend/storage/app/private/reports/**
+backend/storage/app/private/artifacts/**
+backend/storage/app/private/content_releases/**
+backend/storage/app/private/content_packs_cache/**
+backend/storage/app/private/migration_plans/**
+backend/storage/app/private/packs_v2/**
+backend/storage/app/private/private/**
+backend/storage/app/private/prune_plans/**
+backend/storage/app/content_packs_v2/**
+backend/storage/app/archives/**

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+  "search.exclude": {
+    "backend/storage/logs/**": true,
+    "backend/storage/framework/**": true,
+    "backend/storage/app/private/reports/**": true,
+    "backend/storage/app/private/artifacts/**": true,
+    "backend/storage/app/private/content_releases/**": true,
+    "backend/storage/app/private/content_packs_cache/**": true,
+    "backend/storage/app/private/migration_plans/**": true,
+    "backend/storage/app/private/packs_v2/**": true,
+    "backend/storage/app/private/private/**": true,
+    "backend/storage/app/private/prune_plans/**": true,
+    "backend/storage/app/content_packs_v2/**": true,
+    "backend/storage/app/archives/**": true
+  },
+  "files.watcherExclude": {
+    "backend/storage/logs/**": true,
+    "backend/storage/framework/**": true,
+    "backend/storage/app/private/reports/**": true,
+    "backend/storage/app/private/artifacts/**": true,
+    "backend/storage/app/private/content_releases/**": true,
+    "backend/storage/app/private/content_packs_cache/**": true,
+    "backend/storage/app/private/migration_plans/**": true,
+    "backend/storage/app/private/packs_v2/**": true,
+    "backend/storage/app/private/private/**": true,
+    "backend/storage/app/private/prune_plans/**": true,
+    "backend/storage/app/content_packs_v2/**": true,
+    "backend/storage/app/archives/**": true
+  }
+}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,9 +31,14 @@ APP_MAINTENANCE_DRIVER=file
 BCRYPT_ROUNDS=12
 
 LOG_CHANNEL=stack
+# Keep `single` in LOG_STACK when enabling `daily` / `stderr`
+# so tooling that reads storage/logs/laravel.log stays compatible.
 LOG_STACK=single
+# LOG_STACK=single,daily
+# LOG_STACK=single,stderr
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=info
+# LOG_DAILY_DAYS=30
 
 # =========================
 # DB (CI-safe default)

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -30,8 +30,13 @@ Thumbs.db
 /storage/framework/views/*
 /storage/app/private/reports/*
 /storage/app/private/artifacts/*
+/storage/app/private/content_releases/*
+/storage/app/private/content_packs_cache/*
+/storage/app/private/migration_plans/*
 /storage/app/private/packs_v2/*
+/storage/app/private/private/*
 /storage/app/private/prune_plans/*
+/storage/app/content_packs_v2/*
 /storage/app/archives/*
 !/storage/logs/.gitkeep
 !/storage/framework/sessions/.gitkeep

--- a/backend/app/Console/Commands/StorageInventory.php
+++ b/backend/app/Console/Commands/StorageInventory.php
@@ -12,7 +12,13 @@ final class StorageInventory extends Command
 {
     protected $signature = 'storage:inventory {--json : JSON output}';
 
-    protected $description = 'Inventory storage usage by scope (files/bytes/mtime/top dirs).';
+    protected $description = 'Inventory storage usage by scope (files/bytes/mtime/top dirs/files/duplicates).';
+
+    private const TOP_LIMIT = 5;
+
+    private const DUPLICATE_GROUP_LIMIT = 5;
+
+    private const DUPLICATE_SAMPLE_LIMIT = 3;
 
     public function handle(): int
     {
@@ -24,9 +30,10 @@ final class StorageInventory extends Command
             $this->collectScope('content_packs_v2', storage_path('app/content_packs_v2')),
             $this->collectScope('logs', storage_path('logs')),
         ];
+        $payload = $this->buildPayload($rows);
 
         if ((bool) $this->option('json')) {
-            $this->line((string) json_encode($rows, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
         } else {
             $display = array_map(static function (array $row): array {
                 return [
@@ -42,7 +49,7 @@ final class StorageInventory extends Command
             $this->table(['scope', 'files', 'bytes', 'oldest_mtime', 'newest_mtime', 'top_dirs'], $display);
         }
 
-        $this->recordAudit($rows);
+        $this->recordAudit($payload);
 
         return self::SUCCESS;
     }
@@ -50,11 +57,28 @@ final class StorageInventory extends Command
     /**
      * @return array{
      *   scope:string,
+     *   root_path:string,
      *   files:int,
      *   bytes:int,
      *   oldest_mtime:?string,
      *   newest_mtime:?string,
-     *   top_dirs:array<string,int>
+     *   top_dirs:array<string,int>,
+     *   top_dirs_by_bytes:list<array{path:string,files:int,bytes:int}>,
+     *   top_files:list<array{path:string,bytes:int,mtime:?string}>,
+     *   duplicate_summary:array{
+     *     groups:int,
+     *     files:int,
+     *     bytes:int,
+     *     wasted_bytes:int,
+     *     top_groups:list<array{
+     *       sha256:string,
+     *       files:int,
+     *       bytes:int,
+     *       total_bytes:int,
+     *       wasted_bytes:int,
+     *       sample_paths:list<string>
+     *     }>
+     *   }
      * }
      */
     private function collectScope(string $scope, string $root): array
@@ -62,11 +86,15 @@ final class StorageInventory extends Command
         if (! is_dir($root)) {
             return [
                 'scope' => $scope,
+                'root_path' => $root,
                 'files' => 0,
                 'bytes' => 0,
                 'oldest_mtime' => null,
                 'newest_mtime' => null,
                 'top_dirs' => [],
+                'top_dirs_by_bytes' => [],
+                'top_files' => [],
+                'duplicate_summary' => $this->emptyDuplicateSummary(),
             ];
         }
 
@@ -75,6 +103,9 @@ final class StorageInventory extends Command
         $oldest = null;
         $newest = null;
         $topDirs = [];
+        $dirBytes = [];
+        $topFiles = [];
+        $duplicateCandidates = [];
 
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
@@ -106,25 +137,290 @@ final class StorageInventory extends Command
             $first = explode('/', $relative)[0] ?? '.';
             $first = trim((string) $first) !== '' ? (string) $first : '.';
             $topDirs[$first] = (int) (($topDirs[$first] ?? 0) + 1);
+            $dirBytes[$first] = [
+                'path' => $first,
+                'files' => (int) (($dirBytes[$first]['files'] ?? 0) + 1),
+                'bytes' => (int) (($dirBytes[$first]['bytes'] ?? 0) + $size),
+            ];
+            $topFiles[] = [
+                'path' => $relative,
+                'bytes' => $size,
+                'mtime' => $mtime > 0 ? date(DATE_ATOM, $mtime) : null,
+            ];
+            $duplicateCandidates[$size][] = [
+                'path' => $relative,
+                'full_path' => $fullPath,
+            ];
         }
 
         arsort($topDirs);
-        $topDirs = array_slice($topDirs, 0, 5, true);
+        $topDirs = array_slice($topDirs, 0, self::TOP_LIMIT, true);
+
+        uasort($dirBytes, static function (array $left, array $right): int {
+            $bytes = (int) $right['bytes'] <=> (int) $left['bytes'];
+            if ($bytes !== 0) {
+                return $bytes;
+            }
+
+            $files = (int) $right['files'] <=> (int) $left['files'];
+            if ($files !== 0) {
+                return $files;
+            }
+
+            return strcmp((string) $left['path'], (string) $right['path']);
+        });
+        $dirBytes = array_values(array_slice($dirBytes, 0, self::TOP_LIMIT));
+
+        usort($topFiles, static function (array $left, array $right): int {
+            $bytes = (int) $right['bytes'] <=> (int) $left['bytes'];
+            if ($bytes !== 0) {
+                return $bytes;
+            }
+
+            return strcmp((string) $left['path'], (string) $right['path']);
+        });
+        $topFiles = array_slice($topFiles, 0, self::TOP_LIMIT);
 
         return [
             'scope' => $scope,
+            'root_path' => $root,
             'files' => $files,
             'bytes' => $bytes,
             'oldest_mtime' => $oldest !== null ? date(DATE_ATOM, $oldest) : null,
             'newest_mtime' => $newest !== null ? date(DATE_ATOM, $newest) : null,
             'top_dirs' => $topDirs,
+            'top_dirs_by_bytes' => $dirBytes,
+            'top_files' => $topFiles,
+            'duplicate_summary' => $this->buildDuplicateSummary($duplicateCandidates),
         ];
     }
 
     /**
      * @param  list<array<string,mixed>>  $rows
+     * @return array{
+     *   schema_version:int,
+     *   generated_at:string,
+     *   scope_count:int,
+     *   totals:array{files:int,bytes:int,oldest_mtime:?string,newest_mtime:?string},
+     *   scope_totals:array<string,array{files:int,bytes:int,duplicate_groups:int,wasted_bytes:int}>,
+     *   focus_scopes:array<string,array<string,mixed>>,
+     *   scopes:list<array<string,mixed>>
+     * }
      */
-    private function recordAudit(array $rows): void
+    private function buildPayload(array $rows): array
+    {
+        return [
+            'schema_version' => 2,
+            'generated_at' => now()->toAtomString(),
+            'scope_count' => count($rows),
+            'totals' => $this->summarizeTotals($rows),
+            'scope_totals' => $this->buildScopeTotals($rows),
+            'focus_scopes' => $this->buildFocusScopes($rows),
+            'scopes' => $rows,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array{files:int,bytes:int,oldest_mtime:?string,newest_mtime:?string}
+     */
+    private function summarizeTotals(array $rows): array
+    {
+        $files = 0;
+        $bytes = 0;
+        $oldest = null;
+        $newest = null;
+
+        foreach ($rows as $row) {
+            $files += (int) ($row['files'] ?? 0);
+            $bytes += (int) ($row['bytes'] ?? 0);
+
+            $rowOldest = $this->toUnixTimestamp($row['oldest_mtime'] ?? null);
+            if ($rowOldest !== null && ($oldest === null || $rowOldest < $oldest)) {
+                $oldest = $rowOldest;
+            }
+
+            $rowNewest = $this->toUnixTimestamp($row['newest_mtime'] ?? null);
+            if ($rowNewest !== null && ($newest === null || $rowNewest > $newest)) {
+                $newest = $rowNewest;
+            }
+        }
+
+        return [
+            'files' => $files,
+            'bytes' => $bytes,
+            'oldest_mtime' => $oldest !== null ? date(DATE_ATOM, $oldest) : null,
+            'newest_mtime' => $newest !== null ? date(DATE_ATOM, $newest) : null,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array<string,array<string,mixed>>
+     */
+    private function buildFocusScopes(array $rows): array
+    {
+        $focus = [];
+        $wanted = ['logs', 'artifacts', 'content_releases'];
+
+        foreach ($rows as $row) {
+            $scope = (string) ($row['scope'] ?? '');
+            if (in_array($scope, $wanted, true)) {
+                $focus[$scope] = $row;
+            }
+        }
+
+        return $focus;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array<string,array{files:int,bytes:int,duplicate_groups:int,wasted_bytes:int}>
+     */
+    private function buildScopeTotals(array $rows): array
+    {
+        $totals = [];
+
+        foreach ($rows as $row) {
+            $scope = (string) ($row['scope'] ?? '');
+            if ($scope === '') {
+                continue;
+            }
+
+            $totals[$scope] = [
+                'files' => (int) ($row['files'] ?? 0),
+                'bytes' => (int) ($row['bytes'] ?? 0),
+                'duplicate_groups' => (int) data_get($row, 'duplicate_summary.groups', 0),
+                'wasted_bytes' => (int) data_get($row, 'duplicate_summary.wasted_bytes', 0),
+            ];
+        }
+
+        return $totals;
+    }
+
+    /**
+     * @param  array<int,list<array{path:string,full_path:string}>>  $duplicateCandidates
+     * @return array{
+     *   groups:int,
+     *   files:int,
+     *   bytes:int,
+     *   wasted_bytes:int,
+     *   top_groups:list<array{
+     *     sha256:string,
+     *     files:int,
+     *     bytes:int,
+     *     total_bytes:int,
+     *     wasted_bytes:int,
+     *     sample_paths:list<string>
+     *   }>
+     * }
+     */
+    private function buildDuplicateSummary(array $duplicateCandidates): array
+    {
+        $summary = $this->emptyDuplicateSummary();
+        $topGroups = [];
+
+        foreach ($duplicateCandidates as $size => $entries) {
+            $size = max(0, (int) $size);
+            if ($size === 0 || count($entries) < 2) {
+                continue;
+            }
+
+            $hashGroups = [];
+
+            foreach ($entries as $entry) {
+                $hash = @hash_file('sha256', $entry['full_path']);
+                if (! is_string($hash) || $hash === '') {
+                    continue;
+                }
+
+                $hashGroups[$hash][] = $entry['path'];
+            }
+
+            foreach ($hashGroups as $hash => $paths) {
+                $count = count($paths);
+                if ($count < 2) {
+                    continue;
+                }
+
+                $totalBytes = $count * $size;
+                $wastedBytes = ($count - 1) * $size;
+                $summary['groups']++;
+                $summary['files'] += $count;
+                $summary['bytes'] += $totalBytes;
+                $summary['wasted_bytes'] += $wastedBytes;
+                $topGroups[] = [
+                    'sha256' => $hash,
+                    'files' => $count,
+                    'bytes' => $size,
+                    'total_bytes' => $totalBytes,
+                    'wasted_bytes' => $wastedBytes,
+                    'sample_paths' => array_values(array_slice($paths, 0, self::DUPLICATE_SAMPLE_LIMIT)),
+                ];
+            }
+        }
+
+        usort($topGroups, static function (array $left, array $right): int {
+            $wasted = (int) $right['wasted_bytes'] <=> (int) $left['wasted_bytes'];
+            if ($wasted !== 0) {
+                return $wasted;
+            }
+
+            $files = (int) $right['files'] <=> (int) $left['files'];
+            if ($files !== 0) {
+                return $files;
+            }
+
+            return strcmp((string) $left['sha256'], (string) $right['sha256']);
+        });
+
+        $summary['top_groups'] = array_slice($topGroups, 0, self::DUPLICATE_GROUP_LIMIT);
+
+        return $summary;
+    }
+
+    /**
+     * @return array{
+     *   groups:int,
+     *   files:int,
+     *   bytes:int,
+     *   wasted_bytes:int,
+     *   top_groups:list<array{
+     *     sha256:string,
+     *     files:int,
+     *     bytes:int,
+     *     total_bytes:int,
+     *     wasted_bytes:int,
+     *     sample_paths:list<string>
+     *   }>
+     * }
+     */
+    private function emptyDuplicateSummary(): array
+    {
+        return [
+            'groups' => 0,
+            'files' => 0,
+            'bytes' => 0,
+            'wasted_bytes' => 0,
+            'top_groups' => [],
+        ];
+    }
+
+    private function toUnixTimestamp(mixed $value): ?int
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $timestamp = strtotime($value);
+
+        return $timestamp !== false ? $timestamp : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
     {
         if (! Schema::hasTable('audit_logs')) {
             return;
@@ -136,9 +432,7 @@ final class StorageInventory extends Command
             'action' => 'storage_inventory',
             'target_type' => 'storage',
             'target_id' => 'inventory',
-            'meta_json' => json_encode([
-                'scopes' => $rows,
-            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'meta_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'ip' => null,
             'user_agent' => 'cli/storage_inventory',
             'request_id' => null,

--- a/backend/config/logging.php
+++ b/backend/config/logging.php
@@ -6,6 +6,17 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
 
+$stackChannels = array_values(array_unique(array_filter(array_map(
+    static fn (string $channel): string => trim($channel),
+    explode(',', (string) env('LOG_STACK', 'single'))
+), static fn (string $channel): bool => $channel !== '')));
+
+if ($stackChannels === []) {
+    $stackChannels = ['single'];
+}
+
+$dailyRetentionDays = max(1, (int) env('LOG_DAILY_DAYS', (int) env('STORAGE_RETENTION_LOGS_DAYS', 30)));
+
 return [
 
     /*
@@ -55,7 +66,9 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            // Keep `single` in the stack when enabling `daily` / `stderr`
+            // so existing CLI tails and ops evidence still have `laravel.log`.
+            'channels' => $stackChannels,
             'ignore_exceptions' => false,
         ],
 
@@ -74,7 +87,7 @@ return [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
-            'days' => env('LOG_DAILY_DAYS', 14),
+            'days' => $dailyRetentionDays,
             'formatter' => JsonFormatter::class,
             'formatter_with' => [
                 'includeStacktraces' => true,

--- a/backend/config/storage_retention.php
+++ b/backend/config/storage_retention.php
@@ -10,6 +10,7 @@ return [
         'keep_days' => (int) env('STORAGE_RETENTION_RELEASES_DAYS', 180),
     ],
     'logs' => [
+        // PR-13A only aligns logging.daily fallback to this policy; no prune job consumes it yet.
         'keep_days' => (int) env('STORAGE_RETENTION_LOGS_DAYS', 30),
     ],
     'rotation_audits' => [

--- a/backend/scripts/laravel_log_helpers.sh
+++ b/backend/scripts/laravel_log_helpers.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+laravel_log_primary_path() {
+  local backend_dir="${1:?backend_dir required}"
+  printf '%s\n' "${backend_dir}/storage/logs/laravel.log"
+}
+
+laravel_log_rotated_paths() {
+  local backend_dir="${1:?backend_dir required}"
+  local log_dir="${backend_dir}/storage/logs"
+
+  [[ -d "${log_dir}" ]] || return 0
+
+  find "${log_dir}" -maxdepth 1 -type f -name 'laravel-*.log' -print 2>/dev/null | sort -r
+}
+
+print_laravel_log_tails() {
+  local backend_dir="${1:?backend_dir required}"
+  local lines="${2:-200}"
+  local primary
+  local printed=0
+
+  primary="$(laravel_log_primary_path "${backend_dir}")"
+
+  if [[ -f "${primary}" ]]; then
+    echo "--- $(basename "${primary}") (tail) ---"
+    tail -n "${lines}" "${primary}" 2>/dev/null || true
+    printed=1
+  fi
+
+  while IFS= read -r rotated; do
+    [[ -n "${rotated}" ]] || continue
+    echo "--- $(basename "${rotated}") (tail) ---"
+    tail -n "${lines}" "${rotated}" 2>/dev/null || true
+    printed=1
+  done < <(laravel_log_rotated_paths "${backend_dir}")
+
+  return $((printed == 0))
+}
+
+copy_laravel_logs_to_dir() {
+  local backend_dir="${1:?backend_dir required}"
+  local dest_dir="${2:?dest_dir required}"
+  local primary
+
+  mkdir -p "${dest_dir}"
+  primary="$(laravel_log_primary_path "${backend_dir}")"
+
+  if [[ -f "${primary}" ]]; then
+    cp -f "${primary}" "${dest_dir}/$(basename "${primary}")" 2>/dev/null || true
+  fi
+
+  while IFS= read -r rotated; do
+    [[ -n "${rotated}" ]] || continue
+    cp -f "${rotated}" "${dest_dir}/$(basename "${rotated}")" 2>/dev/null || true
+  done < <(laravel_log_rotated_paths "${backend_dir}")
+}

--- a/backend/scripts/pr215_verify.sh
+++ b/backend/scripts/pr215_verify.sh
@@ -7,11 +7,15 @@ export COMPOSER_NO_INTERACTION=1
 export GIT_TERMINAL_PROMPT=0
 export NO_COLOR=1
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 BACKEND_DIR="${REPO_DIR}/backend"
 ART_DIR="${ART_DIR:-${REPO_DIR}/backend/artifacts/pr215}"
 SERVE_PORT="${SERVE_PORT:-1815}"
 API_BASE="http://127.0.0.1:${SERVE_PORT}"
+
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/laravel_log_helpers.sh"
 
 mkdir -p "${ART_DIR}/logs"
 
@@ -57,7 +61,7 @@ if [[ -z "${ATTEMPT_ID}" ]]; then
   echo "create attempt failed" >&2
   cat "${START_JSON}" >&2 || true
   tail -n 200 "${ART_DIR}/logs/server.log" || true
-  tail -n 200 "${BACKEND_DIR}/storage/logs/laravel.log" 2>/dev/null || true
+  print_laravel_log_tails "${BACKEND_DIR}" 200 >&2 || true
   exit 2
 fi
 

--- a/backend/scripts/pr217_accept.sh
+++ b/backend/scripts/pr217_accept.sh
@@ -11,6 +11,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_DIR="$(cd "${BACKEND_DIR}/.." && pwd)"
 
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/laravel_log_helpers.sh"
+
 SERVE_PORT="${SERVE_PORT:-18217}"
 ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr217}"
 mkdir -p "${ART_DIR}"
@@ -44,10 +47,7 @@ fail() {
     echo "--- server.log (tail) ---"
     tail -n 200 "${SERVE_LOG}"
   fi
-  if [ -f "${BACKEND_DIR}/storage/logs/laravel.log" ]; then
-    echo "--- laravel.log (tail) ---"
-    tail -n 200 "${BACKEND_DIR}/storage/logs/laravel.log" | redact
-  fi
+  print_laravel_log_tails "${BACKEND_DIR}" 200 | redact || true
   exit "${code}"
 }
 trap fail ERR

--- a/backend/scripts/pr217_verify.sh
+++ b/backend/scripts/pr217_verify.sh
@@ -11,6 +11,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_DIR="$(cd "${BACKEND_DIR}/.." && pwd)"
 
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/laravel_log_helpers.sh"
+
 SERVE_PORT="${SERVE_PORT:-18217}"
 ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr217}"
 mkdir -p "${ART_DIR}"
@@ -31,10 +34,7 @@ fail() {
     echo "--- server.log (tail) ---"
     tail -n 200 "${ART_DIR}/server.log" | redact
   fi
-  if [ -f "${BACKEND_DIR}/storage/logs/laravel.log" ]; then
-    echo "--- laravel.log (tail) ---"
-    tail -n 200 "${BACKEND_DIR}/storage/logs/laravel.log" | redact
-  fi
+  print_laravel_log_tails "${BACKEND_DIR}" 200 | redact || true
   exit "${code}"
 }
 trap fail ERR

--- a/backend/scripts/pr29_verify.sh
+++ b/backend/scripts/pr29_verify.sh
@@ -13,7 +13,8 @@ export XDEBUG_MODE=off
 export FAP_PAYMENT_FALLBACK_PROVIDER=billing
 export BILLING_WEBHOOK_SECRET="${BILLING_WEBHOOK_SECRET:-billing_secret}"
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 BACKEND_DIR="${REPO_DIR}/backend"
 ART_DIR="${BACKEND_DIR}/artifacts/pr29"
 LOG_DIR="${ART_DIR}/logs"
@@ -21,6 +22,9 @@ SERVE_PORT="${SERVE_PORT:-1829}"
 HOST="127.0.0.1"
 API="http://${HOST}:${SERVE_PORT}"
 DB_PATH="${DB_DATABASE:-/tmp/pr29.sqlite}"
+
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/laravel_log_helpers.sh"
 
 mkdir -p "${ART_DIR}" "${LOG_DIR}"
 mkdir -p "${BACKEND_DIR}/storage/framework/cache" \
@@ -69,7 +73,7 @@ post_billing_webhook() {
 }
 
 cleanup() {
-  cp -f "${BACKEND_DIR}/storage/logs/laravel.log" "${LOG_DIR}/laravel.log" 2>/dev/null || true
+  copy_laravel_logs_to_dir "${BACKEND_DIR}" "${LOG_DIR}"
   if [[ -n "${SERVE_PID:-}" ]] && kill -0 "${SERVE_PID}" >/dev/null 2>&1; then
     kill "${SERVE_PID}" >/dev/null 2>&1 || true
   fi

--- a/backend/scripts/verify_mbti.sh
+++ b/backend/scripts/verify_mbti.sh
@@ -35,6 +35,15 @@ RUN_DIR="${RUN_DIR:-}"
 WORKDIR="${WORKDIR:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LARAVEL_LOG_HELPERS="$SCRIPT_DIR/laravel_log_helpers.sh"
+
+if [[ ! -f "$LARAVEL_LOG_HELPERS" ]]; then
+  echo "[FAIL] missing log helper: $LARAVEL_LOG_HELPERS" >&2
+  exit 2
+fi
+
+# shellcheck disable=SC1090
+source "$LARAVEL_LOG_HELPERS"
 
 if [[ -z "$RUN_DIR" ]]; then
   if [[ -n "$WORKDIR" ]]; then
@@ -404,10 +413,7 @@ else
     echo >&2
     echo "---- server log tail (/tmp/pr4_srv.log) ----" >&2
     tail -n 200 /tmp/pr4_srv.log 2>/dev/null || true
-    echo "---- laravel log tail ($BACKEND_DIR/storage/logs/laravel.log) ----" >&2
-    tail -n 200 "$BACKEND_DIR/storage/logs/laravel.log" 2>/dev/null || true
-    echo "---- laravel log tail (storage/logs/laravel.log) ----" >&2
-    tail -n 200 storage/logs/laravel.log 2>/dev/null || true
+    print_laravel_log_tails "$BACKEND_DIR" 200 >&2 || true
     exit 5
   fi
 

--- a/backend/tests/Feature/Storage/StorageInventoryCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageInventoryCommandTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Storage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Tests\TestCase;
@@ -18,30 +19,72 @@ final class StorageInventoryCommandTest extends TestCase
     public function test_inventory_outputs_json_fields_and_writes_audit_log(): void
     {
         $attemptId = (string) Str::uuid();
-        Storage::disk('local')->put("artifacts/reports/MBTI/{$attemptId}/report.json", '{"ok":true}');
-        Storage::disk('local')->put("artifacts/pdf/MBTI/{$attemptId}/nohash/report_free.pdf", '%PDF-1.4');
-        Storage::disk('local')->put('content_releases/test-release/source_pack/compiled/manifest.json', '{"ok":true}');
+        $logPath = storage_path('logs/laravel.log');
 
-        $this->assertSame(0, Artisan::call('storage:inventory', [
-            '--json' => true,
-        ]));
-        $output = (string) Artisan::output();
-        $this->assertStringContainsString('"scope":"reports"', $output);
-        $this->assertStringContainsString('"scope":"artifacts"', $output);
-        $this->assertStringContainsString('"scope":"content_releases"', $output);
-        $this->assertStringContainsString('"files"', $output);
-        $this->assertStringContainsString('"bytes"', $output);
-        $this->assertStringContainsString('"oldest_mtime"', $output);
-        $this->assertStringContainsString('"newest_mtime"', $output);
-        $this->assertStringContainsString('"top_dirs"', $output);
+        try {
+            Storage::disk('local')->put("artifacts/reports/MBTI/{$attemptId}/report.json", '{"ok":true,"payload":"duplicate"}');
+            Storage::disk('local')->put("artifacts/reports/MBTI/{$attemptId}/report_copy.json", '{"ok":true,"payload":"duplicate"}');
+            Storage::disk('local')->put("artifacts/pdf/MBTI/{$attemptId}/nohash/report_free.pdf", str_repeat('%PDF-1.4', 32));
+            Storage::disk('local')->put('content_releases/test-release/source_pack/compiled/manifest.json', '{"ok":true}');
+            File::ensureDirectoryExists(dirname($logPath));
+            File::put($logPath, str_repeat('{"message":"storage_inventory_test"}'.PHP_EOL, 4));
 
-        $this->assertTrue(
-            DB::table('audit_logs')->where('action', 'storage_inventory')->exists(),
-            'expected storage_inventory audit log'
-        );
+            $this->assertSame(0, Artisan::call('storage:inventory', [
+                '--json' => true,
+            ]));
 
-        Storage::disk('local')->deleteDirectory("artifacts/reports/MBTI/{$attemptId}");
-        Storage::disk('local')->deleteDirectory("artifacts/pdf/MBTI/{$attemptId}");
-        Storage::disk('local')->deleteDirectory('content_releases/test-release');
+            $payload = json_decode((string) Artisan::output(), true);
+            $this->assertIsArray($payload);
+            $this->assertSame(2, (int) ($payload['schema_version'] ?? 0));
+            $this->assertArrayHasKey('generated_at', $payload);
+            $this->assertArrayHasKey('scope_count', $payload);
+            $this->assertArrayHasKey('totals', $payload);
+            $this->assertArrayHasKey('scope_totals', $payload);
+            $this->assertArrayHasKey('focus_scopes', $payload);
+            $this->assertArrayHasKey('scopes', $payload);
+            $this->assertSame(count($payload['scopes'] ?? []), (int) ($payload['scope_count'] ?? -1));
+
+            $focusScopes = is_array($payload['focus_scopes'] ?? null) ? $payload['focus_scopes'] : [];
+            $this->assertArrayHasKey('logs', $focusScopes);
+            $this->assertArrayHasKey('artifacts', $focusScopes);
+            $this->assertArrayHasKey('content_releases', $focusScopes);
+            $this->assertSame(
+                (int) data_get($payload, 'scope_totals.artifacts.files', -1),
+                (int) data_get($focusScopes, 'artifacts.files', -2)
+            );
+
+            $scopes = collect($payload['scopes'] ?? [])->keyBy('scope');
+            $this->assertTrue($scopes->has('reports'));
+            $this->assertTrue($scopes->has('artifacts'));
+            $this->assertTrue($scopes->has('content_releases'));
+            $this->assertTrue($scopes->has('logs'));
+
+            $artifacts = $scopes->get('artifacts');
+            $this->assertIsArray($artifacts);
+            $this->assertArrayHasKey('files', $artifacts);
+            $this->assertArrayHasKey('bytes', $artifacts);
+            $this->assertArrayHasKey('oldest_mtime', $artifacts);
+            $this->assertArrayHasKey('newest_mtime', $artifacts);
+            $this->assertArrayHasKey('top_dirs', $artifacts);
+            $this->assertArrayHasKey('top_dirs_by_bytes', $artifacts);
+            $this->assertArrayHasKey('top_files', $artifacts);
+            $this->assertArrayHasKey('duplicate_summary', $artifacts);
+            $this->assertNotEmpty($artifacts['top_files']);
+            $this->assertGreaterThanOrEqual(1, (int) data_get($artifacts, 'duplicate_summary.groups', 0));
+            $this->assertGreaterThanOrEqual(2, (int) data_get($artifacts, 'duplicate_summary.files', 0));
+
+            $audit = DB::table('audit_logs')->where('action', 'storage_inventory')->first();
+            $this->assertNotNull($audit, 'expected storage_inventory audit log');
+            $auditPayload = json_decode((string) ($audit->meta_json ?? ''), true);
+            $this->assertIsArray($auditPayload);
+            $this->assertSame(2, (int) ($auditPayload['schema_version'] ?? 0));
+            $this->assertArrayHasKey('focus_scopes', $auditPayload);
+            $this->assertArrayHasKey('scopes', $auditPayload);
+        } finally {
+            Storage::disk('local')->deleteDirectory("artifacts/reports/MBTI/{$attemptId}");
+            Storage::disk('local')->deleteDirectory("artifacts/pdf/MBTI/{$attemptId}");
+            Storage::disk('local')->deleteDirectory('content_releases/test-release');
+            File::delete($logPath);
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR implements PR-13A only: storage inventory observability, low-risk logging compatibility, and storage hygiene noise reduction. It does not change storage retention semantics, rollback behavior, content publishing/resolution behavior, artifact canonical paths, or any business API contract.

The immediate user-facing issue behind this work is that `backend/storage` had become expensive to reason about during rollout planning: `storage:inventory --json` exposed only a flat array with per-scope file/byte counts, there was no top-level summary for automation to consume, there was no direct visibility into the largest files or duplicate-heavy areas, and the audit payload did not capture the richer picture we need for rollout decisions. At the same time, the repo and local tooling still indexed large runtime trees under `backend/storage`, which made IDE search and AI context noisier than necessary.

On the logging side, the repository already had `daily` and `stderr` channels configured, but the real operational contract still depended on `storage/logs/laravel.log`. Several verification and diagnostics scripts tail or copy that path directly, and ops evidence collection also assumes the single-file sink. Flipping the default channel in this PR would have widened blast radius immediately and broken the compatibility contract we explicitly decided to preserve in the PR-13A scan.

## Root cause

The root cause was not one missing feature but three small gaps at the rollout boundary:

1. `storage:inventory` only emitted the minimum per-scope counters and could not support higher-signal rollout decisions without manual follow-up inspection.
2. Logging configuration and retention policy existed in parallel, but there was no safe bridge between them, and script compatibility still implicitly depended on `laravel.log` staying present.
3. Ignore/indexing surfaces were incomplete for several large runtime-only storage paths, especially around `content_releases` and related generated trees.

## What changed

`storage:inventory --json` now returns a top-level object instead of a bare array. The new payload adds `schema_version`, `generated_at`, `scope_count`, `totals`, `scope_totals`, `focus_scopes`, and `scopes`. The existing per-scope fields remain present, and each scope now also includes `root_path`, `top_dirs_by_bytes`, `top_files`, and `duplicate_summary`. This keeps the original scope-level contract additive while making the JSON useful for downstream automation and audit review.

The storage inventory audit payload now stores the same richer payload structure in `audit_logs.meta_json`, so scheduled or manual runs preserve the expanded observability record instead of only the previous flat scope rows.

The storage inventory test was expanded to lock the new top-level object contract, the additive per-scope fields, duplicate detection output, and the upgraded audit payload shape.

Logging remains on the current low-risk default path: `LOG_CHANNEL=stack`, `LOG_STACK=single`, and `storage/logs/laravel.log` stays the live compatibility file. The change here is deliberately conservative. `LOG_STACK` is now normalized before use, and `daily.days` now falls back to `STORAGE_RETENTION_LOGS_DAYS` so long-term policy can be governed from one place without forcing an immediate sink switch. `.env.example` was updated to document the safe future pattern of `single,daily` or `single,stderr` while explicitly keeping `single` in the stack for compatibility.

To support that future-compatible logging shape, this PR adds a small shell helper for locating, tailing, and copying both `laravel.log` and rotated `laravel-*.log` files. The existing verification scripts were updated to use that helper instead of assuming that only one file can ever exist.

Finally, storage hygiene was tightened only at the repo/indexing layer. Root and backend `.gitignore` files now exclude additional runtime storage trees that were previously noisy but not useful in source control, and new `.cursorignore`, `.ignore`, `.rgignore`, and `.vscode/settings.json` files reduce IDE/search/AI indexing noise for those same runtime-only paths.

## Explicitly out of scope

This PR intentionally does not:

- change `StoragePrune` or any content release retention/deletion behavior
- change `content_releases/backups` semantics or rollback behavior
- touch `ContentPackPublisher`, `ContentPackV2Publisher`, or `ContentPackV2Resolver`
- introduce blob stores, manifests, or snapshots
- change artifact canonical paths or artifact read/write business behavior
- modify deploy/package blacklist behavior
- change business API contracts

Those belong to later PRs and were intentionally excluded to keep PR-13A mergeable as a single narrow rollout loop.

## Validation

I ran focused checks for the changed surface:

- `./vendor/bin/pint app/Console/Commands/StorageInventory.php tests/Feature/Storage/StorageInventoryCommandTest.php config/logging.php config/storage_retention.php`
- `php -l app/Console/Commands/StorageInventory.php`
- `php -l tests/Feature/Storage/StorageInventoryCommandTest.php`
- `php -l config/logging.php`
- `php -l config/storage_retention.php`
- `bash -n scripts/laravel_log_helpers.sh`
- `bash -n scripts/verify_mbti.sh`
- `bash -n scripts/pr217_verify.sh`
- `bash -n scripts/pr217_accept.sh`
- `bash -n scripts/pr215_verify.sh`
- `bash -n scripts/pr29_verify.sh`
- `php artisan storage:inventory --json > /tmp/storage_inventory.json`
- `php artisan schedule:list`
- `php artisan route:list --path=healthz`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/Storage/StorageInventoryCommandTest.php`
- `php artisan tinker --execute='dump([...logging config...])'`
- `git check-ignore -v ...`
- `python3 -m json.tool .vscode/settings.json`
- `curl -i http://127.0.0.1:18081/api/healthz`

I also ran `bash backend/scripts/ci_verify_mbti.sh`. That gate is currently not green in this branch because the existing report fetch path fails with `ORG_CONTEXT_MISSING` during `/api/v0.3/attempts/{id}/report`. This PR does not change that application path; the failure appears in the report read flow after attempt creation/submission and should be treated as a separate issue from the storage inventory/logging/hygiene changes here.
