### PR TITLE
[codex] add gated resolver materialization and runtime wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
           mkdir -p storage/framework/views
           mkdir -p storage/framework/sessions
           mkdir -p storage/logs
+          mkdir -p storage/app/private/packs_v2_materialized
           mkdir -p bootstrap/cache
           chmod -R ug+rwX storage bootstrap/cache || true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,6 +155,7 @@ jobs:
           mkdir -p storage/framework/views
           mkdir -p storage/framework/sessions
           mkdir -p storage/logs
+          mkdir -p storage/app/private/packs_v2_materialized
           mkdir -p bootstrap/cache
           chmod -R ug+rwX storage bootstrap/cache || true
 

--- a/backend/app/Services/Content/ContentPackV2Materializer.php
+++ b/backend/app/Services/Content/ContentPackV2Materializer.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class ContentPackV2Materializer
+{
+    public function materialize(object $release, string $sourceCompiledDir): string
+    {
+        $sourceCompiledDir = rtrim(str_replace('\\', '/', trim($sourceCompiledDir)), '/');
+        if ($sourceCompiledDir === '' || ! is_file($sourceCompiledDir.'/manifest.json')) {
+            throw new RuntimeException('PACKS2_MATERIALIZATION_SOURCE_INVALID');
+        }
+
+        $targetRoot = $this->targetRoot($release);
+        $targetCompiledDir = $targetRoot.'/compiled';
+        $sentinelPath = $targetRoot.'/.materialization.json';
+
+        if ($this->isFresh($release, $targetCompiledDir, $sentinelPath)) {
+            return $targetCompiledDir;
+        }
+
+        if (File::isDirectory($targetRoot)) {
+            File::deleteDirectory($targetRoot);
+        }
+
+        File::ensureDirectoryExists(dirname($targetRoot));
+        if (! File::copyDirectory($sourceCompiledDir, $targetCompiledDir)) {
+            throw new RuntimeException('PACKS2_MATERIALIZATION_COPY_FAILED');
+        }
+
+        File::put($sentinelPath, json_encode([
+            'release_id' => $this->releaseId($release),
+            'storage_path' => $this->storagePath($release),
+            'manifest_hash' => $this->manifestHash($release),
+            'source_compiled_dir' => $sourceCompiledDir,
+            'materialized_at' => now()->toIso8601String(),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        if (! is_file($targetCompiledDir.'/manifest.json')) {
+            throw new RuntimeException('PACKS2_MATERIALIZATION_MANIFEST_MISSING');
+        }
+
+        return $targetCompiledDir;
+    }
+
+    public function targetCompiledDir(object $release): string
+    {
+        return $this->targetRoot($release).'/compiled';
+    }
+
+    private function isFresh(object $release, string $targetCompiledDir, string $sentinelPath): bool
+    {
+        if (! is_file($targetCompiledDir.'/manifest.json') || ! is_file($sentinelPath)) {
+            return false;
+        }
+
+        $decoded = json_decode((string) File::get($sentinelPath), true);
+        if (! is_array($decoded)) {
+            return false;
+        }
+
+        return (string) ($decoded['storage_path'] ?? '') === $this->storagePath($release)
+            && (string) ($decoded['manifest_hash'] ?? '') === $this->manifestHash($release);
+    }
+
+    private function targetRoot(object $release): string
+    {
+        $packId = strtoupper(trim((string) ($release->to_pack_id ?? '')));
+        $packVersion = trim((string) ($release->pack_version ?? $release->dir_alias ?? ''));
+        $storageIdentity = $this->storageIdentity($release);
+        $manifestHash = $this->manifestHash($release);
+
+        if ($packId === '' || $packVersion === '' || $storageIdentity === '' || $manifestHash === '') {
+            throw new RuntimeException('PACKS2_MATERIALIZATION_CONTEXT_INVALID');
+        }
+
+        return storage_path('app/private/packs_v2_materialized/'.$packId.'/'.$packVersion.'/'.$storageIdentity.'/'.$manifestHash);
+    }
+
+    private function releaseId(object $release): string
+    {
+        return trim((string) ($release->id ?? ''));
+    }
+
+    private function manifestHash(object $release): string
+    {
+        return strtolower(trim((string) ($release->manifest_hash ?? '')));
+    }
+
+    private function storagePath(object $release): string
+    {
+        return trim((string) ($release->storage_path ?? ''));
+    }
+
+    private function storageIdentity(object $release): string
+    {
+        $storagePath = $this->storagePath($release);
+        if ($storagePath === '') {
+            return '';
+        }
+
+        return hash('sha256', $storagePath);
+    }
+}

--- a/backend/app/Services/Content/ContentPackV2Resolver.php
+++ b/backend/app/Services/Content/ContentPackV2Resolver.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace App\Services\Content;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 final class ContentPackV2Resolver
 {
+    public function __construct(
+        private readonly ContentPackV2Materializer $materializer,
+    ) {}
+
     public function resolveActiveCompiledPath(string $packId, string $packVersion): ?string
     {
         $packId = strtoupper(trim($packId));
@@ -85,11 +91,32 @@ final class ContentPackV2Resolver
         foreach ($roots as $root) {
             $compiledDir = is_dir($root.'/compiled') ? $root.'/compiled' : $root;
             if (is_file($compiledDir.'/manifest.json')) {
-                return $compiledDir;
+                if (! $this->shouldMaterialize()) {
+                    return $compiledDir;
+                }
+
+                try {
+                    return $this->materializer->materialize($release, $compiledDir);
+                } catch (Throwable $e) {
+                    Log::warning('PACKS2_RESOLVER_MATERIALIZATION_FAILED', [
+                        'release_id' => trim((string) ($release->id ?? '')),
+                        'manifest_hash' => strtolower(trim((string) ($release->manifest_hash ?? ''))),
+                        'storage_path' => $storagePath,
+                        'source_compiled_dir' => $compiledDir,
+                        'error' => $e->getMessage(),
+                    ]);
+
+                    return $compiledDir;
+                }
             }
         }
 
         return null;
+    }
+
+    private function shouldMaterialize(): bool
+    {
+        return (bool) config('storage_rollout.resolver_materialization_enabled', false);
     }
 
     /**

--- a/backend/scripts/release_pack.sh
+++ b/backend/scripts/release_pack.sh
@@ -71,6 +71,7 @@ rm -rf "${STAGING_DIR}/.git" \
        "${STAGING_DIR}/backend/storage/app/private/reports" \
        "${STAGING_DIR}/backend/storage/app/private/artifacts" \
        "${STAGING_DIR}/backend/storage/app/private/packs_v2" \
+       "${STAGING_DIR}/backend/storage/app/private/packs_v2_materialized" \
        "${STAGING_DIR}/backend/storage/app/content_packs_v2" \
        "${STAGING_DIR}/backend/storage/app/private/prune_plans"
 
@@ -90,6 +91,7 @@ find "${STAGING_DIR}" -type f -name '*.sqlite*' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/reports' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/artifacts' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/packs_v2' -print >> "$HITS_FILE"
+find "${STAGING_DIR}" -type d -path '*/storage/app/private/packs_v2_materialized' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/content_packs_v2' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/prune_plans' -print >> "$HITS_FILE"
 

--- a/backend/tests/Feature/ReleasePackScriptContractTest.php
+++ b/backend/tests/Feature/ReleasePackScriptContractTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+final class ReleasePackScriptContractTest extends TestCase
+{
+    public function test_release_pack_blacklist_covers_packs_v2_materialized_runtime_tree(): void
+    {
+        $scriptPath = base_path('scripts/release_pack.sh');
+        $this->assertFileExists($scriptPath);
+
+        $script = (string) file_get_contents($scriptPath);
+
+        $this->assertStringContainsString(
+            '"${STAGING_DIR}/backend/storage/app/private/packs_v2_materialized"',
+            $script
+        );
+
+        $this->assertStringContainsString(
+            "find \"\${STAGING_DIR}\" -type d -path '*/storage/app/private/packs_v2_materialized' -print >> \"\$HITS_FILE\"",
+            $script
+        );
+    }
+}

--- a/backend/tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php
+++ b/backend/tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Content;
+
+use App\Services\Content\ContentPackV2Resolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ContentPackV2ResolverMaterializationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-packs2-materialization-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath);
+        $this->app->useStoragePath($this->isolatedStoragePath);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->app->useStoragePath($this->originalStoragePath);
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_flags_disabled_resolver_returns_today_source_path_without_materializing(): void
+    {
+        $releaseId = (string) Str::uuid();
+        $manifestHash = str_repeat('a', 64);
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $sourceCompiledDir = storage_path('app/'.$storagePath.'/compiled');
+
+        $this->insertRelease($releaseId, $manifestHash, $storagePath);
+        $this->activateRelease($releaseId);
+        $this->writeCompiledTree($sourceCompiledDir, [
+            'manifest.json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'questions.compiled.json' => '{"source":"primary"}',
+        ]);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1');
+
+        $this->assertSame($sourceCompiledDir, $resolved);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/packs_v2_materialized'));
+    }
+
+    public function test_flags_enabled_resolver_materializes_from_primary_and_reuses_fresh_target(): void
+    {
+        config()->set('storage_rollout.resolver_materialization_enabled', true);
+
+        $releaseId = (string) Str::uuid();
+        $manifestHash = str_repeat('b', 64);
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $sourceCompiledDir = storage_path('app/'.$storagePath.'/compiled');
+
+        $this->insertRelease($releaseId, $manifestHash, $storagePath);
+        $this->activateRelease($releaseId);
+        $this->writeCompiledTree($sourceCompiledDir, [
+            'manifest.json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'questions.compiled.json' => '{"source":"primary"}',
+        ]);
+
+        $storageIdentity = hash('sha256', $storagePath);
+        $expectedMaterializedDir = storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.$storageIdentity.'/'.$manifestHash.'/compiled');
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $firstResolved = $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1');
+
+        $this->assertSame($expectedMaterializedDir, $firstResolved);
+        $this->assertFileExists($expectedMaterializedDir.'/manifest.json');
+        $this->assertSame('{"source":"primary"}', (string) File::get($expectedMaterializedDir.'/questions.compiled.json'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+
+        $targetRoot = dirname($expectedMaterializedDir);
+        File::put($targetRoot.'/marker.txt', 'keep-me');
+
+        $secondResolved = $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1');
+
+        $this->assertSame($expectedMaterializedDir, $secondResolved);
+        $this->assertFileExists($targetRoot.'/marker.txt');
+    }
+
+    public function test_flags_enabled_materializes_from_mirror_and_replaces_stale_target_when_sentinel_mismatches(): void
+    {
+        config()->set('storage_rollout.resolver_materialization_enabled', true);
+
+        $releaseId = (string) Str::uuid();
+        $manifestHash = str_repeat('c', 64);
+        $primaryStoragePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $mirrorStoragePath = 'content_packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $mirrorCompiledDir = storage_path('app/'.$mirrorStoragePath.'/compiled');
+
+        $this->insertRelease($releaseId, $manifestHash, $primaryStoragePath);
+        $this->writeCompiledTree($mirrorCompiledDir, [
+            'manifest.json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'questions.compiled.json' => '{"source":"mirror"}',
+        ]);
+
+        $storageIdentity = hash('sha256', $primaryStoragePath);
+        $targetRoot = storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.$storageIdentity.'/'.$manifestHash);
+        $staleCompiledDir = $targetRoot.'/compiled';
+        $this->writeCompiledTree($staleCompiledDir, [
+            'manifest.json' => '{"compiled_hash":"stale"}',
+            'questions.compiled.json' => '{"source":"stale"}',
+        ]);
+        File::put($targetRoot.'/.materialization.json', json_encode([
+            'release_id' => 'stale-release',
+            'manifest_hash' => 'stale-hash',
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $manifestHash);
+
+        $this->assertSame($staleCompiledDir, $resolved);
+        $this->assertSame('{"source":"mirror"}', (string) File::get($staleCompiledDir.'/questions.compiled.json'));
+        $this->assertStringContainsString($releaseId, (string) File::get($targetRoot.'/.materialization.json'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    public function test_flags_enabled_reuses_materialized_target_for_latest_history_row_with_same_storage_path_and_manifest_hash(): void
+    {
+        config()->set('storage_rollout.resolver_materialization_enabled', true);
+
+        $releaseId = (string) Str::uuid();
+        $historyRowId = (string) Str::uuid();
+        $manifestHash = str_repeat('d', 64);
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/source-tree-1';
+        $sourceCompiledDir = storage_path('app/'.$storagePath.'/compiled');
+        $storageIdentity = hash('sha256', $storagePath);
+        $expectedMaterializedDir = storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.$storageIdentity.'/'.$manifestHash.'/compiled');
+
+        $this->insertRelease($releaseId, $manifestHash, $storagePath, createdAt: now()->subMinute());
+        $this->insertRelease($historyRowId, $manifestHash, $storagePath, action: 'packs2_rollback', createdAt: now());
+        $this->writeCompiledTree($sourceCompiledDir, [
+            'manifest.json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'questions.compiled.json' => '{"source":"shared-tree"}',
+        ]);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $manifestHash);
+
+        $this->assertSame($expectedMaterializedDir, $resolved);
+        $this->assertSame('{"source":"shared-tree"}', (string) File::get($expectedMaterializedDir.'/questions.compiled.json'));
+
+        $sentinel = json_decode((string) File::get(dirname($expectedMaterializedDir).'/.materialization.json'), true);
+        $this->assertIsArray($sentinel);
+        $this->assertSame($storagePath, (string) ($sentinel['storage_path'] ?? ''));
+        $this->assertSame($historyRowId, (string) ($sentinel['release_id'] ?? ''));
+    }
+
+    private function insertRelease(
+        string $releaseId,
+        string $manifestHash,
+        string $storagePath,
+        string $action = 'packs2_publish',
+        mixed $createdAt = null,
+    ): void {
+        $createdAt ??= now();
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => $action,
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v1',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => 'test',
+            'created_by' => 'test',
+            'manifest_hash' => $manifestHash,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => null,
+            'norms_version' => null,
+            'git_sha' => null,
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $storagePath,
+            'source_commit' => null,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ]);
+    }
+
+    private function activateRelease(string $releaseId): void
+    {
+        DB::table('content_pack_activations')->updateOrInsert(
+            [
+                'pack_id' => 'BIG5_OCEAN',
+                'pack_version' => 'v1',
+            ],
+            [
+                'release_id' => $releaseId,
+                'activated_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function writeCompiledTree(string $compiledDir, array $files): void
+    {
+        File::ensureDirectoryExists($compiledDir);
+
+        foreach ($files as $relativePath => $contents) {
+            $absolutePath = $compiledDir.'/'.ltrim($relativePath, '/');
+            File::ensureDirectoryExists(dirname($absolutePath));
+            File::put($absolutePath, $contents);
+        }
+    }
+}

--- a/backend/tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php
+++ b/backend/tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php
@@ -59,6 +59,7 @@ final class ContentPackV2ResolverPathFallbackTest extends TestCase
         $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $manifestHash);
 
         $this->assertSame($mirrorCompiledDir, $resolved);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/packs_v2_materialized'));
 
         File::deleteDirectory(storage_path('app/private/packs_v2/BIG5_OCEAN/v1/'.$releaseId));
         File::deleteDirectory(storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId));

--- a/deploy.php
+++ b/deploy.php
@@ -243,6 +243,9 @@ task('ensure:healthz-deps', function () {
     run("mkdir -p {$base}/app/content-packs");
     run("chmod 2775 {$base}/app/content-packs");
 
+    run("mkdir -p {$base}/app/private/packs_v2_materialized");
+    run("chmod 2775 {$base}/app/private/packs_v2_materialized");
+
     run("mkdir -p {$base}/framework/cache {$base}/framework/sessions {$base}/framework/views {$base}/logs");
     run("chmod 2775 {$base}/framework/cache {$base}/framework/sessions {$base}/framework/views {$base}/logs");
 });


### PR DESCRIPTION
## Summary

This PR implements PR-13F only: gated resolver materialization plus the minimum runtime wiring for the new materialized V2 content directory.

The change stays strict additive. It does not change the existing V2 publish layout, `content_pack_releases.storage_path` semantics, primary/mirror fallback order, or any business API behavior. When `storage_rollout.resolver_materialization_enabled` is off, resolver behavior remains identical to today.

When the flag is on, `ContentPackV2Resolver` now performs read-through materialization after it has already resolved the same real source compiled directory that today's runtime would have used. It then returns a real materialized compiled directory under `storage/app/private/packs_v2_materialized/.../compiled`.

## Root cause

PR-13E added rollout metadata, but the V2 runtime still read directly from the primary/mirror physical release tree. There was no runtime cache layer that could safely materialize a compiled directory for future rollout work.

The safe boundary identified in the scan was:

- keep the existing release lookup logic unchanged
- keep the existing primary -> mirror physical fallback unchanged
- only materialize after the resolver has already selected the same source compiled directory that today's runtime would use
- treat materialization as best-effort: on failure, log and fall back to the old resolved path

## What changed

### Resolver materialization

`ContentPackV2Resolver` now delegates to a small `ContentPackV2Materializer` service at the end of `resolveCompiledPathFromRelease()`.

Behavior:

- flag off: return today's source compiled dir unchanged
- flag on: materialize from the resolved source compiled dir and return the materialized compiled dir
- materialization failure: log a warning and return the original source compiled dir

### Source-of-bytes truth

This PR does not introduce any physical blob reads.

Materialization bytes still come only from the existing V2 physical release tree:

- primary tree first
- mirror tree only if primary is missing

The rollout metadata created in PR-13E remains advisory only. It is not used as a byte source.

### Materialized directory contract

The materialized target is now:

`storage/app/private/packs_v2_materialized/{pack_id}/{pack_version}/{sha256(storage_path)}/{manifest_hash}/compiled`

This keeps the cache identity closer to the real source tree instead of the transient release row id. That matters for rollback history rows, which can reuse the same `storage_path` and `manifest_hash` while introducing a newer `content_pack_releases.id`.

The materializer writes a `.materialization.json` sentinel at the target root and reuses the target only when:

- `compiled/manifest.json` exists
- the sentinel exists
- `storage_path` matches
- `manifest_hash` matches

Otherwise it replaces the whole target directory.

### Deploy / package wiring

This PR adds the minimum wiring for the new runtime cache directory:

- `deploy.php`: ensure `backend/storage/app/private/packs_v2_materialized` exists during deploy healthz prep
- `.github/workflows/ci.yml`: create the materialized runtime dir in CI prep
- `.github/workflows/deploy.yml`: create the materialized runtime dir in deploy workflow prep
- `backend/scripts/release_pack.sh`: blacklist and hard-gate `backend/storage/app/private/packs_v2_materialized` so runtime cache data never enters the release package

### Test coverage

New focused coverage:

- `tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php`
  - flags off returns today's source dir
  - flags on materializes from primary and reuses a fresh target
  - flags on falls back to mirror as source and replaces stale target content
  - same `storage_path` + `manifest_hash` across later history rows reuses the same materialized target
  - no physical `storage/app/private/blobs/**` tree is created

- `tests/Feature/ReleasePackScriptContractTest.php`
  - locks the `release_pack.sh` blacklist cleanup and hard gate for `packs_v2_materialized`

Existing tests kept green:

- `tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php`
- `tests/Feature/Content/Packs2DualWritePublishTest.php`
- `tests/Feature/Content/Packs2MetadataDualWriteTest.php`
- `tests/Feature/Content/Packs2SnapshotDualWriteTest.php`

## Commands run

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php -l app/Services/Content/ContentPackV2Resolver.php
php -l app/Services/Content/ContentPackV2Materializer.php
php -l config/storage_rollout.php
php -l tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php
php -l tests/Feature/ReleasePackScriptContractTest.php

./vendor/bin/pint \
  app/Services/Content/ContentPackV2Resolver.php \
  app/Services/Content/ContentPackV2Materializer.php \
  config/storage_rollout.php \
  tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php \
  tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php \
  tests/Feature/Content/Packs2DualWritePublishTest.php \
  tests/Feature/Content/Packs2MetadataDualWriteTest.php \
  tests/Feature/Content/Packs2SnapshotDualWriteTest.php \
  tests/Feature/ReleasePackScriptContractTest.php

bash -n scripts/release_pack.sh
php artisan migrate

vendor/bin/phpunit \
  tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php \
  tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php \
  tests/Feature/ReleasePackScriptContractTest.php \
  tests/Feature/Content/Packs2DualWritePublishTest.php \
  tests/Feature/Content/Packs2MetadataDualWriteTest.php \
  tests/Feature/Content/Packs2SnapshotDualWriteTest.php

php artisan route:list > /tmp/pr13f_route_list.txt
php artisan serve --host=127.0.0.1 --port=18081
curl -i http://127.0.0.1:18081/api/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
```

## Validation

- focused PHPUnit suite: `OK (12 tests, 87 assertions)`
- `php artisan migrate`: `Nothing to migrate.`
- `curl -i http://127.0.0.1:18081/api/healthz`: `HTTP/1.1 200 OK`
- `bash -n scripts/release_pack.sh`: passed

## Known baseline failure unchanged

`bash backend/scripts/ci_verify_mbti.sh` still fails on the existing content-package self-check baseline:

- `report_dynamic_sections.json :: missing manifest.schemas mapping (asset=dynamic_sections)`

This PR does not touch `content_packages/**` and does not attempt to fix that out-of-scope baseline issue.
