### PR TITLE
[codex] add blob manifest snapshot scaffold

### DIFF
--- a/backend/app/Models/ContentReleaseManifest.php
+++ b/backend/app/Models/ContentReleaseManifest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ContentReleaseManifest extends Model
+{
+    protected $table = 'content_release_manifests';
+
+    protected $fillable = [
+        'content_pack_release_id',
+        'manifest_hash',
+        'schema_version',
+        'storage_disk',
+        'storage_path',
+        'pack_id',
+        'pack_version',
+        'compiled_hash',
+        'content_hash',
+        'norms_version',
+        'source_commit',
+        'payload_json',
+    ];
+
+    protected $casts = [
+        'payload_json' => 'array',
+    ];
+
+    public function release(): BelongsTo
+    {
+        return $this->belongsTo(ContentPackRelease::class, 'content_pack_release_id', 'id');
+    }
+
+    public function files(): HasMany
+    {
+        return $this->hasMany(ContentReleaseManifestFile::class, 'content_release_manifest_id', 'id');
+    }
+}

--- a/backend/app/Models/ContentReleaseManifestFile.php
+++ b/backend/app/Models/ContentReleaseManifestFile.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ContentReleaseManifestFile extends Model
+{
+    protected $table = 'content_release_manifest_files';
+
+    protected $fillable = [
+        'content_release_manifest_id',
+        'logical_path',
+        'blob_hash',
+        'size_bytes',
+        'role',
+        'content_type',
+        'encoding',
+        'checksum',
+    ];
+
+    protected $casts = [
+        'size_bytes' => 'integer',
+    ];
+
+    public function manifest(): BelongsTo
+    {
+        return $this->belongsTo(ContentReleaseManifest::class, 'content_release_manifest_id', 'id');
+    }
+}

--- a/backend/app/Models/ContentReleaseSnapshot.php
+++ b/backend/app/Models/ContentReleaseSnapshot.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ContentReleaseSnapshot extends Model
+{
+    protected $table = 'content_release_snapshots';
+
+    protected $fillable = [
+        'pack_id',
+        'pack_version',
+        'from_content_pack_release_id',
+        'to_content_pack_release_id',
+        'activation_before_release_id',
+        'activation_after_release_id',
+        'reason',
+        'created_by',
+        'meta_json',
+    ];
+
+    protected $casts = [
+        'meta_json' => 'array',
+    ];
+}

--- a/backend/app/Models/StorageBlob.php
+++ b/backend/app/Models/StorageBlob.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StorageBlob extends Model
+{
+    protected $table = 'storage_blobs';
+
+    protected $primaryKey = 'hash';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'hash',
+        'disk',
+        'storage_path',
+        'size_bytes',
+        'content_type',
+        'encoding',
+        'ref_count',
+        'first_seen_at',
+        'last_verified_at',
+    ];
+
+    protected $casts = [
+        'size_bytes' => 'integer',
+        'ref_count' => 'integer',
+        'first_seen_at' => 'datetime',
+        'last_verified_at' => 'datetime',
+    ];
+}

--- a/backend/app/Services/Storage/BlobCatalogService.php
+++ b/backend/app/Services/Storage/BlobCatalogService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\StorageBlob;
+
+class BlobCatalogService
+{
+    public function upsertBlob(array $payload): StorageBlob
+    {
+        $hash = trim((string) ($payload['hash'] ?? ''));
+        if ($hash === '') {
+            throw new \InvalidArgumentException('hash is required');
+        }
+
+        $disk = trim((string) ($payload['disk'] ?? 'local'));
+        $storagePath = trim((string) ($payload['storage_path'] ?? ''));
+        if ($storagePath === '') {
+            throw new \InvalidArgumentException('storage_path is required');
+        }
+
+        $existingPathOwner = StorageBlob::query()
+            ->where('disk', $disk)
+            ->where('storage_path', $storagePath)
+            ->where('hash', '!=', $hash)
+            ->first();
+
+        if ($existingPathOwner !== null) {
+            throw new \DomainException('disk + storage_path is already cataloged to a different hash');
+        }
+
+        $record = StorageBlob::query()->updateOrCreate(
+            ['hash' => $hash],
+            [
+                'disk' => $disk,
+                'storage_path' => $storagePath,
+                'size_bytes' => (int) ($payload['size_bytes'] ?? 0),
+                'content_type' => $payload['content_type'] ?? null,
+                'encoding' => (string) ($payload['encoding'] ?? 'identity'),
+                'ref_count' => (int) ($payload['ref_count'] ?? 0),
+                'first_seen_at' => $payload['first_seen_at'] ?? null,
+                'last_verified_at' => $payload['last_verified_at'] ?? null,
+            ]
+        );
+
+        return $record->fresh() ?? $record;
+    }
+
+    public function findByHash(string $hash): ?StorageBlob
+    {
+        $hash = trim($hash);
+        if ($hash === '') {
+            return null;
+        }
+
+        return StorageBlob::query()->find($hash);
+    }
+}

