### PR TITLE
[codex] Ship MBTI Phase 7B user state layer and dynamic orchestration (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -14,6 +14,7 @@ use App\Services\Attempts\AttemptSubmissionService;
 use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
+use App\Services\Mbti\MbtiUserStateOrchestrationService;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
@@ -39,6 +40,7 @@ class AttemptReadController extends Controller
         private ReportPdfDocumentService $reportPdfDocumentService,
         private MbtiPublicProjectionService $mbtiPublicProjectionService,
         private MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
+        private MbtiUserStateOrchestrationService $mbtiUserStateOrchestrationService,
         private MbtiAccessHubBuilder $mbtiAccessHubBuilder,
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
@@ -132,6 +134,7 @@ class AttemptReadController extends Controller
                 'sections' => is_array($report['sections'] ?? null) ? $report['sections'] : [],
             ];
 
+            $request->merge(['attempt_id' => $attemptId]);
             $this->eventRecorder->recordFromRequest($request, 'result_view', $this->resolveUserId($request), [
                 'scale_code' => $scaleCode,
                 'pack_id' => $packId,
@@ -194,6 +197,7 @@ class AttemptReadController extends Controller
             ? $this->resolveMbtiResultViewEventMeta($request, $result, $attempt, $attemptId)
             : [];
 
+        $request->merge(['attempt_id' => $attemptId]);
         $this->eventRecorder->recordFromRequest($request, 'result_view', $this->resolveUserId($request), [
             'scale_code' => $scaleCode,
             'pack_id' => $packId,
@@ -331,10 +335,24 @@ class AttemptReadController extends Controller
             );
         }
 
-        $mbtiEventMeta = $scaleCode === 'MBTI'
-            ? $this->resolveMbtiEventMetaFromReportEnvelope($result, $attempt, $responsePayload)
+        $effectiveMbtiPersonalization = $scaleCode === 'MBTI'
+            ? $this->resolveEffectiveMbtiPersonalization(
+                $result,
+                $attempt,
+                $responsePayload,
+                ! ((bool) ($gate['locked'] ?? false))
+            )
             : [];
 
+        if ($effectiveMbtiPersonalization !== []) {
+            $responsePayload = $this->applyMbtiPersonalizationToEnvelope($responsePayload, $effectiveMbtiPersonalization);
+        }
+
+        $mbtiEventMeta = $scaleCode === 'MBTI'
+            ? $this->mbtiTelemetryMetaFromPersonalization($effectiveMbtiPersonalization)
+            : [];
+
+        $request->merge(['attempt_id' => (string) $attempt->id]);
         $this->eventRecorder->recordFromRequest($request, 'report_view', $this->resolveUserId($request), [
             'scale_code' => (string) ($attempt->scale_code ?? ''),
             'pack_id' => (string) ($attempt->pack_id ?? ''),
@@ -488,7 +506,12 @@ class AttemptReadController extends Controller
         array $reportEnvelope
     ): array {
         return $this->mbtiTelemetryMetaFromPersonalization(
-            $this->resolveMbtiPersonalizationFromReportEnvelope($result, $attempt, $reportEnvelope)
+            $this->resolveEffectiveMbtiPersonalization(
+                $result,
+                $attempt,
+                $reportEnvelope,
+                ! ((bool) data_get($reportEnvelope, 'locked', false))
+            )
         );
     }
 
@@ -533,6 +556,8 @@ class AttemptReadController extends Controller
             'relationship_action_keys' => is_array($personalization['relationship_action_keys'] ?? null) ? $personalization['relationship_action_keys'] : [],
             'work_experiment_keys' => is_array($personalization['work_experiment_keys'] ?? null) ? $personalization['work_experiment_keys'] : [],
             'watchout_keys' => is_array($personalization['watchout_keys'] ?? null) ? $personalization['watchout_keys'] : [],
+            'user_state' => is_array($personalization['user_state'] ?? null) ? $personalization['user_state'] : [],
+            'orchestration' => is_array($personalization['orchestration'] ?? null) ? $personalization['orchestration'] : [],
             'engine_version' => trim((string) ($personalization['engine_version'] ?? '')),
         ];
 
@@ -592,6 +617,57 @@ class AttemptReadController extends Controller
         $projectionPersonalization = data_get($projection, '_meta.personalization');
 
         return is_array($projectionPersonalization) ? $projectionPersonalization : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $reportEnvelope
+     * @return array<string,mixed>
+     */
+    private function resolveEffectiveMbtiPersonalization(
+        Result $result,
+        Attempt $attempt,
+        array $reportEnvelope,
+        bool $hasUnlock
+    ): array {
+        $personalization = $this->resolveMbtiPersonalizationFromReportEnvelope($result, $attempt, $reportEnvelope);
+        if ($personalization === []) {
+            return [];
+        }
+
+        return $this->mbtiUserStateOrchestrationService->overlayEffective(
+            $personalization,
+            (int) ($attempt->org_id ?? 0),
+            (string) ($attempt->id ?? ''),
+            $hasUnlock
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $reportEnvelope
+     * @param  array<string,mixed>  $personalization
+     * @return array<string,mixed>
+     */
+    private function applyMbtiPersonalizationToEnvelope(array $reportEnvelope, array $personalization): array
+    {
+        if ($personalization === []) {
+            return $reportEnvelope;
+        }
+
+        if (is_array(data_get($reportEnvelope, 'report'))) {
+            $reportMeta = is_array(data_get($reportEnvelope, 'report._meta')) ? data_get($reportEnvelope, 'report._meta') : [];
+            $reportMeta['personalization'] = $personalization;
+            data_set($reportEnvelope, 'report._meta', $reportMeta);
+        }
+
+        if (is_array(data_get($reportEnvelope, 'mbti_public_projection_v1'))) {
+            $projectionMeta = is_array(data_get($reportEnvelope, 'mbti_public_projection_v1._meta'))
+                ? data_get($reportEnvelope, 'mbti_public_projection_v1._meta')
+                : [];
+            $projectionMeta['personalization'] = $personalization;
+            data_set($reportEnvelope, 'mbti_public_projection_v1._meta', $projectionMeta);
+        }
+
+        return $reportEnvelope;
     }
 
     private function isPublicResultScale(string $scaleCode): bool
@@ -693,6 +769,7 @@ class AttemptReadController extends Controller
         $inline = in_array(strtolower(trim((string) $request->query('inline', '0'))), ['1', 'true', 'yes', 'on'], true);
         $disposition = $inline ? 'inline' : 'attachment';
 
+        $request->merge(['attempt_id' => (string) $attempt->id]);
         $this->eventRecorder->recordFromRequest($request, 'report_pdf_view', $this->resolveUserId($request), [
             'scale_code' => (string) ($attempt->scale_code ?? ''),
             'pack_id' => (string) ($attempt->pack_id ?? ''),

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -566,6 +566,7 @@ final class MbtiResultPersonalizationService
 
     public function __construct(
         private readonly ContentPacksIndex $packsIndex,
+        private readonly MbtiUserStateOrchestrationService $userStateOrchestrationService,
     ) {
     }
 
@@ -652,8 +653,8 @@ final class MbtiResultPersonalizationService
             $variantKeys[$sectionKey] = (string) ($variant['variant_key'] ?? '');
         }
 
-        return [
-            'schema_version' => 'mbti.personalization.phase7a.v1',
+        return $this->userStateOrchestrationService->withBaseline([
+            'schema_version' => 'mbti.personalization.phase7b.v1',
             'locale' => $locale,
             'type_code' => $typeCode,
             'identity' => $identity,
@@ -688,7 +689,7 @@ final class MbtiResultPersonalizationService
             'engine_version' => trim((string) ($context['engine_version'] ?? data_get($reportPayload, 'versions.engine', ''))),
             'content_package_dir' => trim((string) ($context['dir_version'] ?? data_get($reportPayload, 'versions.dir_version', ''))),
             'dynamic_sections_version' => trim((string) ($dynamicDoc['version'] ?? '')),
-        ];
+        ], (bool) ($context['has_unlock'] ?? false));
     }
 
     /**

--- a/backend/app/Services/Mbti/MbtiUserStateOrchestrationService.php
+++ b/backend/app/Services/Mbti/MbtiUserStateOrchestrationService.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti;
+
+use Illuminate\Support\Facades\DB;
+
+final class MbtiUserStateOrchestrationService
+{
+    /**
+     * @var array<string, list<string>>
+     */
+    private const CHAPTER_SECTIONS = [
+        'career' => [
+            'career.summary',
+            'career.collaboration_fit',
+            'career.work_environment',
+            'career.work_experiments',
+            'career.advantages',
+            'career.weaknesses',
+            'career.preferred_roles',
+            'career.next_step',
+            'career.upgrade_suggestions',
+        ],
+        'growth' => [
+            'growth.summary',
+            'growth.stability_confidence',
+            'growth.next_actions',
+            'growth.weekly_experiments',
+            'growth.strengths',
+            'growth.weaknesses',
+            'growth.stress_recovery',
+            'growth.watchouts',
+            'growth.motivators',
+            'growth.drainers',
+        ],
+        'traits' => [
+            'letters_intro',
+            'overview',
+            'trait_overview',
+            'traits.why_this_type',
+            'traits.close_call_axes',
+            'traits.adjacent_type_contrast',
+            'traits.decision_style',
+        ],
+        'relationships' => [
+            'relationships.summary',
+            'relationships.strengths',
+            'relationships.weaknesses',
+            'relationships.communication_style',
+            'relationships.try_this_week',
+            'relationships.rel_advantages',
+            'relationships.rel_risks',
+        ],
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const SECTION_FOCUS_FIRST_VIEW = [
+        'traits.close_call_axes',
+        'traits.adjacent_type_contrast',
+        'career.work_experiments',
+        'relationships.try_this_week',
+        'growth.watchouts',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const SECTION_FOCUS_REVISIT = [
+        'career.work_experiments',
+        'relationships.try_this_week',
+        'growth.watchouts',
+        'traits.close_call_axes',
+        'traits.adjacent_type_contrast',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ACTION_SECTION_KEYS = [
+        'growth.next_actions',
+        'growth.weekly_experiments',
+        'relationships.try_this_week',
+        'career.work_experiments',
+        'growth.watchouts',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @return array<string, mixed>
+     */
+    public function withBaseline(array $personalization, bool $hasUnlock): array
+    {
+        if ($personalization === []) {
+            return [];
+        }
+
+        $userState = [
+            'is_first_view' => true,
+            'is_revisit' => false,
+            'has_unlock' => $hasUnlock,
+            'has_feedback' => false,
+            'has_share' => false,
+            'has_action_engagement' => false,
+        ];
+
+        return $this->mergeAuthority($personalization, $userState);
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @return array<string, mixed>
+     */
+    public function overlayEffective(array $personalization, int $orgId, string $attemptId, bool $hasUnlock): array
+    {
+        if ($personalization === []) {
+            return [];
+        }
+
+        if ($attemptId === '') {
+            return $this->withBaseline($personalization, $hasUnlock);
+        }
+
+        $isRevisit = $this->attemptHasAnyEvent($orgId, $attemptId, ['result_view', 'report_view']);
+        $hasFeedback = $this->attemptHasAnyEvent($orgId, $attemptId, ['accuracy_feedback']);
+        $hasShare = $this->attemptHasAnyEvent($orgId, $attemptId, ['share_result']) || $this->attemptHasShareRow($attemptId);
+        $hasActionEngagement = $this->attemptHasActionEngagement($orgId, $attemptId);
+
+        $userState = [
+            'is_first_view' => ! $isRevisit,
+            'is_revisit' => $isRevisit,
+            'has_unlock' => $hasUnlock,
+            'has_feedback' => $hasFeedback,
+            'has_share' => $hasShare,
+            'has_action_engagement' => $hasActionEngagement,
+        ];
+
+        return $this->mergeAuthority($personalization, $userState);
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @param  array<string, bool>  $userState
+     * @return array<string, mixed>
+     */
+    private function mergeAuthority(array $personalization, array $userState): array
+    {
+        $primaryFocusKey = $this->resolvePrimaryFocusKey($personalization, $userState);
+        $secondaryFocusKeys = $this->resolveSecondaryFocusKeys($primaryFocusKey, $userState);
+
+        return array_merge($personalization, [
+            'user_state' => $userState,
+            'orchestration' => [
+                'ordered_section_keys' => $this->resolveOrderedSectionKeys($primaryFocusKey, $secondaryFocusKeys),
+                'primary_focus_key' => $primaryFocusKey,
+                'secondary_focus_keys' => $secondaryFocusKeys,
+                'cta_priority_keys' => $this->resolveCtaPriorityKeys($userState),
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @param  array<string, bool>  $userState
+     */
+    private function resolvePrimaryFocusKey(array $personalization, array $userState): string
+    {
+        if (($userState['has_feedback'] ?? false) && $this->isLowConfidencePath($personalization)) {
+            return 'growth.stability_confidence';
+        }
+
+        if (($userState['is_revisit'] ?? false) === false) {
+            return ($userState['has_unlock'] ?? false) ? 'career.next_step' : 'growth.next_actions';
+        }
+
+        if ($userState['has_action_engagement'] ?? false) {
+            return 'growth.watchouts';
+        }
+
+        return 'growth.weekly_experiments';
+    }
+
+    /**
+     * @param  array<string, bool>  $userState
+     * @return list<string>
+     */
+    private function resolveSecondaryFocusKeys(string $primaryFocusKey, array $userState): array
+    {
+        $candidates = ($userState['is_revisit'] ?? false) ? self::SECTION_FOCUS_REVISIT : self::SECTION_FOCUS_FIRST_VIEW;
+        $selected = [];
+
+        foreach ($candidates as $candidate) {
+            if ($candidate === $primaryFocusKey || in_array($candidate, $selected, true)) {
+                continue;
+            }
+
+            $selected[] = $candidate;
+            if (count($selected) >= 2) {
+                break;
+            }
+        }
+
+        return $selected;
+    }
+
+    /**
+     * @param  list<string>  $secondaryFocusKeys
+     * @return list<string>
+     */
+    private function resolveOrderedSectionKeys(string $primaryFocusKey, array $secondaryFocusKeys): array
+    {
+        $ordered = [];
+
+        foreach (self::CHAPTER_SECTIONS as $sections) {
+            $chapterSections = $sections;
+
+            if (in_array($primaryFocusKey, $chapterSections, true)) {
+                $chapterSections = $this->promoteSection($chapterSections, $primaryFocusKey, 0);
+            }
+
+            $insertionIndex = in_array($primaryFocusKey, $chapterSections, true) ? 1 : 0;
+            foreach ($secondaryFocusKeys as $secondaryFocusKey) {
+                if (! in_array($secondaryFocusKey, $chapterSections, true)) {
+                    continue;
+                }
+
+                $chapterSections = $this->promoteSection($chapterSections, $secondaryFocusKey, $insertionIndex);
+                $insertionIndex++;
+            }
+
+            $ordered = array_merge($ordered, $chapterSections);
+        }
+
+        return array_values(array_unique(array_filter($ordered)));
+    }
+
+    /**
+     * @param  array<string, bool>  $userState
+     * @return list<string>
+     */
+    private function resolveCtaPriorityKeys(array $userState): array
+    {
+        $hasUnlock = (bool) ($userState['has_unlock'] ?? false);
+        $isRevisit = (bool) ($userState['is_revisit'] ?? false);
+        $hasFeedback = (bool) ($userState['has_feedback'] ?? false);
+        $hasShare = (bool) ($userState['has_share'] ?? false);
+        $hasActionEngagement = (bool) ($userState['has_action_engagement'] ?? false);
+
+        if (! $hasUnlock) {
+            if ($isRevisit && ($hasFeedback || $hasShare)) {
+                return ['career_bridge', 'unlock_full_report', 'share_result'];
+            }
+
+            return ['unlock_full_report', 'career_bridge', 'share_result'];
+        }
+
+        if ($isRevisit && $hasActionEngagement) {
+            return ['career_bridge', 'workspace_lite', 'share_result'];
+        }
+
+        return ['career_bridge', 'share_result', 'workspace_lite'];
+    }
+
+    /**
+     * @param  list<string>  $sections
+     * @return list<string>
+     */
+    private function promoteSection(array $sections, string $target, int $position): array
+    {
+        $remaining = array_values(array_filter($sections, static fn (string $section): bool => $section !== $target));
+        array_splice($remaining, max(0, min($position, count($remaining))), 0, [$target]);
+
+        return $remaining;
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     */
+    private function isLowConfidencePath(array $personalization): bool
+    {
+        foreach ((array) ($personalization['confidence_or_stability_keys'] ?? []) as $key) {
+            $normalized = strtolower(trim((string) $key));
+            if ($normalized === '') {
+                continue;
+            }
+
+            if (str_contains($normalized, 'context_sensitive') || str_contains($normalized, 'mixed')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string>  $eventCodes
+     */
+    private function attemptHasAnyEvent(int $orgId, string $attemptId, array $eventCodes): bool
+    {
+        if ($eventCodes === []) {
+            return false;
+        }
+
+        return DB::table('events')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->whereIn('event_code', $eventCodes)
+            ->exists();
+    }
+
+    private function attemptHasShareRow(string $attemptId): bool
+    {
+        return DB::table('shares')
+            ->where('attempt_id', $attemptId)
+            ->exists();
+    }
+
+    private function attemptHasActionEngagement(int $orgId, string $attemptId): bool
+    {
+        $rows = DB::table('events')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->where('event_code', 'ui_card_interaction')
+            ->orderByDesc('occurred_at')
+            ->limit(25)
+            ->pluck('meta_json');
+
+        foreach ($rows as $rawMeta) {
+            $meta = $this->normalizeMetaJson($rawMeta);
+            $sectionKey = trim((string) ($meta['sectionKey'] ?? $meta['section_key'] ?? ''));
+            $actionKey = trim((string) ($meta['actionKey'] ?? $meta['action_key'] ?? ''));
+
+            if ($actionKey !== '' || in_array($sectionKey, self::ACTION_SECTION_KEYS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeMetaJson(mixed $rawMeta): array
+    {
+        if (is_array($rawMeta)) {
+            return $rawMeta;
+        }
+
+        if (is_string($rawMeta) && $rawMeta !== '') {
+            $decoded = json_decode($rawMeta, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+}

--- a/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php
+++ b/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php
@@ -202,6 +202,11 @@ trait ReportPayloadAssemblerComposeFinalizeTrait
                 'dir_version' => $contentPackageDir,
                 'locale' => $locale,
                 'engine_version' => $reportEngineVersion !== '' ? $reportEngineVersion : (string) data_get($reportPayload, 'versions.engine', 'v1.2'),
+                'has_unlock' => in_array(
+                    strtolower(trim((string) ($input['reportAccessLevel'] ?? ''))),
+                    ['paid', 'full'],
+                    true
+                ) || strtolower(trim((string) ($input['variant'] ?? ''))) === 'full',
             ]);
 
             if ($personalization !== []) {

--- a/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+++ b/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
@@ -96,7 +96,7 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
 
         $this->assertTrue((bool) ($payload['ok'] ?? false));
         $this->assertSame(
-            'mbti.personalization.phase7a.v1',
+            'mbti.personalization.phase7b.v1',
             data_get($payload, 'report._meta.personalization.schema_version')
         );
         $this->assertSame(
@@ -104,8 +104,23 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             data_get($payload, 'report._meta.personalization.engine_version')
         );
         $this->assertSame(
-            'phase7a.v1',
+            'phase7b.v1',
             data_get($payload, 'report._meta.personalization.dynamic_sections_version')
+        );
+        $this->assertSame(
+            [
+                'is_first_view' => true,
+                'is_revisit' => false,
+                'has_unlock' => false,
+                'has_feedback' => false,
+                'has_share' => false,
+                'has_action_engagement' => false,
+            ],
+            data_get($payload, 'report._meta.personalization.user_state')
+        );
+        $this->assertSame(
+            'growth.next_actions',
+            data_get($payload, 'report._meta.personalization.orchestration.primary_focus_key')
         );
         $this->assertNotSame(
             '',
@@ -315,12 +330,16 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             ->first(static fn (array $section): bool => (string) ($section['key'] ?? '') === 'relationships.try_this_week');
 
         $this->assertSame(
-            'mbti.personalization.phase7a.v1',
+            'mbti.personalization.phase7b.v1',
             data_get($projection, '_meta.personalization.schema_version')
         );
         $this->assertSame(
-            'phase7a.v1',
+            'phase7b.v1',
             data_get($projection, '_meta.personalization.dynamic_sections_version')
+        );
+        $this->assertSame(
+            'growth.next_actions',
+            data_get($projection, '_meta.personalization.orchestration.primary_focus_key')
         );
         $this->assertSame(
             'overview:EI.E.clear:identity.T:boundary.none',

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -25,6 +25,7 @@ class MbtiResultTelemetryContractTest extends TestCase
 
         $anonId = 'mbti_phase3a_anon';
         $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $this->seedPhase7bSignals($attemptId);
 
         $resultResponse = $this->invokeController('result', $attemptId, $anonId);
         $this->assertSame(200, $resultResponse->getStatusCode());
@@ -42,8 +43,8 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertSame('INTJ-A', (string) ($meta['type_code'] ?? ''));
             $this->assertSame('A', (string) ($meta['identity'] ?? ''));
             $this->assertSame('report_phase4a_contract', (string) ($meta['engine_version'] ?? ''));
-            $this->assertSame('mbti.personalization.phase7a.v1', (string) ($meta['schema_version'] ?? ''));
-            $this->assertSame('phase7a.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
+            $this->assertSame('mbti.personalization.phase7b.v1', (string) ($meta['schema_version'] ?? ''));
+            $this->assertSame('phase7b.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
             $this->assertIsArray($meta['axis_bands'] ?? null);
             $this->assertSame('boundary', (string) (($meta['axis_bands']['EI'] ?? '')));
             $this->assertSame('boundary', (string) (($meta['axis_bands']['AT'] ?? '')));
@@ -88,6 +89,8 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertIsArray($meta['relationship_action_keys'] ?? null);
             $this->assertIsArray($meta['work_experiment_keys'] ?? null);
             $this->assertIsArray($meta['watchout_keys'] ?? null);
+            $this->assertIsArray($meta['user_state'] ?? null);
+            $this->assertIsArray($meta['orchestration'] ?? null);
             $this->assertContains('role_fit.role.NT', $meta['role_fit_keys'] ?? []);
         }
 
@@ -106,6 +109,25 @@ class MbtiResultTelemetryContractTest extends TestCase
         $this->assertSame($eventMeta['report_view']['relationship_action_keys'] ?? null, $eventMeta['result_view']['relationship_action_keys'] ?? null);
         $this->assertSame($eventMeta['report_view']['work_experiment_keys'] ?? null, $eventMeta['result_view']['work_experiment_keys'] ?? null);
         $this->assertSame($eventMeta['report_view']['watchout_keys'] ?? null, $eventMeta['result_view']['watchout_keys'] ?? null);
+        $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.is_first_view'));
+        $this->assertSame(false, data_get($eventMeta, 'result_view.user_state.is_revisit'));
+        $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.has_share'));
+        $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.has_feedback'));
+        $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.has_action_engagement'));
+        $this->assertSame(false, data_get($eventMeta, 'report_view.user_state.is_first_view'));
+        $this->assertSame(true, data_get($eventMeta, 'report_view.user_state.is_revisit'));
+        $this->assertSame(
+            'growth.stability_confidence',
+            data_get($eventMeta, 'result_view.orchestration.primary_focus_key')
+        );
+        $this->assertSame(
+            'growth.stability_confidence',
+            data_get($eventMeta, 'report_view.orchestration.primary_focus_key')
+        );
+        $this->assertSame(
+            ['unlock_full_report', 'career_bridge', 'share_result'],
+            data_get($eventMeta, 'result_view.orchestration.cta_priority_keys')
+        );
     }
 
     private function seedScales(): void
@@ -245,5 +267,47 @@ class MbtiResultTelemetryContractTest extends TestCase
             });
 
         return $query->orderByDesc('occurred_at')->first();
+    }
+
+    private function seedPhase7bSignals(string $attemptId): void
+    {
+        DB::table('events')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'accuracy_feedback',
+                'event_name' => 'accuracy_feedback',
+                'org_id' => 0,
+                'attempt_id' => $attemptId,
+                'meta_json' => json_encode(['sectionKey' => 'growth.stability_confidence'], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(10),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 0,
+                'attempt_id' => $attemptId,
+                'meta_json' => json_encode([
+                    'sectionKey' => 'growth.next_actions',
+                    'actionKey' => 'weekly_action.theme.name_decision_rule',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(9),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        DB::table('shares')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'anon_id' => 'mbti_phase3a_anon',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'v0.3',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 }

--- a/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
@@ -60,14 +60,34 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
 
         $this->assertSame('ENFP-T', $clear['type_code']);
         $this->assertSame('T', $clear['identity']);
-        $this->assertSame('mbti.personalization.phase7a.v1', $clear['schema_version']);
+        $this->assertSame('mbti.personalization.phase7b.v1', $clear['schema_version']);
         $this->assertSame('clear', data_get($clear, 'axis_bands.EI'));
         $this->assertSame('strong', data_get($strong, 'axis_bands.EI'));
         $this->assertSame(false, data_get($clear, 'boundary_flags.EI'));
         $this->assertSame(false, data_get($strong, 'boundary_flags.EI'));
         $this->assertSame('MBTI.cn-mainland.zh-CN.v0.3', $clear['pack_id']);
         $this->assertSame('report_phase4a_contract', $clear['engine_version']);
-        $this->assertSame('phase7a.v1', $clear['dynamic_sections_version']);
+        $this->assertSame('phase7b.v1', $clear['dynamic_sections_version']);
+        $this->assertSame(
+            [
+                'is_first_view' => true,
+                'is_revisit' => false,
+                'has_unlock' => false,
+                'has_feedback' => false,
+                'has_share' => false,
+                'has_action_engagement' => false,
+            ],
+            data_get($clear, 'user_state')
+        );
+        $this->assertSame('growth.next_actions', data_get($clear, 'orchestration.primary_focus_key'));
+        $this->assertSame(
+            ['unlock_full_report', 'career_bridge', 'share_result'],
+            data_get($clear, 'orchestration.cta_priority_keys')
+        );
+        $this->assertLessThan(
+            array_search('growth.summary', data_get($clear, 'orchestration.ordered_section_keys', []), true),
+            array_search('growth.next_actions', data_get($clear, 'orchestration.ordered_section_keys', []), true)
+        );
         $this->assertNotSame('', trim((string) ($clear['explainability_summary'] ?? '')));
         $this->assertSame(
             ['ENFJ', 'ENTP'],

--- a/backend/tests/Unit/Services/Mbti/MbtiUserStateOrchestrationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiUserStateOrchestrationServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mbti;
+
+use App\Services\Mbti\MbtiResultPersonalizationService;
+use App\Services\Mbti\MbtiUserStateOrchestrationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiUserStateOrchestrationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_overlay_effective_marks_revisit_feedback_share_and_action_engagement(): void
+    {
+        $personalization = app(MbtiResultPersonalizationService::class)->buildForReportPayload(
+            $this->reportPayload(),
+            [
+                'type_code' => 'ENFP-T',
+                'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'dir_version' => 'MBTI-CN-v0.3',
+                'locale' => 'zh-CN',
+                'engine_version' => 'report_phase4a_contract',
+                'has_unlock' => true,
+            ]
+        );
+
+        DB::table('events')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'result_view',
+                'event_name' => 'result_view',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-phase7b',
+                'meta_json' => json_encode(['attempt_id' => 'attempt-phase7b'], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(5),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'accuracy_feedback',
+                'event_name' => 'accuracy_feedback',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-phase7b',
+                'meta_json' => json_encode(['sectionKey' => 'growth.stability_confidence'], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(4),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-phase7b',
+                'meta_json' => json_encode([
+                    'sectionKey' => 'growth.next_actions',
+                    'actionKey' => 'weekly_action.theme.name_decision_rule',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(3),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        DB::table('shares')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => 'attempt-phase7b',
+            'anon_id' => 'anon-phase7b',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'v0.3',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $effective = app(MbtiUserStateOrchestrationService::class)->overlayEffective(
+            $personalization,
+            7,
+            'attempt-phase7b',
+            true
+        );
+
+        $this->assertSame(
+            [
+                'is_first_view' => false,
+                'is_revisit' => true,
+                'has_unlock' => true,
+                'has_feedback' => true,
+                'has_share' => true,
+                'has_action_engagement' => true,
+            ],
+            data_get($effective, 'user_state')
+        );
+        $this->assertSame('growth.stability_confidence', data_get($effective, 'orchestration.primary_focus_key'));
+        $this->assertSame(
+            ['career_bridge', 'workspace_lite', 'share_result'],
+            data_get($effective, 'orchestration.cta_priority_keys')
+        );
+        $this->assertSame(
+            ['career.work_experiments', 'relationships.try_this_week'],
+            data_get($effective, 'orchestration.secondary_focus_keys')
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function reportPayload(): array
+    {
+        return [
+            'versions' => [
+                'engine' => 'v1.2',
+                'content_pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'dir_version' => 'MBTI-CN-v0.3',
+            ],
+            'profile' => [
+                'type_code' => 'ENFP-T',
+            ],
+            'scores' => [
+                'EI' => ['pct' => 67, 'delta' => 17, 'side' => 'E', 'state' => 'clear'],
+                'SN' => ['pct' => 64, 'delta' => 14, 'side' => 'N', 'state' => 'clear'],
+                'TF' => ['pct' => 59, 'delta' => 9, 'side' => 'T', 'state' => 'balanced'],
+                'JP' => ['pct' => 57, 'delta' => 7, 'side' => 'J', 'state' => 'moderate'],
+                'AT' => ['pct' => 68, 'delta' => 18, 'side' => 'T', 'state' => 'clear'],
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'balanced',
+                'JP' => 'moderate',
+                'AT' => 'clear',
+            ],
+        ];
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
@@ -1,6 +1,6 @@
 {
     "schema": "fap.mbti.dynamic_sections.v1",
-    "version": "phase7a.v1",
+    "version": "phase7b.v1",
   "labels": {
     "block_kinds": {
       "type_skeleton": "类型骨架",


### PR DESCRIPTION
## Summary

This PR ships the backend half of MBTI Phase 7B: the user state layer and dynamic orchestration.

The MBTI result stack already had a strong single-authority chain for:

- strength-layered variants
- scene fingerprint and boundary deepening
- accuracy feedback and telemetry
- decision / stress / communication section authority
- career / working-life bridge
- explainability / borderline contrast
- action plan / guided next steps

What was still missing was the orchestration layer that turns those signals into read-time ordering and emphasis based on user state.

This PR closes that gap by extending the existing MBTI personalization envelope with backend-owned user-state and orchestration authority, then overlaying the effective state at read time when result/report payloads are served.

## Problem

Before this change, the MBTI authority graph could say a lot about what the user is like and what they should do next, but it could not yet formally express:

- whether the current read was a first view or revisit
- whether the user had already unlocked, shared, given feedback, or engaged with action sections
- which section should be the primary focus for this user state
- which sections should be promoted within their chapters
- which CTA should come first

That meant the content layer was personalized, but the orchestration layer remained implicit and largely frontend-driven.

There was also a subtle event-chain problem in GET read flows: `result_view` / `report_view` events could miss `attempt_id` in the request input bag, which weakened the attempt-level event history needed to derive read-time user state.

## Root cause

The existing report / projection / snapshot pipeline already had enough MBTI authority to support orchestration, and the `events` table already had enough truth to derive attempt-level user state.

The missing piece was a backend service that would:

- derive effective user state from current access plus prior attempt events
- compute stable ordering / focus / CTA priority authority
- attach that authority to report, projection, snapshot metadata, and telemetry
- do so without introducing a new persistence layer or changing the MBTI scoring path

## Fix

This PR introduces a dedicated MBTI user-state orchestration resolver and wires it into the existing authority chain.

It adds backend-owned fields for:

- `user_state`
  - `is_first_view`
  - `is_revisit`
  - `has_unlock`
  - `has_feedback`
  - `has_share`
  - `has_action_engagement`
- `orchestration`
  - `ordered_section_keys`
  - `primary_focus_key`
  - `secondary_focus_keys`
  - `cta_priority_keys`

It also formally bumps the metadata boundary:

- `schema_version` -> `mbti.personalization.phase7b.v1`
- `dynamic_sections_version` -> `phase7b.v1`

Implementation details:

- adds `MbtiUserStateOrchestrationService` to derive baseline and effective orchestration from current access state plus prior attempt events
- extends MBTI personalization so report / projection / snapshot metadata can carry Phase 7B orchestration authority
- overlays effective read-time state back into the served report/projection payload in the report compose/read path
- updates result/report telemetry normalization so read events carry the same Phase 7B authority
- fixes GET read flows by merging `attempt_id` into the request before recording `result_view` / `report_view`, so event history stays attached to the correct attempt

## User impact

This change is infrastructure-heavy, but it directly affects the product experience.

After this PR, the backend can formally decide:

- whether the user is seeing the page for the first time or revisiting
- what section should be emphasized first
- what other sections should be promoted next
- which CTA should get first priority
- how those decisions should be replayed, tested, and analyzed later

That turns the MBTI result page from a highly personalized static experience into the first real version of user-state-aware orchestration.

## Validation

I ran:

- `php artisan test tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php tests/Unit/Services/Mbti/MbtiUserStateOrchestrationServiceTest.php tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php tests/Feature/V0_3/MbtiResultTelemetryContractTest.php tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php tests/Unit/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilderTest.php`

All passed:

- 17 tests passed
- 415 assertions

## Scope note

This PR intentionally excludes unrelated local dirty changes already present in the repo, especially:

- `backend/content_packs/BIG5_OCEAN/v1/compiled/*`
- `backend/tests/Feature/V0_3/ExperimentExposureContractTest.php`

Only the MBTI Phase 7B backend files are included.
