### PR TITLE
[codex] Ship MBTI Phase 3A accuracy feedback and variant telemetry (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -13,6 +13,7 @@ use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
 use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Mbti\MbtiPublicProjectionService;
+use App\Services\Mbti\MbtiResultPersonalizationService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
@@ -33,6 +34,18 @@ class AttemptReadController extends Controller
 
     private const SENSITIVE_RESULT_READ_SCALES = ['SDS_20', 'CLINICAL_COMBO_68'];
 
+    private const MBTI_AXIS_ORDER = ['EI', 'SN', 'TF', 'JP', 'AT'];
+
+    private const MBTI_AXIS_TYPE_INDEX = ['EI' => 0, 'SN' => 1, 'TF' => 2, 'JP' => 3];
+
+    private const MBTI_AXIS_SIDE_FALLBACK = [
+        'EI' => ['E', 'I'],
+        'SN' => ['S', 'N'],
+        'TF' => ['T', 'F'],
+        'JP' => ['J', 'P'],
+        'AT' => ['A', 'T'],
+    ];
+
     public function __construct(
         private AttemptSubmissionService $attemptSubmissionService,
         private ReportGatekeeper $reportGatekeeper,
@@ -43,6 +56,7 @@ class AttemptReadController extends Controller
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
         private ReportSubjectRepository $reportSubjects,
+        private MbtiResultPersonalizationService $mbtiPersonalization,
         protected OrgContext $orgContext,
     ) {}
 
@@ -190,12 +204,28 @@ class AttemptReadController extends Controller
             $compatScoresPct = [];
         }
 