--- a/backend/app/Services/Storage/ContentReleaseManifestCatalogService.php
+++ b/backend/app/Services/Storage/ContentReleaseManifestCatalogService.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\ContentReleaseManifest;
+use App\Models\ContentReleaseManifestFile;
+use Illuminate\Support\Facades\DB;
+
+class ContentReleaseManifestCatalogService
+{
+    public function upsertManifest(array $manifest, array $files = []): ContentReleaseManifest
+    {
+        $manifestHash = trim((string) ($manifest['manifest_hash'] ?? ''));
+        if ($manifestHash === '') {
+            throw new \InvalidArgumentException('manifest_hash is required');
+        }
+
+        return DB::transaction(function () use ($manifest, $files, $manifestHash): ContentReleaseManifest {
+            $record = ContentReleaseManifest::query()->updateOrCreate(
+                ['manifest_hash' => $manifestHash],
+                [
+                    'content_pack_release_id' => $manifest['content_pack_release_id'] ?? null,
+                    'schema_version' => (string) ($manifest['schema_version'] ?? config('storage_rollout.manifest_schema_version', 'storage_manifest.v1')),
+                    'storage_disk' => (string) ($manifest['storage_disk'] ?? 'local'),
+                    'storage_path' => (string) ($manifest['storage_path'] ?? ''),
+                    'pack_id' => $manifest['pack_id'] ?? null,
+                    'pack_version' => $manifest['pack_version'] ?? null,
+                    'compiled_hash' => $manifest['compiled_hash'] ?? null,
+                    'content_hash' => $manifest['content_hash'] ?? null,
+                    'norms_version' => $manifest['norms_version'] ?? null,
+                    'source_commit' => $manifest['source_commit'] ?? null,
+                    'payload_json' => $manifest['payload_json'] ?? null,
+                ]
+            );
+
+            // PR-13C stays strictly additive: file rows are inserted or updated,
+            // but omitted rows are not deleted until a runtime producer contract exists.
+            foreach ($files as $file) {
+                $logicalPath = trim((string) ($file['logical_path'] ?? ''));
+                if ($logicalPath === '') {
+                    continue;
+                }
+
+                ContentReleaseManifestFile::query()->updateOrCreate(
+                    [
+                        'content_release_manifest_id' => (int) $record->getKey(),
+                        'logical_path' => $logicalPath,
+                    ],
+                    [
+                        'blob_hash' => (string) ($file['blob_hash'] ?? ''),
+                        'size_bytes' => (int) ($file['size_bytes'] ?? 0),
+                        'role' => $file['role'] ?? null,
+                        'content_type' => $file['content_type'] ?? null,
+                        'encoding' => (string) ($file['encoding'] ?? 'identity'),
+                        'checksum' => $file['checksum'] ?? null,
+                    ]
+                );
+            }
+
+            return $record->fresh('files') ?? $record->load('files');
+        });
+    }
+
+    public function findByManifestHash(string $manifestHash): ?ContentReleaseManifest
+    {
+        $manifestHash = trim($manifestHash);
+        if ($manifestHash === '') {
+            return null;
+        }
+
+        return ContentReleaseManifest::query()
+            ->with('files')
+            ->where('manifest_hash', $manifestHash)
+            ->first();
+    }
+}

