### PR TITLE
[codex] add gated ContentPackV2 rollout metadata dual-write

### DIFF
--- a/backend/app/Services/Content/Publisher/ContentPackV2Publisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackV2Publisher.php
@@ -4,13 +4,24 @@ declare(strict_types=1);
 
 namespace App\Services\Content\Publisher;
 
+use App\Services\Storage\BlobCatalogService;
+use App\Services\Storage\ContentReleaseManifestCatalogService;
+use App\Services\Storage\ContentReleaseSnapshotCatalogService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use RuntimeException;
+use Throwable;
 
 final class ContentPackV2Publisher
 {
+    public function __construct(
+        private readonly BlobCatalogService $blobCatalogService,
+        private readonly ContentReleaseManifestCatalogService $manifestCatalogService,
+        private readonly ContentReleaseSnapshotCatalogService $snapshotCatalogService,
+    ) {}
+
     /**
      * @param  array<string,mixed>  $options
      * @return array<string,mixed>
@@ -97,45 +108,14 @@ final class ContentPackV2Publisher
         ];
 
         DB::table('content_pack_releases')->insert($release);
+        $this->dualWritePublishedReleaseMetadata($release);
 
         return $release;
     }
 
     public function activateRelease(string $releaseId): void
     {
-        $releaseId = trim($releaseId);
-        if ($releaseId === '') {
-            throw new RuntimeException('RELEASE_ID_REQUIRED');
-        }
-
-        $release = DB::table('content_pack_releases')->where('id', $releaseId)->first();
-        if (! $release) {
-            throw new RuntimeException('RELEASE_NOT_FOUND');
-        }
-
-        if (! $this->releaseHasCompiledPayload($release)) {
-            throw new RuntimeException('RELEASE_COMPILED_PAYLOAD_MISSING');
-        }
-
-        $packId = strtoupper(trim((string) ($release->to_pack_id ?? '')));
-        $packVersion = trim((string) ($release->pack_version ?? $release->dir_alias ?? ''));
-        if ($packId === '' || $packVersion === '') {
-            throw new RuntimeException('RELEASE_PACK_CONTEXT_INVALID');
-        }
-
-        $now = now();
-        DB::table('content_pack_activations')->updateOrInsert(
-            [
-                'pack_id' => $packId,
-                'pack_version' => $packVersion,
-            ],
-            [
-                'release_id' => $releaseId,
-                'activated_at' => $now,
-                'updated_at' => $now,
-                'created_at' => $now,
-            ]
-        );
+        $this->switchActivation($releaseId, 'packs2_activate');
     }
 
     public function rollbackToRelease(string $packId, string $packVersion, string $toReleaseId): void
@@ -160,7 +140,7 @@ final class ContentPackV2Publisher
             throw new RuntimeException('ROLLBACK_TARGET_MISMATCH');
         }
 
-        $this->activateRelease($toReleaseId);
+        $this->switchActivation($toReleaseId, 'packs2_rollback');
 
         DB::table('content_pack_releases')->insert([
             'id' => (string) Str::uuid(),
@@ -271,9 +251,291 @@ final class ContentPackV2Publisher
             return false;
         }
 
-        $root = storage_path('app/'.ltrim(str_starts_with($storagePath, 'app/') ? substr($storagePath, 4) : $storagePath, '/'));
+        $root = $this->absoluteStorageRoot($storagePath);
 
         return is_file($root.'/compiled/manifest.json') || is_file($root.'/manifest.json');
+    }
+
+    private function switchActivation(string $releaseId, string $reason): void
+    {
+        $releaseId = trim($releaseId);
+        if ($releaseId === '') {
+            throw new RuntimeException('RELEASE_ID_REQUIRED');
+        }
+
+        $release = DB::table('content_pack_releases')->where('id', $releaseId)->first();
+        if (! $release) {
+            throw new RuntimeException('RELEASE_NOT_FOUND');
+        }
+
+        if (! $this->releaseHasCompiledPayload($release)) {
+            throw new RuntimeException('RELEASE_COMPILED_PAYLOAD_MISSING');
+        }
+
+        $packId = strtoupper(trim((string) ($release->to_pack_id ?? '')));
+        $packVersion = trim((string) ($release->pack_version ?? $release->dir_alias ?? ''));
+        if ($packId === '' || $packVersion === '') {
+            throw new RuntimeException('RELEASE_PACK_CONTEXT_INVALID');
+        }
+
+        $activationBeforeReleaseId = trim((string) DB::table('content_pack_activations')
+            ->where('pack_id', $packId)
+            ->where('pack_version', $packVersion)
+            ->value('release_id'));
+
+        $now = now();
+        DB::table('content_pack_activations')->updateOrInsert(
+            [
+                'pack_id' => $packId,
+                'pack_version' => $packVersion,
+            ],
+            [
+                'release_id' => $releaseId,
+                'activated_at' => $now,
+                'updated_at' => $now,
+                'created_at' => $now,
+            ]
+        );
+
+        if ($activationBeforeReleaseId !== $releaseId) {
+            $this->dualWriteActivationSnapshot(
+                $packId,
+                $packVersion,
+                $activationBeforeReleaseId !== '' ? $activationBeforeReleaseId : null,
+                $releaseId,
+                $reason,
+                $release,
+            );
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $release
+     */
+    private function dualWritePublishedReleaseMetadata(array $release): void
+    {
+        if (! $this->shouldDualWriteContentPackV2()) {
+            return;
+        }
+        if (! $this->shouldCatalogBlobs() && ! $this->shouldCatalogManifest()) {
+            return;
+        }
+
+        $storagePath = trim((string) ($release['storage_path'] ?? ''));
+        if ($storagePath === '') {
+            return;
+        }
+
+        $manifestHash = trim((string) ($release['manifest_hash'] ?? ''));
+
+        try {
+            $compiledFiles = $this->collectCompiledFiles($storagePath);
+        } catch (Throwable $e) {
+            Log::warning('PACKS2_METADATA_FILE_SCAN_FAILED', [
+                'storage_path' => $storagePath,
+                'release_id' => (string) ($release['id'] ?? ''),
+                'error' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $blobCatalogHadFailures = false;
+        if ($this->shouldCatalogBlobs()) {
+            foreach ($compiledFiles as $file) {
+                try {
+                    $this->blobCatalogService->upsertBlob([
+                        'hash' => $file['hash'],
+                        'disk' => 'local',
+                        'storage_path' => $this->blobCatalogService->storagePathForHash($file['hash']),
+                        'size_bytes' => $file['size_bytes'],
+                        'content_type' => $file['content_type'],
+                        'encoding' => 'identity',
+                        'ref_count' => 0,
+                        'last_verified_at' => now(),
+                    ]);
+                } catch (Throwable $e) {
+                    Log::warning('PACKS2_BLOB_CATALOG_WRITE_FAILED', [
+                        'release_id' => (string) ($release['id'] ?? ''),
+                        'storage_path' => (string) $file['logical_path'],
+                        'blob_hash' => (string) $file['hash'],
+                        'error' => $e->getMessage(),
+                    ]);
+                    $blobCatalogHadFailures = true;
+                }
+            }
+        }
+
+        if (! $this->shouldCatalogManifest()) {
+            return;
+        }
+        if ($this->shouldCatalogBlobs() && $blobCatalogHadFailures) {
+            Log::warning('PACKS2_MANIFEST_CATALOG_SKIPPED_DUE_TO_BLOB_FAILURE', [
+                'release_id' => (string) ($release['id'] ?? ''),
+                'manifest_hash' => $manifestHash,
+                'storage_path' => $storagePath,
+            ]);
+
+            return;
+        }
+
+        $existingManifest = $manifestHash !== ''
+            ? $this->manifestCatalogService->findByManifestHash($manifestHash)
+            : null;
+        $manifestReleaseId = $existingManifest?->content_pack_release_id ?: ($release['id'] ?? null);
+        $manifestStorageDisk = trim((string) ($existingManifest?->storage_disk ?? ''));
+        if ($manifestStorageDisk === '') {
+            $manifestStorageDisk = 'local';
+        }
+        $manifestStoragePath = trim((string) ($existingManifest?->storage_path ?? ''));
+        if ($manifestStoragePath === '') {
+            $manifestStoragePath = $storagePath;
+        }
+
+        $payloadJson = $release['manifest_json'] ?? null;
+        if (is_string($payloadJson) && $payloadJson !== '') {
+            $decoded = json_decode($payloadJson, true);
+            $payloadJson = is_array($decoded) ? $decoded : null;
+        }
+
+        $files = [];
+        foreach ($compiledFiles as $file) {
+            $files[] = [
+                'logical_path' => $file['logical_path'],
+                'blob_hash' => $file['hash'],
+                'size_bytes' => $file['size_bytes'],
+                'role' => $file['role'],
+                'content_type' => $file['content_type'],
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.$file['hash'],
+            ];
+        }
+
+        try {
+            $this->manifestCatalogService->upsertManifest([
+                'content_pack_release_id' => $manifestReleaseId,
+                'manifest_hash' => $manifestHash,
+                'storage_disk' => $manifestStorageDisk,
+                'storage_path' => $manifestStoragePath,
+                'pack_id' => $release['to_pack_id'] ?? null,
+                'pack_version' => $release['pack_version'] ?? null,
+                'compiled_hash' => $release['compiled_hash'] ?? null,
+                'content_hash' => $release['content_hash'] ?? null,
+                'norms_version' => $release['norms_version'] ?? null,
+                'source_commit' => $release['source_commit'] ?? null,
+                'payload_json' => is_array($payloadJson) ? $payloadJson : null,
+            ], $files);
+        } catch (Throwable $e) {
+            Log::warning('PACKS2_MANIFEST_CATALOG_WRITE_FAILED', [
+                'release_id' => (string) ($release['id'] ?? ''),
+                'manifest_hash' => (string) ($release['manifest_hash'] ?? ''),
+                'storage_path' => $storagePath,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function dualWriteActivationSnapshot(
+        string $packId,
+        string $packVersion,
+        ?string $activationBeforeReleaseId,
+        string $activationAfterReleaseId,
+        string $reason,
+        object $release,
+    ): void {
+        if (! $this->shouldCatalogSnapshot()) {
+            return;
+        }
+
+        try {
+            $this->snapshotCatalogService->recordSnapshot([
+                'pack_id' => $packId,
+                'pack_version' => $packVersion,
+                'from_content_pack_release_id' => $activationBeforeReleaseId,
+                'to_content_pack_release_id' => $activationAfterReleaseId,
+                'activation_before_release_id' => $activationBeforeReleaseId,
+                'activation_after_release_id' => $activationAfterReleaseId,
+                'reason' => $reason,
+                'created_by' => 'packs2',
+                'meta_json' => [
+                    'manifest_hash' => (string) ($release->manifest_hash ?? ''),
+                    'storage_path' => (string) ($release->storage_path ?? ''),
+                ],
+            ]);
+        } catch (Throwable $e) {
+            Log::warning('PACKS2_SNAPSHOT_CATALOG_WRITE_FAILED', [
+                'pack_id' => $packId,
+                'pack_version' => $packVersion,
+                'activation_before_release_id' => $activationBeforeReleaseId,
+                'activation_after_release_id' => $activationAfterReleaseId,
+                'reason' => $reason,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @return list<array{logical_path:string,hash:string,size_bytes:int,content_type:?string,role:?string}>
+     */
+    private function collectCompiledFiles(string $storagePath): array
+    {
+        $root = $this->absoluteStorageRoot($storagePath);
+        $compiledDir = $root.'/compiled';
+        if (! is_dir($compiledDir)) {
+            return [];
+        }
+
+        $files = [];
+        foreach (File::allFiles($compiledDir) as $file) {
+            $absolutePath = $file->getPathname();
+            $relative = ltrim(str_replace('\\', '/', substr($absolutePath, strlen(rtrim($root, '/\\')))), '/');
+            $bytes = (string) File::get($absolutePath);
+            $hash = hash('sha256', $bytes);
+            $files[] = [
+                'logical_path' => $relative,
+                'hash' => $hash,
+                'size_bytes' => strlen($bytes),
+                'content_type' => $this->contentTypeForLogicalPath($relative),
+                'role' => $relative === 'compiled/manifest.json' ? 'manifest' : null,
+            ];
+        }
+
+        usort($files, static fn (array $a, array $b): int => strcmp((string) $a['logical_path'], (string) $b['logical_path']));
+
+        return $files;
+    }
+
+    private function contentTypeForLogicalPath(string $logicalPath): ?string
+    {
+        return str_ends_with(strtolower($logicalPath), '.json') ? 'application/json' : null;
+    }
+
+    private function absoluteStorageRoot(string $storagePath): string
+    {
+        return storage_path('app/'.ltrim(str_starts_with($storagePath, 'app/') ? substr($storagePath, 4) : $storagePath, '/'));
+    }
+
+    private function shouldDualWriteContentPackV2(): bool
+    {
+        return (bool) config('storage_rollout.content_pack_v2_dual_write_enabled', false);
+    }
+
+    private function shouldCatalogBlobs(): bool
+    {
+        return $this->shouldDualWriteContentPackV2()
+            && (bool) config('storage_rollout.blob_catalog_enabled', false);
+    }
+
+    private function shouldCatalogManifest(): bool
+    {
+        return $this->shouldDualWriteContentPackV2()
+            && (bool) config('storage_rollout.manifest_catalog_enabled', false);
+    }
+
+    private function shouldCatalogSnapshot(): bool
+    {
+        return $this->shouldDualWriteContentPackV2()
+            && (bool) config('storage_rollout.snapshot_catalog_enabled', false);
     }
 
     private function copyCompiledToStoragePath(string $sourceCompiledDir, string $storagePath): void

--- a/backend/app/Services/Storage/BlobCatalogService.php
+++ b/backend/app/Services/Storage/BlobCatalogService.php
@@ -44,7 +44,7 @@ class BlobCatalogService
                 'content_type' => $payload['content_type'] ?? null,
                 'encoding' => (string) ($payload['encoding'] ?? 'identity'),
                 'ref_count' => max(0, (int) ($payload['ref_count'] ?? $existing?->ref_count ?? 0)),
-                'first_seen_at' => $payload['first_seen_at'] ?? $existing?->first_seen_at,
+                'first_seen_at' => $payload['first_seen_at'] ?? $existing?->first_seen_at ?? now(),
                 'last_verified_at' => $payload['last_verified_at'] ?? $existing?->last_verified_at,
             ]
         );

--- a/backend/tests/Feature/Content/Packs2MetadataDualWriteTest.php
+++ b/backend/tests/Feature/Content/Packs2MetadataDualWriteTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Models\StorageBlob;
+use App\Services\Content\Publisher\ContentPackV2Publisher;
+use App\Services\Storage\BlobCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class Packs2MetadataDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var list<string>
+     */
+    private array $publishedStoragePaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach (array_values(array_unique($this->publishedStoragePaths)) as $storagePath) {
+            if ($storagePath !== '') {
+                File::deleteDirectory(storage_path('app/'.$storagePath));
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_flags_disabled_publish_compiled_skips_rollout_metadata(): void
+    {
+        $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
+
+        /** @var ContentPackV2Publisher $publisher */
+        $publisher = app(ContentPackV2Publisher::class);
+        $release = $publisher->publishCompiled('BIG5_OCEAN', 'v1', [
+            'created_by' => 'test',
+        ]);
+
+        $releaseId = (string) ($release['id'] ?? '');
+        $this->rememberPublishedPaths('BIG5_OCEAN', 'v1', $releaseId);
+
+        $primaryPath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $mirrorPath = 'content_packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+
+        $this->assertSame($primaryPath, (string) ($release['storage_path'] ?? ''));
+        $this->assertFileExists(storage_path('app/'.$primaryPath.'/compiled/manifest.json'));
+        $this->assertFileExists(storage_path('app/'.$mirrorPath.'/compiled/manifest.json'));
+
+        $this->assertDatabaseCount('storage_blobs', 0);
+        $this->assertDatabaseCount('content_release_manifests', 0);
+        $this->assertDatabaseCount('content_release_manifest_files', 0);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    public function test_flags_enabled_publish_compiled_dual_writes_blob_and_manifest_metadata(): void
+    {
+        config()->set('storage_rollout.content_pack_v2_dual_write_enabled', true);
+        config()->set('storage_rollout.blob_catalog_enabled', true);
+        config()->set('storage_rollout.manifest_catalog_enabled', true);
+
+        $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
+
+        /** @var ContentPackV2Publisher $publisher */
+        $publisher = app(ContentPackV2Publisher::class);
+
+        $firstRelease = $publisher->publishCompiled('BIG5_OCEAN', 'v1', [
+            'created_by' => 'test',
+        ]);
+        $firstReleaseId = (string) ($firstRelease['id'] ?? '');
+        $firstPrimaryPath = (string) ($firstRelease['storage_path'] ?? '');
+        $this->rememberPublishedPaths('BIG5_OCEAN', 'v1', $firstReleaseId);
+
+        $catalogedFiles = $this->catalogedFilesForRoot(storage_path('app/'.$firstPrimaryPath));
+        $this->assertNotEmpty($catalogedFiles);
+
+        $manifestFile = collect($catalogedFiles)->firstWhere('logical_path', 'compiled/manifest.json');
+        $this->assertIsArray($manifestFile);
+
+        $this->assertDatabaseCount('content_release_manifests', 1);
+        $this->assertDatabaseCount('content_release_manifest_files', count($catalogedFiles));
+        $this->assertDatabaseCount('content_release_snapshots', 0);
+        $this->assertDatabaseHas('content_release_manifests', [
+            'manifest_hash' => (string) ($firstRelease['manifest_hash'] ?? ''),
+            'content_pack_release_id' => $firstReleaseId,
+            'storage_disk' => 'local',
+            'storage_path' => $firstPrimaryPath,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+        ]);
+        $this->assertDatabaseHas('content_release_manifest_files', [
+            'logical_path' => 'compiled/manifest.json',
+            'blob_hash' => (string) ($manifestFile['hash'] ?? ''),
+            'size_bytes' => (int) ($manifestFile['size_bytes'] ?? 0),
+            'role' => 'manifest',
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'checksum' => 'sha256:'.(string) ($manifestFile['hash'] ?? ''),
+        ]);
+        $this->assertDatabaseHas('storage_blobs', [
+            'hash' => (string) ($manifestFile['hash'] ?? ''),
+            'disk' => 'local',
+            'storage_path' => 'blobs/sha256/'.substr((string) ($manifestFile['hash'] ?? ''), 0, 2).'/'.(string) ($manifestFile['hash'] ?? ''),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+        ]);
+
+        $blobCountAfterFirstPublish = (int) DB::table('storage_blobs')->count();
+
+        $secondRelease = $publisher->publishCompiled('BIG5_OCEAN', 'v1', [
+            'created_by' => 'test',
+        ]);
+        $secondReleaseId = (string) ($secondRelease['id'] ?? '');
+        $secondPrimaryPath = (string) ($secondRelease['storage_path'] ?? '');
+        $this->rememberPublishedPaths('BIG5_OCEAN', 'v1', $secondReleaseId);
+
+        $this->assertDatabaseCount('content_release_manifests', 1);
+        $this->assertDatabaseCount('content_release_manifest_files', count($catalogedFiles));
+        $this->assertSame($blobCountAfterFirstPublish, (int) DB::table('storage_blobs')->count());
+        $this->assertDatabaseHas('content_release_manifests', [
+            'manifest_hash' => (string) ($secondRelease['manifest_hash'] ?? ''),
+            'content_pack_release_id' => $firstReleaseId,
+            'storage_path' => $firstPrimaryPath,
+        ]);
+        $this->assertFileExists(storage_path('app/'.$secondPrimaryPath.'/compiled/manifest.json'));
+        $this->assertFileExists(storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$secondReleaseId.'/compiled/manifest.json'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    public function test_manifest_catalog_is_skipped_when_any_blob_catalog_write_fails(): void
+    {
+        config()->set('storage_rollout.content_pack_v2_dual_write_enabled', true);
+        config()->set('storage_rollout.blob_catalog_enabled', true);
+        config()->set('storage_rollout.manifest_catalog_enabled', true);
+
+        $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
+
+        $this->app->instance(BlobCatalogService::class, new class extends BlobCatalogService
+        {
+            private int $calls = 0;
+
+            public function upsertBlob(array $payload): StorageBlob
+            {
+                $this->calls++;
+                if ($this->calls === 1) {
+                    throw new \RuntimeException('SIMULATED_BLOB_CATALOG_FAILURE');
+                }
+
+                return parent::upsertBlob($payload);
+            }
+        });
+
+        /** @var ContentPackV2Publisher $publisher */
+        $publisher = app(ContentPackV2Publisher::class);
+        $release = $publisher->publishCompiled('BIG5_OCEAN', 'v1', [
+            'created_by' => 'test',
+        ]);
+
+        $releaseId = (string) ($release['id'] ?? '');
+        $this->rememberPublishedPaths('BIG5_OCEAN', 'v1', $releaseId);
+
+        $this->assertFileExists(storage_path('app/private/packs_v2/BIG5_OCEAN/v1/'.$releaseId.'/compiled/manifest.json'));
+        $this->assertFileExists(storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId.'/compiled/manifest.json'));
+        $this->assertDatabaseCount('content_release_manifests', 0);
+        $this->assertDatabaseCount('content_release_manifest_files', 0);
+        $this->assertGreaterThan(0, (int) DB::table('storage_blobs')->count());
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    private function rememberPublishedPaths(string $packId, string $packVersion, string $releaseId): void
+    {
+        if ($releaseId === '') {
+            return;
+        }
+
+        $this->publishedStoragePaths[] = 'private/packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
+        $this->publishedStoragePaths[] = 'content_packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
+    }
+
+    /**
+     * @return list<array{logical_path:string,hash:string,size_bytes:int}>
+     */
+    private function catalogedFilesForRoot(string $root): array
+    {
+        $compiledDir = $root.'/compiled';
+        $files = [];
+        foreach (File::allFiles($compiledDir) as $file) {
+            $absolutePath = $file->getPathname();
+            $logicalPath = ltrim(str_replace('\\', '/', substr($absolutePath, strlen(rtrim($root, '/\\')))), '/');
+            $bytes = (string) File::get($absolutePath);
+            $files[] = [
+                'logical_path' => $logicalPath,
+                'hash' => hash('sha256', $bytes),
+                'size_bytes' => strlen($bytes),
+            ];
+        }
+
+        usort($files, static fn (array $a, array $b): int => strcmp($a['logical_path'], $b['logical_path']));
+
+        return $files;
+    }
+}

--- a/backend/tests/Feature/Content/Packs2SnapshotDualWriteTest.php
+++ b/backend/tests/Feature/Content/Packs2SnapshotDualWriteTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Services\Content\Publisher\ContentPackV2Publisher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class Packs2SnapshotDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var list<string>
+     */
+    private array $publishedStoragePaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach (array_values(array_unique($this->publishedStoragePaths)) as $storagePath) {
+            if ($storagePath !== '') {
+                File::deleteDirectory(storage_path('app/'.$storagePath));
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_flags_disabled_activate_and_rollback_do_not_write_snapshot_metadata(): void
+    {
+        $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
+
+        /** @var ContentPackV2Publisher $publisher */
+        $publisher = app(ContentPackV2Publisher::class);
+
+        $firstRelease = $publisher->publishCompiled('BIG5_OCEAN', 'v1', ['created_by' => 'test']);
+        $firstReleaseId = (string) ($firstRelease['id'] ?? '');
+        $this->rememberPublishedPaths('BIG5_OCEAN', 'v1', $firstReleaseId);
+
+        $publisher->activateRelease($firstReleaseId);
+        $this->assertDatabaseCount('content_release_snapshots', 0);
+
+        $secondRelease = $publisher->publishCompiled('BIG5_OCEAN', 'v1', ['created_by' => 'test']);
+        $secondReleaseId = (string) ($secondRelease['id'] ?? '');
+        $this->rememberPublishedPaths('BIG5_OCEAN', 'v1', $secondReleaseId);
+
+        $publisher->activateRelease($secondReleaseId);
+        $publisher->rollbackToRelease('BIG5_OCEAN', 'v1', $firstReleaseId);
+
+        $this->assertDatabaseCount('content_release_snapshots', 0);
+        $this->assertSame(
+            $firstReleaseId,
+            (string) DB::table('content_pack_activations')
+                ->where('pack_id', 'BIG5_OCEAN')
+                ->where('pack_version', 'v1')
+                ->value('release_id')
+        );
+    }
+
+    public function test_flags_enabled_activate_and_rollback_write_snapshot_rows_with_accurate_before_after_ids(): void
+    {
+        config()->set('storage_rollout.content_pack_v2_dual_write_enabled', true);
+        config()->set('storage_rollout.snapshot_catalog_enabled', true);
+
+        $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
+
+        /** @var ContentPackV2Publisher $publisher */
+        $publisher = app(ContentPackV2Publisher::class);
+
+        $firstRelease = $publisher->publishCompiled('BIG5_OCEAN', 'v1', ['created_by' => 'test']);
+        $firstReleaseId = (string) ($firstRelease['id'] ?? '');
+        $this->rememberPublishedPaths('BIG5_OCEAN', 'v1', $firstReleaseId);
+
+        $publisher->activateRelease($firstReleaseId);
+
+        $firstSnapshot = DB::table('content_release_snapshots')->orderBy('id')->first();
+        $this->assertNotNull($firstSnapshot);
+        $this->assertSame('BIG5_OCEAN', (string) ($firstSnapshot->pack_id ?? ''));
+        $this->assertSame('v1', (string) ($firstSnapshot->pack_version ?? ''));
+        $this->assertNull($firstSnapshot->from_content_pack_release_id);
+        $this->assertSame($firstReleaseId, (string) ($firstSnapshot->to_content_pack_release_id ?? ''));
+        $this->assertNull($firstSnapshot->activation_before_release_id);
+        $this->assertSame($firstReleaseId, (string) ($firstSnapshot->activation_after_release_id ?? ''));
+        $this->assertSame('packs2_activate', (string) ($firstSnapshot->reason ?? ''));
+
+        $secondRelease = $publisher->publishCompiled('BIG5_OCEAN', 'v1', ['created_by' => 'test']);
+        $secondReleaseId = (string) ($secondRelease['id'] ?? '');
+        $this->rememberPublishedPaths('BIG5_OCEAN', 'v1', $secondReleaseId);
+
+        $publisher->activateRelease($secondReleaseId);
+
+        $secondSnapshot = DB::table('content_release_snapshots')->orderByDesc('id')->first();
+        $this->assertNotNull($secondSnapshot);
+        $this->assertSame($firstReleaseId, (string) ($secondSnapshot->from_content_pack_release_id ?? ''));
+        $this->assertSame($secondReleaseId, (string) ($secondSnapshot->to_content_pack_release_id ?? ''));
+        $this->assertSame($firstReleaseId, (string) ($secondSnapshot->activation_before_release_id ?? ''));
+        $this->assertSame($secondReleaseId, (string) ($secondSnapshot->activation_after_release_id ?? ''));
+        $this->assertSame('packs2_activate', (string) ($secondSnapshot->reason ?? ''));
+
+        $publisher->rollbackToRelease('BIG5_OCEAN', 'v1', $firstReleaseId);
+
+        $rollbackSnapshot = DB::table('content_release_snapshots')->orderByDesc('id')->first();
+        $rollbackHistoryRow = DB::table('content_pack_releases')
+            ->where('action', 'packs2_rollback')
+            ->orderByDesc('created_at')
+            ->first();
+
+        $this->assertNotNull($rollbackSnapshot);
+        $this->assertNotNull($rollbackHistoryRow);
+        $this->assertSame($secondReleaseId, (string) ($rollbackSnapshot->from_content_pack_release_id ?? ''));
+        $this->assertSame($firstReleaseId, (string) ($rollbackSnapshot->to_content_pack_release_id ?? ''));
+        $this->assertSame($secondReleaseId, (string) ($rollbackSnapshot->activation_before_release_id ?? ''));
+        $this->assertSame($firstReleaseId, (string) ($rollbackSnapshot->activation_after_release_id ?? ''));
+        $this->assertSame('packs2_rollback', (string) ($rollbackSnapshot->reason ?? ''));
+        $this->assertNotSame((string) ($rollbackHistoryRow->id ?? ''), (string) ($rollbackSnapshot->to_content_pack_release_id ?? ''));
+        $this->assertSame(
+            $firstReleaseId,
+            (string) DB::table('content_pack_activations')
+                ->where('pack_id', 'BIG5_OCEAN')
+                ->where('pack_version', 'v1')
+                ->value('release_id')
+        );
+    }
+
+    private function rememberPublishedPaths(string $packId, string $packVersion, string $releaseId): void
+    {
+        if ($releaseId === '') {
+            return;
+        }
+
+        $this->publishedStoragePaths[] = 'private/packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
+        $this->publishedStoragePaths[] = 'content_packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
+    }
+}

--- a/backend/tests/Feature/Storage/BlobCatalogServiceTest.php
+++ b/backend/tests/Feature/Storage/BlobCatalogServiceTest.php
@@ -142,6 +142,7 @@ final class BlobCatalogServiceTest extends TestCase
 
         $this->assertSame('blobs/sha256/cc/'.$hash, $blob->storage_path);
         $this->assertSame('blobs/sha256/cc/'.$hash, $service->storagePathForHash($hash));
+        $this->assertNotNull($blob->first_seen_at);
         $this->assertDatabaseHas('storage_blobs', [
             'hash' => $hash,
             'storage_path' => 'blobs/sha256/cc/'.$hash,


### PR DESCRIPTION
## Summary

This PR implements PR-13E only: gated `ContentPackV2` rollout metadata dual-write.

The change stays strict additive. It does not change the current V2 physical publish layout, resolver mirror fallback, release `storage_path` semantics, active pointer reads, or any runtime content loading behavior. It only adds optional DB-only metadata side-writes into the rollout catalogs introduced in PR-13C.

When the new rollout flags are off, `ContentPackV2` behaves exactly as it does today.

When the flags are on:

- `publishCompiled()` can catalog V2 compiled files into `storage_blobs`
- `publishCompiled()` can upsert one manifest row plus file-map rows into `content_release_manifests` and `content_release_manifest_files`
- the real active-pointer switch in `activateRelease()` can record `content_release_snapshots`
- `rollbackToRelease()` reuses the same pointer-switch seam and records rollback snapshots against the target release id, not the rollback history row id

## Root cause

Before this PR, the V2 publish/activate chain had stable runtime storage behavior but no rollout metadata linkage.

That left the storage rollout scaffold disconnected from the real V2 lifecycle:

- no blob metadata for compiled V2 files
- no manifest/file-map record tied to the published V2 release
- no snapshot record tied to active-pointer changes

The safe seams were already present in runtime:

- post-publish, after the release row is inserted
- activation, at the real `content_pack_activations` pointer switch

This PR attaches metadata only at those seams and keeps runtime behavior unchanged.

## What changed

`ContentPackV2Publisher` now injects the rollout catalog services and performs gated metadata side-writes.

### Publish seam

After both physical copies succeed and after the release row is inserted, `publishCompiled()` can now:

- scan the primary published `compiled/**` tree only
- catalog each compiled file into `storage_blobs` using the PR-13D hash-derived metadata path rule:
  - `blobs/sha256/{first2}/{hash}`
- upsert a manifest row into `content_release_manifests`
- upsert deterministic file-map rows into `content_release_manifest_files`

Important preserved runtime truths:

- primary physical tree remains `private/packs_v2/.../{releaseId}/compiled`
- mirror physical tree remains `content_packs_v2/.../{releaseId}/compiled`
- the release row still stores the primary root in `content_pack_releases.storage_path`
- no physical `storage/app/private/blobs/**` tree is created

### Activation / rollback seam

`activateRelease()` now routes through a shared internal activation helper that:

- performs the existing `content_pack_activations` pointer switch
- reads the previous active release id
- writes one snapshot row only when the pointer actually changes

`rollbackToRelease()` now reuses that same pointer-switch helper before inserting the rollback history row, so rollback snapshot metadata reflects the actual before/after active release ids and still does not change runtime rollback behavior.

### Safety refinements included in this PR

This PR also tightens two metadata integrity edges:

1. Repeated same-hash publish no longer rebinds the existing manifest row to the later release identity.
   - `content_release_manifests` is still unique by `manifest_hash`
   - but when the same `manifest_hash` is republished, the existing manifest row now preserves the first release id and first storage path instead of being rebound to the later release

2. If any blob catalog write fails during publish, manifest/file-map cataloging is skipped for that publish.
   - runtime publish still succeeds
   - metadata failure is logged as a warning
   - but this avoids writing manifest file-map rows that would reference blob hashes with no corresponding `storage_blobs` row

## Flags

The rollout remains fully gated.

This PR uses these existing flags in `storage_rollout.php`:

- `content_pack_v2_dual_write_enabled`
- `blob_catalog_enabled`
- `manifest_catalog_enabled`
- `snapshot_catalog_enabled`

All remain default `false`.

## Tests

New focused tests:

- `tests/Feature/Content/Packs2MetadataDualWriteTest.php`
- `tests/Feature/Content/Packs2SnapshotDualWriteTest.php`

These cover:

- flags off: no rollout metadata is written
- flags on: publish writes blob + manifest + file-map metadata
- repeated same-hash publish does not duplicate rows and preserves first manifest identity
- blob failure causes manifest/file-map catalog skip without breaking runtime publish
- activate writes snapshot metadata with correct before/after ids
- rollback writes snapshot metadata against the target release id, not the rollback history row id
- no physical `storage/app/private/blobs/**` files are created

Existing compatibility tests kept green:

- `tests/Feature/Content/Packs2DualWritePublishTest.php`
- `tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php`
- `tests/Feature/Storage/BlobCatalogServiceTest.php`
- `tests/Feature/Storage/ContentReleaseManifestCatalogServiceTest.php`
- `tests/Feature/Storage/ContentReleaseSnapshotCatalogServiceTest.php`

## Commands run

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php -l app/Services/Content/Publisher/ContentPackV2Publisher.php
php -l app/Services/Storage/BlobCatalogService.php
php -l app/Services/Storage/ContentReleaseManifestCatalogService.php
php -l app/Services/Storage/ContentReleaseSnapshotCatalogService.php
php -l config/storage_rollout.php

./vendor/bin/pint \
  app/Services/Content/Publisher/ContentPackV2Publisher.php \
  app/Services/Storage/BlobCatalogService.php \
  app/Services/Storage/ContentReleaseManifestCatalogService.php \
  app/Services/Storage/ContentReleaseSnapshotCatalogService.php \
  config/storage_rollout.php \
  tests/Feature/Content/Packs2DualWritePublishTest.php \
  tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php \
  tests/Feature/Storage/BlobCatalogServiceTest.php \
  tests/Feature/Storage/ContentReleaseManifestCatalogServiceTest.php \
  tests/Feature/Storage/ContentReleaseSnapshotCatalogServiceTest.php \
  tests/Feature/Content/Packs2MetadataDualWriteTest.php \
  tests/Feature/Content/Packs2SnapshotDualWriteTest.php

php artisan migrate

vendor/bin/phpunit \
  tests/Feature/Content/Packs2DualWritePublishTest.php \
  tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php \
  tests/Feature/Storage/BlobCatalogServiceTest.php \
  tests/Feature/Storage/ContentReleaseManifestCatalogServiceTest.php \
  tests/Feature/Storage/ContentReleaseSnapshotCatalogServiceTest.php \
  tests/Feature/Content/Packs2MetadataDualWriteTest.php \
  tests/Feature/Content/Packs2SnapshotDualWriteTest.php

php artisan route:list > /tmp/pr13e_route_list.txt
php artisan serve --host=127.0.0.1 --port=18081
curl -i http://127.0.0.1:18081/api/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
```

## Validation results

- `php -l`: passed
- `pint`: passed
- focused PHPUnit suite: `OK (13 tests, 104 assertions)`
- `php artisan migrate`: `Nothing to migrate.`
- `curl -i http://127.0.0.1:18081/api/healthz`: `HTTP/1.1 200 OK`

## Known baseline failure unchanged

`bash backend/scripts/ci_verify_mbti.sh` still fails on the existing MBTI self-check baseline issue:

- `report_dynamic_sections.json :: missing manifest.schemas mapping (asset=dynamic_sections)`

This PR does not touch `content_packages/**` and does not attempt to fix that out-of-scope baseline failure.
