### PR TITLE
[codex] bridge legacy publish and rollback into rollout metadata

### DIFF
--- a/backend/app/Services/Content/Publisher/ContentPackPublisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackPublisher.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Content\Publisher;
 
+use App\Services\Storage\BlobCatalogService;
+use App\Services\Storage\ContentReleaseManifestCatalogService;
 use App\Support\CacheKeys;
 use App\Support\Http\ResilientClient;
 use Illuminate\Http\UploadedFile;
@@ -19,6 +21,11 @@ final class ContentPackPublisher
     private const SOURCE_UPLOAD = 'upload';
 
     private const SOURCE_S3 = 's3';
+
+    public function __construct(
+        private readonly BlobCatalogService $blobCatalogService,
+        private readonly ContentReleaseManifestCatalogService $manifestCatalogService,
+    ) {}
 
     public function ingest(?UploadedFile $file, ?string $s3Key, array $options = []): array
     {
@@ -189,6 +196,10 @@ final class ContentPackPublisher
 
         $tmpDir = '';
         $previousPackPath = '';
+        $sourcePath = '';
+        $packVersion = '';
+        $releaseManifestJson = '';
+        $gitSha = $this->resolveGitSha();
 
         try {
             $version = DB::table('content_pack_versions')->where('id', $versionId)->first();
@@ -218,9 +229,13 @@ final class ContentPackPublisher
             $sourceManifest = $this->manifestFieldsFromDir($sourcePath);
             $toPackId = (string) ($sourceManifest['pack_id'] ?? '');
             $expectedPackId = $toPackId;
+            $packVersion = trim((string) ($sourceManifest['content_package_version'] ?? ''));
             if ($toPackId === '') {
                 $toPackId = (string) ($version->pack_id ?? '');
                 $expectedPackId = $toPackId;
+            }
+            if ($packVersion === '') {
+                $packVersion = trim((string) ($version->content_package_version ?? ''));
             }
 
             $packsRoot = $this->packsRoot();
@@ -260,6 +275,10 @@ final class ContentPackPublisher
                 is_string($version->manifest_json ?? null) ? (string) $version->manifest_json : '',
                 $targetDir
             );
+            $releaseManifestJson = $this->manifestJsonFromDir($targetDir);
+            if ($releaseManifestJson === '' && is_string($version->manifest_json ?? null)) {
+                $releaseManifestJson = (string) $version->manifest_json;
+            }
             $status = 'success';
         } catch (\Throwable $e) {
             $message = $e->getMessage();
@@ -283,7 +302,11 @@ final class ContentPackPublisher
             }
         }
 
-        DB::table('content_pack_releases')->insert([
+        $releaseStoragePath = $status === 'success' && $sourcePath !== ''
+            ? $this->absoluteContentPath($sourcePath)
+            : null;
+
+        $releaseRow = [
             'id' => $releaseId,
             'action' => 'publish',
             'region' => $region,
@@ -300,12 +323,19 @@ final class ContentPackPublisher
             'compiled_hash' => $releaseEvidence['compiled_hash'] !== '' ? $releaseEvidence['compiled_hash'] : null,
             'content_hash' => $releaseEvidence['content_hash'] !== '' ? $releaseEvidence['content_hash'] : null,
             'norms_version' => $releaseEvidence['norms_version'] !== '' ? $releaseEvidence['norms_version'] : null,
-            'git_sha' => $this->resolveGitSha(),
+            'git_sha' => $gitSha,
+            'pack_version' => $status === 'success' && $packVersion !== '' ? $packVersion : null,
+            'manifest_json' => $status === 'success' && $releaseManifestJson !== '' ? $releaseManifestJson : null,
+            'storage_path' => $releaseStoragePath,
+            'source_commit' => $status === 'success' ? $gitSha : null,
             'created_at' => now(),
             'updated_at' => now(),
-        ]);
+        ];
+        DB::table('content_pack_releases')->insert($releaseRow);
+        $this->shadowActivateLegacyRelease($releaseRow);
+        $this->dualWriteLegacyReleaseMetadata($releaseRow);
         $resolvedScaleCode = strtoupper(trim($toPackId));
-        if (!in_array($resolvedScaleCode, ['BIG5_OCEAN', 'SDS_20'], true)) {
+        if (! in_array($resolvedScaleCode, ['BIG5_OCEAN', 'SDS_20'], true)) {
             $resolvedScaleCode = 'BIG5_OCEAN';
         }
         $auditAction = $resolvedScaleCode === 'SDS_20' ? 'sds_pack_publish' : 'big5_pack_publish';
@@ -332,7 +362,7 @@ final class ContentPackPublisher
                 'compiled_hash' => $releaseEvidence['compiled_hash'],
                 'content_hash' => $releaseEvidence['content_hash'],
                 'norms_version' => $releaseEvidence['norms_version'],
-                'git_sha' => $this->resolveGitSha(),
+                'git_sha' => $gitSha,
             ]
         );
 
@@ -354,8 +384,7 @@ final class ContentPackPublisher
         bool $probe,
         ?string $baseUrl = null,
         ?string $toReleaseId = null