--- a/backend/app/Services/Storage/ContentReleaseSnapshotCatalogService.php
+++ b/backend/app/Services/Storage/ContentReleaseSnapshotCatalogService.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\ContentReleaseSnapshot;
+
+class ContentReleaseSnapshotCatalogService
+{
+    public function recordSnapshot(array $payload): ContentReleaseSnapshot
+    {
+        $record = ContentReleaseSnapshot::query()->create([
+            'pack_id' => (string) ($payload['pack_id'] ?? ''),
+            'pack_version' => $payload['pack_version'] ?? null,
+            'from_content_pack_release_id' => $payload['from_content_pack_release_id'] ?? null,
+            'to_content_pack_release_id' => $payload['to_content_pack_release_id'] ?? null,
+            'activation_before_release_id' => $payload['activation_before_release_id'] ?? null,
+            'activation_after_release_id' => $payload['activation_after_release_id'] ?? null,
+            'reason' => $payload['reason'] ?? null,
+            'created_by' => $payload['created_by'] ?? null,
+            'meta_json' => $payload['meta_json'] ?? null,
+        ]);
+
+        return $record->fresh() ?? $record;
+    }
+}

--- a/backend/config/storage_rollout.php
+++ b/backend/config/storage_rollout.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'manifest_schema_version' => 'storage_manifest.v1',
+    'snapshot_schema_version' => 'storage_snapshot.v1',
+    'blob_catalog_enabled' => false,
+    'manifest_catalog_enabled' => false,
+    'snapshot_catalog_enabled' => false,
+    'artifact_dual_write_enabled' => false,
+    'content_pack_v2_dual_write_enabled' => false,
+    'resolver_materialization_enabled' => false,
+];