+        $mbtiEventMeta = $scaleCode === 'MBTI'
+            ? $this->mbtiTelemetryMetaFromPersonalization(
+                $this->buildMbtiPersonalizationForResultEvent(
+                    $result,
+                    $attempt,
+                    $compatTypeCode,
+                    $compatScoresPct,
+                    $this->resolveMbtiAxisStates($result, $payload),
+                    $packId,
+                    $dirVersion,
+                    $reportEngineVersion
+                )
+            )
+            : [];
+
         $this->eventRecorder->recordFromRequest($request, 'result_view', $this->resolveUserId($request), [
             'scale_code' => $scaleCode,
             'pack_id' => $packId,
             'dir_version' => $dirVersion,
             'type_code' => (string) ($result->type_code ?? ''),
             'attempt_id' => $attemptId,
+            ...$mbtiEventMeta,
         ]);
 
         return response()->json([
@@ -270,17 +300,31 @@ class AttemptReadController extends Controller
         $reportPersonalization = is_array(data_get($gate, 'report._meta.personalization'))
             ? data_get($gate, 'report._meta.personalization')
             : [];
+        $mbtiEventMeta = $scaleCode === 'MBTI'
+            ? $this->mbtiTelemetryMetaFromPersonalization(
+                $reportPersonalization !== []
+                    ? $reportPersonalization
+                    : $this->buildMbtiPersonalizationForResultEvent(
+                        $result,
+                        $attempt,
+                        (string) ($result->type_code ?? ''),
+                        is_array($result->scores_pct) ? $result->scores_pct : [],
+                        $this->resolveMbtiAxisStates($result, []),
+                        (string) ($attempt->pack_id ?? ''),
+                        (string) ($attempt->dir_version ?? ''),
+                        (string) ($result->report_engine_version ?? 'v1.2')
+                    )
+            )
+            : [];
 
         $this->eventRecorder->recordFromRequest($request, 'report_view', $this->resolveUserId($request), [
             'scale_code' => (string) ($attempt->scale_code ?? ''),
             'pack_id' => (string) ($attempt->pack_id ?? ''),
             'dir_version' => (string) ($attempt->dir_version ?? ''),
             'type_code' => (string) ($result->type_code ?? ''),
-            'identity' => (string) data_get($reportPersonalization, 'identity', ''),
-            'variant_keys' => array_values((array) data_get($reportPersonalization, 'variant_keys', [])),
-            'engine_version' => (string) data_get($reportPersonalization, 'engine_version', (string) ($result->report_engine_version ?? 'v1.2')),
             'attempt_id' => (string) $attempt->id,
             'locked' => (bool) ($gate['locked'] ?? false),
+            ...$mbtiEventMeta,
         ]);
         $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
         $reportViewMeta = [
@@ -445,6 +489,138 @@ class AttemptReadController extends Controller
         }
 
         throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoresPct
+     * @param  array<string,mixed>  $axisStates
+     * @return array<string,mixed>
+     */
+    private function buildMbtiPersonalizationForResultEvent(
+        Result $result,
+        ?Attempt $attempt,
+        string $typeCode,
+        array $scoresPct,
+        array $axisStates,
+        string $packId,
+        string $dirVersion,
+        string $reportEngineVersion
+    ): array {
+        $normalizedTypeCode = strtoupper(trim($typeCode));
+        if ($normalizedTypeCode === '') {
+            return [];
+        }
+
+        $scores = [];
+        foreach (self::MBTI_AXIS_ORDER as $axisCode) {
+            $pctRaw = $scoresPct[$axisCode] ?? null;
+            if (! is_numeric($pctRaw)) {
+                continue;
+            }
+
+            $pct = (int) round((float) $pctRaw);
+            $scores[$axisCode] = [
+                'pct' => $pct,
+                'delta' => (int) round(abs($pct - 50)),
+                'side' => $this->resolveMbtiAxisSide($axisCode, $normalizedTypeCode, $pct),
+                'state' => trim((string) ($axisStates[$axisCode] ?? '')),
+            ];
+        }
+
+        if ($scores === []) {
+            return [];
+        }
+
+        return $this->mbtiPersonalization->buildForReportPayload([
+            'type_code' => $normalizedTypeCode,
+            'scores' => $scores,
+            'axis_states' => $axisStates,
+        ], [
+            'type_code' => $normalizedTypeCode,
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'locale' => (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN')),
+            'engine_version' => $reportEngineVersion,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $personalization
+     * @return array<string,mixed>
+     */
+    private function mbtiTelemetryMetaFromPersonalization(array $personalization): array
+    {
+        $sceneFingerprint = [];
+        foreach ((array) ($personalization['scene_fingerprint'] ?? []) as $sceneKey => $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $styleKey = trim((string) ($entry['style_key'] ?? $entry['styleKey'] ?? ''));
+            if ($styleKey !== '') {
+                $sceneFingerprint[(string) $sceneKey] = $styleKey;
+            }
+        }
+
+        $meta = [
+            'identity' => trim((string) ($personalization['identity'] ?? '')),
+            'variant_keys' => is_array($personalization['variant_keys'] ?? null) ? $personalization['variant_keys'] : [],
+            'scene_fingerprint' => $sceneFingerprint,
+            'boundary_flags' => is_array($personalization['boundary_flags'] ?? null) ? $personalization['boundary_flags'] : [],
+            'axis_bands' => is_array($personalization['axis_bands'] ?? null) ? $personalization['axis_bands'] : [],
+            'engine_version' => trim((string) ($personalization['engine_version'] ?? '')),
+        ];
+
+        return array_filter($meta, static function (mixed $value): bool {
+            if (is_string($value)) {
+                return $value !== '';
+            }
+
+            if (is_array($value)) {
+                return $value !== [];
+            }
+
+            return $value !== null;
+        });
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    private function resolveMbtiAxisStates(Result $result, array $payload): array
+    {
+        if (is_array($result->axis_states)) {
+            return $result->axis_states;
+        }
+
+        $nested = data_get($payload, 'axis_scores_json.axis_states');
+        if (is_array($nested)) {
+            return $nested;
+        }
+
+        return [];
+    }
+
+    private function resolveMbtiAxisSide(string $axisCode, string $typeCode, int $pct): string
+    {
+        $normalizedAxis = strtoupper(trim($axisCode));
+        $normalizedType = strtoupper(trim($typeCode));
+
+        if ($normalizedAxis === 'AT' && preg_match('/-(A|T)$/', $normalizedType, $matches) === 1) {
+            return (string) ($matches[1] ?? '');
+        }
+
+        if (isset(self::MBTI_AXIS_TYPE_INDEX[$normalizedAxis])) {
+            $index = self::MBTI_AXIS_TYPE_INDEX[$normalizedAxis];
+            if (isset($normalizedType[$index])) {
+                return $normalizedType[$index];
+            }
+        }
+
+        [$primary, $secondary] = self::MBTI_AXIS_SIDE_FALLBACK[$normalizedAxis] ?? ['E', 'I'];
+
+        return $pct >= 50 ? $primary : $secondary;
     }
 
     private function isPublicResultScale(string $scaleCode): bool

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Http\Controllers\API\V0_3\AttemptReadController;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Support\OrgContext;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class MbtiResultTelemetryContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mbti_result_and_report_events_include_personalization_meta(): void
+    {
+        $this->seedScales();
+        Config::set('fap_experiments.experiments', []);
+
+        $anonId = 'mbti_phase3a_anon';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+
+        $resultResponse = $this->invokeController('result', $attemptId, $anonId);
+        $this->assertSame(200, $resultResponse->getStatusCode());
+
+        $reportResponse = $this->invokeController('report', $attemptId, $anonId);
+        $this->assertSame(200, $reportResponse->getStatusCode());
+
+        foreach (['result_view', 'report_view'] as $eventCode) {
+            $event = $this->findLatestEventByAttempt($eventCode, $attemptId);
+            $this->assertNotNull($event, 'missing event row: ' . $eventCode);
+
+            $meta = json_decode((string) ($event->meta_json ?? '{}'), true) ?: [];
+            $this->assertSame('INTJ-A', (string) ($meta['type_code'] ?? ''));
+            $this->assertSame('A', (string) ($meta['identity'] ?? ''));
+            $this->assertSame('v1.2', (string) ($meta['engine_version'] ?? ''));
+            $this->assertIsArray($meta['axis_bands'] ?? null);
+            $this->assertSame('boundary', (string) (($meta['axis_bands']['EI'] ?? '')));
+            $this->assertSame('boundary', (string) (($meta['axis_bands']['AT'] ?? '')));
+            $this->assertIsArray($meta['boundary_flags'] ?? null);
+            $this->assertTrue((bool) (($meta['boundary_flags']['EI'] ?? false)));
+            $this->assertTrue((bool) (($meta['boundary_flags']['AT'] ?? false)));
+            $this->assertIsArray($meta['variant_keys'] ?? null);
+            $this->assertNotSame('', trim((string) (($meta['variant_keys']['overview'] ?? ''))));
+            $this->assertIsArray($meta['scene_fingerprint'] ?? null);
+            $this->assertNotSame('', trim((string) (($meta['scene_fingerprint']['work'] ?? ''))));
+        }
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'raw_score' => 0,
+                'final_score' => 0,
+                'breakdown_json' => [],
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function invokeController(string $method, string $attemptId, string $anonId): \Illuminate\Http\JsonResponse
+    {
+        $path = "/api/v0.3/attempts/{$attemptId}/" . ($method === 'report' ? 'report' : 'result');
+        $request = Request::create($path, 'GET');
+        $request->headers->set('X-Anon-Id', $anonId);
+        $request->attributes->set('anon_id', $anonId);
+        $request->attributes->set('org_context_resolved', true);
+        $request->attributes->set('org_context_kind', OrgContext::KIND_PUBLIC);
+
+        $this->app->instance('request', $request);
+        app(OrgContext::class)->set(0, null, 'public', $anonId, OrgContext::KIND_PUBLIC);
+
+        /** @var AttemptReadController $controller */
+        $controller = app(AttemptReadController::class);
+
+        return $controller->{$method}($request, $attemptId);
+    }
+
+    private function findLatestEventByAttempt(string $eventCode, string $attemptId): ?object
+    {
+        $query = DB::table('events')
+            ->where('event_code', $eventCode)
+            ->where(function ($inner) use ($attemptId): void {
+                $inner->where('attempt_id', $attemptId);
+
+                $driver = DB::connection()->getDriverName();
+                if ($driver === 'mysql') {
+                    $inner->orWhereRaw(
+                        "JSON_UNQUOTE(JSON_EXTRACT(meta_json, '$.attempt_id')) = ?",
+                        [$attemptId]
+                    );
+
+                    return;
+                }
+
+                if ($driver === 'sqlite') {
+                    $inner->orWhereRaw(
+                        "json_extract(meta_json, '$.attempt_id') = ?",
+                        [$attemptId]
+                    );
+
+                    return;
+                }
+
+                $inner->orWhereRaw('meta_json like ?', ['%"attempt_id":"' . $attemptId . '"%']);
+            });
+
+        return $query->orderByDesc('occurred_at')->first();
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of MBTI Phase 3A: accuracy feedback and variant exposure telemetry.

The MBTI result experience already had a single personalization authority after Phase 1 and Phase 2, but the product still lacked a clean event contract that could answer two practical questions in production:

1. which variant, scene fingerprint, and boundary state a user actually saw when they opened a result or report page; and
2. whether the user felt that the interpretation was accurate enough to trust.

This PR closes the backend side of that gap without widening scope into dashboards, CMS, payment, or other scales.

## Problem

Before this change, MBTI result and report reads emitted their standard analytics events, but those events did not consistently carry the Phase 1 / Phase 2 personalization context needed for analysis.

That meant downstream analysis could see that a result page was viewed, but could not reliably segment by:

- MBTI identity
- axis bands
- boundary flags
- scene fingerprint
- stable variant keys
- engine version

At the same time, the frontend could add richer telemetry payloads, but without a backend-side contract test the read path was still not proven end to end.

## Root cause

The read controller still treated result/report events as generic read events. The MBTI personalization contract existed in the report/projection pipeline, but it was not being normalized and attached to the result/report event stream in a stable backend-owned way.

## Fix

This PR introduces a backend-owned MBTI telemetry normalization path inside `AttemptReadController`.

The controller now:

- rebuilds MBTI personalization metadata for result-view events when needed;
- reuses report personalization metadata for report-view events when available;
- normalizes the event payload into a stable contract containing:
  - `identity`
  - `variant_keys`
  - `scene_fingerprint`
  - `boundary_flags`
  - `axis_bands`
  - `engine_version`
- keeps the existing result/report flow intact instead of inventing a second authority path.

A dedicated feature contract test was added to verify that both `result_view` and `report_view` persist the expected MBTI personalization metadata.

## User impact

This change is not a visible UI feature by itself, but it is required product infrastructure.

After this PR, MBTI result telemetry can answer questions like:

- which users saw a boundary-heavy interpretation;
- which scene fingerprint variants correlate with unlock, share, or revisit behavior; and
- whether accuracy feedback is clustering around specific variant keys or engine versions.

That makes the Phase 1 / Phase 2 result engine measurable instead of just expressive.

## Validation

I ran:

- `php artisan test tests/Feature/V0_3/MbtiResultTelemetryContractTest.php`

Result:

- 1 test passed
- 30 assertions

## Scope note

This PR intentionally excludes unrelated local changes already present in the repo, especially the `BIG5_OCEAN` compiled artifacts and an unrelated experiment exposure contract edit. Only the MBTI Phase 3A backend files are included.