-    ): array
-    {
+    ): array {
         $releaseId = (string) Str::uuid();
         $status = 'failed';
         $message = '';
@@ -378,21 +407,27 @@ final class ContentPackPublisher
         $sourceReleaseId = '';
         $releaseEvidence = $this->emptyReleaseEvidence();
         $targetDir = '';
+        $releaseManifestJson = '';
+        $restoredPackVersion = '';
+        $gitSha = $this->resolveGitSha();
+        $manifestVersion = '';
+        $rollbackSourcePath = '';
 
         $tmpDir = '';
 
         try {
             $selected = $this->selectRollbackSourceRelease($region, $locale, $dirAlias, $toReleaseId);
-            if (!($selected['ok'] ?? false)) {
+            if (! ($selected['ok'] ?? false)) {
                 throw new RuntimeException((string) ($selected['error'] ?? 'NO_PUBLISH_TO_ROLLBACK'));
             }
 
             $last = $selected['release'] ?? null;
             $backupPath = (string) ($selected['backup_path'] ?? '');
-            if (!is_object($last) || $backupPath === '') {
+            if (! is_object($last) || $backupPath === '') {
                 throw new RuntimeException('BACKUP_NOT_FOUND');
             }
             $sourceReleaseId = (string) ($last->id ?? '');
+            $rollbackSourcePath = $backupPath;
 
             $fromVersionId = $last->to_version_id ?? null;
             $fromPackId = (string) ($last->to_pack_id ?? '');
@@ -430,6 +465,7 @@ final class ContentPackPublisher
 
             $toVersionId = $rolledBack['version_id'] !== '' ? $rolledBack['version_id'] : ($last->from_version_id ?? null);
             $toPackId = $rolledBack['pack_id'];
+            $restoredPackVersion = trim((string) ($rolledBack['content_package_version'] ?? ''));
             if ($toPackId === '') {
                 $toPackId = (string) ($last->from_pack_id ?? '');
                 if ($toPackId === '') {
@@ -443,15 +479,26 @@ final class ContentPackPublisher
                 $versionRow = DB::table('content_pack_versions')->where('id', (string) $last->from_version_id)->first();
                 if (is_object($versionRow)) {
                     $manifestJson = is_string($versionRow->manifest_json ?? null) ? (string) $versionRow->manifest_json : '';
+                    $manifestVersion = trim((string) ($versionRow->content_package_version ?? ''));
                 }
             }
             if ($manifestJson === '' && is_string($last->to_version_id ?? null) && trim((string) $last->to_version_id) !== '') {
                 $versionRow = DB::table('content_pack_versions')->where('id', (string) $last->to_version_id)->first();
                 if (is_object($versionRow)) {
                     $manifestJson = is_string($versionRow->manifest_json ?? null) ? (string) $versionRow->manifest_json : '';
+                    if ($manifestVersion === '') {
+                        $manifestVersion = trim((string) ($versionRow->content_package_version ?? ''));
+                    }
                 }
             }
+            if ($restoredPackVersion === '') {
+                $restoredPackVersion = $manifestVersion;
+            }
             $releaseEvidence = $this->resolveReleaseEvidence($manifestJson, $targetDir);
+            $releaseManifestJson = $this->manifestJsonFromDir($targetDir);
+            if ($releaseManifestJson === '') {
+                $releaseManifestJson = $manifestJson;
+            }
             $status = 'success';
         } catch (\Throwable $e) {
             $message = $e->getMessage();
@@ -475,7 +522,11 @@ final class ContentPackPublisher
             }
         }
 
-        DB::table('content_pack_releases')->insert([
+        $releaseStoragePath = $status === 'success' && $rollbackSourcePath !== ''
+            ? $this->absoluteContentPath($rollbackSourcePath)
+            : null;
+
+        $releaseRow = [
             'id' => $releaseId,
             'action' => 'rollback',
             'region' => $region,
@@ -491,11 +542,18 @@ final class ContentPackPublisher
             'compiled_hash' => $releaseEvidence['compiled_hash'] !== '' ? $releaseEvidence['compiled_hash'] : null,
             'content_hash' => $releaseEvidence['content_hash'] !== '' ? $releaseEvidence['content_hash'] : null,
             'norms_version' => $releaseEvidence['norms_version'] !== '' ? $releaseEvidence['norms_version'] : null,
-            'git_sha' => $this->resolveGitSha(),
+            'git_sha' => $gitSha,
+            'pack_version' => $status === 'success' && $restoredPackVersion !== '' ? $restoredPackVersion : null,
+            'manifest_json' => $status === 'success' && $releaseManifestJson !== '' ? $releaseManifestJson : null,
+            'storage_path' => $releaseStoragePath,
+            'source_commit' => $status === 'success' ? $gitSha : null,
             'created_by' => 'admin',
             'created_at' => now(),
             'updated_at' => now(),
-        ]);
+        ];
+        DB::table('content_pack_releases')->insert($releaseRow);
+        $this->shadowActivateLegacyRelease($releaseRow);
+        $this->dualWriteLegacyReleaseMetadata($releaseRow);
         $this->recordReleaseAudit(
             'big5_pack_rollback',
             $releaseId,
@@ -517,7 +575,7 @@ final class ContentPackPublisher
                 'compiled_hash' => $releaseEvidence['compiled_hash'],
                 'content_hash' => $releaseEvidence['content_hash'],
                 'norms_version' => $releaseEvidence['norms_version'],
-                'git_sha' => $this->resolveGitSha(),
+                'git_sha' => $gitSha,
             ]
         );
 
@@ -565,7 +623,7 @@ final class ContentPackPublisher
                 ->where('dir_alias', $dirAlias)
                 ->first();
 
-            if (!$candidate) {
+            if (! $candidate) {
                 return [
                     'ok' => false,
                     'error' => 'TARGET_RELEASE_NOT_FOUND',
@@ -573,7 +631,7 @@ final class ContentPackPublisher
             }
 
             $backupPath = $this->backupsRoot((string) $candidate->id).DIRECTORY_SEPARATOR.'previous_pack';
-            if (!File::isDirectory($backupPath)) {
+            if (! File::isDirectory($backupPath)) {
                 return [
                     'ok' => false,
                     'error' => 'TARGET_RELEASE_BACKUP_NOT_FOUND',
@@ -606,7 +664,7 @@ final class ContentPackPublisher
 
         foreach ($publishRows as $candidate) {
             $backupPath = $this->backupsRoot((string) $candidate->id).DIRECTORY_SEPARATOR.'previous_pack';
-            if (!File::isDirectory($backupPath)) {
+            if (! File::isDirectory($backupPath)) {
                 continue;
             }
 
@@ -621,6 +679,173 @@ final class ContentPackPublisher
             'ok' => false,
             'error' => 'BACKUP_NOT_FOUND',
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $release
+     */
+    private function shadowActivateLegacyRelease(array $release): void
+    {
+        if (! $this->shouldDualWriteLegacyBridge()) {
+            return;
+        }
+        if (($release['status'] ?? '') !== 'success') {
+            return;
+        }
+
+        $releaseId = trim((string) ($release['id'] ?? ''));
+        $packId = strtoupper(trim((string) ($release['to_pack_id'] ?? '')));
+        $packVersion = trim((string) ($release['pack_version'] ?? ''));
+        if ($releaseId === '' || $packId === '' || $packVersion === '') {
+            return;
+        }
+
+        try {
+            DB::table('content_pack_activations')->updateOrInsert(
+                [
+                    'pack_id' => $packId,
+                    'pack_version' => $packVersion,
+                ],
+                [
+                    'release_id' => $releaseId,
+                    'activated_at' => now(),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]
+            );
+        } catch (\Throwable $e) {
+            Log::warning('LEGACY_CONTENT_ACTIVATION_WRITE_FAILED', [
+                'release_id' => $releaseId,
+                'pack_id' => $packId,
+                'pack_version' => $packVersion,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $release
+     */
+    private function dualWriteLegacyReleaseMetadata(array $release): void
+    {
+        if (! $this->shouldDualWriteLegacyBridge()) {
+            return;
+        }
+        if (($release['status'] ?? '') !== 'success') {
+            return;
+        }
+        if (! $this->shouldCatalogLegacyBlobs() && ! $this->shouldCatalogLegacyManifest()) {
+            return;
+        }
+
+        $storagePath = trim((string) ($release['storage_path'] ?? ''));
+        if ($storagePath === '' || ! File::isDirectory($storagePath)) {
+            return;
+        }
+
+        try {
+            $compiledFiles = $this->collectCompiledFilesFromRoot($storagePath);
+        } catch (\Throwable $e) {
+            Log::warning('LEGACY_CONTENT_METADATA_FILE_SCAN_FAILED', [
+                'release_id' => (string) ($release['id'] ?? ''),
+                'storage_path' => $storagePath,
+                'error' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $blobCatalogHadFailures = false;
+        if ($this->shouldCatalogLegacyBlobs()) {
+            foreach ($compiledFiles as $file) {
+                try {
+                    $this->blobCatalogService->upsertBlob([
+                        'hash' => $file['hash'],
+                        'disk' => 'local',
+                        'storage_path' => $this->blobCatalogService->storagePathForHash($file['hash']),
+                        'size_bytes' => $file['size_bytes'],
+                        'content_type' => $file['content_type'],
+                        'encoding' => 'identity',
+                        'ref_count' => 0,
+                        'last_verified_at' => now(),
+                    ]);
+                } catch (\Throwable $e) {
+                    Log::warning('LEGACY_CONTENT_BLOB_CATALOG_WRITE_FAILED', [
+                        'release_id' => (string) ($release['id'] ?? ''),
+                        'logical_path' => (string) ($file['logical_path'] ?? ''),
+                        'blob_hash' => (string) ($file['hash'] ?? ''),
+                        'error' => $e->getMessage(),
+                    ]);
+                    $blobCatalogHadFailures = true;
+                }
+            }
+        }
+
+        if (! $this->shouldCatalogLegacyManifest()) {
+            return;
+        }
+
+        $manifestHash = trim((string) ($release['manifest_hash'] ?? ''));
+        if ($manifestHash === '') {
+            return;
+        }
+
+        if ($this->shouldCatalogLegacyBlobs() && $blobCatalogHadFailures) {
+            Log::warning('LEGACY_CONTENT_MANIFEST_CATALOG_SKIPPED_DUE_TO_BLOB_FAILURE', [
+                'release_id' => (string) ($release['id'] ?? ''),
+                'manifest_hash' => $manifestHash,
+                'storage_path' => $storagePath,
+            ]);
+
+            return;
+        }
+
+        $existingManifest = $this->manifestCatalogService->findByManifestHash($manifestHash);
+        $manifestReleaseId = $existingManifest?->content_pack_release_id ?: ($release['id'] ?? null);
+        $manifestStorageDisk = trim((string) ($existingManifest?->storage_disk ?? ''));
+        if ($manifestStorageDisk === '') {
+            $manifestStorageDisk = 'local';
+        }
+        $manifestStoragePath = trim((string) ($existingManifest?->storage_path ?? ''));
+        if ($manifestStoragePath === '') {
+            $manifestStoragePath = $storagePath;
+        }
+
+        $files = [];
+        foreach ($compiledFiles as $file) {
+            $files[] = [
+                'logical_path' => $file['logical_path'],
+                'blob_hash' => $file['hash'],
+                'size_bytes' => $file['size_bytes'],
+                'role' => $file['role'],
+                'content_type' => $file['content_type'],
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.$file['hash'],
+            ];
+        }
+
+        try {
+            $this->manifestCatalogService->upsertManifest([
+                'content_pack_release_id' => $manifestReleaseId,
+                'manifest_hash' => $manifestHash,
+                'storage_disk' => $manifestStorageDisk,
+                'storage_path' => $manifestStoragePath,
+                'pack_id' => $release['to_pack_id'] ?? null,
+                'pack_version' => $release['pack_version'] ?? null,
+                'compiled_hash' => $release['compiled_hash'] ?? null,
+                'content_hash' => $release['content_hash'] ?? null,
+                'norms_version' => $release['norms_version'] ?? null,
+                'source_commit' => $release['source_commit'] ?? null,
+                'payload_json' => $this->decodeManifestJson($release['manifest_json'] ?? null),
+            ], $files);
+        } catch (\Throwable $e) {
+            Log::warning('LEGACY_CONTENT_MANIFEST_CATALOG_WRITE_FAILED', [
+                'release_id' => (string) ($release['id'] ?? ''),
+                'manifest_hash' => $manifestHash,
+                'storage_path' => $storagePath,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**
@@ -686,7 +911,7 @@ final class ContentPackPublisher
     }
 
     /**
-     * @param array<string,mixed> $hashes
+     * @param  array<string,mixed>  $hashes
      */
     private function hashMap(array $hashes): string
     {
@@ -704,7 +929,7 @@ final class ContentPackPublisher
 
     private function hashDirectory(string $dir): string
     {
-        if (!File::isDirectory($dir)) {
+        if (! File::isDirectory($dir)) {
             return '';
         }
 
@@ -722,14 +947,14 @@ final class ContentPackPublisher
     }
 
     /**
-     * @param array<string,mixed> $groups
+     * @param  array<string,mixed>  $groups
      */
     private function resolveNormsVersionFromGroups(array $groups): string
     {
         $preferred = '';
         $fallback = '';
         foreach ($groups as $group) {
-            if (!is_array($group)) {
+            if (! is_array($group)) {
                 continue;
             }
             $normsVersion = trim((string) ($group['norms_version'] ?? ''));
@@ -761,6 +986,20 @@ final class ContentPackPublisher
         return substr($sha, 0, 64);
     }
 
+    private function manifestJsonFromDir(string $packDir): string
+    {
+        $manifestPath = $packDir.DIRECTORY_SEPARATOR.'manifest.json';
+        if (! File::exists($manifestPath)) {
+            return '';
+        }
+
+        try {
+            return (string) File::get($manifestPath);
+        } catch (\Throwable) {
+            return '';
+        }
+    }
+
     private function recordReleaseAudit(
         string $action,
         string $releaseId,
@@ -768,7 +1007,7 @@ final class ContentPackPublisher
         string $message,
         array $meta
     ): void {
-        if (!\Illuminate\Support\Facades\Schema::hasTable('audit_logs')) {
+        if (! \Illuminate\Support\Facades\Schema::hasTable('audit_logs')) {
             return;
         }
 
@@ -811,6 +1050,20 @@ final class ContentPackPublisher
         }
 
         return $packsRoot;
+    }
+
+    private function absoluteContentPath(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return '';
+        }
+
+        if (str_starts_with($path, DIRECTORY_SEPARATOR)) {
+            return rtrim($path, '/\\');
+        }
+
+        return rtrim(base_path($path), '/\\');
     }
 
     private function targetPackDir(string $packsRoot, string $region, string $locale, string $dirAlias): string
@@ -1198,6 +1451,74 @@ final class ContentPackPublisher
         $row = $query->orderByDesc('created_at')->first();
 
         return $row ? (string) $row->id : null;
+    }
+
+    private function shouldDualWriteLegacyBridge(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.content_publish_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    private function shouldCatalogLegacyBlobs(): bool
+    {
+        return $this->shouldDualWriteLegacyBridge()
+            && (bool) config('storage_rollout.blob_catalog_enabled', false);
+    }
+
+    private function shouldCatalogLegacyManifest(): bool
+    {
+        return $this->shouldDualWriteLegacyBridge()
+            && (bool) config('storage_rollout.manifest_catalog_enabled', false);
+    }
+
+    /**
+     * @return list<array{logical_path:string,hash:string,size_bytes:int,content_type:?string,role:?string}>
+     */
+    private function collectCompiledFilesFromRoot(string $root): array
+    {
+        $compiledDir = $root.DIRECTORY_SEPARATOR.'compiled';
+        if (! File::isDirectory($compiledDir)) {
+            return [];
+        }
+
+        $files = [];
+        foreach (File::allFiles($compiledDir) as $file) {
+            $absolutePath = $file->getPathname();
+            $relative = ltrim(str_replace('\\', '/', substr($absolutePath, strlen(rtrim($root, '/\\')))), '/');
+            $bytes = (string) File::get($absolutePath);
+            $hash = hash('sha256', $bytes);
+            $files[] = [
+                'logical_path' => $relative,
+                'hash' => $hash,
+                'size_bytes' => strlen($bytes),
+                'content_type' => $this->contentTypeForLogicalPath($relative),
+                'role' => $relative === 'compiled/manifest.json' ? 'manifest' : null,
+            ];
+        }
+
+        usort($files, static fn (array $a, array $b): int => strcmp((string) $a['logical_path'], (string) $b['logical_path']));
+
+        return $files;
+    }
+
+    private function contentTypeForLogicalPath(string $logicalPath): ?string
+    {
+        return str_ends_with(strtolower($logicalPath), '.json') ? 'application/json' : null;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function decodeManifestJson(mixed $manifestJson): ?array
+    {
+        if (! is_string($manifestJson) || trim($manifestJson) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($manifestJson, true);
+
+        return is_array($decoded) ? $decoded : null;
     }
 
     private function relativeToPrivate(string $path): string

--- a/backend/tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php
+++ b/backend/tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Services\Content\ContentPackV2Resolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class LegacyContentPackBridgeMetadataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PUBLISH_ALIAS = 'BIG5-OCEAN-LEGACY-BRIDGE-PUBLISH';
+
+    private const ROLLBACK_ALIAS = 'BIG5-OCEAN-LEGACY-BRIDGE-ROLLBACK';
+
+    protected function tearDown(): void
+    {
+        foreach ([self::PUBLISH_ALIAS, self::ROLLBACK_ALIAS] as $alias) {
+            $target = $this->targetDir($alias);
+            if (File::isDirectory($target)) {
+                File::deleteDirectory($target);
+            }
+
+            $releaseIds = DB::table('content_pack_releases')
+                ->where('dir_alias', $alias)
+                ->pluck('id');
+            foreach ($releaseIds as $releaseId) {
+                File::deleteDirectory(storage_path('app/private/content_releases/backups/'.(string) $releaseId));
+            }
+
+            $versionIds = DB::table('content_pack_versions')
+                ->where('dir_version_alias', $alias)
+                ->pluck('id');
+            foreach ($versionIds as $versionId) {
+                File::deleteDirectory(storage_path('app/private/content_releases/'.(string) $versionId));
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_dual_mode_publish_bridges_release_fields_and_rollout_metadata(): void
+    {
+        config()->set('scale_identity.content_publish_mode', 'dual');
+        config()->set('storage_rollout.blob_catalog_enabled', true);
+        config()->set('storage_rollout.manifest_catalog_enabled', true);
+
+        $target = $this->targetDir(self::PUBLISH_ALIAS);
+        if (File::isDirectory($target)) {
+            File::deleteDirectory($target);
+        }
+
+        $this->artisan(sprintf(
+            'packs:publish --scale=BIG5_OCEAN --pack=BIG5_OCEAN --pack-version=v1 --region=CN_MAINLAND --locale=zh-CN --dir_alias=%s --probe=0',
+            self::PUBLISH_ALIAS
+        ))->assertExitCode(0);
+
+        $release = DB::table('content_pack_releases')
+            ->where('action', 'publish')
+            ->where('dir_alias', self::PUBLISH_ALIAS)
+            ->orderByDesc('created_at')
+            ->first();
+
+        $this->assertNotNull($release);
+        $this->assertSame('success', (string) ($release->status ?? ''));
+        $expectedSourcePath = storage_path('app/private/content_releases/'.(string) ($release->to_version_id ?? '').'/source_pack');
+        $this->assertSame('v1', (string) ($release->pack_version ?? ''));
+        $this->assertSame($expectedSourcePath, (string) ($release->storage_path ?? ''));
+        $this->assertSame((string) ($release->git_sha ?? ''), (string) ($release->source_commit ?? ''));
+
+        $releaseManifest = json_decode((string) ($release->manifest_json ?? '{}'), true);
+        $this->assertIsArray($releaseManifest);
+        $this->assertSame('BIG5_OCEAN', (string) ($releaseManifest['pack_id'] ?? ''));
+        $this->assertSame('v1', (string) ($releaseManifest['content_package_version'] ?? ''));
+
+        $manifest = DB::table('content_release_manifests')
+            ->where('manifest_hash', (string) ($release->manifest_hash ?? ''))
+            ->first();
+        $this->assertNotNull($manifest);
+        $this->assertSame((string) $release->id, (string) ($manifest->content_pack_release_id ?? ''));
+        $this->assertSame('local', (string) ($manifest->storage_disk ?? ''));
+        $this->assertSame($expectedSourcePath, (string) ($manifest->storage_path ?? ''));
+        $this->assertSame('BIG5_OCEAN', (string) ($manifest->pack_id ?? ''));
+        $this->assertSame('v1', (string) ($manifest->pack_version ?? ''));
+
+        $manifestFile = DB::table('content_release_manifest_files')
+            ->where('content_release_manifest_id', (int) $manifest->id)
+            ->where('logical_path', 'compiled/manifest.json')
+            ->first();
+        $this->assertNotNull($manifestFile);
+        $this->assertSame('manifest', (string) ($manifestFile->role ?? ''));
+        $this->assertSame('application/json', (string) ($manifestFile->content_type ?? ''));
+
+        $blob = DB::table('storage_blobs')
+            ->where('hash', (string) ($manifestFile->blob_hash ?? ''))
+            ->first();
+        $this->assertNotNull($blob);
+        $this->assertSame('local', (string) ($blob->disk ?? ''));
+        $this->assertStringStartsWith('blobs/sha256/', (string) ($blob->storage_path ?? ''));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'big5_pack_publish')
+            ->where('target_id', (string) $release->id)
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($audit);
+        $auditMeta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($auditMeta);
+        $this->assertSame('dual', (string) ($auditMeta['content_publish_mode'] ?? ''));
+        $this->assertSame('BIG5_OCEAN', (string) ($auditMeta['to_pack_id'] ?? ''));
+
+        $this->assertDatabaseHas('content_pack_activations', [
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'release_id' => (string) $release->id,
+        ]);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $this->assertSame($expectedSourcePath.'/compiled', $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1'));
+    }
+
+    public function test_dual_mode_rollback_keeps_backup_selection_and_bridges_release_metadata(): void
+    {
+        config()->set('scale_identity.content_publish_mode', 'dual');
+        config()->set('storage_rollout.blob_catalog_enabled', true);
+        config()->set('storage_rollout.manifest_catalog_enabled', true);
+
+        $target = $this->targetDir(self::ROLLBACK_ALIAS);
+        if (File::isDirectory($target)) {
+            File::deleteDirectory($target);
+        }
+
+        $publishCommand = sprintf(
+            'packs:publish --scale=BIG5_OCEAN --pack=BIG5_OCEAN --pack-version=v1 --region=CN_MAINLAND --locale=zh-CN --dir_alias=%s --probe=0',
+            self::ROLLBACK_ALIAS
+        );
+        $this->artisan($publishCommand)->assertExitCode(0);
+        $this->artisan($publishCommand)->assertExitCode(0);
+
+        $targetReleaseId = '';
+        $sourceBackupPath = '';
+        $publishRows = DB::table('content_pack_releases')
+            ->where('action', 'publish')
+            ->where('status', 'success')
+            ->where('dir_alias', self::ROLLBACK_ALIAS)
+            ->orderByDesc('created_at')
+            ->orderByDesc('updated_at')
+            ->get();
+        foreach ($publishRows as $row) {
+            $backupPath = storage_path('app/private/content_releases/backups/'.(string) $row->id.'/previous_pack');
+            if (! File::isDirectory($backupPath)) {
+                continue;
+            }
+            $targetReleaseId = (string) $row->id;
+            $sourceBackupPath = $backupPath;
+            break;
+        }
+
+        $this->assertNotSame('', $targetReleaseId);
+        $this->assertTrue(File::isDirectory($sourceBackupPath));
+        $initialPublish = DB::table('content_pack_releases')
+            ->where('action', 'publish')
+            ->where('status', 'success')
+            ->where('dir_alias', self::ROLLBACK_ALIAS)
+            ->orderBy('created_at')
+            ->orderBy('updated_at')
+            ->first();
+        $this->assertNotNull($initialPublish);
+        $initialManifestStoragePath = storage_path('app/private/content_releases/'.(string) ($initialPublish->to_version_id ?? '').'/source_pack');
+
+        $this->artisan(sprintf(
+            'packs:rollback --scale=BIG5_OCEAN --region=CN_MAINLAND --locale=zh-CN --dir_alias=%s --to_release_id=%s --probe=0',
+            self::ROLLBACK_ALIAS,
+            $targetReleaseId
+        ))->assertExitCode(0);
+
+        $release = DB::table('content_pack_releases')
+            ->where('action', 'rollback')
+            ->where('dir_alias', self::ROLLBACK_ALIAS)
+            ->orderByDesc('created_at')
+            ->first();
+
+        $this->assertNotNull($release);
+        $this->assertSame('success', (string) ($release->status ?? ''));
+        $this->assertSame('v1', (string) ($release->pack_version ?? ''));
+        $this->assertSame($sourceBackupPath, (string) ($release->storage_path ?? ''));
+        $this->assertSame((string) ($release->git_sha ?? ''), (string) ($release->source_commit ?? ''));
+
+        $releaseManifest = json_decode((string) ($release->manifest_json ?? '{}'), true);
+        $this->assertIsArray($releaseManifest);
+        $this->assertSame('BIG5_OCEAN', (string) ($releaseManifest['pack_id'] ?? ''));
+        $this->assertSame('v1', (string) ($releaseManifest['content_package_version'] ?? ''));
+
+        $manifest = DB::table('content_release_manifests')
+            ->where('manifest_hash', (string) ($release->manifest_hash ?? ''))
+            ->first();
+        $this->assertNotNull($manifest);
+        $this->assertSame($initialManifestStoragePath, (string) ($manifest->storage_path ?? ''));
+        $this->assertGreaterThan(0, (int) DB::table('content_release_manifest_files')->where('content_release_manifest_id', (int) $manifest->id)->count());
+        $this->assertGreaterThan(0, (int) DB::table('storage_blobs')->count());
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+
+        $rollbackBackupPath = storage_path('app/private/content_releases/backups/'.(string) $release->id.'/current_pack');
+        $this->assertTrue(File::isDirectory($rollbackBackupPath));
+        $this->assertTrue(File::isDirectory($sourceBackupPath));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'big5_pack_rollback')
+            ->where('target_id', (string) $release->id)
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($audit);
+        $auditMeta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($auditMeta);
+        $this->assertSame($targetReleaseId, (string) ($auditMeta['source_release_id'] ?? ''));
+        $this->assertSame(self::ROLLBACK_ALIAS, (string) ($auditMeta['dir_alias'] ?? ''));
+
+        $this->assertDatabaseHas('content_pack_activations', [
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'release_id' => (string) $release->id,
+        ]);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $this->assertSame($sourceBackupPath.'/compiled', $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1'));
+    }
+
+    private function targetDir(string $dirAlias): string
+    {
+        return base_path('../content_packages/default/CN_MAINLAND/zh-CN/'.$dirAlias);
+    }
+}

--- a/backend/tests/Feature/Content/PacksPublishBig5Test.php
+++ b/backend/tests/Feature/Content/PacksPublishBig5Test.php
@@ -35,7 +35,11 @@ final class PacksPublishBig5Test extends TestCase
         $this->artisan(sprintf(
             'packs:publish --scale=BIG5_OCEAN --pack=BIG5_OCEAN --pack-version=v1 --region=CN_MAINLAND --locale=zh-CN --dir_alias=%s --probe=0',
             self::DIR_ALIAS
-        ))->assertExitCode(0);
+        ))
+            ->expectsOutputToContain('release_id=')
+            ->expectsOutput('status=success')
+            ->expectsOutput('to_pack_id=BIG5_OCEAN')
+            ->assertExitCode(0);
 
         $release = DB::table('content_pack_releases')
             ->where('action', 'publish')
@@ -51,6 +55,19 @@ final class PacksPublishBig5Test extends TestCase
         $this->assertNotEmpty((string) ($release->compiled_hash ?? ''));
         $this->assertNotEmpty((string) ($release->content_hash ?? ''));
         $this->assertNotEmpty((string) ($release->norms_version ?? ''));
+        $expectedSourcePath = storage_path('app/private/content_releases/'.(string) $release->to_version_id.'/source_pack');
+        $this->assertSame('v1', (string) ($release->pack_version ?? ''));
+        $this->assertSame($expectedSourcePath, (string) ($release->storage_path ?? ''));
+        $this->assertSame((string) ($release->git_sha ?? ''), (string) ($release->source_commit ?? ''));
+        $this->assertDatabaseMissing('content_pack_activations', [
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+        ]);
+
+        $releaseManifest = json_decode((string) ($release->manifest_json ?? '{}'), true);
+        $this->assertIsArray($releaseManifest);
+        $this->assertSame('BIG5_OCEAN', (string) ($releaseManifest['pack_id'] ?? ''));
+        $this->assertSame('v1', (string) ($releaseManifest['content_package_version'] ?? ''));
 
         $version = DB::table('content_pack_versions')->where('id', (string) $release->to_version_id)->first();
         $this->assertNotNull($version);

--- a/backend/tests/Feature/Content/PacksPublishSds20Test.php
+++ b/backend/tests/Feature/Content/PacksPublishSds20Test.php
@@ -35,7 +35,11 @@ final class PacksPublishSds20Test extends TestCase
         $this->artisan(sprintf(
             'packs:publish --scale=SDS_20 --pack=SDS_20 --pack-version=v1 --region=CN_MAINLAND --locale=zh-CN --dir_alias=%s --probe=0 --skip_drift=1',
             self::DIR_ALIAS
-        ))->assertExitCode(0);
+        ))
+            ->expectsOutputToContain('release_id=')
+            ->expectsOutput('status=success')
+            ->expectsOutput('to_pack_id=SDS_20')
+            ->assertExitCode(0);
 
         $release = DB::table('content_pack_releases')
             ->where('action', 'publish')
@@ -50,6 +54,19 @@ final class PacksPublishSds20Test extends TestCase
         $this->assertNotEmpty((string) ($release->manifest_hash ?? ''));
         $this->assertNotEmpty((string) ($release->compiled_hash ?? ''));
         $this->assertNotEmpty((string) ($release->content_hash ?? ''));
+        $expectedSourcePath = storage_path('app/private/content_releases/'.(string) $release->to_version_id.'/source_pack');
+        $this->assertSame('v1', (string) ($release->pack_version ?? ''));
+        $this->assertSame($expectedSourcePath, (string) ($release->storage_path ?? ''));
+        $this->assertSame((string) ($release->git_sha ?? ''), (string) ($release->source_commit ?? ''));
+        $this->assertDatabaseMissing('content_pack_activations', [
+            'pack_id' => 'SDS_20',
+            'pack_version' => 'v1',
+        ]);
+
+        $releaseManifest = json_decode((string) ($release->manifest_json ?? '{}'), true);
+        $this->assertIsArray($releaseManifest);
+        $this->assertSame('SDS_20', (string) ($releaseManifest['pack_id'] ?? ''));
+        $this->assertSame('v1', (string) ($releaseManifest['content_package_version'] ?? ''));
 
         $version = DB::table('content_pack_versions')->where('id', (string) $release->to_version_id)->first();
         $this->assertNotNull($version);

--- a/backend/tests/Feature/Content/PacksRollbackBig5Test.php
+++ b/backend/tests/Feature/Content/PacksRollbackBig5Test.php
@@ -48,8 +48,8 @@ final class PacksRollbackBig5Test extends TestCase
             ->orderByDesc('updated_at')
             ->get();
         foreach ($publishRows as $row) {
-            $backupPath = storage_path('app/private/content_releases/backups/' . (string) $row->id . '/previous_pack');
-            if (!File::isDirectory($backupPath)) {
+            $backupPath = storage_path('app/private/content_releases/backups/'.(string) $row->id.'/previous_pack');
+            if (! File::isDirectory($backupPath)) {
                 continue;
             }
             $targetReleaseId = (string) $row->id;
@@ -61,7 +61,12 @@ final class PacksRollbackBig5Test extends TestCase
             'packs:rollback --scale=BIG5_OCEAN --region=CN_MAINLAND --locale=zh-CN --dir_alias=%s --to_release_id=%s --probe=0',
             self::DIR_ALIAS,
             $targetReleaseId
-        ))->assertExitCode(0);
+        ))
+            ->expectsOutputToContain('release_id=')
+            ->expectsOutput('status=success')
+            ->expectsOutput('rolled_back_pack_id=BIG5_OCEAN')
+            ->expectsOutput('source_release_id='.$targetReleaseId)
+            ->assertExitCode(0);
 
         $release = DB::table('content_pack_releases')
             ->where('action', 'rollback')
@@ -76,6 +81,18 @@ final class PacksRollbackBig5Test extends TestCase
         $this->assertNotEmpty((string) ($release->compiled_hash ?? ''));
         $this->assertNotEmpty((string) ($release->content_hash ?? ''));
         $this->assertNotEmpty((string) ($release->norms_version ?? ''));
+        $this->assertSame('v1', (string) ($release->pack_version ?? ''));
+        $this->assertSame(storage_path('app/private/content_releases/backups/'.$targetReleaseId.'/previous_pack'), (string) ($release->storage_path ?? ''));
+        $this->assertSame((string) ($release->git_sha ?? ''), (string) ($release->source_commit ?? ''));
+        $this->assertDatabaseMissing('content_pack_activations', [
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+        ]);
+
+        $releaseManifest = json_decode((string) ($release->manifest_json ?? '{}'), true);
+        $this->assertIsArray($releaseManifest);
+        $this->assertSame('BIG5_OCEAN', (string) ($releaseManifest['pack_id'] ?? ''));
+        $this->assertSame('v1', (string) ($releaseManifest['content_package_version'] ?? ''));
 
         $this->assertTrue(File::isDirectory($target.'/compiled'));
         $this->assertTrue(File::exists($target.'/compiled/manifest.json'));

--- a/backend/tests/Feature/Ops/BigFiveOpsReleaseFlowTest.php
+++ b/backend/tests/Feature/Ops/BigFiveOpsReleaseFlowTest.php
@@ -14,12 +14,13 @@ final class BigFiveOpsReleaseFlowTest extends TestCase
     use RefreshDatabase;
 
     private const DIR_ALIAS = 'BIG5-OCEAN-OPS-FLOW-CI-TEST';
+
     private const DIR_ALIAS_FAIL = 'BIG5-OCEAN-OPS-FLOW-FAIL-CI-TEST';
 
     protected function tearDown(): void
     {
         foreach ([self::DIR_ALIAS, self::DIR_ALIAS_FAIL] as $alias) {
-            $target = base_path('../content_packages/default/CN_MAINLAND/zh-CN/' . $alias);
+            $target = base_path('../content_packages/default/CN_MAINLAND/zh-CN/'.$alias);
             if (File::isDirectory($target)) {
                 File::deleteDirectory($target);
             }
@@ -30,7 +31,7 @@ final class BigFiveOpsReleaseFlowTest extends TestCase
 
     public function test_ops_release_flow_writes_publish_and_rollback_audits(): void
     {
-        $target = base_path('../content_packages/default/CN_MAINLAND/zh-CN/' . self::DIR_ALIAS);
+        $target = base_path('../content_packages/default/CN_MAINLAND/zh-CN/'.self::DIR_ALIAS);
         if (File::isDirectory($target)) {
             File::deleteDirectory($target);
         }
@@ -51,8 +52,8 @@ final class BigFiveOpsReleaseFlowTest extends TestCase
             ->orderByDesc('updated_at')
             ->get();
         foreach ($publishRows as $row) {
-            $backupPath = storage_path('app/private/content_releases/backups/' . (string) $row->id . '/previous_pack');
-            if (!File::isDirectory($backupPath)) {
+            $backupPath = storage_path('app/private/content_releases/backups/'.(string) $row->id.'/previous_pack');
+            if (! File::isDirectory($backupPath)) {
                 continue;
             }
             $targetReleaseId = (string) $row->id;
@@ -72,6 +73,12 @@ final class BigFiveOpsReleaseFlowTest extends TestCase
         $this->assertNotNull($publishRelease);
         $this->assertSame('success', (string) $publishRelease->status);
         $this->assertNotSame('', (string) ($publishRelease->manifest_hash ?? ''));
+        $this->assertNotSame('', (string) ($publishRelease->to_version_id ?? ''));
+        $this->assertSame('v1', (string) ($publishRelease->pack_version ?? ''));
+        $this->assertSame(
+            storage_path('app/private/content_releases/'.(string) $publishRelease->to_version_id.'/source_pack'),
+            (string) ($publishRelease->storage_path ?? '')
+        );
 
         $rollbackRelease = DB::table('content_pack_releases')
             ->where('action', 'rollback')
@@ -83,6 +90,15 @@ final class BigFiveOpsReleaseFlowTest extends TestCase
         $this->assertNotSame('', (string) ($rollbackRelease->manifest_hash ?? ''));
         $this->assertNotSame('', (string) ($rollbackRelease->compiled_hash ?? ''));
         $this->assertNotSame('', (string) ($rollbackRelease->content_hash ?? ''));
+        $this->assertSame('v1', (string) ($rollbackRelease->pack_version ?? ''));
+        $this->assertSame(
+            storage_path('app/private/content_releases/backups/'.$targetReleaseId.'/previous_pack'),
+            (string) ($rollbackRelease->storage_path ?? '')
+        );
+        $this->assertDatabaseMissing('content_pack_activations', [
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+        ]);
 
         $publishAudit = DB::table('audit_logs')
             ->where('action', 'big5_pack_publish')
@@ -108,7 +124,7 @@ final class BigFiveOpsReleaseFlowTest extends TestCase
 
     public function test_ops_release_flow_records_failed_rollback_audit_for_unknown_target_release(): void
     {
-        $target = base_path('../content_packages/default/CN_MAINLAND/zh-CN/' . self::DIR_ALIAS_FAIL);
+        $target = base_path('../content_packages/default/CN_MAINLAND/zh-CN/'.self::DIR_ALIAS_FAIL);
         if (File::isDirectory($target)) {
             File::deleteDirectory($target);
         }


### PR DESCRIPTION
## Summary

This PR implements PR-13G only: the minimum safe legacy publish / rollback / ops cutover into the rollout bridge.

The change stays narrow and additive. It does not replace the current legacy success path, does not remove `backups/{releaseId}/previous_pack`, does not change CLI stdout keys, does not change BigFive ops route shape, and does not expand into PR-14 or PR-15.

What it does do is bridge successful legacy publish and rollback operations into the rollout-compatible metadata/runtime contract that already exists after PR-13C through PR-13F.

## Root cause

Before this PR, the legacy write chain still depended entirely on:

- legacy live directory swaps
- `previous_pack/current_pack` backup directories
- legacy `content_pack_releases` rows
- legacy audit rows

PR-13E and PR-13F had already introduced rollout metadata plus resolver materialization, but the legacy publisher was not producing stable bridge data for that system.

Two concrete gaps remained:

1. Legacy bridge rows were pointing at the mutable live alias directory under `content_packages/default/.../{dirAlias}`.
   - That directory is overwritten in place by later publish/rollback operations.
   - So older release rows and older manifest rows could stop identifying the bytes actually associated with their own `manifest_hash`.

2. Legacy success paths were not updating `content_pack_activations`.
   - So the V2 active resolver/materialization path still could not see successful legacy publish/rollback operations through the current activation contract.

## Fix

This PR keeps the existing legacy publish/rollback behavior intact, but upgrades the same success path with immutable bridge metadata and activation wiring.

### 1. Immutable bridge `storage_path`

Successful legacy release rows now store an immutable source tree instead of the mutable live alias path:

- publish success rows use the staged source tree:
  - `storage/app/private/content_releases/{to_version_id}/source_pack`
- rollback success rows use the selected rollback backup tree:
  - `storage/app/private/content_releases/backups/{source_release_id}/previous_pack`

That means old legacy release rows and old manifest rows keep pointing at the actual bytes that belonged to that release, even after later publish/rollback operations modify the live alias directory.

### 2. Legacy activation bridge

On successful legacy publish/rollback, when `scale_identity.content_publish_mode` is `dual` or `v2`, the publisher now shadow-updates `content_pack_activations` for the bridged legacy release row.

This is warning-only side write behavior:

- activation failures are logged
- legacy publish/rollback still succeed
- stdout / audit / ops adapter behavior is unchanged

This lets the existing `ContentPackV2Resolver` / `ContentPackV2Materializer` active-read path see legacy success rows through the same activation contract used by packs2.

### 3. Rollout metadata side write stays dual-track

The legacy publisher still preserves the existing backup-first rollback truth and still writes the same live directories.

In addition, when dual/v2 mode and rollout flags are enabled, it now side-writes rollout metadata from the immutable source tree:

- `storage_blobs`
- `content_release_manifests`
- `content_release_manifest_files`

Important safety constraints preserved:

- source bytes still come from the actual legacy source tree, not from a physical blobs tree
- `previous_pack/current_pack` semantics are preserved
- blob/manifest catalog failures are warning-only and do not break publish/rollback
- if any blob catalog write fails, manifest/file-map cataloging is skipped for that release to avoid inconsistent metadata

## Scope intentionally not included

This PR does **not**:

- replace backup-first rollback source selection
- remove `backups/{releaseId}/previous_pack`
- change BigFive ops controller or route shape
- change CLI stdout key names
- change audit action names or existing audit meta keys
- implement PR-14/PR-15 backfill, pruning, or GC work

## Tests

Updated existing focused coverage:

- `tests/Feature/Content/PacksPublishBig5Test.php`
- `tests/Feature/Content/PacksPublishSds20Test.php`
- `tests/Feature/Content/PacksRollbackBig5Test.php`
- `tests/Feature/Ops/BigFiveOpsReleaseFlowTest.php`

Added new focused coverage:

- `tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php`

The focused suite now locks that:

- legacy publish/rollback stdout keys remain unchanged
- legacy release rows get immutable bridge fields
- legacy mode does **not** write activation rows
- dual mode **does** write activation rows
- `ContentPackV2Resolver::resolveActiveCompiledPath()` can resolve the dual-mode legacy active row
- rollback keeps using `previous_pack` and does not lose the backup-first contract
- no physical `storage/app/private/blobs/**` tree is created

## Commands run

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php -l app/Services/Content/Publisher/ContentPackPublisher.php
php -l app/Console/Commands/PacksPublish.php
php -l app/Console/Commands/PacksRollback.php
php -l app/Services/Ops/BigFiveOpsActionService.php
php -l app/Http/Controllers/API/V0_3/BigFiveOpsController.php
php -l tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php

./vendor/bin/pint \
  app/Services/Content/Publisher/ContentPackPublisher.php \
  app/Console/Commands/PacksPublish.php \
  app/Console/Commands/PacksRollback.php \
  app/Services/Ops/BigFiveOpsActionService.php \
  app/Http/Controllers/API/V0_3/BigFiveOpsController.php \
  tests/Feature/Content/PacksPublishBig5Test.php \
  tests/Feature/Content/PacksPublishSds20Test.php \
  tests/Feature/Content/PacksRollbackBig5Test.php \
  tests/Feature/Ops/BigFiveOpsReleaseFlowTest.php \
  tests/Feature/Ops/BigFiveOpsWriteEndpointsTest.php \
  tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php \
  tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php

php artisan migrate

vendor/bin/phpunit \
  tests/Feature/Content/PacksPublishBig5Test.php \
  tests/Feature/Content/PacksPublishSds20Test.php \
  tests/Feature/Content/PacksRollbackBig5Test.php \
  tests/Feature/Ops/BigFiveOpsReleaseFlowTest.php \
  tests/Feature/Ops/BigFiveOpsWriteEndpointsTest.php \
  tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php \
  tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php

php artisan route:list > /tmp/pr13g_route_list.txt
php artisan serve --host=127.0.0.1 --port=18081
curl -i http://127.0.0.1:18081/api/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
```

## Validation

- `php -l`: passed
- `pint`: passed after formatting fixes
- focused PHPUnit suite: `OK (25 tests, 316 assertions)`
- `php artisan migrate`: `Nothing to migrate.`
- `curl -i http://127.0.0.1:18081/api/healthz`: `HTTP/1.1 200 OK`

## Known baseline failure unchanged

`bash backend/scripts/ci_verify_mbti.sh` still fails on the existing content-package self-check baseline:

- `report_dynamic_sections.json :: missing manifest.schemas mapping (asset=dynamic_sections)`

This PR does not touch `content_packages/**` and does not attempt to fix that out-of-scope baseline issue.