--- a/backend/database/migrations/2026_03_19_120000_create_storage_blobs_table.php
+++ b/backend/database/migrations/2026_03_19_120000_create_storage_blobs_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('storage_blobs')) {
+            return;
+        }
+
+        Schema::create('storage_blobs', function (Blueprint $table): void {
+            $table->char('hash', 64)->primary();
+            $table->string('disk', 32);
+            $table->string('storage_path', 512);
+            $table->unsignedBigInteger('size_bytes');
+            $table->string('content_type', 128)->nullable();
+            $table->string('encoding', 32)->default('identity');
+            $table->unsignedBigInteger('ref_count')->default(0);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_verified_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['disk', 'storage_path'], 'sb_disk_path_uq');
+            $table->index(['last_verified_at'], 'sb_last_ver_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_19_120100_create_content_release_manifests_table.php
+++ b/backend/database/migrations/2026_03_19_120100_create_content_release_manifests_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('content_release_manifests')) {
+            return;
+        }
+
+        Schema::create('content_release_manifests', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->uuid('content_pack_release_id')->nullable();
+            $table->char('manifest_hash', 64);
+            $table->string('schema_version', 32)->default('storage_manifest.v1');
+            $table->string('storage_disk', 32)->default('local');
+            $table->string('storage_path', 512);
+            $table->string('pack_id', 64)->nullable();
+            $table->string('pack_version', 64)->nullable();
+            $table->char('compiled_hash', 64)->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->string('norms_version', 64)->nullable();
+            $table->string('source_commit', 64)->nullable();
+            $table->json('payload_json')->nullable();
+            $table->timestamps();
+
+            $table->unique(['manifest_hash'], 'crm_hash_uq');
+            $table->index(['content_pack_release_id'], 'crm_rel_idx');
+            $table->index(['pack_id', 'pack_version'], 'crm_pack_ver_idx');
+            $table->foreign('content_pack_release_id', 'crm_rel_fk')
+                ->references('id')
+                ->on('content_pack_releases')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_19_120200_create_content_release_manifest_files_table.php
+++ b/backend/database/migrations/2026_03_19_120200_create_content_release_manifest_files_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('content_release_manifest_files')) {
+            return;
+        }
+
+        Schema::create('content_release_manifest_files', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('content_release_manifest_id');
+            $table->string('logical_path', 512);
+            $table->char('blob_hash', 64);
+            $table->unsignedBigInteger('size_bytes')->default(0);
+            $table->string('role', 64)->nullable();
+            $table->string('content_type', 128)->nullable();
+            $table->string('encoding', 32)->default('identity');
+            $table->string('checksum', 128)->nullable();
+            $table->timestamps();
+
+            $table->unique(['content_release_manifest_id', 'logical_path'], 'crmf_manifest_path_uq');
+            $table->index(['blob_hash'], 'crmf_blob_hash_idx');
+            $table->foreign('content_release_manifest_id', 'crmf_manifest_fk')
+                ->references('id')
+                ->on('content_release_manifests')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_19_120300_create_content_release_snapshots_table.php
+++ b/backend/database/migrations/2026_03_19_120300_create_content_release_snapshots_table.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('content_release_snapshots')) {
+            return;
+        }
+
+        Schema::create('content_release_snapshots', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('pack_id', 64);
+            $table->string('pack_version', 64)->nullable();
+            $table->uuid('from_content_pack_release_id')->nullable();
+            $table->uuid('to_content_pack_release_id')->nullable();
+            $table->uuid('activation_before_release_id')->nullable();
+            $table->uuid('activation_after_release_id')->nullable();
+            $table->string('reason', 64)->nullable();
+            $table->string('created_by', 128)->nullable();
+            $table->json('meta_json')->nullable();
+            $table->timestamps();
+
+            $table->index(['pack_id', 'created_at'], 'crs_pack_time_idx');
+            $table->index(['from_content_pack_release_id'], 'crs_from_rel_idx');
+            $table->index(['to_content_pack_release_id'], 'crs_to_rel_idx');
+            $table->index(['activation_before_release_id'], 'crs_ab_rel_idx');
+            $table->index(['activation_after_release_id'], 'crs_aa_rel_idx');
+
+            $table->foreign('from_content_pack_release_id', 'crs_from_rel_fk')
+                ->references('id')
+                ->on('content_pack_releases')
+                ->nullOnDelete();
+            $table->foreign('to_content_pack_release_id', 'crs_to_rel_fk')
+                ->references('id')
+                ->on('content_pack_releases')
+                ->nullOnDelete();
+            $table->foreign('activation_before_release_id', 'crs_ab_rel_fk')
+                ->references('id')
+                ->on('content_pack_releases')
+                ->nullOnDelete();
+            $table->foreign('activation_after_release_id', 'crs_aa_rel_fk')
+                ->references('id')
+                ->on('content_pack_releases')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Storage/BlobCatalogServiceTest.php
+++ b/backend/tests/Feature/Storage/BlobCatalogServiceTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\BlobCatalogService;
+use DomainException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BlobCatalogServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-rollout-blob-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath);
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_storage_rollout_tables_exist_and_blob_upsert_is_idempotent(): void
+    {
+        $this->assertTrue(Schema::hasTable('storage_blobs'));
+        $this->assertTrue(Schema::hasTable('content_release_manifests'));
+        $this->assertTrue(Schema::hasTable('content_release_manifest_files'));
+        $this->assertTrue(Schema::hasTable('content_release_snapshots'));
+
+        $service = app(BlobCatalogService::class);
+
+        $first = $service->upsertBlob([
+            'hash' => str_repeat('a', 64),
+            'disk' => 'local',
+            'storage_path' => 'artifacts/reports/demo/report.json',
+            'size_bytes' => 128,
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 1,
+            'first_seen_at' => now()->subMinute(),
+        ]);
+
+        $second = $service->upsertBlob([
+            'hash' => str_repeat('a', 64),
+            'disk' => 'local',
+            'storage_path' => 'artifacts/reports/demo/report.json',
+            'size_bytes' => 256,
+            'content_type' => 'application/vnd.test+json',
+            'encoding' => 'gzip',
+            'ref_count' => 3,
+            'last_verified_at' => now(),
+        ]);
+
+        $this->assertSame(str_repeat('a', 64), $first->hash);
+        $this->assertSame(str_repeat('a', 64), $second->hash);
+        $this->assertDatabaseCount('storage_blobs', 1);
+        $this->assertDatabaseHas('storage_blobs', [
+            'hash' => str_repeat('a', 64),
+            'storage_path' => 'artifacts/reports/demo/report.json',
+            'size_bytes' => 256,
+            'content_type' => 'application/vnd.test+json',
+            'encoding' => 'gzip',
+            'ref_count' => 3,
+        ]);
+        $this->assertNotNull($service->findByHash(str_repeat('a', 64)));
+        $this->assertNull($service->findByHash(str_repeat('b', 64)));
+        $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private');
+    }
+
+    public function test_blob_upsert_rejects_rebinding_the_same_storage_path_to_a_different_hash(): void
+    {
+        $service = app(BlobCatalogService::class);
+
+        $service->upsertBlob([
+            'hash' => str_repeat('a', 64),
+            'disk' => 'local',
+            'storage_path' => 'artifacts/reports/demo/report.json',
+            'size_bytes' => 128,
+        ]);
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('disk + storage_path is already cataloged to a different hash');
+
+        try {
+            $service->upsertBlob([
+                'hash' => str_repeat('b', 64),
+                'disk' => 'local',
+                'storage_path' => 'artifacts/reports/demo/report.json',
+                'size_bytes' => 256,
+            ]);
+        } finally {
+            $this->assertDatabaseCount('storage_blobs', 1);
+            $this->assertDatabaseHas('storage_blobs', [
+                'hash' => str_repeat('a', 64),
+                'storage_path' => 'artifacts/reports/demo/report.json',
+            ]);
+            $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private');
+        }
+    }
+}

