### PR TITLE
[codex] Close MBTI Phase 2 review gaps (backend)

### DIFF
--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -21,7 +21,86 @@ final class MbtiResultPersonalizationService
     /**
      * @var list<string>
      */
-    private const TARGET_SECTIONS = ['overview', 'growth', 'relationships', 'career'];
+    private const TARGET_SECTIONS = [
+        'overview',
+        'trait_overview',
+        'career.summary',
+        'career.advantages',
+        'career.weaknesses',
+        'career.preferred_roles',
+        'career.upgrade_suggestions',
+        'growth.summary',
+        'growth.strengths',
+        'growth.weaknesses',
+        'growth.motivators',
+        'growth.drainers',
+        'relationships.summary',
+        'relationships.strengths',
+        'relationships.weaknesses',
+        'relationships.rel_advantages',
+        'relationships.rel_risks',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const SECTION_SCENE_MAP = [
+        'overview' => 'overview',
+        'trait_overview' => 'overview',
+        'career.summary' => 'work',
+        'career.advantages' => 'work',
+        'career.weaknesses' => 'work',
+        'career.preferred_roles' => 'work',
+        'career.upgrade_suggestions' => 'work',
+        'growth.summary' => 'growth',
+        'growth.strengths' => 'growth',
+        'growth.weaknesses' => 'growth',
+        'growth.motivators' => 'growth',
+        'growth.drainers' => 'stress_recovery',
+        'relationships.summary' => 'relationships',
+        'relationships.strengths' => 'relationships',
+        'relationships.weaknesses' => 'relationships',
+        'relationships.rel_advantages' => 'communication',
+        'relationships.rel_risks' => 'decision',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const SCENE_FINGERPRINT_ORDER = [
+        'work',
+        'relationships',
+        'growth',
+        'decision',
+        'stress_recovery',
+        'communication',
+    ];
+
+    /**
+     * @var array<string, list<string>>
+     */
+    private const SCENE_AXIS_PRIORITY = [
+        'overview' => ['EI', 'SN', 'TF', 'JP'],
+        'work' => ['EI', 'JP', 'TF', 'SN'],
+        'relationships' => ['TF', 'EI', 'JP', 'SN'],
+        'growth' => ['EI', 'SN', 'TF', 'JP'],
+        'decision' => ['TF', 'JP', 'SN', 'EI'],
+        'stress_recovery' => ['JP', 'EI', 'TF', 'SN'],
+        'communication' => ['EI', 'TF', 'SN', 'JP'],
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const SCENE_ANCHORS = [
+        'overview' => 'overview',
+        'work' => 'career',
+        'relationships' => 'relationships',
+        'growth' => 'growth',
+        'decision' => 'overview',
+        'stress_recovery' => 'growth',
+        'communication' => 'relationships',
+    ];
 
     /**
      * @var array<string, array{label:array<string,string>, sides:array<string,string>}>
@@ -55,7 +134,7 @@ final class MbtiResultPersonalizationService
     private const DEFAULT_BLOCK_LABELS = [
         'type_skeleton' => '类型骨架',
         'axis_strength' => '强度层',
-        'boundary' => '边界提示',
+        'boundary' => '边界深解释',
         'identity' => '身份层',
         'scene' => '场景应用',
     ];
@@ -66,9 +145,33 @@ final class MbtiResultPersonalizationService
     private const DEFAULT_BLOCK_LABELS_EN = [
         'type_skeleton' => 'Type skeleton',
         'axis_strength' => 'Strength layer',
-        'boundary' => 'Boundary note',
+        'boundary' => 'Boundary deepening',
         'identity' => 'Identity layer',
         'scene' => 'Scene application',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const DEFAULT_SCENE_TITLES = [
+        'work' => '你的工作模式',
+        'relationships' => '你的关系模式',
+        'growth' => '你的成长模式',
+        'decision' => '你的决策模式',
+        'stress_recovery' => '你的压力恢复模式',
+        'communication' => '你的沟通模式',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const DEFAULT_SCENE_TITLES_EN = [
+        'work' => 'Your work pattern',
+        'relationships' => 'Your relationship pattern',
+        'growth' => 'Your growth pattern',
+        'decision' => 'Your decision pattern',
+        'stress_recovery' => 'Your stress pattern',
+        'communication' => 'Your communication pattern',
     ];
 
     /**
@@ -111,6 +214,22 @@ final class MbtiResultPersonalizationService
         'career.clear' => '在工作里，{{side_label}}已经是你较稳定的默认操作方式。它会影响你更顺手的工作节奏、协作方式和反馈偏好。',
         'career.strong' => '在工作里，{{side_label}}已经很鲜明。你通常不是“什么环境都行”，而是会在某类节奏里明显更快进入高质量输出。',
         'career.very_strong' => '在工作里，你的{{side_label}}偏好非常强。这会让你在适配环境里效率极高，但也会放大与不匹配环境之间的摩擦感。',
+        'work.boundary' => '在工作场景里，这条轴靠近中线，意味着你会根据任务、人和节奏切换挡位；真正关键的是你何时切换，以及团队是否读得懂这种切换。',
+        'work.clear' => '在工作场景里，{{side_label}}已经是你较稳定的默认工作方式。它会影响你启动任务、协作和接收反馈的第一反应。',
+        'work.strong' => '在工作场景里，{{side_label}}已经很鲜明。匹配环境会放大你的效率，不匹配环境也会更快放大摩擦。',
+        'work.very_strong' => '在工作场景里，你的{{side_label}}风格极其稳定。优势是输出速度和风格识别度都很高，代价是环境不合拍时不适感也会非常明显。',
+        'decision.boundary' => '做决定时，这条轴靠近中线，所以你不是单一路径地下判断，而是会在两套入口之间切换。',
+        'decision.clear' => '做决定时，{{side_label}}已经是你更常见的默认入口，但另一侧仍然会在复核和收尾阶段发挥作用。',
+        'decision.strong' => '做决定时，{{side_label}}已经很鲜明。你往往会先沿着这一侧推进，再决定是否需要另一侧补位。',
+        'decision.very_strong' => '做决定时，你的{{side_label}}倾向非常强。这会让判断更快更稳，也会让别人更容易把你理解成“只会这样判断的人”。',
+        'stress_recovery.boundary' => '在压力与恢复上，这条轴靠近中线，意味着你在过载时和恢复时可能会切到不同挡位。',
+        'stress_recovery.clear' => '在压力与恢复上，{{side_label}}已经是你更稳定的应对入口，但恢复阶段通常还需要另一侧来重新平衡。',
+        'stress_recovery.strong' => '在压力与恢复上，{{side_label}}已经很鲜明。你容易先用这一侧救火，所以更需要一条固定的恢复回路。',
+        'stress_recovery.very_strong' => '在压力与恢复上，你的{{side_label}}风格非常强。优势是应对快，风险是过度依赖同一套自救方式。',
+        'communication.boundary' => '在沟通里，这条轴靠近中线，所以你不是只会一种表达方式；你会根据对象、氛围和目标来切换。',
+        'communication.clear' => '在沟通里，{{side_label}}已经是你更常见的起手方式，但当场景变化时，另一侧仍会迅速进场补位。',
+        'communication.strong' => '在沟通里，{{side_label}}已经很鲜明。别人通常会先感受到这一侧，因此误读也往往从这里开始。',
+        'communication.very_strong' => '在沟通里，你的{{side_label}}风格非常稳定。优势是辨识度高，风险是别人容易把你的表达方式误读成你的全部意图。',
     ];
 
     /**
@@ -133,6 +252,22 @@ final class MbtiResultPersonalizationService
         'career.clear' => 'At work, {{side_label}} is already a stable operating mode. It shapes the pace, collaboration pattern, and feedback style that feel most natural to you.',
         'career.strong' => 'At work, {{side_label}} is already strong. You are not equally effective everywhere; some environments let you enter high-quality output much faster.',
         'career.very_strong' => 'At work, your {{side_label}} preference is very strong. That can make you exceptionally effective in a good-fit environment and noticeably strained in a bad-fit one.',
+        'work.boundary' => 'At work, this axis sits close to the middle, which means you shift gears depending on task, people, and pace. The real question is when you switch and whether the team can read that switch.',
+        'work.clear' => 'At work, {{side_label}} is already your more stable operating mode. It shapes how you start, collaborate, and take feedback.',
+        'work.strong' => 'At work, {{side_label}} is already strong. Fit environments amplify your output, while poor-fit environments amplify friction faster.',
+        'work.very_strong' => 'At work, your {{side_label}} style is extremely stable. The upside is speed and recognizability; the downside is that mismatch becomes much more obvious.',
+        'decision.boundary' => 'In decisions, this axis sits close to the middle, so you do not judge through one path only. You switch between two entry points.',
+        'decision.clear' => 'In decisions, {{side_label}} is already your more common first entry point, while the opposite side still comes in during review and closure.',
+        'decision.strong' => 'In decisions, {{side_label}} is already strong. You often move forward through this side first, then decide whether the opposite side needs to step in.',
+        'decision.very_strong' => 'In decisions, your {{side_label}} preference is very strong. That makes your judgment faster and more stable, but also easier for others to oversimplify.',
+        'stress_recovery.boundary' => 'In stress and recovery, this axis sits close to the middle. Your overload mode and your recovery mode may not use the same gear.',
+        'stress_recovery.clear' => 'In stress and recovery, {{side_label}} is already your steadier coping entry point, but recovery often still needs the opposite side to rebalance.',
+        'stress_recovery.strong' => 'In stress and recovery, {{side_label}} is already strong. You naturally use this side to contain overload, so you need a deliberate reset loop.',
+        'stress_recovery.very_strong' => 'In stress and recovery, your {{side_label}} style is very strong. The upside is fast coping; the downside is over-relying on the same self-protection move.',
+        'communication.boundary' => 'In communication, this axis sits close to the middle, so you do not express yourself in only one way. You switch with audience, atmosphere, and goal.',
+        'communication.clear' => 'In communication, {{side_label}} is already your more common opening move, but the opposite side still comes in quickly when the context changes.',
+        'communication.strong' => 'In communication, {{side_label}} is already strong. People usually feel this side first, so misunderstandings often begin there too.',
+        'communication.very_strong' => 'In communication, your {{side_label}} style is extremely stable. The upside is recognizability; the downside is that people may mistake the style for the whole intention.',
     ];
 
     /**
@@ -143,6 +278,10 @@ final class MbtiResultPersonalizationService
         'growth' => '把它放进成长情境时，更有效的做法不是否定这条主轴，而是让它在{{axis_label}}上多带一个反向校正动作：{{scene_side_hint}}。',
         'relationships' => '放到关系里，这条主轴通常会变成一种相处节奏：{{scene_side_hint}}。如果对方没有读懂这一点，就容易把你的方式误解成距离感、迟疑或控制感。',
         'career' => '放到工作里，这条主轴更像你的默认操作系统：{{scene_side_hint}}。它会直接影响你更适配的岗位节奏与协作环境。',
+        'work' => '放到工作里，这条主轴更像你的默认操作系统：{{scene_side_hint}}。它会直接影响你更适配的岗位节奏与协作环境。',
+        'decision' => '放到决策里，这条主轴会决定你先用哪一种入口缩小范围：{{scene_side_hint}}。',
+        'stress_recovery' => '放到压力与恢复里，这条主轴通常会变成你最先启动的自救方式：{{scene_side_hint}}。',
+        'communication' => '放到沟通里，这条主轴通常会变成你的起手表达方式：{{scene_side_hint}}。',
     ];
 
     /**
@@ -153,6 +292,60 @@ final class MbtiResultPersonalizationService
         'growth' => 'In growth work, the best move is not to reject this axis but to add one opposite-side correction on {{axis_label}}: {{scene_side_hint}}.',
         'relationships' => 'In relationships, this axis often turns into a rhythm: {{scene_side_hint}}. If the other person misses that pattern, they may misread your style as distance, hesitation, or control.',
         'career' => 'At work, this axis behaves like your default operating system: {{scene_side_hint}}. It directly affects the pace and collaboration environment that fit you best.',
+        'work' => 'At work, this axis behaves like your default operating system: {{scene_side_hint}}. It directly affects the pace and collaboration environment that fit you best.',
+        'decision' => 'In decisions, this axis shapes which entry point you use first to narrow the field: {{scene_side_hint}}.',
+        'stress_recovery' => 'In stress and recovery, this axis often becomes the first coping move you activate: {{scene_side_hint}}.',
+        'communication' => 'In communication, this axis often becomes your opening expression style: {{scene_side_hint}}.',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const DEFAULT_SCENE_FINGERPRINT_TEMPLATES = [
+        'work' => '在工作里，你通常先用{{primary_hint}}开局，再用{{support_hint}}把节奏拉回可执行。{{identity_clause}} {{boundary_clause}}',
+        'relationships' => '在关系里，你常先以{{primary_hint}}让别人感受到你，再通过{{support_hint}}决定要靠近、回应还是设边界。{{identity_clause}} {{boundary_clause}}',
+        'growth' => '成长上，你的高杠杆点通常来自{{primary_hint}}；当你再补上{{support_hint}}时，进步会更稳定。{{identity_clause}} {{boundary_clause}}',
+        'decision' => '做决定时，你通常先靠{{primary_hint}}缩小范围，再用{{support_hint}}确认是否值得推进。{{identity_clause}} {{boundary_clause}}',
+        'stress_recovery' => '压力升高时，你容易先滑向{{primary_hint}}来求快或求稳；恢复阶段则更需要{{support_hint}}把你拉回可用区。{{identity_clause}} {{boundary_clause}}',
+        'communication' => '沟通里，你通常先以{{primary_hint}}发起，再用{{support_hint}}修正对齐。{{identity_clause}} {{boundary_clause}}',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const DEFAULT_SCENE_FINGERPRINT_TEMPLATES_EN = [
+        'work' => 'At work, you usually start through {{primary_hint}}, then use {{support_hint}} to bring the rhythm back into something executable. {{identity_clause}} {{boundary_clause}}',
+        'relationships' => 'In relationships, people often feel you first through {{primary_hint}}, and then through {{support_hint}} you decide how to approach, respond, or set boundaries. {{identity_clause}} {{boundary_clause}}',
+        'growth' => 'In growth work, your biggest leverage often comes from {{primary_hint}}; when you add {{support_hint}}, progress becomes more repeatable. {{identity_clause}} {{boundary_clause}}',
+        'decision' => 'In decisions, you usually narrow the field through {{primary_hint}} first, then use {{support_hint}} to decide whether it is worth moving forward. {{identity_clause}} {{boundary_clause}}',
+        'stress_recovery' => 'When pressure rises, you tend to slide toward {{primary_hint}} first to cope quickly or stay stable; recovery then needs {{support_hint}} to bring you back into a usable range. {{identity_clause}} {{boundary_clause}}',
+        'communication' => 'In communication, you usually open through {{primary_hint}} and then use {{support_hint}} to recalibrate alignment. {{identity_clause}} {{boundary_clause}}',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const DEFAULT_BOUNDARY_NARRATIVE_TEMPLATES = [
+        'overview' => '{{axis_label}}靠近中线时，你不是“有点像两边”，而是会在不同情境下切换入口。熟悉场景里你可能先用{{side_label}}，压力或高风险情境里又会迅速调动{{opposite_side_label}}。别人如果只看到其中一面，就容易把你误读成忽冷忽热、摇摆或前后不一。',
+        'relationships' => '在人际里，{{axis_label}}靠近中线意味着你不会永远只走{{side_label}}这一条路。你可能先用{{side_label}}靠近，遇到压力或误解时又改用{{opposite_side_label}}保护自己。别人如果只看到其中一段，就会误判你到底是在拉近、保持距离，还是突然变得难以捉摸。',
+        'growth' => '成长上，{{axis_label}}靠近中线意味着你真正要学的不是选边站，而是识别什么时候该让{{side_label}}先开路，什么时候该让{{opposite_side_label}}接手收尾。会切换并不可怕，不知道自己在什么时候切换才会让你觉得“我怎么又变了”。',
+        'work' => '在工作里，{{axis_label}}靠近中线会让你在任务、协作和压力场景下切换齿轮。你有时像{{side_label}}，有时又会突然拉出{{opposite_side_label}}来修正，所以团队很容易只记住其中一面。真正有价值的是让别人知道：你在什么信号下会切换，以及切换后需要怎样的协作方式。',
+        'decision' => '做决定时，{{axis_label}}靠近中线意味着你并不是摇摆不定，而是在两套判断入口之间来回校准。你可能先用{{side_label}}开路，再用{{opposite_side_label}}复核；场景一变，顺序也会反过来。别人会以为你前后矛盾，其实你是在同时守住速度与准确度、标准与关系，或结构与弹性。',
+        'stress_recovery' => '压力上来时，{{axis_label}}靠近中线意味着你可能先滑向{{side_label}}来保住当下，再在恢复阶段调回{{opposite_side_label}}重新平衡。它的难点不是“你为什么不稳定”，而是如果你没意识到自己在切换，就会把这种来回误读成状态失控。',
+        'communication' => '沟通里，{{axis_label}}靠近中线意味着你不会永远只用一种表达方式。你可能先用{{side_label}}出手，但一旦对方反馈变化，又迅速调动{{opposite_side_label}}补位。别人如果只看到前半段，常会误读你的真实意图；而你自己则会觉得“我明明已经说清楚了”。',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const DEFAULT_BOUNDARY_NARRATIVE_TEMPLATES_EN = [
+        'overview' => 'When {{axis_label}} sits near the middle, you are not simply “a bit of both.” You switch entry points across situations. In familiar settings you may lead with {{side_label}}, while pressure or high-stakes contexts quickly bring in {{opposite_side_label}}. If people only see one side, they can misread you as inconsistent or hard to pin down.',
+        'relationships' => 'In relationships, a near-boundary {{axis_label}} means you do not move through connection in only one way. You may open with {{side_label}}, then shift into {{opposite_side_label}} when stress or misunderstanding rises. If someone only sees one segment of that pattern, they may misread whether you are moving closer, taking distance, or protecting yourself.',
+        'growth' => 'For growth, a near-boundary {{axis_label}} means the real task is not picking one side forever. It is learning when {{side_label}} should open the move and when {{opposite_side_label}} should finish it. Switching is not the problem; not knowing when you switch is what creates the feeling that you are changing unpredictably.',
+        'work' => 'At work, a near-boundary {{axis_label}} makes you shift gears across tasks, collaboration, and pressure. Sometimes you read as {{side_label}}, then suddenly pull in {{opposite_side_label}} to correct course. Teams often remember only one side. The useful move is to make the switch legible: what triggers it, and what collaboration pattern helps once it happens.',
+        'decision' => 'In decisions, a near-boundary {{axis_label}} does not mean you are indecisive. It means you recalibrate between two judgment entry points. You may start with {{side_label}} and then use {{opposite_side_label}} to verify, or reverse that order when the context changes. People may call it inconsistency when it is really a dual-track calibration.',
+        'stress_recovery' => 'Under stress, a near-boundary {{axis_label}} means you may slide toward {{side_label}} to contain the moment, then return through {{opposite_side_label}} during recovery. The hard part is not instability; it is failing to notice the shift and then misreading it as being out of control.',
+        'communication' => 'In communication, a near-boundary {{axis_label}} means you do not express yourself in only one register. You may open with {{side_label}}, then rapidly bring in {{opposite_side_label}} as feedback changes. If people only catch the first half, they can misunderstand your intent; if you miss the shift yourself, it can feel like you already made yourself clear.',
     ];
 
     /**
@@ -256,10 +449,16 @@ final class MbtiResultPersonalizationService
 
         $dominantAxes = $this->resolveDominantAxes($axisVector);
         $dynamicDoc = $this->loadDynamicSectionsDoc($context, $locale);
+        $sceneFingerprint = $this->buildSceneFingerprint(
+            $axisVector,
+            $identity,
+            $dynamicDoc,
+            $locale
+        );
         $sectionVariants = $this->buildSectionVariants(
             $axisVector,
             $identity,
-            $dominantAxes,
+            $sceneFingerprint,
             $dynamicDoc,
             $locale
         );
@@ -270,7 +469,7 @@ final class MbtiResultPersonalizationService
         }
 
         return [
-            'schema_version' => 'mbti.personalization.phase1.v1',
+            'schema_version' => 'mbti.personalization.phase2.v1',
             'locale' => $locale,
             'type_code' => $typeCode,
             'identity' => $identity,
@@ -278,6 +477,11 @@ final class MbtiResultPersonalizationService
             'axis_bands' => $axisBands,
             'boundary_flags' => $boundaryFlags,
             'dominant_axes' => $dominantAxes,
+            'scene_fingerprint' => $sceneFingerprint,
+            'work_style_keys' => array_values((array) data_get($sceneFingerprint, 'work.style_keys', [])),
+            'relationship_style_keys' => array_values((array) data_get($sceneFingerprint, 'relationships.style_keys', [])),
+            'decision_style_keys' => array_values((array) data_get($sceneFingerprint, 'decision.style_keys', [])),
+            'stress_recovery_keys' => array_values((array) data_get($sceneFingerprint, 'stress_recovery.style_keys', [])),
             'variant_keys' => $variantKeys,
             'sections' => $sectionVariants,
             'pack_id' => trim((string) ($context['pack_id'] ?? data_get($reportPayload, 'versions.content_pack_id', ''))),
@@ -313,11 +517,10 @@ final class MbtiResultPersonalizationService
             }
 
             $sectionKey = strtolower(trim((string) ($section['key'] ?? '')));
-            if ($sectionKey === '' || ! is_array($sectionMeta[$sectionKey] ?? null)) {
+            $dynamic = $this->resolveProjectionSectionMeta($sectionKey, $sectionMeta);
+            if ($sectionKey === '' || ! is_array($dynamic)) {
                 continue;
             }
-
-            $dynamic = $sectionMeta[$sectionKey];
             $body = trim((string) ($section['body_md'] ?? $section['body'] ?? ''));
             $payload = is_array($section['payload'] ?? null) ? $section['payload'] : [];
             $blocks = [];
@@ -354,6 +557,8 @@ final class MbtiResultPersonalizationService
                 'variant_key' => (string) ($dynamic['variant_key'] ?? ''),
                 'selected_blocks' => array_values((array) ($dynamic['selected_blocks'] ?? [])),
                 'primary_axis' => is_array($dynamic['primary_axis'] ?? null) ? $dynamic['primary_axis'] : null,
+                'scene_key' => (string) ($dynamic['scene_key'] ?? ''),
+                'style_key' => (string) ($dynamic['style_key'] ?? ''),
                 'boundary_axes' => array_values((array) ($dynamic['boundary_axes'] ?? [])),
             ];
 
@@ -490,37 +695,92 @@ final class MbtiResultPersonalizationService
     }
 
     /**
-     * @param  list<array<string, mixed>>  $dominantAxes
+     * @param  array<string, array<string, mixed>>  $axisVector
+     * @param  array<string, mixed>  $doc
+     * @return array<string, array<string, mixed>>
+     */
+    private function buildSceneFingerprint(
+        array $axisVector,
+        string $identity,
+        array $doc,
+        string $locale
+    ): array {
+        $fingerprint = [];
+
+        foreach (self::SCENE_FINGERPRINT_ORDER as $sceneKey) {
+            $primaryAxis = $this->resolveScenePrimaryAxis($sceneKey, $axisVector);
+            if (! is_array($primaryAxis)) {
+                continue;
+            }
+
+            $supportAxis = $this->resolveSceneSupportAxis($sceneKey, $axisVector, (string) ($primaryAxis['axis'] ?? ''));
+            $boundaryAxes = $this->resolveSceneBoundaryAxes($sceneKey, $axisVector);
+            $styleKeys = $this->buildSceneStyleKeys($sceneKey, $primaryAxis, $supportAxis, $identity, $boundaryAxes);
+            $fingerprint[$sceneKey] = [
+                'scene' => $sceneKey,
+                'title' => $this->sceneTitle($sceneKey, $doc, $locale),
+                'summary' => $this->resolveSceneFingerprintText(
+                    $doc,
+                    $sceneKey,
+                    $locale,
+                    $axisVector,
+                    $primaryAxis,
+                    $supportAxis,
+                    $identity,
+                    $boundaryAxes
+                ),
+                'style_key' => $styleKeys[0] ?? '',
+                'style_keys' => $styleKeys,
+                'chapter_anchor' => self::SCENE_ANCHORS[$sceneKey] ?? 'overview',
+                'primary_axis' => $primaryAxis,
+                'support_axis' => $supportAxis,
+                'boundary_axes' => $boundaryAxes,
+            ];
+        }
+
+        return $fingerprint;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $axisVector
+     * @param  array<string, array<string, mixed>>  $sceneFingerprint
      * @param  array<string, mixed>  $doc
      * @return array<string, array<string, mixed>>
      */
     private function buildSectionVariants(
         array $axisVector,
         string $identity,
-        array $dominantAxes,
+        array $sceneFingerprint,
         array $doc,
         string $locale
     ): array {
-        $primaryAxis = is_array($dominantAxes[0] ?? null) ? $dominantAxes[0] : null;
-        $boundaryAxes = array_values(array_map(
-            static fn (string $axisCode): string => $axisCode,
-            array_keys(array_filter($axisVector, static fn (array $node): bool => (string) ($node['band'] ?? '') === 'boundary'))
-        ));
-
         $sectionVariants = [];
 
         foreach (self::TARGET_SECTIONS as $sectionKey) {
+            $sceneKey = self::SECTION_SCENE_MAP[$sectionKey] ?? 'overview';
+            $primaryAxis = is_array(data_get($sceneFingerprint, $sceneKey.'.primary_axis'))
+                ? data_get($sceneFingerprint, $sceneKey.'.primary_axis')
+                : $this->resolveScenePrimaryAxis($sceneKey, $axisVector);
+
             if (! is_array($primaryAxis)) {
                 continue;
             }
 
-            $blocks = [];
-            $selectedBlocks = [];
-            $band = (string) ($primaryAxis['band'] ?? 'clear');
+            $supportAxis = is_array(data_get($sceneFingerprint, $sceneKey.'.support_axis'))
+                ? data_get($sceneFingerprint, $sceneKey.'.support_axis')
+                : $this->resolveSceneSupportAxis($sceneKey, $axisVector, (string) ($primaryAxis['axis'] ?? ''));
+            $boundaryAxes = array_values((array) data_get($sceneFingerprint, $sceneKey.'.boundary_axes', []));
+            $boundaryAxis = $boundaryAxes[0] ?? null;
             $axisCode = (string) ($primaryAxis['axis'] ?? 'EI');
             $side = (string) ($primaryAxis['side'] ?? 'E');
+            $band = (string) ($primaryAxis['band'] ?? 'clear');
+            $styleKey = (string) data_get($sceneFingerprint, $sceneKey.'.style_key', '');
+            $templateGroup = $this->templateGroupForSection($sectionKey, $sceneKey);
 
-            $axisStrengthText = $this->resolveAxisStrengthText($doc, $sectionKey, $band, $locale, $primaryAxis);
+            $blocks = [];
+            $selectedBlocks = [];
+
+            $axisStrengthText = $this->resolveAxisStrengthText($doc, $templateGroup, $band, $locale, $primaryAxis);
             if ($axisStrengthText !== '') {
                 $blockId = sprintf('%s.axis_strength.%s.%s.%s', $sectionKey, $axisCode, $side, $band);
                 $selectedBlocks[] = $blockId;
@@ -532,7 +792,7 @@ final class MbtiResultPersonalizationService
                 ];
             }
 
-            $sceneText = $this->resolveSceneText($doc, $sectionKey, $locale, $primaryAxis);
+            $sceneText = $this->resolveSceneText($doc, $templateGroup, $locale, $primaryAxis);
             if ($sceneText !== '') {
                 $blockId = sprintf('%s.scene.%s.%s', $sectionKey, $axisCode, $side);
                 $selectedBlocks[] = $blockId;
@@ -558,9 +818,15 @@ final class MbtiResultPersonalizationService
                 }
             }
 
-            $boundaryAxis = $boundaryAxes[0] ?? null;
             if (is_string($boundaryAxis) && $boundaryAxis !== '') {
-                $boundaryText = $this->resolveBoundaryText($doc, $boundaryAxis, $locale);
+                $boundaryText = $this->resolveBoundaryNarrativeText(
+                    $doc,
+                    $sceneKey,
+                    $boundaryAxis,
+                    $locale,
+                    $axisVector,
+                    $primaryAxis
+                );
                 if ($boundaryText !== '') {
                     $blockId = sprintf('%s.boundary.%s', $sectionKey, $boundaryAxis);
                     $selectedBlocks[] = $blockId;
@@ -582,7 +848,10 @@ final class MbtiResultPersonalizationService
 
             $sectionVariants[$sectionKey] = [
                 'variant_key' => implode(':', $variantParts),
+                'style_key' => $styleKey,
+                'scene_key' => $sceneKey,
                 'primary_axis' => $primaryAxis,
+                'support_axis' => $supportAxis,
                 'boundary_axes' => $boundaryAxes,
                 'selected_blocks' => $selectedBlocks,
                 'blocks' => $blocks,
@@ -593,15 +862,328 @@ final class MbtiResultPersonalizationService
     }
 
     /**
+     * @param  array<string, array<string, mixed>>  $axisVector
+     * @return array<string, mixed>|null
+     */
+    private function resolveScenePrimaryAxis(string $sceneKey, array $axisVector): ?array
+    {
+        foreach (self::SCENE_AXIS_PRIORITY[$sceneKey] ?? self::DOMINANT_AXIS_ORDER as $axisCode) {
+            if (is_array($axisVector[$axisCode] ?? null)) {
+                return $axisVector[$axisCode];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $axisVector
+     * @return array<string, mixed>|null
+     */
+    private function resolveSceneSupportAxis(string $sceneKey, array $axisVector, string $primaryAxisCode): ?array
+    {
+        foreach (self::SCENE_AXIS_PRIORITY[$sceneKey] ?? self::DOMINANT_AXIS_ORDER as $axisCode) {
+            if ($axisCode === $primaryAxisCode) {
+                continue;
+            }
+
+            if (is_array($axisVector[$axisCode] ?? null)) {
+                return $axisVector[$axisCode];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $axisVector
+     * @return list<string>
+     */
+    private function resolveSceneBoundaryAxes(string $sceneKey, array $axisVector): array
+    {
+        $ordered = [];
+        $priority = self::SCENE_AXIS_PRIORITY[$sceneKey] ?? self::DOMINANT_AXIS_ORDER;
+
+        foreach ($priority as $axisCode) {
+            if ((string) data_get($axisVector, $axisCode.'.band') !== 'boundary') {
+                continue;
+            }
+
+            $ordered[] = $axisCode;
+        }
+
+        return array_values(array_unique($ordered));
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $primaryAxis
+     * @param  array<string, mixed>|null  $supportAxis
+     * @param  list<string>  $boundaryAxes
+     * @return list<string>
+     */
+    private function buildSceneStyleKeys(
+        string $sceneKey,
+        ?array $primaryAxis,
+        ?array $supportAxis,
+        string $identity,
+        array $boundaryAxes
+    ): array {
+        $keys = [];
+
+        if (is_array($primaryAxis)) {
+            $keys[] = sprintf(
+                '%s.primary.%s.%s.%s',
+                $sceneKey,
+                (string) ($primaryAxis['axis'] ?? ''),
+                (string) ($primaryAxis['side'] ?? ''),
+                (string) ($primaryAxis['band'] ?? 'clear')
+            );
+        }
+
+        if (is_array($supportAxis)) {
+            $keys[] = sprintf(
+                '%s.support.%s.%s.%s',
+                $sceneKey,
+                (string) ($supportAxis['axis'] ?? ''),
+                (string) ($supportAxis['side'] ?? ''),
+                (string) ($supportAxis['band'] ?? 'clear')
+            );
+        }
+
+        if ($identity !== '') {
+            $keys[] = sprintf('%s.identity.%s', $sceneKey, $identity);
+        }
+
+        foreach ($boundaryAxes as $axisCode) {
+            $keys[] = sprintf('%s.boundary.%s', $sceneKey, $axisCode);
+        }
+
+        return array_values(array_filter($keys));
+    }
+
+    private function templateGroupForSection(string $sectionKey, string $sceneKey): string
+    {
+        return match ($sceneKey) {
+            'work' => 'work',
+            'relationships' => 'relationships',
+            'growth' => 'growth',
+            'decision' => 'decision',
+            'stress_recovery' => 'stress_recovery',
+            'communication' => 'communication',
+            default => $sectionKey === 'trait_overview' ? 'overview' : 'overview',
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $doc
+     */
+    private function sceneTitle(string $sceneKey, array $doc, string $locale): string
+    {
+        return $this->resolveTemplate(
+            data_get($doc, 'scene_titles.'.$sceneKey),
+            $locale,
+            $locale === 'zh-CN'
+                ? (self::DEFAULT_SCENE_TITLES[$sceneKey] ?? $sceneKey)
+                : (self::DEFAULT_SCENE_TITLES_EN[$sceneKey] ?? $sceneKey)
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $doc
+     * @param  array<string, mixed>  $primaryAxis
+     * @param  array<string, mixed>|null  $supportAxis
+     * @param  list<string>  $boundaryAxes
+     */
+    private function resolveSceneFingerprintText(
+        array $doc,
+        string $sceneKey,
+        string $locale,
+        array $axisVector,
+        array $primaryAxis,
+        ?array $supportAxis,
+        string $identity,
+        array $boundaryAxes
+    ): string {
+        $template = $this->resolveTemplate(
+            data_get($doc, 'scene_fingerprint_templates.'.$sceneKey),
+            $locale,
+            $locale === 'zh-CN'
+                ? (self::DEFAULT_SCENE_FINGERPRINT_TEMPLATES[$sceneKey] ?? '')
+                : (self::DEFAULT_SCENE_FINGERPRINT_TEMPLATES_EN[$sceneKey] ?? '')
+        );
+
+        $primaryHint = $this->sceneSummaryHint($this->sceneHintText($doc, $locale, $primaryAxis), $locale);
+        $supportHint = is_array($supportAxis)
+            ? $this->sceneSummaryHint($this->sceneHintText($doc, $locale, $supportAxis), $locale)
+            : ($locale === 'zh-CN' ? '另一侧提供的校正' : 'an opposite-side correction');
+        $identityClause = $this->shortIdentityClause($identity, $locale);
+        $boundaryClause = '';
+
+        $boundaryAxis = $boundaryAxes[0] ?? null;
+        if (is_string($boundaryAxis) && $boundaryAxis !== '') {
+            $boundaryClause = $this->resolveBoundaryNarrativeText(
+                $doc,
+                $sceneKey,
+                $boundaryAxis,
+                $locale,
+                $axisVector,
+                $primaryAxis,
+                true
+            );
+        }
+
+        return $this->renderTemplate($template, [
+            'primary_hint' => $primaryHint,
+            'support_hint' => $supportHint,
+            'identity_clause' => $identityClause,
+            'boundary_clause' => $boundaryClause,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $doc
+     * @param  array<string, array<string, mixed>>  $axisVector
+     * @param  array<string, mixed>  $primaryAxis
+     */
+    private function resolveBoundaryNarrativeText(
+        array $doc,
+        string $sceneKey,
+        string $axisCode,
+        string $locale,
+        array $axisVector,
+        array $primaryAxis,
+        bool $compact = false
+    ): string {
+        $template = $this->resolveTemplate(
+            data_get($doc, 'boundary_narrative_templates.'.$sceneKey),
+            $locale,
+            $locale === 'zh-CN'
+                ? (self::DEFAULT_BOUNDARY_NARRATIVE_TEMPLATES[$sceneKey] ?? '')
+                : (self::DEFAULT_BOUNDARY_NARRATIVE_TEMPLATES_EN[$sceneKey] ?? '')
+        );
+
+        $boundaryAxis = is_array($axisVector[$axisCode] ?? null)
+            ? $axisVector[$axisCode]
+            : $primaryAxis;
+        $side = (string) ($boundaryAxis['side'] ?? '');
+        $opposite = $this->oppositeSide($axisCode, $side);
+
+        $text = $this->renderTemplate($template, [
+            'axis_label' => $this->axisLabel($axisCode, $locale),
+            'side_label' => $this->sideLabel($axisCode, $side, $locale),
+            'opposite_side_label' => $this->sideLabel($axisCode, $opposite, $locale),
+        ]);
+
+        if (! $compact) {
+            return $text;
+        }
+
+        $sentences = preg_split('/(?<=[。.!?])\s+/u', $text) ?: [$text];
+
+        return trim((string) ($sentences[0] ?? $text));
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $sectionMeta
+     * @return array<string, mixed>|null
+     */
+    private function resolveProjectionSectionMeta(string $sectionKey, array $sectionMeta): ?array
+    {
+        if (is_array($sectionMeta[$sectionKey] ?? null)) {
+            return $sectionMeta[$sectionKey];
+        }
+
+        $groupKey = strtolower(trim((string) strtok($sectionKey, '.')));
+        if ($groupKey !== '' && is_array($sectionMeta[$groupKey] ?? null)) {
+            return $sectionMeta[$groupKey];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $doc
+     * @param  array<string, mixed>  $axis
+     */
+    private function sceneHintText(array $doc, string $locale, array $axis): string
+    {
+        return $this->resolveTemplate(
+            data_get($doc, 'scene_hints.'.($axis['axis'] ?? '').'.'.($axis['side'] ?? '')),
+            $locale,
+            $locale === 'zh-CN'
+                ? (self::DEFAULT_SCENE_HINTS[(string) ($axis['axis'] ?? '').':'.(string) ($axis['side'] ?? '')] ?? '')
+                : (self::DEFAULT_SCENE_HINTS_EN[(string) ($axis['axis'] ?? '').':'.(string) ($axis['side'] ?? '')] ?? '')
+        );
+    }
+
+    private function shortIdentityClause(string $identity, string $locale): string
+    {
+        if ($identity === 'A') {
+            return $locale === 'zh-CN'
+                ? 'A 身份层让这个场景里的你更稳、更不容易被短期波动带偏。'
+                : 'The A identity layer makes this scene feel steadier and less reactive to short-term fluctuation.';
+        }
+
+        if ($identity === 'T') {
+            return $locale === 'zh-CN'
+                ? 'T 身份层会放大你对反馈、细节和结果波动的感知。'
+                : 'The T identity layer heightens your sensitivity to feedback, detail, and outcome variance.';
+        }
+
+        return '';
+    }
+
+    private function sceneSummaryHint(string $hint, string $locale): string
+    {
+        $normalized = trim($hint);
+        if ($normalized === '') {
+            return '';
+        }
+
+        if ($locale === 'zh-CN') {
+            $normalized = preg_replace('/^你更容易先/u', '', $normalized) ?? $normalized;
+            $normalized = preg_replace('/^你通常会先/u', '', $normalized) ?? $normalized;
+
+            return trim($normalized);
+        }
+
+        $normalized = preg_replace('/^you usually /i', '', $normalized) ?? $normalized;
+        $normalized = preg_replace('/^you first /i', '', $normalized) ?? $normalized;
+
+        return trim($normalized);
+    }
+
+    private function oppositeSide(string $axisCode, string $side): string
+    {
+        return match ($axisCode.':'.strtoupper($side)) {
+            'EI:E' => 'I',
+            'EI:I' => 'E',
+            'SN:S' => 'N',
+            'SN:N' => 'S',
+            'TF:T' => 'F',
+            'TF:F' => 'T',
+            'JP:J' => 'P',
+            'JP:P' => 'J',
+            'AT:A' => 'T',
+            'AT:T' => 'A',
+            default => '',
+        };
+    }
+
+    /**
      * @param  array<string, mixed>  $doc
      * @param  array<string, mixed>  $axis
      */
     private function resolveAxisStrengthText(array $doc, string $sectionKey, string $band, string $locale, array $axis): string
     {
+        $fallbackTemplate = $locale === 'zh-CN'
+            ? (self::DEFAULT_AXIS_STRENGTH_TEMPLATES["{$sectionKey}.{$band}"] ?? '')
+            : (self::DEFAULT_AXIS_STRENGTH_TEMPLATES_EN["{$sectionKey}.{$band}"] ?? '');
+
         $template = $this->resolveTemplate(
             data_get($doc, "axis_strength_templates.{$sectionKey}.{$band}"),
             $locale,
-            self::DEFAULT_AXIS_STRENGTH_TEMPLATES["{$sectionKey}.{$band}"] ?? ($locale === 'zh-CN' ? '' : (self::DEFAULT_AXIS_STRENGTH_TEMPLATES_EN["{$sectionKey}.{$band}"] ?? ''))
+            $fallbackTemplate
         );
 
         return $this->renderTemplate($template, [
@@ -719,6 +1301,7 @@ final class MbtiResultPersonalizationService
     {
         $packId = trim((string) ($context['pack_id'] ?? ''));
         $dirVersion = trim((string) ($context['dir_version'] ?? ''));
+        $requestedLocale = $this->normalizeLocale($locale);
 
         if ($packId !== '' && $dirVersion !== '') {
             $found = $this->packsIndex->find($packId, $dirVersion);
@@ -727,6 +1310,10 @@ final class MbtiResultPersonalizationService
                 $manifestPath = trim((string) ($item['manifest_path'] ?? ''));
                 if ($manifestPath !== '' && is_file($manifestPath)) {
                     $manifest = json_decode((string) file_get_contents($manifestPath), true);
+                    $manifestLocale = $this->normalizeLocale((string) ($item['locale'] ?? (is_array($manifest) ? ($manifest['locale'] ?? '') : '')));
+                    if ($manifestLocale !== '' && $requestedLocale !== '' && $manifestLocale !== $requestedLocale) {
+                        return [];
+                    }
                     $baseDir = dirname($manifestPath);
                     $doc = $this->loadDynamicDocFromBaseDir($baseDir, is_array($manifest) ? $manifest : []);
                     if ($doc !== []) {

--- a/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeEntryTrait.php
+++ b/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeEntryTrait.php
@@ -363,6 +363,7 @@ trait ReportPayloadAssemblerComposeEntryTrait
             'contentPackId' => $contentPackId,
             'profileVersion' => $profileVersion,
             'contentPackageVersion' => $contentPackageVersion,
+            'reportEngineVersion' => (string) ($result->report_engine_version ?? ''),
             'locale' => $locale,
             'region' => $region,
             'scaleCode' => $scaleCode,

--- a/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php
+++ b/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php
@@ -12,6 +12,7 @@ trait ReportPayloadAssemblerComposeFinalizeTrait
         $contentPackId = (string) ($input['contentPackId'] ?? '');
         $profileVersion = (string) ($input['profileVersion'] ?? '');
         $contentPackageVersion = (string) ($input['contentPackageVersion'] ?? '');
+        $reportEngineVersion = trim((string) ($input['reportEngineVersion'] ?? ''));
         $locale = (string) ($input['locale'] ?? '');
         $scores = is_array($input['scores'] ?? null) ? $input['scores'] : [];
         $scoresPct = is_array($input['scoresPct'] ?? null) ? $input['scoresPct'] : [];
@@ -50,7 +51,7 @@ trait ReportPayloadAssemblerComposeFinalizeTrait
 
         $reportPayload = [
             'versions' => [
-                'engine' => 'v1.2',
+                'engine' => $reportEngineVersion !== '' ? $reportEngineVersion : 'v1.2',
                 'profile_version' => $profileVersion,
                 'content_package_version' => $contentPackageVersion,
                 'content_pack_id' => $contentPackId,
@@ -200,7 +201,7 @@ trait ReportPayloadAssemblerComposeFinalizeTrait
                 'pack_id' => $contentPackId,
                 'dir_version' => $contentPackageDir,
                 'locale' => $locale,
-                'engine_version' => 'v1.2',
+                'engine_version' => $reportEngineVersion !== '' ? $reportEngineVersion : (string) data_get($reportPayload, 'versions.engine', 'v1.2'),
             ]);
 
             if ($personalization !== []) {

--- a/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+++ b/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use App\Models\Attempt;
+use App\Models\ReportSnapshot;
+use App\Models\Result;
+use App\Services\Report\Composer\ReportComposeContext;
+use App\Services\Report\Composer\ReportPayloadAssembler;
+use App\Services\Mbti\MbtiPublicProjectionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiPhase2AssemblerIntegrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_phase2_personalization_survives_assembler_snapshot_round_trip_and_projection(): void
+    {
+        $attempt = Attempt::query()->create([
+            'anon_id' => 'anon_mbti_phase2_contract',
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI',
+            'scale_uid' => 'mbti',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 8,
+            'answers_summary_json' => ['stage' => 'seed'],
+            'client_platform' => 'test',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.03',
+            'started_at' => now(),
+            'submitted_at' => now(),
+        ]);
+
+        $result = Result::query()->create([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => (string) $attempt->id,
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI',
+            'scale_uid' => 'mbti',
+            'scale_version' => 'v0.3',
+            'type_code' => 'ENFP-T',
+            'scores_json' => [
+                'EI' => ['a' => 13, 'b' => 7, 'neutral' => 0, 'sum' => 6, 'total' => 20],
+                'SN' => ['a' => 12, 'b' => 8, 'neutral' => 0, 'sum' => 4, 'total' => 20],
+                'TF' => ['a' => 9, 'b' => 11, 'neutral' => 0, 'sum' => -2, 'total' => 20],
+                'JP' => ['a' => 9, 'b' => 11, 'neutral' => 0, 'sum' => -2, 'total' => 20],
+                'AT' => ['a' => 6, 'b' => 14, 'neutral' => 0, 'sum' => -8, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 67,
+                'SN' => 64,
+                'TF' => 59,
+                'JP' => 57,
+                'AT' => 68,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'balanced',
+                'JP' => 'moderate',
+                'AT' => 'clear',
+            ],
+            'profile_version' => 'mbti32-v2.5',
+            'content_package_version' => 'v0.3',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.03',
+            'report_engine_version' => 'report_phase2_contract',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        $payload = app(ReportPayloadAssembler::class)->assemble(
+            ReportComposeContext::fromAttempt($attempt, $result, [
+                'org_id' => 0,
+                'variant' => 'free',
+                'report_access_level' => 'free',
+                'modules_allowed' => [],
+                'modules_preview' => [],
+                'persist' => false,
+                'strict' => false,
+                'explain' => false,
+            ])
+        );
+
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertSame(
+            'mbti.personalization.phase2.v1',
+            data_get($payload, 'report._meta.personalization.schema_version')
+        );
+        $this->assertSame(
+            'report_phase2_contract',
+            data_get($payload, 'report._meta.personalization.engine_version')
+        );
+        $this->assertSame(
+            'work.primary.EI.E.clear',
+            data_get($payload, 'report._meta.personalization.scene_fingerprint.work.style_key')
+        );
+
+        ReportSnapshot::query()->create([
+            'org_id' => 0,
+            'attempt_id' => (string) $attempt->id,
+            'order_no' => null,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI',
+            'scale_uid' => 'mbti',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.03',
+            'report_engine_version' => 'report_phase2_contract',
+            'snapshot_version' => 'phase2.contract',
+            'report_json' => data_get($payload, 'report', []),
+            'report_free_json' => data_get($payload, 'report', []),
+            'report_full_json' => data_get($payload, 'report', []),
+            'status' => 'ready',
+            'last_error' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $snapshot = ReportSnapshot::query()->findOrFail((string) $attempt->id);
+        $roundTrippedReport = is_array($snapshot->report_json) ? $snapshot->report_json : [];
+        $roundTrippedVariantKeys = Arr::wrap(data_get($roundTrippedReport, '_meta.personalization.variant_keys', []));
+
+        $this->assertSame(
+            'relationships.rel_risks:TF.T.boundary:identity.T:boundary.TF',
+            $roundTrippedVariantKeys['relationships.rel_risks'] ?? null
+        );
+
+        $projection = app(MbtiPublicProjectionService::class)->buildForReportEnvelope(
+            $result,
+            [
+                'report' => $roundTrippedReport,
+                'meta' => [
+                    'pack_id' => (string) $attempt->pack_id,
+                    'dir_version' => (string) $attempt->dir_version,
+                    'report_engine_version' => (string) $result->report_engine_version,
+                ],
+            ],
+            'zh-CN',
+            0
+        );
+
+        $relationshipsRelRisks = collect(Arr::wrap($projection['sections'] ?? []))
+            ->first(static fn (array $section): bool => (string) ($section['key'] ?? '') === 'relationships.rel_risks');
+
+        $this->assertSame(
+            'mbti.personalization.phase2.v1',
+            data_get($projection, '_meta.personalization.schema_version')
+        );
+        $this->assertSame(
+            'overview:EI.E.clear:identity.T:boundary.none',
+            data_get($projection, '_meta.personalization.variant_keys.overview')
+        );
+        $projectionVariantKeys = Arr::wrap(data_get($projection, '_meta.personalization.variant_keys', []));
+        $this->assertSame(
+            'relationships.rel_risks:TF.T.boundary:identity.T:boundary.TF',
+            $projectionVariantKeys['relationships.rel_risks'] ?? null
+        );
+        $this->assertIsArray($relationshipsRelRisks);
+        $this->assertSame(
+            'relationships.rel_risks:TF.T.boundary:identity.T:boundary.TF',
+            data_get($relationshipsRelRisks, '_meta.variant_key')
+        );
+        $this->assertStringContainsString(
+            '两套判断入口之间来回校准',
+            (string) data_get($relationshipsRelRisks, 'payload.blocks.3.text', '')
+        );
+    }
+}

--- a/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
@@ -25,7 +25,7 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
             'scores' => [
                 'EI' => ['pct' => 67, 'delta' => 17, 'side' => 'E', 'state' => 'clear'],
                 'SN' => ['pct' => 64, 'delta' => 14, 'side' => 'N', 'state' => 'clear'],
-                'TF' => ['pct' => 59, 'delta' => 9, 'side' => 'F', 'state' => 'balanced'],
+                'TF' => ['pct' => 59, 'delta' => 9, 'side' => 'T', 'state' => 'balanced'],
                 'JP' => ['pct' => 57, 'delta' => 7, 'side' => 'P', 'state' => 'moderate'],
                 'AT' => ['pct' => 68, 'delta' => 18, 'side' => 'T', 'state' => 'clear'],
             ],
@@ -47,7 +47,7 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
             'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
             'dir_version' => 'MBTI-CN-v0.3',
             'locale' => 'zh-CN',
-            'engine_version' => 'v1.2',
+            'engine_version' => 'report_phase2_contract',
         ]);
 
         $strong = $service->buildForReportPayload($strongPayload, [
@@ -55,28 +55,45 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
             'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
             'dir_version' => 'MBTI-CN-v0.3',
             'locale' => 'zh-CN',
-            'engine_version' => 'v1.2',
+            'engine_version' => 'report_phase2_contract',
         ]);
 
         $this->assertSame('ENFP-T', $clear['type_code']);
         $this->assertSame('T', $clear['identity']);
+        $this->assertSame('mbti.personalization.phase2.v1', $clear['schema_version']);
         $this->assertSame('clear', data_get($clear, 'axis_bands.EI'));
         $this->assertSame('strong', data_get($strong, 'axis_bands.EI'));
         $this->assertSame(false, data_get($clear, 'boundary_flags.EI'));
         $this->assertSame(false, data_get($strong, 'boundary_flags.EI'));
         $this->assertSame('MBTI.cn-mainland.zh-CN.v0.3', $clear['pack_id']);
-        $this->assertSame('v1.2', $clear['engine_version']);
+        $this->assertSame('report_phase2_contract', $clear['engine_version']);
+        $this->assertSame('work.primary.EI.E.clear', data_get($clear, 'scene_fingerprint.work.style_key'));
+        $this->assertSame('work.primary.EI.E.strong', data_get($strong, 'scene_fingerprint.work.style_key'));
+        $this->assertSame(
+            [
+                'relationships.primary.TF.T.boundary',
+                'relationships.support.EI.E.clear',
+                'relationships.identity.T',
+                'relationships.boundary.TF',
+                'relationships.boundary.JP',
+            ],
+            data_get($clear, 'relationship_style_keys')
+        );
         $this->assertNotSame(
             data_get($clear, 'variant_keys.overview'),
             data_get($strong, 'variant_keys.overview')
         );
         $this->assertSame(
-            'overview:EI.E.clear:identity.T:boundary.TF',
+            'overview:EI.E.clear:identity.T:boundary.none',
             data_get($clear, 'variant_keys.overview')
         );
         $this->assertSame(
-            'overview:EI.E.strong:identity.T:boundary.TF',
+            'overview:EI.E.strong:identity.T:boundary.none',
             data_get($strong, 'variant_keys.overview')
+        );
+        $this->assertSame(
+            'relationships.rel_risks:TF.T.boundary:identity.T:boundary.TF',
+            $clear['variant_keys']['relationships.rel_risks'] ?? null
         );
         $this->assertNotSame(
             data_get($clear, 'sections.overview.selected_blocks.0'),
@@ -89,6 +106,70 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
         $this->assertStringContainsString(
             '外倾偏好已经很鲜明',
             (string) data_get($strong, 'sections.overview.blocks.0.text', '')
+        );
+        $this->assertStringContainsString(
+            '两套判断入口之间来回校准',
+            (string) ($clear['sections']['relationships.rel_risks']['blocks'][3]['text'] ?? '')
+        );
+        $this->assertStringContainsString(
+            '压力升高时',
+            (string) data_get($clear, 'scene_fingerprint.stress_recovery.summary', '')
+        );
+    }
+
+    public function test_it_falls_back_to_english_defaults_when_requested_locale_does_not_match_pack_locale(): void
+    {
+        $service = app(MbtiResultPersonalizationService::class);
+
+        $payload = [
+            'versions' => [
+                'engine' => 'report_phase2_contract',
+                'content_pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'dir_version' => 'MBTI-CN-v0.3',
+            ],
+            'profile' => [
+                'type_code' => 'ENFP-T',
+            ],
+            'scores' => [
+                'EI' => ['pct' => 67, 'delta' => 17, 'side' => 'E', 'state' => 'clear'],
+                'SN' => ['pct' => 64, 'delta' => 14, 'side' => 'N', 'state' => 'clear'],
+                'TF' => ['pct' => 59, 'delta' => 9, 'side' => 'T', 'state' => 'balanced'],
+                'JP' => ['pct' => 57, 'delta' => 7, 'side' => 'P', 'state' => 'moderate'],
+                'AT' => ['pct' => 68, 'delta' => 18, 'side' => 'T', 'state' => 'clear'],
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'balanced',
+                'JP' => 'moderate',
+                'AT' => 'clear',
+            ],
+        ];
+
+        $english = $service->buildForReportPayload($payload, [
+            'type_code' => 'ENFP-T',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'locale' => 'en',
+            'engine_version' => 'report_phase2_contract',
+        ]);
+
+        $this->assertSame('en', $english['locale']);
+        $this->assertStringContainsString(
+            'stable Extraversion preference',
+            (string) data_get($english, 'sections.overview.blocks.0.text', '')
+        );
+        $this->assertStringContainsString(
+            'At work, you usually start through',
+            (string) data_get($english, 'scene_fingerprint.work.summary', '')
+        );
+        $this->assertStringNotContainsString(
+            '稳定的外倾倾向',
+            (string) data_get($english, 'sections.overview.blocks.0.text', '')
+        );
+        $this->assertStringNotContainsString(
+            '在工作里',
+            (string) data_get($english, 'scene_fingerprint.work.summary', '')
         );
     }
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
@@ -1,11 +1,11 @@
 {
     "schema": "fap.mbti.dynamic_sections.v1",
-    "version": "phase1.v1",
+    "version": "phase2.v1",
     "labels": {
         "block_kinds": {
             "type_skeleton": "类型骨架",
             "axis_strength": "强度层",
-            "boundary": "边界提示",
+            "boundary": "边界深解释",
             "identity": "身份层",
             "scene": "场景应用"
         },
@@ -15,6 +15,14 @@
             "strong": "强偏好",
             "very_strong": "极强偏好"
         }
+    },
+    "scene_titles": {
+        "work": "你的工作模式",
+        "relationships": "你的关系模式",
+        "growth": "你的成长模式",
+        "decision": "你的决策模式",
+        "stress_recovery": "你的压力恢复模式",
+        "communication": "你的沟通模式"
     },
     "axis_strength_templates": {
         "overview": {
@@ -40,13 +48,41 @@
             "clear": "在工作里，{{side_label}}已经是你较稳定的默认操作方式。它会影响你更顺手的工作节奏、协作方式和反馈偏好。",
             "strong": "在工作里，{{side_label}}已经很鲜明。你通常不是“什么环境都行”，而是会在某类节奏里明显更快进入高质量输出。",
             "very_strong": "在工作里，你的{{side_label}}偏好非常强。这会让你在适配环境里效率极高，但也会放大与不匹配环境之间的摩擦感。"
+        },
+        "work": {
+            "boundary": "在工作场景里，这条轴靠近中线，意味着你会根据任务、人和节奏切换挡位；真正关键的是你何时切换，以及团队是否读得懂这种切换。",
+            "clear": "在工作场景里，{{side_label}}已经是你较稳定的默认工作方式。它会影响你启动任务、协作和接收反馈的第一反应。",
+            "strong": "在工作场景里，{{side_label}}已经很鲜明。匹配环境会放大你的效率，不匹配环境也会更快放大摩擦。",
+            "very_strong": "在工作场景里，你的{{side_label}}风格极其稳定。优势是输出速度和风格识别度都很高，代价是环境不合拍时不适感也会非常明显。"
+        },
+        "decision": {
+            "boundary": "做决定时，这条轴靠近中线，所以你不是单一路径地下判断，而是会在两套入口之间切换。",
+            "clear": "做决定时，{{side_label}}已经是你更常见的默认入口，但另一侧仍然会在复核和收尾阶段发挥作用。",
+            "strong": "做决定时，{{side_label}}已经很鲜明。你往往会先沿着这一侧推进，再决定是否需要另一侧补位。",
+            "very_strong": "做决定时，你的{{side_label}}倾向非常强。这会让判断更快更稳，也会让别人更容易把你理解成“只会这样判断的人”。"
+        },
+        "stress_recovery": {
+            "boundary": "在压力与恢复上，这条轴靠近中线，意味着你在过载时和恢复时可能会切到不同挡位。",
+            "clear": "在压力与恢复上，{{side_label}}已经是你更稳定的应对入口，但恢复阶段通常还需要另一侧来重新平衡。",
+            "strong": "在压力与恢复上，{{side_label}}已经很鲜明。你容易先用这一侧救火，所以更需要一条固定的恢复回路。",
+            "very_strong": "在压力与恢复上，你的{{side_label}}风格非常强。优势是应对快，风险是过度依赖同一套自救方式。"
+        },
+        "communication": {
+            "boundary": "在沟通里，这条轴靠近中线，所以你不是只会一种表达方式；你会根据对象、氛围和目标来切换。",
+            "clear": "在沟通里，{{side_label}}已经是你更常见的起手方式，但当场景变化时，另一侧仍会迅速进场补位。",
+            "strong": "在沟通里，{{side_label}}已经很鲜明。别人通常会先感受到这一侧，因此误读也往往从这里开始。",
+            "very_strong": "在沟通里，你的{{side_label}}风格非常稳定。优势是辨识度高，风险是别人容易把你的表达方式误读成你的全部意图。"
         }
     },
     "scene_templates": {
         "overview": "放到日常场景里，这条主轴通常会表现成：{{scene_side_hint}}。这会决定别人首先从哪里理解你。",
         "growth": "把它放进成长情境时，更有效的做法不是否定这条主轴，而是让它在{{axis_label}}上多带一个反向校正动作：{{scene_side_hint}}。",
         "relationships": "放到关系里，这条主轴通常会变成一种相处节奏：{{scene_side_hint}}。如果对方没有读懂这一点，就容易把你的方式误解成距离感、迟疑或控制感。",
-        "career": "放到工作里，这条主轴更像你的默认操作系统：{{scene_side_hint}}。它会直接影响你更适配的岗位节奏与协作环境。"
+        "career": "放到工作里，这条主轴更像你的默认操作系统：{{scene_side_hint}}。它会直接影响你更适配的岗位节奏与协作环境。",
+        "work": "放到工作里，这条主轴更像你的默认操作系统：{{scene_side_hint}}。它会直接影响你更适配的岗位节奏与协作环境。",
+        "decision": "放到决策里，这条主轴会决定你先用哪一种入口缩小范围：{{scene_side_hint}}。",
+        "stress_recovery": "放到压力与恢复里，这条主轴通常会变成你最先启动的自救方式：{{scene_side_hint}}。",
+        "communication": "放到沟通里，这条主轴通常会变成你的起手表达方式：{{scene_side_hint}}。"
     },
     "scene_hints": {
         "EI": {
@@ -72,6 +108,23 @@
         "TF": "T / F 这一轴离中线较近，所以你并不是单纯“理性”或“感性”，而是会在标准与关系之间反复校准。",
         "JP": "J / P 这一轴离中线较近，所以你既需要一定结构，也需要一定弹性；节奏感比绝对规则更重要。",
         "AT": "A / T 这一轴离中线较近，所以你的稳定感和敏感度都在参与结果，不适合把自己读成单一的“稳”或“紧”。"
+    },
+    "scene_fingerprint_templates": {
+        "work": "在工作里，你通常先用{{primary_hint}}开局，再用{{support_hint}}把节奏拉回可执行。{{identity_clause}} {{boundary_clause}}",
+        "relationships": "在关系里，你常先以{{primary_hint}}让别人感受到你，再通过{{support_hint}}决定要靠近、回应还是设边界。{{identity_clause}} {{boundary_clause}}",
+        "growth": "成长上，你的高杠杆点通常来自{{primary_hint}}；当你再补上{{support_hint}}时，进步会更稳定。{{identity_clause}} {{boundary_clause}}",
+        "decision": "做决定时，你通常先靠{{primary_hint}}缩小范围，再用{{support_hint}}确认是否值得推进。{{identity_clause}} {{boundary_clause}}",
+        "stress_recovery": "压力升高时，你容易先滑向{{primary_hint}}来求快或求稳；恢复阶段则更需要{{support_hint}}把你拉回可用区。{{identity_clause}} {{boundary_clause}}",
+        "communication": "沟通里，你通常先以{{primary_hint}}发起，再用{{support_hint}}修正对齐。{{identity_clause}} {{boundary_clause}}"
+    },
+    "boundary_narrative_templates": {
+        "overview": "{{axis_label}}靠近中线时，你不是“有点像两边”，而是会在不同情境下切换入口。熟悉场景里你可能先用{{side_label}}，压力或高风险情境里又会迅速调动{{opposite_side_label}}。别人如果只看到其中一面，就容易把你误读成忽冷忽热、摇摆或前后不一。",
+        "relationships": "在人际里，{{axis_label}}靠近中线意味着你不会永远只走{{side_label}}这一条路。你可能先用{{side_label}}靠近，遇到压力或误解时又改用{{opposite_side_label}}保护自己。别人如果只看到其中一段，就会误判你到底是在拉近、保持距离，还是突然变得难以捉摸。",
+        "growth": "成长上，{{axis_label}}靠近中线意味着你真正要学的不是选边站，而是识别什么时候该让{{side_label}}先开路，什么时候该让{{opposite_side_label}}接手收尾。会切换并不可怕，不知道自己在什么时候切换才会让你觉得“我怎么又变了”。",
+        "work": "在工作里，{{axis_label}}靠近中线会让你在任务、协作和压力场景下切换齿轮。你有时像{{side_label}}，有时又会突然拉出{{opposite_side_label}}来修正，所以团队很容易只记住其中一面。真正有价值的是让别人知道：你在什么信号下会切换，以及切换后需要怎样的协作方式。",
+        "decision": "做决定时，{{axis_label}}靠近中线意味着你并不是摇摆不定，而是在两套判断入口之间来回校准。你可能先用{{side_label}}开路，再用{{opposite_side_label}}复核；场景一变，顺序也会反过来。别人会以为你前后矛盾，其实你是在同时守住速度与准确度、标准与关系，或结构与弹性。",
+        "stress_recovery": "压力上来时，{{axis_label}}靠近中线意味着你可能先滑向{{side_label}}来保住当下，再在恢复阶段调回{{opposite_side_label}}重新平衡。它的难点不是“你为什么不稳定”，而是如果你没意识到自己在切换，就会把这种来回误读成状态失控。",
+        "communication": "沟通里，{{axis_label}}靠近中线意味着你不会永远只用一种表达方式。你可能先用{{side_label}}出手，但一旦对方反馈变化，又迅速调动{{opposite_side_label}}补位。别人如果只看到前半段，常会误读你的真实意图；而你自己则会觉得“我明明已经说清楚了”。"
     },
     "identity_templates": {
         "A": "A 身份层会让你在当前类型骨架上更容易保持稳定推进、少被短期波动牵着走。",


### PR DESCRIPTION
## Summary

This PR closes the remaining review gaps in the MBTI Phase 2 scene fingerprint and boundary deepening backend flow.

Phase 2 had already landed the main product behavior, but four issues kept it from being considered fully closed:

1. dynamic MBTI section copy could leak `zh-CN` text into English result routes;
2. personalization metadata still stamped a hard-coded `engine_version` instead of the real report engine version;
3. backend verification still leaned too heavily on service-level output and did not prove that Phase 2 authority survived the real `assembler -> report -> snapshot -> projection` path; and
4. synthetic unit fixtures were not fully aligned with repo-truth axis polarity in the real assembler flow.

This PR closes those gaps without widening scope beyond MBTI Phase 2.

## Problem

The user-visible risk was that an English route could render Chinese scene or boundary narrative, while telemetry and snapshot audit could not reliably distinguish a real engine revision from a stale hard-coded value.

At the same time, the existing backend tests did not fully prove that the new Phase 2 authority contract survived the real report assembly and replay path unchanged. That left a correctness gap between service-unit output and the actual runtime pipeline.

## Root cause

The main causes were:

- dynamic section docs were pack-local, but locale mismatch handling stopped at the pack file boundary and did not fully force the service onto locale-correct fallback templates;
- personalization metadata was still receiving a literal `v1.2` inside the report assembler finalization step;
- no dedicated backend integration test exercised the real report assembler, persisted a snapshot, and then rebuilt the public projection from that round-tripped payload; and
- test fixtures were not fully aligned with the assembler's score polarity rules for `scores_pct`.

## Fix

This PR makes four targeted backend fixes.

First, `MbtiResultPersonalizationService` now hardens locale handling for dynamic section docs and fallback templates, so an English result route no longer consumes `zh-CN` dynamic copy from the MBTI content pack.

Second, `ReportPayloadAssembler` now threads the actual `result->report_engine_version` into the assembled report payload and into `_meta.personalization.engine_version`, instead of stamping a constant.

Third, the backend test suite now includes a real integration contract test that exercises:

- `ReportPayloadAssembler`
- assembled report personalization metadata
- `ReportSnapshot` persistence and round-trip
- `MbtiPublicProjectionService`

That test verifies that Phase 2 authority survives the real runtime path and remains replayable.

Fourth, the MBTI personalization unit test now aligns its polarity assumptions with the real assembler truth, so the unit and integration layers are no longer asserting different interpretations for the same score vector.

## User impact

This closes the last meaningful backend correctness gaps for MBTI Phase 2.

After this PR:

- English routes no longer risk rendering Chinese scene or boundary copy from the Phase 2 dynamic layer;
- replay, telemetry, and audit now see the real engine version that produced the personalization payload;
- the Phase 2 authority path is covered by a real assembler-to-snapshot-to-projection integration test; and
- the backend contract is materially closer to a production-safe, replayable single-authority implementation.

## Validation

I ran:

- `php artisan test tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php tests/Feature/Content/ContentPackCoverageMatrixTest.php`

All passed:

- 7 tests passed
- 1739 assertions

## Scope note

This PR intentionally excludes unrelated dirty changes already present in the repo, especially the `BIG5_OCEAN` compiled artifacts. Only MBTI Phase 2 backend closure files are included here.
