### PR TITLE
[codex] add gated ArtifactStore dual-write to storage_blobs

### DIFF
--- a/backend/app/Services/Storage/ArtifactStore.php
+++ b/backend/app/Services/Storage/ArtifactStore.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace App\Services\Storage;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 final class ArtifactStore
 {
+    public function __construct(
+        private readonly BlobCatalogService $blobCatalogService,
+    ) {}
+
     public function reportCanonicalPath(string $scaleCode, string $attemptId): string
     {
         $scale = $this->sanitizeScaleCode($scaleCode);
@@ -48,6 +53,7 @@ final class ArtifactStore
         }
 
         Storage::disk('local')->put($path, $json);
+        $this->catalogBlobMetadata($json, 'application/json');
 
         return $path;
     }
@@ -110,6 +116,7 @@ final class ArtifactStore
     public function putPdf(string $path, string $bytes): void
     {
         Storage::disk('local')->put($path, $bytes);
+        $this->catalogBlobMetadata($bytes, 'application/pdf');
     }
 
     /**
@@ -147,6 +154,42 @@ final class ArtifactStore
         $contents = $disk->get($path);
 
         return is_string($contents) && $contents !== '' ? $contents : null;
+    }
+
+    private function catalogBlobMetadata(string $content, string $contentType): void
+    {
+        if (! $this->shouldDualWriteBlobCatalog()) {
+            return;
+        }
+
+        try {
+            $hash = hash('sha256', $content);
+            $now = now();
+            $existing = $this->blobCatalogService->findByHash($hash);
+
+            $this->blobCatalogService->upsertBlob([
+                'hash' => $hash,
+                'disk' => 'local',
+                'storage_path' => $this->blobCatalogService->storagePathForHash($hash),
+                'size_bytes' => strlen($content),
+                'content_type' => $contentType,
+                'encoding' => 'identity',
+                'ref_count' => 0,
+                'first_seen_at' => $existing?->first_seen_at ?? $now,
+                'last_verified_at' => $now,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('ARTIFACT_BLOB_CATALOG_WRITE_FAILED', [
+                'content_type' => $contentType,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function shouldDualWriteBlobCatalog(): bool
+    {
+        return (bool) config('storage_rollout.blob_catalog_enabled')
+            && (bool) config('storage_rollout.artifact_dual_write_enabled');
     }
 
     private function sanitizeScaleCode(string $scaleCode): string

--- a/backend/app/Services/Storage/BlobCatalogService.php
+++ b/backend/app/Services/Storage/BlobCatalogService.php
@@ -8,18 +8,22 @@ use App\Models\StorageBlob;
 
 class BlobCatalogService
 {
+    public function storagePathForHash(string $hash): string
+    {
+        $hash = $this->normalizeHash($hash);
+
+        return 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+    }
+
     public function upsertBlob(array $payload): StorageBlob
     {
-        $hash = trim((string) ($payload['hash'] ?? ''));
-        if ($hash === '') {
-            throw new \InvalidArgumentException('hash is required');
-        }
+        $hash = $this->normalizeHash((string) ($payload['hash'] ?? ''));
 
         $disk = trim((string) ($payload['disk'] ?? 'local'));
-        $storagePath = trim((string) ($payload['storage_path'] ?? ''));
-        if ($storagePath === '') {
-            throw new \InvalidArgumentException('storage_path is required');
-        }
+        $storagePath = trim((string) ($payload['storage_path'] ?? $this->storagePathForHash($hash)));
+        $storagePath = $storagePath !== '' ? $storagePath : $this->storagePathForHash($hash);
+
+        $existing = StorageBlob::query()->find($hash);
 
         $existingPathOwner = StorageBlob::query()
             ->where('disk', $disk)
@@ -39,9 +43,9 @@ class BlobCatalogService
                 'size_bytes' => (int) ($payload['size_bytes'] ?? 0),
                 'content_type' => $payload['content_type'] ?? null,
                 'encoding' => (string) ($payload['encoding'] ?? 'identity'),
-                'ref_count' => (int) ($payload['ref_count'] ?? 0),
-                'first_seen_at' => $payload['first_seen_at'] ?? null,
-                'last_verified_at' => $payload['last_verified_at'] ?? null,
+                'ref_count' => max(0, (int) ($payload['ref_count'] ?? $existing?->ref_count ?? 0)),
+                'first_seen_at' => $payload['first_seen_at'] ?? $existing?->first_seen_at,
+                'last_verified_at' => $payload['last_verified_at'] ?? $existing?->last_verified_at,
             ]
         );
 
@@ -50,11 +54,24 @@ class BlobCatalogService
 
     public function findByHash(string $hash): ?StorageBlob
     {
-        $hash = trim($hash);
+        $hash = strtolower(trim($hash));
         if ($hash === '') {
             return null;
         }
 
         return StorageBlob::query()->find($hash);
+    }
+
+    private function normalizeHash(string $hash): string
+    {
+        $hash = strtolower(trim($hash));
+        if ($hash === '') {
+            throw new \InvalidArgumentException('hash is required');
+        }
+        if (preg_match('/^[a-f0-9]{64}$/', $hash) !== 1) {
+            throw new \InvalidArgumentException('hash must be a 64 character sha256 hex digest');
+        }
+
+        return $hash;
     }
 }

--- a/backend/tests/Feature/Storage/ArtifactStoreDualWriteTest.php
+++ b/backend/tests/Feature/Storage/ArtifactStoreDualWriteTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Models\Attempt;
+use App\Services\Report\Pdf\ReportPdfArtifactStore;
+use App\Services\Report\Pdf\ReportPdfDocumentService;
+use App\Services\Storage\ArtifactStore;
+use App\Services\Storage\BlobCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArtifactStoreDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-artifact-dual-write-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath);
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+        config()->set('storage_rollout.blob_catalog_enabled', false);
+        config()->set('storage_rollout.artifact_dual_write_enabled', false);
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_flags_disabled_canonical_report_and_pdf_writes_do_not_create_blob_rows(): void
+    {
+        $store = app(ArtifactStore::class);
+        $pdfStore = app(ReportPdfArtifactStore::class);
+        $attemptId = (string) Str::uuid();
+
+        $reportPath = $store->putReportJson('MBTI', $attemptId, [
+            'ok' => true,
+            'attempt_id' => $attemptId,
+        ]);
+        $pdfPath = $store->pdfCanonicalPath('MBTI', $attemptId, 'manifesthash', 'free');
+        $pdfStore->put($pdfPath, '%PDF-1.4 disabled');
+
+        $this->assertTrue(Storage::disk('local')->exists($reportPath));
+        $this->assertTrue(Storage::disk('local')->exists($pdfPath));
+        $this->assertDatabaseCount('storage_blobs', 0);
+        $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private/blobs');
+    }
+
+    public function test_flags_enabled_canonical_report_and_pdf_writes_create_blob_rows_and_same_bytes_do_not_duplicate(): void
+    {
+        config()->set('storage_rollout.blob_catalog_enabled', true);
+        config()->set('storage_rollout.artifact_dual_write_enabled', true);
+
+        $store = app(ArtifactStore::class);
+        $pdfStore = app(ReportPdfArtifactStore::class);
+        $blobCatalog = app(BlobCatalogService::class);
+        $attemptId = (string) Str::uuid();
+
+        $reportPayload = [
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'nested' => ['key' => 'value'],
+        ];
+
+        $reportPath = $store->putReportJson('MBTI', $attemptId, $reportPayload);
+        $pdfPath = $store->pdfCanonicalPath('MBTI', $attemptId, 'manifesthash', 'free');
+        $pdfStore->put($pdfPath, '%PDF-1.4 enabled');
+
+        $store->putReportJson('MBTI', $attemptId, $reportPayload);
+        $pdfStore->put($pdfPath, '%PDF-1.4 enabled');
+
+        $reportBytes = (string) Storage::disk('local')->get($reportPath);
+        $pdfBytes = (string) Storage::disk('local')->get($pdfPath);
+        $reportHash = hash('sha256', $reportBytes);
+        $pdfHash = hash('sha256', $pdfBytes);
+
+        $this->assertDatabaseCount('storage_blobs', 2);
+        $this->assertDatabaseHas('storage_blobs', [
+            'hash' => $reportHash,
+            'disk' => 'local',
+            'storage_path' => $blobCatalog->storagePathForHash($reportHash),
+            'size_bytes' => strlen($reportBytes),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+        ]);
+        $this->assertDatabaseHas('storage_blobs', [
+            'hash' => $pdfHash,
+            'disk' => 'local',
+            'storage_path' => $blobCatalog->storagePathForHash($pdfHash),
+            'size_bytes' => strlen($pdfBytes),
+            'content_type' => 'application/pdf',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+        ]);
+        $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private/blobs');
+    }
+
+    public function test_flags_enabled_rewriting_same_canonical_report_path_with_new_bytes_is_safe_and_catalogs_a_new_hash(): void
+    {
+        config()->set('storage_rollout.blob_catalog_enabled', true);
+        config()->set('storage_rollout.artifact_dual_write_enabled', true);
+
+        $store = app(ArtifactStore::class);
+        $blobCatalog = app(BlobCatalogService::class);
+        $attemptId = (string) Str::uuid();
+
+        $path = $store->putReportJson('MBTI', $attemptId, ['version' => 1]);
+        $firstBytes = (string) Storage::disk('local')->get($path);
+        $firstHash = hash('sha256', $firstBytes);
+
+        $pathAgain = $store->putReportJson('MBTI', $attemptId, ['version' => 2]);
+        $secondBytes = (string) Storage::disk('local')->get($pathAgain);
+        $secondHash = hash('sha256', $secondBytes);
+
+        $this->assertSame($path, $pathAgain);
+        $this->assertNotSame($firstHash, $secondHash);
+        $this->assertDatabaseCount('storage_blobs', 2);
+        $this->assertDatabaseHas('storage_blobs', [
+            'hash' => $firstHash,
+            'storage_path' => $blobCatalog->storagePathForHash($firstHash),
+            'content_type' => 'application/json',
+        ]);
+        $this->assertDatabaseHas('storage_blobs', [
+            'hash' => $secondHash,
+            'storage_path' => $blobCatalog->storagePathForHash($secondHash),
+            'content_type' => 'application/json',
+        ]);
+        $this->assertJsonStringEqualsJsonString('{"version":2}', $secondBytes);
+        $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private/blobs');
+    }
+
+    public function test_flags_enabled_pdf_legacy_backfill_also_dual_writes_blob_metadata(): void
+    {
+        config()->set('storage_rollout.blob_catalog_enabled', true);
+        config()->set('storage_rollout.artifact_dual_write_enabled', true);
+
+        $store = app(ArtifactStore::class);
+        $service = app(ReportPdfDocumentService::class);
+        $blobCatalog = app(BlobCatalogService::class);
+        $attemptId = (string) Str::uuid();
+        $manifestHash = 'legacyhash123';
+        $legacyBytes = '%PDF-1.4 legacy backfill';
+        $legacyPath = $store->pdfLegacyPaths('BIG5_OCEAN', $attemptId, $manifestHash, 'free')[0];
+        Storage::disk('local')->put($legacyPath, $legacyBytes);
+
+        $attempt = new Attempt([
+            'id' => $attemptId,
+            'scale_code' => 'BIG5_OCEAN',
+            'answers_summary_json' => [
+                'meta' => [
+                    'pack_release_manifest_hash' => $manifestHash,
+                ],
+            ],
+        ]);
+
+        $resolved = $service->readArtifact($attempt, 'free');
+        $canonicalPath = $store->pdfCanonicalPath('BIG5_OCEAN', $attemptId, $manifestHash, 'free');
+        $pdfHash = hash('sha256', $legacyBytes);
+
+        $this->assertSame($legacyBytes, $resolved);
+        $this->assertTrue(Storage::disk('local')->exists($canonicalPath));
+        $this->assertSame($legacyBytes, (string) Storage::disk('local')->get($canonicalPath));
+        $this->assertDatabaseHas('storage_blobs', [
+            'hash' => $pdfHash,
+            'disk' => 'local',
+            'storage_path' => $blobCatalog->storagePathForHash($pdfHash),
+            'size_bytes' => strlen($legacyBytes),
+            'content_type' => 'application/pdf',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+        ]);
+        $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private/blobs');
+    }
+}

--- a/backend/tests/Feature/Storage/BlobCatalogServiceTest.php
+++ b/backend/tests/Feature/Storage/BlobCatalogServiceTest.php
@@ -127,4 +127,28 @@ final class BlobCatalogServiceTest extends TestCase
             $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private');
         }
     }
+
+    public function test_blob_upsert_derives_a_stable_hash_storage_path_when_omitted(): void
+    {
+        $service = app(BlobCatalogService::class);
+        $hash = str_repeat('c', 64);
+
+        $blob = $service->upsertBlob([
+            'hash' => $hash,
+            'disk' => 'local',
+            'size_bytes' => 512,
+            'content_type' => 'application/json',
+        ]);
+
+        $this->assertSame('blobs/sha256/cc/'.$hash, $blob->storage_path);
+        $this->assertSame('blobs/sha256/cc/'.$hash, $service->storagePathForHash($hash));
+        $this->assertDatabaseHas('storage_blobs', [
+            'hash' => $hash,
+            'storage_path' => 'blobs/sha256/cc/'.$hash,
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+        ]);
+        $this->assertDirectoryDoesNotExist($this->isolatedStoragePath.'/app/private');
+    }
 }

--- a/backend/tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php
@@ -81,5 +81,6 @@ final class StorageMigrateLegacyArtifactsCommandTest extends TestCase
             ->where('action', 'storage_migrate_legacy_artifacts')
             ->count();
         $this->assertGreaterThanOrEqual(1, $auditCount);
+        $this->assertDatabaseCount('storage_blobs', 0);
     }
 }


### PR DESCRIPTION
## Summary

This PR implements PR-13D only: gated artifact metadata dual-write from the existing canonical artifact writer seam into `storage_blobs`.

The goal of this change is narrow: preserve the current runtime behavior for artifact paths, reads, legacy fallback, and read-time backfill, while adding a metadata catalog side-write that prepares the artifact layer for later rollout work.

After this change:

- report JSON canonical writes can dual-write blob metadata
- PDF canonical writes can dual-write blob metadata
- PDF legacy-hit canonical backfill can dual-write blob metadata through the same existing writer seam
- all dual-write behavior remains fully gated behind `storage_rollout.blob_catalog_enabled` and `storage_rollout.artifact_dual_write_enabled`
- physical artifact paths do not change
- reader order does not change
- legacy fallback behavior does not change
- no physical `storage/app/private/blobs/**` files are created

## Root cause

Before this PR, the repository already had canonical artifact writers and PR-13C had already introduced the `storage_blobs` schema plus catalog scaffold, but there was no safe way to connect the two.

A naive dual-write would have caused two problems:

1. it could have changed runtime behavior if metadata failures leaked back into artifact writes
2. it could have incorrectly tied blob catalog rows to mutable canonical artifact paths, which are allowed to be rewritten over time

The safe seam identified in the PR-13D scan was the existing `ArtifactStore` canonical writer surface. This PR uses that seam and keeps metadata-only state separate from the artifact runtime path contract.

## What changed

`ArtifactStore` now performs an optional metadata side-write immediately after successful canonical artifact writes:

- `putReportJson()` catalogs the exact bytes written as `application/json`
- `putPdf()` catalogs the exact bytes written as `application/pdf`

The side-write is best-effort and guarded by both rollout flags. If blob cataloging fails, the runtime artifact write still succeeds and the failure is logged as a warning instead of breaking report delivery.

`BlobCatalogService` now provides a stable, explicit metadata path rule:

- `blobs/sha256/{first2}/{hash}`

This path is written only to database metadata. The PR does not create any physical blob file tree.

The service was also tightened so hash validation is explicit and the default `storage_path` can be derived from the hash when omitted.

To avoid misleading future rollout work, this PR uses a metadata-only `ref_count` default of `0` rather than pretending the system already knows an exact artifact reference count.

## Why runtime semantics remain unchanged

This PR does not touch:

- artifact canonical paths
- artifact reader order
- legacy fallback order
- report/PDF controller response contracts
- content publishers/resolvers
- rollback behavior
- deploy/package logic
- content package files

The only runtime behavior added is an optional post-write metadata catalog step behind flags. When flags are off, the old behavior is identical.

## Tests and validation

Focused PR-13D coverage now includes:

- flags off: canonical report/PDF writes do not create blob rows
- flags on: canonical report/PDF writes create blob rows
- repeated same-bytes writes do not duplicate blob rows
- same canonical report path rewritten with new bytes remains safe and catalogs a second hash row
- PDF legacy-hit read-time backfill also dual-writes blob metadata through the existing runtime path
- migrate command remains copy-only and does not create blob rows by default

Commands run:

- `php -l app/Services/Storage/ArtifactStore.php`
- `php -l app/Services/Storage/BlobCatalogService.php`
- `php -l tests/Feature/Storage/ArtifactStoreDualWriteTest.php`
- `php -l tests/Feature/Storage/BlobCatalogServiceTest.php`
- `./vendor/bin/pint app/Services/Storage/ArtifactStore.php app/Services/Storage/BlobCatalogService.php tests/Feature/Storage/ArtifactStoreDualWriteTest.php tests/Feature/Storage/BlobCatalogServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/ArtifactStoreDualWriteTest.php tests/Feature/Storage/BlobCatalogServiceTest.php tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php`
- `php artisan route:list`
- `php artisan migrate`
- `curl -i http://127.0.0.1:18081/api/healthz`

## Known baseline failures

Two repository-level checks still fail in the current baseline and were not expanded into this PR:

- `vendor/bin/phpunit tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php --debug`
  - still returns `404` on the first `report.pdf` request
- `bash backend/scripts/ci_verify_mbti.sh`
  - still fails on MBTI self-check with `report_dynamic_sections.json :: missing manifest.schemas mapping (asset=dynamic_sections)`

Those failures were observed before and remain out of scope for this PR. This PR does not attempt to fix them.