--- a/backend/tests/Feature/Storage/ContentReleaseManifestCatalogServiceTest.php
+++ b/backend/tests/Feature/Storage/ContentReleaseManifestCatalogServiceTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Models\ContentPackRelease;
+use App\Services\Storage\ContentReleaseManifestCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ContentReleaseManifestCatalogServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-rollout-manifest-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath);
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_manifest_upsert_is_idempotent_and_file_map_updates_without_duplicate_rows(): void
+    {
+        $release = ContentPackRelease::query()->create([
+            'id' => (string) Str::uuid(),
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'PR13C-MANIFEST',
+            'status' => 'success',
+            'created_by' => 'test',
+        ]);
+
+        $service = app(ContentReleaseManifestCatalogService::class);
+
+        $service->upsertManifest([
+            'content_pack_release_id' => $release->id,
+            'manifest_hash' => str_repeat('c', 64),
+            'storage_path' => 'content_packs_v2/BIG5_OCEAN/v1/release-1/manifest.json',
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => str_repeat('d', 64),
+            'content_hash' => str_repeat('e', 64),
+            'norms_version' => '2026-Q1',
+            'source_commit' => str_repeat('f', 40),
+            'payload_json' => ['schema' => 'v1'],
+        ], [
+            [
+                'logical_path' => 'compiled/manifest.json',
+                'blob_hash' => str_repeat('1', 64),
+                'size_bytes' => 101,
+                'role' => 'manifest',
+                'content_type' => 'application/json',
+            ],
+        ]);
+
+        $manifest = $service->upsertManifest([
+            'content_pack_release_id' => $release->id,
+            'manifest_hash' => str_repeat('c', 64),
+            'storage_path' => 'content_packs_v2/BIG5_OCEAN/v1/release-1/manifest.json',
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => str_repeat('d', 64),
+            'content_hash' => str_repeat('9', 64),
+            'norms_version' => '2026-Q2',
+            'source_commit' => str_repeat('f', 40),
+            'payload_json' => ['schema' => 'v1', 'updated' => true],
+        ], [
+            [
+                'logical_path' => 'compiled/manifest.json',
+                'blob_hash' => str_repeat('2', 64),
+                'size_bytes' => 202,
+                'role' => 'manifest',
+                'content_type' => 'application/json',
+                'checksum' => 'sha256:compiled-manifest',
+            ],
+            [
+                'logical_path' => 'compiled/questions.json',
+                'blob_hash' => str_repeat('3', 64),
+                'size_bytes' => 303,
+                'role' => 'questions',
+                'content_type' => 'application/json',
+            ],
+        ]);
+
+        $this->assertDatabaseCount('content_release_manifests', 1);
+        $this->assertDatabaseCount('content_release_manifest_files', 2);
+        $this->assertDatabaseHas('content_release_manifests', [
+            'manifest_hash' => str_repeat('c', 64),
+            'content_pack_release_id' => $release->id,
+            'content_hash' => str_repeat('9', 64),
+            'norms_version' => '2026-Q2',
+        ]);
+        $this->assertDatabaseHas('content_release_manifest_files', [
+            'content_release_manifest_id' => $manifest->id,
+            'logical_path' => 'compiled/manifest.json',
+            'blob_hash' => str_repeat('2', 64),
+            'size_bytes' => 202,
+            'checksum' => 'sha256:compiled-manifest',
+        ]);
+        $this->assertDatabaseHas('content_release_manifest_files', [
+            'content_release_manifest_id' => $manifest->id,
+            'logical_path' => 'compiled/questions.json',
+            'blob_hash' => str_repeat('3', 64),
+            'size_bytes' => 303,
+        ]);
+
+        $reloaded = $service->findByManifestHash(str_repeat('c', 64));
+        $this->assertNotNull($reloaded);
+        $this->assertCount(2, $reloaded->files);
+        $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private');
+    }
+
+    public function test_manifest_upsert_keeps_omitted_file_rows_to_preserve_additive_scaffold_semantics(): void
+    {
+        $release = ContentPackRelease::query()->create([
+            'id' => (string) Str::uuid(),
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'PR13C-MANIFEST-ADDITIVE',
+            'status' => 'success',
+            'created_by' => 'test',
+        ]);
+
+        $service = app(ContentReleaseManifestCatalogService::class);
+
+        $service->upsertManifest([
+            'content_pack_release_id' => $release->id,
+            'manifest_hash' => str_repeat('d', 64),
+            'storage_path' => 'content_packs_v2/BIG5_OCEAN/v1/release-2/manifest.json',
+        ], [
+            [
+                'logical_path' => 'compiled/manifest.json',
+                'blob_hash' => str_repeat('4', 64),
+                'size_bytes' => 404,
+            ],
+            [
+                'logical_path' => 'compiled/questions.json',
+                'blob_hash' => str_repeat('5', 64),
+                'size_bytes' => 505,
+            ],
+        ]);
+
+        $service->upsertManifest([
+            'content_pack_release_id' => $release->id,
+            'manifest_hash' => str_repeat('d', 64),
+            'storage_path' => 'content_packs_v2/BIG5_OCEAN/v1/release-2/manifest.json',
+        ], [
+            [
+                'logical_path' => 'compiled/manifest.json',
+                'blob_hash' => str_repeat('6', 64),
+                'size_bytes' => 606,
+            ],
+        ]);
+
+        $this->assertDatabaseCount('content_release_manifests', 1);
+        $this->assertDatabaseCount('content_release_manifest_files', 2);
+        $this->assertDatabaseHas('content_release_manifest_files', [
+            'logical_path' => 'compiled/manifest.json',
+            'blob_hash' => str_repeat('6', 64),
+            'size_bytes' => 606,
+        ]);
+        $this->assertDatabaseHas('content_release_manifest_files', [
+            'logical_path' => 'compiled/questions.json',
+            'blob_hash' => str_repeat('5', 64),
+            'size_bytes' => 505,
+        ]);
+        $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private');
+    }
+}

