### PR TITLE
[codex] Ship MBTI Phase 8A cross-page continuity and focus carryover (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -558,6 +558,7 @@ class AttemptReadController extends Controller
             'watchout_keys' => is_array($personalization['watchout_keys'] ?? null) ? $personalization['watchout_keys'] : [],
             'user_state' => is_array($personalization['user_state'] ?? null) ? $personalization['user_state'] : [],
             'orchestration' => is_array($personalization['orchestration'] ?? null) ? $personalization['orchestration'] : [],
+            'continuity' => is_array($personalization['continuity'] ?? null) ? $personalization['continuity'] : [],
             'engine_version' => trim((string) ($personalization['engine_version'] ?? '')),
         ];
 

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -654,7 +654,7 @@ final class MbtiResultPersonalizationService
         }
 
         return $this->userStateOrchestrationService->withBaseline([
-            'schema_version' => 'mbti.personalization.phase7b.v1',
+            'schema_version' => 'mbti.personalization.phase8a.v1',
             'locale' => $locale,
             'type_code' => $typeCode,
             'identity' => $identity,

--- a/backend/app/Services/Mbti/MbtiUserStateOrchestrationService.php
+++ b/backend/app/Services/Mbti/MbtiUserStateOrchestrationService.php
@@ -89,6 +89,42 @@ final class MbtiUserStateOrchestrationService
     ];
 
     /**
+     * @var array<string, list<string>>
+     */
+    private const SECTION_CARRYOVER_SCENE_KEYS = [
+        'career.summary' => ['work'],
+        'career.collaboration_fit' => ['work', 'communication'],
+        'career.work_environment' => ['work'],
+        'career.work_experiments' => ['work', 'decision'],
+        'career.next_step' => ['work', 'decision'],
+        'growth.summary' => ['growth'],
+        'growth.stability_confidence' => ['stability'],
+        'growth.next_actions' => ['growth'],
+        'growth.weekly_experiments' => ['growth'],
+        'growth.stress_recovery' => ['stress_recovery'],
+        'growth.watchouts' => ['stress_recovery', 'growth'],
+        'traits.why_this_type' => ['explainability'],
+        'traits.close_call_axes' => ['explainability'],
+        'traits.adjacent_type_contrast' => ['explainability'],
+        'traits.decision_style' => ['decision'],
+        'relationships.communication_style' => ['communication', 'relationships'],
+        'relationships.try_this_week' => ['relationships', 'communication'],
+    ];
+
+    /**
+     * @var array<string, list<string>>
+     */
+    private const SECTION_CARRYOVER_ACTION_FIELDS = [
+        'career.next_step' => ['career_next_step_keys'],
+        'career.work_experiments' => ['work_experiment_keys'],
+        'growth.next_actions' => ['weekly_action_keys'],
+        'growth.weekly_experiments' => ['weekly_action_keys'],
+        'growth.stability_confidence' => ['watchout_keys'],
+        'growth.watchouts' => ['watchout_keys'],
+        'relationships.try_this_week' => ['relationship_action_keys'],
+    ];
+
+    /**
      * @param  array<string, mixed>  $personalization
      * @return array<string, mixed>
      */
@@ -150,6 +186,7 @@ final class MbtiUserStateOrchestrationService
     {
         $primaryFocusKey = $this->resolvePrimaryFocusKey($personalization, $userState);
         $secondaryFocusKeys = $this->resolveSecondaryFocusKeys($primaryFocusKey, $userState);
+        $continuity = $this->resolveContinuity($personalization, $userState, $primaryFocusKey, $secondaryFocusKeys);
 
         return array_merge($personalization, [
             'user_state' => $userState,
@@ -159,7 +196,29 @@ final class MbtiUserStateOrchestrationService
                 'secondary_focus_keys' => $secondaryFocusKeys,
                 'cta_priority_keys' => $this->resolveCtaPriorityKeys($userState),
             ],
+            'continuity' => $continuity,
         ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @param  array<string, bool>  $userState
+     * @param  list<string>  $secondaryFocusKeys
+     * @return array<string, mixed>
+     */
+    private function resolveContinuity(
+        array $personalization,
+        array $userState,
+        string $primaryFocusKey,
+        array $secondaryFocusKeys
+    ): array {
+        return [
+            'carryover_focus_key' => $primaryFocusKey,
+            'carryover_reason' => $this->resolveCarryoverReason($primaryFocusKey, $userState),
+            'recommended_resume_keys' => $this->resolveRecommendedResumeKeys($primaryFocusKey, $secondaryFocusKeys, $userState),
+            'carryover_scene_keys' => $this->resolveCarryoverSceneKeys($personalization, $primaryFocusKey, $secondaryFocusKeys),
+            'carryover_action_keys' => $this->resolveCarryoverActionKeys($personalization, $primaryFocusKey, $secondaryFocusKeys),
+        ];
     }
 
     /**
@@ -262,6 +321,148 @@ final class MbtiUserStateOrchestrationService
         }
 
         return ['career_bridge', 'share_result', 'workspace_lite'];
+    }
+
+    /**
+     * @param  array<string, bool>  $userState
+     */
+    private function resolveCarryoverReason(string $primaryFocusKey, array $userState): string
+    {
+        $isRevisit = (bool) ($userState['is_revisit'] ?? false);
+        $hasUnlock = (bool) ($userState['has_unlock'] ?? false);
+        $hasFeedback = (bool) ($userState['has_feedback'] ?? false);
+        $hasShare = (bool) ($userState['has_share'] ?? false);
+        $hasActionEngagement = (bool) ($userState['has_action_engagement'] ?? false);
+
+        if ($isRevisit && $hasActionEngagement) {
+            return 'resume_action_loop';
+        }
+
+        if ($isRevisit && $hasShare) {
+            return 'return_from_share';
+        }
+
+        if ($isRevisit && $hasFeedback) {
+            return 'refine_after_feedback';
+        }
+
+        if (! $hasUnlock) {
+            return 'unlock_to_continue_focus';
+        }
+
+        if (str_starts_with($primaryFocusKey, 'career.')) {
+            return 'continue_career_bridge';
+        }
+
+        if (str_starts_with($primaryFocusKey, 'relationships.')) {
+            return 'continue_relationship_practice';
+        }
+
+        if (str_starts_with($primaryFocusKey, 'traits.')) {
+            return 'continue_explainability_focus';
+        }
+
+        if ($isRevisit) {
+            return 'resume_previous_focus';
+        }
+
+        return 'continue_action_plan';
+    }
+
+    /**
+     * @param  list<string>  $secondaryFocusKeys
+     * @param  array<string, bool>  $userState
+     * @return list<string>
+     */
+    private function resolveRecommendedResumeKeys(
+        string $primaryFocusKey,
+        array $secondaryFocusKeys,
+        array $userState
+    ): array {
+        $keys = [$primaryFocusKey, ...$secondaryFocusKeys];
+        $defaultKey = (bool) ($userState['has_unlock'] ?? false) ? 'career.next_step' : 'growth.next_actions';
+        $keys[] = $defaultKey;
+
+        return array_values(array_slice(array_values(array_unique(array_filter($keys))), 0, 3));
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @param  list<string>  $secondaryFocusKeys
+     * @return list<string>
+     */
+    private function resolveCarryoverSceneKeys(
+        array $personalization,
+        string $primaryFocusKey,
+        array $secondaryFocusKeys
+    ): array {
+        $sceneKeys = [];
+
+        foreach ([$primaryFocusKey, ...$secondaryFocusKeys] as $sectionKey) {
+            foreach (self::SECTION_CARRYOVER_SCENE_KEYS[$sectionKey] ?? [] as $sceneKey) {
+                $sceneKeys[] = $sceneKey;
+            }
+        }
+
+        if ($sceneKeys === []) {
+            foreach (array_keys((array) ($personalization['scene_fingerprint'] ?? [])) as $sceneKey) {
+                $sceneKeys[] = trim((string) $sceneKey);
+                if (count($sceneKeys) >= 2) {
+                    break;
+                }
+            }
+        }
+
+        return array_values(array_slice(array_values(array_unique(array_filter($sceneKeys))), 0, 3));
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @param  list<string>  $secondaryFocusKeys
+     * @return list<string>
+     */
+    private function resolveCarryoverActionKeys(
+        array $personalization,
+        string $primaryFocusKey,
+        array $secondaryFocusKeys
+    ): array {
+        $actionKeys = [];
+
+        foreach ([$primaryFocusKey, ...$secondaryFocusKeys] as $sectionKey) {
+            foreach (self::SECTION_CARRYOVER_ACTION_FIELDS[$sectionKey] ?? [] as $field) {
+                $preferredKey = $this->selectPreferredCarryoverActionKey((array) ($personalization[$field] ?? []));
+                if ($preferredKey !== '') {
+                    $actionKeys[] = $preferredKey;
+                }
+            }
+        }
+
+        return array_values(array_slice(array_values(array_unique($actionKeys)), 0, 4));
+    }
+
+    /**
+     * @param  list<mixed>  $keys
+     */
+    private function selectPreferredCarryoverActionKey(array $keys): string
+    {
+        $normalizedKeys = array_values(array_filter(array_map(
+            static fn (mixed $key): string => trim((string) $key),
+            $keys
+        )));
+
+        if ($normalizedKeys === []) {
+            return '';
+        }
+
+        foreach (['.theme.', '.stability.', '.close_call.'] as $needle) {
+            foreach ($normalizedKeys as $key) {
+                if (str_contains($key, $needle)) {
+                    return $key;
+                }
+            }
+        }
+
+        return $normalizedKeys[0];
     }
 
     /**

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -676,6 +676,7 @@ class ShareService
                 $publicSafeReport,
                 $this->normalizeArray($result->result_json ?? null)
             );
+            $payload['mbti_continuity_v1'] = $this->extractMbtiContinuity($publicSafeReport);
             $payload = $this->applyMbtiProjectionAliases($payload);
         }
 
@@ -728,5 +729,50 @@ class ShareService
     private function resolveCompareCtaLabel(string $locale): string
     {
         return $locale === 'zh-CN' ? '邀请朋友来测并对比' : 'Invite a friend to compare';
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     * @return array<string, mixed>
+     */
+    private function extractMbtiContinuity(array $report): array
+    {
+        $personalization = is_array(data_get($report, '_meta.personalization'))
+            ? data_get($report, '_meta.personalization')
+            : [];
+        $continuity = is_array($personalization['continuity'] ?? null) ? $personalization['continuity'] : [];
+
+        if ($continuity === []) {
+            return [];
+        }
+
+        $payload = [
+            'carryover_focus_key' => trim((string) ($continuity['carryover_focus_key'] ?? '')),
+            'carryover_reason' => trim((string) ($continuity['carryover_reason'] ?? '')),
+            'recommended_resume_keys' => array_values(array_filter(array_map(
+                static fn (mixed $value): string => trim((string) $value),
+                (array) ($continuity['recommended_resume_keys'] ?? [])
+            ))),
+            'carryover_scene_keys' => array_values(array_filter(array_map(
+                static fn (mixed $value): string => trim((string) $value),
+                (array) ($continuity['carryover_scene_keys'] ?? [])
+            ))),
+            'carryover_action_keys' => array_values(array_filter(array_map(
+                static fn (mixed $value): string => trim((string) $value),
+                (array) ($continuity['carryover_action_keys'] ?? [])
+            ))),
+        ];
+
+        return array_filter($payload, static function (mixed $value): bool {
+            if (is_string($value)) {
+                return $value !== '';
+            }
+
+            if (is_array($value)) {
+                return $value !== [];
+            }
+
+            return $value !== null;
+        });
     }
 }

--- a/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+++ b/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
@@ -96,7 +96,7 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
 
         $this->assertTrue((bool) ($payload['ok'] ?? false));
         $this->assertSame(
-            'mbti.personalization.phase7b.v1',
+            'mbti.personalization.phase8a.v1',
             data_get($payload, 'report._meta.personalization.schema_version')
         );
         $this->assertSame(
@@ -104,7 +104,7 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             data_get($payload, 'report._meta.personalization.engine_version')
         );
         $this->assertSame(
-            'phase7b.v1',
+            'phase8a.v1',
             data_get($payload, 'report._meta.personalization.dynamic_sections_version')
         );
         $this->assertSame(
@@ -121,6 +121,18 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
         $this->assertSame(
             'growth.next_actions',
             data_get($payload, 'report._meta.personalization.orchestration.primary_focus_key')
+        );
+        $this->assertSame(
+            'growth.next_actions',
+            data_get($payload, 'report._meta.personalization.continuity.carryover_focus_key')
+        );
+        $this->assertSame(
+            'unlock_to_continue_focus',
+            data_get($payload, 'report._meta.personalization.continuity.carryover_reason')
+        );
+        $this->assertContains(
+            'weekly_action.theme.name_decision_rule',
+            data_get($payload, 'report._meta.personalization.continuity.carryover_action_keys', [])
         );
         $this->assertNotSame(
             '',
@@ -330,16 +342,20 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             ->first(static fn (array $section): bool => (string) ($section['key'] ?? '') === 'relationships.try_this_week');
 
         $this->assertSame(
-            'mbti.personalization.phase7b.v1',
+            'mbti.personalization.phase8a.v1',
             data_get($projection, '_meta.personalization.schema_version')
         );
         $this->assertSame(
-            'phase7b.v1',
+            'phase8a.v1',
             data_get($projection, '_meta.personalization.dynamic_sections_version')
         );
         $this->assertSame(
             'growth.next_actions',
             data_get($projection, '_meta.personalization.orchestration.primary_focus_key')
+        );
+        $this->assertSame(
+            'growth.next_actions',
+            data_get($projection, '_meta.personalization.continuity.carryover_focus_key')
         );
         $this->assertSame(
             'overview:EI.E.clear:identity.T:boundary.none',

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -43,8 +43,8 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertSame('INTJ-A', (string) ($meta['type_code'] ?? ''));
             $this->assertSame('A', (string) ($meta['identity'] ?? ''));
             $this->assertSame('report_phase4a_contract', (string) ($meta['engine_version'] ?? ''));
-            $this->assertSame('mbti.personalization.phase7b.v1', (string) ($meta['schema_version'] ?? ''));
-            $this->assertSame('phase7b.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
+            $this->assertSame('mbti.personalization.phase8a.v1', (string) ($meta['schema_version'] ?? ''));
+            $this->assertSame('phase8a.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
             $this->assertIsArray($meta['axis_bands'] ?? null);
             $this->assertSame('boundary', (string) (($meta['axis_bands']['EI'] ?? '')));
             $this->assertSame('boundary', (string) (($meta['axis_bands']['AT'] ?? '')));
@@ -91,6 +91,7 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertIsArray($meta['watchout_keys'] ?? null);
             $this->assertIsArray($meta['user_state'] ?? null);
             $this->assertIsArray($meta['orchestration'] ?? null);
+            $this->assertIsArray($meta['continuity'] ?? null);
             $this->assertContains('role_fit.role.NT', $meta['role_fit_keys'] ?? []);
         }
 
@@ -127,6 +128,50 @@ class MbtiResultTelemetryContractTest extends TestCase
         $this->assertSame(
             ['unlock_full_report', 'career_bridge', 'share_result'],
             data_get($eventMeta, 'result_view.orchestration.cta_priority_keys')
+        );
+        $this->assertSame(
+            'growth.stability_confidence',
+            data_get($eventMeta, 'result_view.continuity.carryover_focus_key')
+        );
+        $this->assertSame(
+            'growth.stability_confidence',
+            data_get($eventMeta, 'report_view.continuity.carryover_focus_key')
+        );
+        $this->assertSame(
+            'unlock_to_continue_focus',
+            data_get($eventMeta, 'result_view.continuity.carryover_reason')
+        );
+        $this->assertSame(
+            'resume_action_loop',
+            data_get($eventMeta, 'report_view.continuity.carryover_reason')
+        );
+        $this->assertSame(
+            ['growth.stability_confidence', 'traits.close_call_axes', 'traits.adjacent_type_contrast'],
+            data_get($eventMeta, 'result_view.continuity.recommended_resume_keys')
+        );
+        $this->assertSame(
+            ['growth.stability_confidence', 'career.work_experiments', 'relationships.try_this_week'],
+            data_get($eventMeta, 'report_view.continuity.recommended_resume_keys')
+        );
+        $this->assertSame(
+            ['stability', 'explainability'],
+            data_get($eventMeta, 'result_view.continuity.carryover_scene_keys')
+        );
+        $this->assertSame(
+            ['stability', 'work', 'decision'],
+            data_get($eventMeta, 'report_view.continuity.carryover_scene_keys')
+        );
+        $this->assertSame(
+            ['watchout.stability.context_sensitive'],
+            data_get($eventMeta, 'result_view.continuity.carryover_action_keys')
+        );
+        $this->assertSame(
+            [
+                'watchout.stability.context_sensitive',
+                'work_experiment.theme.protect_energy_lane',
+                'relationship_action.theme.protect_energy_lane',
+            ],
+            data_get($eventMeta, 'report_view.continuity.carryover_action_keys')
         );
     }
 

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -67,6 +67,9 @@ final class ShareSummaryContractTest extends TestCase
         $this->assertSame('INTJ', $response->json('mbti_public_projection_v1.canonical_type_code'));
         $this->assertSame('建筑师型', $response->json('mbti_public_projection_v1.profile.type_name'));
         $this->assertSame('公开人格简介兜底文案', $response->json('mbti_public_projection_v1.summary_card.summary'));
+        $this->assertSame('growth.next_actions', $response->json('mbti_continuity_v1.carryover_focus_key'));
+        $this->assertSame('unlock_to_continue_focus', $response->json('mbti_continuity_v1.carryover_reason'));
+        $this->assertSame(['growth.next_actions', 'traits.close_call_axes', 'traits.adjacent_type_contrast'], $response->json('mbti_continuity_v1.recommended_resume_keys'));
         $this->assertSame($response->json('type_code'), $response->json('mbti_public_projection_v1.display_type'));
         $this->assertSame($response->json('type_name'), $response->json('mbti_public_projection_v1.profile.type_name'));
         $this->assertSame($response->json('dimensions'), $response->json('mbti_public_projection_v1.dimensions'));
@@ -132,6 +135,7 @@ final class ShareSummaryContractTest extends TestCase
             'dimensions',
             'primary_cta_label',
             'primary_cta_path',
+            'mbti_continuity_v1',
             'mbti_public_summary_v1',
             'mbti_public_projection_v1',
         ] as $key) {

--- a/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
@@ -60,14 +60,14 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
 
         $this->assertSame('ENFP-T', $clear['type_code']);
         $this->assertSame('T', $clear['identity']);
-        $this->assertSame('mbti.personalization.phase7b.v1', $clear['schema_version']);
+        $this->assertSame('mbti.personalization.phase8a.v1', $clear['schema_version']);
         $this->assertSame('clear', data_get($clear, 'axis_bands.EI'));
         $this->assertSame('strong', data_get($strong, 'axis_bands.EI'));
         $this->assertSame(false, data_get($clear, 'boundary_flags.EI'));
         $this->assertSame(false, data_get($strong, 'boundary_flags.EI'));
         $this->assertSame('MBTI.cn-mainland.zh-CN.v0.3', $clear['pack_id']);
         $this->assertSame('report_phase4a_contract', $clear['engine_version']);
-        $this->assertSame('phase7b.v1', $clear['dynamic_sections_version']);
+        $this->assertSame('phase8a.v1', $clear['dynamic_sections_version']);
         $this->assertSame(
             [
                 'is_first_view' => true,
@@ -83,6 +83,20 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
         $this->assertSame(
             ['unlock_full_report', 'career_bridge', 'share_result'],
             data_get($clear, 'orchestration.cta_priority_keys')
+        );
+        $this->assertSame('growth.next_actions', data_get($clear, 'continuity.carryover_focus_key'));
+        $this->assertSame('unlock_to_continue_focus', data_get($clear, 'continuity.carryover_reason'));
+        $this->assertSame(
+            ['growth.next_actions', 'traits.close_call_axes', 'traits.adjacent_type_contrast'],
+            data_get($clear, 'continuity.recommended_resume_keys')
+        );
+        $this->assertSame(
+            ['growth', 'explainability'],
+            data_get($clear, 'continuity.carryover_scene_keys')
+        );
+        $this->assertContains(
+            'weekly_action.theme.name_decision_rule',
+            data_get($clear, 'continuity.carryover_action_keys', [])
         );
         $this->assertLessThan(
             array_search('growth.summary', data_get($clear, 'orchestration.ordered_section_keys', []), true),

--- a/backend/tests/Unit/Services/Mbti/MbtiUserStateOrchestrationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiUserStateOrchestrationServiceTest.php
@@ -106,6 +106,18 @@ final class MbtiUserStateOrchestrationServiceTest extends TestCase
             ['career.work_experiments', 'relationships.try_this_week'],
             data_get($effective, 'orchestration.secondary_focus_keys')
         );
+        $this->assertSame('growth.stability_confidence', data_get($effective, 'continuity.carryover_focus_key'));
+        $this->assertSame('resume_action_loop', data_get($effective, 'continuity.carryover_reason'));
+        $this->assertSame(
+            ['growth.stability_confidence', 'career.work_experiments', 'relationships.try_this_week'],
+            data_get($effective, 'continuity.recommended_resume_keys')
+        );
+        $this->assertSame(
+            ['stability', 'work', 'decision'],
+            data_get($effective, 'continuity.carryover_scene_keys')
+        );
+        $this->assertContains('watchout.stability.context_sensitive', data_get($effective, 'continuity.carryover_action_keys', []));
+        $this->assertContains('work_experiment.theme.name_decision_rule', data_get($effective, 'continuity.carryover_action_keys', []));
     }
 
     /**

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
@@ -1,6 +1,6 @@
 {
     "schema": "fap.mbti.dynamic_sections.v1",
-    "version": "phase7b.v1",
+    "version": "phase8a.v1",
   "labels": {
     "block_kinds": {
       "type_skeleton": "类型骨架",


### PR DESCRIPTION
## Summary

This PR ships the backend half of MBTI Phase 8A: cross-page continuity and focus carryover.

The MBTI result stack already had a strong single-authority chain for:

- strength-layered variants
- scene fingerprint and boundary deepening
- explainability and borderline contrast
- career / working-life bridge
- action plan / guided next steps
- user-state-aware ordering

What was still missing was continuity outside the result page itself.

This PR closes that gap by extending the existing MBTI personalization envelope with carryover authority that can survive report/projection/snapshot boundaries and be reused on the next relevant surface.

## Problem

Before this change, MBTI had become strong at single-page personalization, but the user could still fall out of context when moving between surfaces such as:

- result page
- share landing page and share return flow
- revisit / history re-entry
- post-purchase continuation
- career recommendation entry points

The result page knew the current focus, but the next page often did not. That weakened continuity and made the product behave like a series of isolated pages instead of one continuing experience.

## Root cause

The repo already had enough authority to solve this:

- result/report personalization already held focus and orchestration
- snapshot/projection already provided a stable envelope
- user-state signals already existed from the Phase 7B work

What was missing was a formal carryover layer that could be serialized and reused across surfaces, plus share/read endpoints that would propagate it.

## Fix

This PR introduces a formal Phase 8A carryover authority on the backend.

It adds and persists these continuity fields:

- `carryover_focus_key`
- `carryover_reason`
- `recommended_resume_keys`
- `carryover_scene_keys`
- `carryover_action_keys`

The implementation keeps the existing architecture intact:

- no migration
- no new dependency
- no new scoring path
- no second authority source
- no change to payment, CMS, AIC, or the career recommendation system itself

Implementation highlights:

- extends MBTI personalization and user-state orchestration to produce continuity authority
- carries continuity through report/projection/snapshot metadata
- exposes the continuity envelope in read-time telemetry meta
- extends share summary payloads so share surfaces can continue the same MBTI focus
- bumps metadata boundaries to the Phase 8A contract

This PR also tightens carryover selection by preferring semantically meaningful action/focus keys rather than forwarding only structural section keys.

## User impact

After this PR, MBTI context no longer resets at the result page boundary.

The backend can now formally tell downstream surfaces:

- what the current focus is
- why that focus should continue
- which sections are worth resuming first
- which scene and action keys should travel with the user

That is the first real cross-page continuity layer for MBTI.

## Validation

I ran:

- `php artisan test tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php tests/Unit/Services/Mbti/MbtiUserStateOrchestrationServiceTest.php tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php tests/Feature/V0_3/MbtiResultTelemetryContractTest.php tests/Feature/V0_3/ShareSummaryContractTest.php`

All passed:

- 11 tests passed
- 481 assertions

## Scope note

This PR intentionally excludes unrelated local dirty changes already present in the repo, especially:

- `backend/content_packs/BIG5_OCEAN/v1/compiled/*`
- `backend/app/Console/Commands/PacksPublish.php`
- `backend/app/Console/Commands/PacksRollback.php`
- `backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php`

Only the MBTI Phase 8A backend continuity files are included.