--- a/backend/tests/Feature/Storage/ContentReleaseSnapshotCatalogServiceTest.php
+++ b/backend/tests/Feature/Storage/ContentReleaseSnapshotCatalogServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Models\ContentPackRelease;
+use App\Services\Storage\ContentReleaseSnapshotCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ContentReleaseSnapshotCatalogServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-rollout-snapshot-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath);
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_snapshot_catalog_records_db_metadata_without_touching_storage_files(): void
+    {
+        $fromRelease = ContentPackRelease::query()->create([
+            'id' => (string) Str::uuid(),
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'PR13C-SNAPSHOT-FROM',
+            'status' => 'success',
+            'created_by' => 'test',
+        ]);
+        $toRelease = ContentPackRelease::query()->create([
+            'id' => (string) Str::uuid(),
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'PR13C-SNAPSHOT-TO',
+            'status' => 'success',
+            'created_by' => 'test',
+        ]);
+
+        $service = app(ContentReleaseSnapshotCatalogService::class);
+
+        $snapshot = $service->recordSnapshot([
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'from_content_pack_release_id' => $fromRelease->id,
+            'to_content_pack_release_id' => $toRelease->id,
+            'activation_before_release_id' => $fromRelease->id,
+            'activation_after_release_id' => $toRelease->id,
+            'reason' => 'scaffold_seed',
+            'created_by' => 'codex',
+            'meta_json' => ['note' => 'metadata only'],
+        ]);
+
+        $this->assertNotNull($snapshot->id);
+        $this->assertDatabaseCount('content_release_snapshots', 1);
+        $this->assertDatabaseHas('content_release_snapshots', [
+            'id' => $snapshot->id,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'from_content_pack_release_id' => $fromRelease->id,
+            'to_content_pack_release_id' => $toRelease->id,
+            'activation_before_release_id' => $fromRelease->id,
+            'activation_after_release_id' => $toRelease->id,
+            'reason' => 'scaffold_seed',
+            'created_by' => 'codex',
+        ]);
+        $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private');
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements PR-13C only: a strict additive scaffold for storage rollout metadata.

It adds four new database tables, four Eloquent models, three DB-only catalog services, and a rollout config file so later rollout PRs can write blob / manifest / snapshot metadata without having to introduce schema work and runtime integration in the same change.

The intent of this PR is to prepare the repository for later storage rollout steps while keeping current runtime behavior unchanged. It does not connect the new services to any existing writer or reader path, does not alter rollback semantics, does not change artifact canonical paths, and does not touch content pack publish or resolver behavior.

## What changed

New schema:

- `storage_blobs`
- `content_release_manifests`
- `content_release_manifest_files`
- `content_release_snapshots`

All indexes, unique constraints, and foreign keys use explicit short names to avoid the MySQL identifier-length failures we have seen in production.

New models:

- `App\\Models\\StorageBlob`
- `App\\Models\\ContentReleaseManifest`
- `App\\Models\\ContentReleaseManifestFile`
- `App\\Models\\ContentReleaseSnapshot`

New services:

- `App\\Services\\Storage\\BlobCatalogService`
- `App\\Services\\Storage\\ContentReleaseManifestCatalogService`
- `App\\Services\\Storage\\ContentReleaseSnapshotCatalogService`

New config:

- `config/storage_rollout.php`

New targeted tests:

- `BlobCatalogServiceTest`
- `ContentReleaseManifestCatalogServiceTest`
- `ContentReleaseSnapshotCatalogServiceTest`

## Important implementation notes

This PR intentionally stays additive.

The new catalog services only write database metadata. They do not call `Storage::put`, `Storage::copy`, `Storage::move`, or `Storage::delete`, and they are not wired into any runtime publish, rollback, artifact, or resolver path.

The manifest catalog service is explicitly additive at this stage: it inserts or updates known file rows for a manifest hash, but it does not delete omitted rows. That behavior is now locked by tests so later rollout PRs can change it deliberately if and when a runtime producer contract exists.

The blob catalog service now fails fast if the same `disk + storage_path` is presented with a different hash. This prevents the current unique constraint from surfacing later as an opaque database error once runtime integration begins.

One repo-compatible adjustment was required versus the initial field sketch: release reference columns were implemented as UUID foreign keys rather than unsigned big integers, because `content_pack_releases.id` is already a UUID primary key in this repository.

## Explicitly out of scope

This PR does not:

- modify `ContentPackPublisher`
- modify `ContentPackV2Publisher`
- modify `ContentPackV2Resolver`
- modify `ArtifactStore`
- change rollback semantics
- change artifact canonical paths
- introduce blob runtime storage, manifests in the runtime path, or snapshots in the publish path
- change deploy or package behavior
- change routes, controllers, or business API contracts

## Validation

Focused checks run for this PR:

- `php -l` on the new models, services, and config
- `./vendor/bin/pint` on the new models, services, config, migrations, and tests
- `php artisan migrate`
- `php artisan migrate:status | grep -E 'storage_blobs|content_release_manifests|content_release_manifest_files|content_release_snapshots'`
- `vendor/bin/phpunit tests/Feature/Storage/BlobCatalogServiceTest.php tests/Feature/Storage/ContentReleaseManifestCatalogServiceTest.php tests/Feature/Storage/ContentReleaseSnapshotCatalogServiceTest.php`
- `php artisan route:list > /tmp/pr13c_route_list.txt`
- `php artisan serve --host=127.0.0.1 --port=18081`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`

Validation status:

- migrations: green
- targeted tests: green
- healthz: green
- runtime semantics: unchanged
- `ci_verify_mbti.sh`: still red, but unchanged from baseline

The current CI red remains the existing MBTI self-check failure:

- `report_dynamic_sections.json :: missing manifest.schemas mapping (asset=dynamic_sections)`

That failure is outside PR-13C scope and was not changed here.
