### PR TITLE
[codex] add historical metadata backfill and dry-run blob gc plan

### DIFF
--- a/backend/app/Console/Commands/StorageBackfillReleaseMetadata.php
+++ b/backend/app/Console/Commands/StorageBackfillReleaseMetadata.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\ReleaseMetadataBackfillService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageBackfillReleaseMetadata extends Command
+{
+    protected $signature = 'storage:backfill-release-metadata
+        {--dry-run : Scan only and report summary}
+        {--execute : Execute idempotent metadata backfill}';
+
+    protected $description = 'Backfill historical release/artifact rollout metadata without touching runtime bytes.';
+
+    public function __construct(
+        private readonly ReleaseMetadataBackfillService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $payload = $this->service->run($execute);
+        $warningCount = is_array($payload['warnings'] ?? null) ? count($payload['warnings']) : 0;
+
+        $this->line('status='.(($payload['mode'] ?? '') === 'execute' ? 'executed' : 'planned'));
+        $this->line('mode='.(string) ($payload['mode'] ?? ''));
+        $this->line('release_rows_scanned='.(int) ($payload['release_rows_scanned'] ?? 0));
+        if (($payload['mode'] ?? '') === 'execute') {
+            $this->line('release_rows_backfilled='.(int) ($payload['release_rows_backfilled'] ?? 0));
+            $this->line('manifests_upserted='.(int) ($payload['manifests_upserted'] ?? 0));
+            $this->line('manifest_files_upserted='.(int) ($payload['manifest_files_upserted'] ?? 0));
+            $this->line('blobs_upserted='.(int) ($payload['blobs_upserted'] ?? 0));
+        } else {
+            $this->line('release_rows_backfillable='.(int) ($payload['release_rows_backfillable'] ?? 0));
+            $this->line('artifact_files_scanned='.(int) ($payload['artifact_files_scanned'] ?? 0));
+        }
+        $this->line('warnings='.$warningCount);
+
+        $this->recordAudit($payload);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_backfill_release_metadata',
+            'target_type' => 'storage',
+            'target_id' => 'release_metadata',
+            'meta_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_backfill_release_metadata',
+            'request_id' => null,
+            'reason' => 'historical_metadata_backfill',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/app/Console/Commands/StorageBlobGc.php
+++ b/backend/app/Console/Commands/StorageBlobGc.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\BlobReachabilityService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageBlobGc extends Command
+{
+    protected $signature = 'storage:blob-gc
+        {--dry-run : Build conservative reachability plan only}';
+
+    protected $description = 'Build a conservative blob reachability plan without executing destructive delete.';
+
+    public function __construct(
+        private readonly BlobReachabilityService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! (bool) $this->option('dry-run')) {
+            $this->error('--dry-run is required. PR-14 does not implement execute mode.');
+
+            return self::FAILURE;
+        }
+
+        $plan = $this->service->buildPlan();
+        $planDir = storage_path('app/private/gc_plans');
+        File::ensureDirectoryExists($planDir);
+        $planPath = $planDir.DIRECTORY_SEPARATOR.now()->format('Ymd_His').'_blob_gc_'.substr(bin2hex(random_bytes(4)), 0, 8).'.json';
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed to encode gc plan json.');
+
+            return self::FAILURE;
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        $summary = is_array($plan['summary'] ?? null) ? $plan['summary'] : [];
+        $this->line('status=planned');
+        $this->line('plan='.$planPath);
+        $this->line('reachable_blobs='.(int) ($summary['reachable_blob_count'] ?? 0));
+        $this->line('unreachable_blobs='.(int) ($summary['unreachable_blob_count'] ?? 0));
+        $this->line('planned_deletions='.(int) ($summary['planned_deletion_count'] ?? 0));
+        $this->line('dry_run_only=1');
+
+        $this->recordAudit($planPath, $plan);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(string $planPath, array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_blob_gc',
+            'target_type' => 'storage',
+            'target_id' => 'blob_gc',
+            'meta_json' => json_encode([
+                'schema' => $payload['schema'] ?? null,
+                'plan' => $planPath,
+                'root_summary' => [
+                    'root_release_count' => (int) ($summary['root_release_count'] ?? 0),
+                    'root_activation_count' => (int) ($summary['root_activation_count'] ?? 0),
+                    'root_snapshot_release_ref_count' => (int) ($summary['root_snapshot_release_ref_count'] ?? 0),
+                    'root_artifact_count' => (int) ($summary['root_artifact_count'] ?? 0),
+                ],
+                'reachable_blob_count' => (int) ($summary['reachable_blob_count'] ?? 0),
+                'unreachable_blob_count' => (int) ($summary['unreachable_blob_count'] ?? 0),
+                'planned_deletion_count' => (int) ($summary['planned_deletion_count'] ?? 0),
+                'reachable_bytes' => (int) ($summary['reachable_bytes'] ?? 0),
+                'unreachable_bytes' => (int) ($summary['unreachable_bytes'] ?? 0),
+                'planned_deletion_bytes' => (int) ($summary['planned_deletion_bytes'] ?? 0),
+                'dry_run_only' => true,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_blob_gc',
+            'request_id' => null,
+            'reason' => 'reachability_plan',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/app/Services/Storage/BlobReachabilityService.php
+++ b/backend/app/Services/Storage/BlobReachabilityService.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+final class BlobReachabilityService
+{
+    public function __construct(
+        private readonly ReleaseStorageLocator $releaseStorageLocator,
+        private readonly ArtifactStore $artifactStore,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildPlan(): array
+    {
+        $activeReleaseIds = $this->activeReleaseIds();
+        $snapshotReleaseIds = $this->snapshotReleaseIds();
+
+        $releaseRows = DB::table('content_pack_releases')
+            ->where(function ($query): void {
+                $query->where('status', 'success')
+                    ->orWhereIn('id', $this->activeReleaseIds())
+                    ->orWhereIn('id', $this->snapshotReleaseIds());
+            })
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get()
+            ->keyBy('id');
+
+        $reachableHashes = [];
+        $reachableManifestHashes = [];
+        $releaseStoragePaths = [];
+
+        foreach ($releaseRows as $release) {
+            $manifestHash = strtolower(trim((string) ($release->manifest_hash ?? '')));
+            if ($manifestHash !== '') {
+                $reachableManifestHashes[$manifestHash] = true;
+            }
+
+            $source = $this->releaseStorageLocator->resolveReleaseSource($release);
+            if ($source === null) {
+                continue;
+            }
+
+            $releaseStoragePaths[] = $source['root'];
+            $manifestMeta = $this->releaseStorageLocator->readManifestMetadataFromRoot($source['root']);
+            if ($manifestMeta['manifest_hash'] !== '') {
+                $reachableManifestHashes[strtolower($manifestMeta['manifest_hash'])] = true;
+            }
+
+            foreach ($this->releaseStorageLocator->collectCompiledFilesFromRoot($source['root']) as $file) {
+                $reachableHashes[(string) $file['hash']] = true;
+            }
+        }
+
+        foreach ($this->releaseStorageLocator->legacyBackupRoots() as $backupRoot) {
+            $releaseStoragePaths[] = $backupRoot;
+            $manifestMeta = $this->releaseStorageLocator->readManifestMetadataFromRoot($backupRoot);
+            if ($manifestMeta['manifest_hash'] !== '') {
+                $reachableManifestHashes[strtolower($manifestMeta['manifest_hash'])] = true;
+            }
+
+            foreach ($this->releaseStorageLocator->collectCompiledFilesFromRoot($backupRoot) as $file) {
+                $reachableHashes[(string) $file['hash']] = true;
+            }
+        }
+
+        $liveAliasPaths = [];
+        foreach ($this->releaseStorageLocator->liveAliasRoots() as $liveAliasRoot) {
+            $liveAliasPaths[] = $liveAliasRoot;
+            $manifestMeta = $this->releaseStorageLocator->readManifestMetadataFromRoot($liveAliasRoot);
+            if ($manifestMeta['manifest_hash'] !== '') {
+                $reachableManifestHashes[strtolower($manifestMeta['manifest_hash'])] = true;
+            }
+
+            foreach ($this->releaseStorageLocator->collectCompiledFilesFromRoot($liveAliasRoot) as $file) {
+                $reachableHashes[(string) $file['hash']] = true;
+            }
+        }
+
+        $artifactPaths = [];
+        foreach ($this->artifactRootFiles() as $entry) {
+            $artifactPaths[] = $entry['relative_path'];
+
+            try {
+                $bytes = (string) Storage::disk('local')->get($entry['relative_path']);
+                $reachableHashes[hash('sha256', $bytes)] = true;
+            } catch (\Throwable) {
+                continue;
+            }
+        }
+
+        $manifestIds = DB::table('content_release_manifests')
+            ->whereIn('manifest_hash', array_keys($reachableManifestHashes))
+            ->pluck('id');
+
+        if ($manifestIds->isNotEmpty()) {
+            $manifestFileHashes = DB::table('content_release_manifest_files')
+                ->whereIn('content_release_manifest_id', $manifestIds->all())
+                ->pluck('blob_hash');
+            foreach ($manifestFileHashes as $blobHash) {
+                $hash = strtolower(trim((string) $blobHash));
+                if ($hash !== '') {
+                    $reachableHashes[$hash] = true;
+                }
+            }
+        }
+
+        $catalogedBlobs = DB::table('storage_blobs')
+            ->select(['hash', 'size_bytes'])
+            ->get();
+
+        $reachableBlobHashes = [];
+        $unreachableBlobHashes = [];
+        $reachableBytes = 0;
+        $unreachableBytes = 0;
+
+        foreach ($catalogedBlobs as $blob) {
+            $hash = strtolower(trim((string) ($blob->hash ?? '')));
+            if ($hash === '') {
+                continue;
+            }
+
+            $sizeBytes = max(0, (int) ($blob->size_bytes ?? 0));
+            if (isset($reachableHashes[$hash])) {
+                $reachableBlobHashes[] = $hash;
+                $reachableBytes += $sizeBytes;
+            } else {
+                $unreachableBlobHashes[] = $hash;
+                $unreachableBytes += $sizeBytes;
+            }
+        }
+
+        sort($reachableBlobHashes);
+        sort($unreachableBlobHashes);
+        sort($activeReleaseIds);
+        sort($snapshotReleaseIds);
+        $releaseStoragePaths = array_values(array_unique($releaseStoragePaths));
+        sort($releaseStoragePaths);
+        $artifactPaths = array_values(array_unique($artifactPaths));
+        sort($artifactPaths);
+        $liveAliasPaths = array_values(array_unique($liveAliasPaths));
+        sort($liveAliasPaths);
+
+        return [
+            'schema' => 'storage_blob_gc_plan.v1',
+            'generated_at' => now()->toAtomString(),
+            'summary' => [
+                'root_release_count' => count($releaseStoragePaths),
+                'root_activation_count' => count($activeReleaseIds),
+                'root_snapshot_release_ref_count' => count($snapshotReleaseIds),
+                'root_artifact_count' => count($artifactPaths),
+                'reachable_blob_count' => count($reachableBlobHashes),
+                'unreachable_blob_count' => count($unreachableBlobHashes),
+                'planned_deletion_count' => 0,
+                'reachable_bytes' => $reachableBytes,
+                'unreachable_bytes' => $unreachableBytes,
+                'planned_deletion_bytes' => 0,
+            ],
+            'roots' => [
+                'active_release_ids' => $activeReleaseIds,
+                'snapshot_release_ids' => $snapshotReleaseIds,
+                'release_storage_paths' => $releaseStoragePaths,
+                'artifact_paths' => $artifactPaths,
+                'live_alias_paths' => $liveAliasPaths,
+            ],
+            'reachable' => [
+                'blob_hashes' => $reachableBlobHashes,
+            ],
+            'unreachable' => [
+                'blob_hashes' => $unreachableBlobHashes,
+            ],
+            'planned_deletions' => [
+                'dry_run_only' => true,
+                'blob_hashes' => [],
+            ],
+            'bytes' => [
+                'reachable' => $reachableBytes,
+                'unreachable' => $unreachableBytes,
+                'planned_deletions' => 0,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function activeReleaseIds(): array
+    {
+        return DB::table('content_pack_activations')
+            ->pluck('release_id')
+            ->filter(static fn (mixed $value): bool => trim((string) $value) !== '')
+            ->map(static fn (mixed $value): string => trim((string) $value))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function snapshotReleaseIds(): array
+    {
+        $columns = [
+            'from_content_pack_release_id',
+            'to_content_pack_release_id',
+            'activation_before_release_id',
+            'activation_after_release_id',
+        ];
+
+        $ids = [];
+        foreach (DB::table('content_release_snapshots')->get($columns) as $row) {
+            foreach ($columns as $column) {
+                $value = trim((string) ($row->{$column} ?? ''));
+                if ($value !== '') {
+                    $ids[$value] = true;
+                }
+            }
+        }
+
+        return array_keys($ids);
+    }
+
+    /**
+     * @return list<array{relative_path:string}>
+     */
+    private function artifactRootFiles(): array
+    {
+        $disk = Storage::disk('local');
+        $entries = [];
+
+        foreach ($disk->allFiles('artifacts/reports') as $relativePath) {
+            $entries[$relativePath] = ['relative_path' => $relativePath];
+        }
+        foreach ($disk->allFiles('artifacts/pdf') as $relativePath) {
+            $entries[$relativePath] = ['relative_path' => $relativePath];
+        }
+
+        foreach (['reports', 'private/reports'] as $prefix) {
+            foreach ($disk->allFiles($prefix) as $relativePath) {
+                if (! $this->shouldTreatLegacyArtifactAsRoot($relativePath)) {
+                    continue;
+                }
+
+                $entries[$relativePath] = ['relative_path' => $relativePath];
+            }
+        }
+
+        ksort($entries);
+
+        return array_values($entries);
+    }
+
+    private function shouldTreatLegacyArtifactAsRoot(string $relativePath): bool
+    {
+        $canonicalTarget = $this->canonicalArtifactTargetForLegacyPath($relativePath);
+        if ($canonicalTarget === null) {
+            return true;
+        }
+
+        return ! Storage::disk('local')->exists($canonicalTarget);
+    }
+
+    private function canonicalArtifactTargetForLegacyPath(string $relativePath): ?string
+    {
+        if (preg_match('#^(?:private/)?reports/([^/]+)/report\.json$#', $relativePath, $matches) === 1) {
+            return $this->artifactStore->reportCanonicalPath('MBTI', (string) $matches[1]);
+        }
+
+        if (preg_match('#^(?:private/)?reports/([^/]+)/([^/]+)/report\.json$#', $relativePath, $matches) === 1) {
+            return $this->artifactStore->reportCanonicalPath((string) $matches[1], (string) $matches[2]);
+        }
+
+        if (preg_match('#^(?:private/)?reports/([^/]+)/([^/]+)/([^/]+)/report_(free|full)\.pdf$#i', $relativePath, $matches) === 1) {
+            return $this->artifactStore->pdfCanonicalPath(
+                (string) $matches[1],
+                (string) $matches[2],
+                (string) $matches[3],
+                strtolower((string) $matches[4]),
+            );
+        }
+
+        if (preg_match('#^(?:private/)?reports/big5/([^/]+)/report_(free|full)\.pdf$#i', $relativePath, $matches) === 1) {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Storage/ReleaseMetadataBackfillService.php
+++ b/backend/app/Services/Storage/ReleaseMetadataBackfillService.php
@@ -1,0 +1,438 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+final class ReleaseMetadataBackfillService
+{
+    public function __construct(
+        private readonly BlobCatalogService $blobCatalogService,
+        private readonly ContentReleaseManifestCatalogService $manifestCatalogService,
+        private readonly ReleaseStorageLocator $releaseStorageLocator,
+    ) {}
+
+    /**
+     * @return array{
+     *   schema_version:int,
+     *   mode:string,
+     *   generated_at:string,
+     *   release_rows_scanned:int,
+     *   release_rows_backfillable:int,
+     *   release_rows_backfilled:int,
+     *   release_rows_skipped:int,
+     *   backup_roots_scanned:int,
+     *   backup_roots_backfillable:int,
+     *   backup_roots_backfilled:int,
+     *   artifact_files_scanned:int,
+     *   artifact_blobs_upserted:int,
+     *   manifests_upserted:int,
+     *   manifest_files_upserted:int,
+     *   blobs_upserted:int,
+     *   missing_physical_sources:int,
+     *   warnings:list<string>
+     * }
+     */
+    public function run(bool $execute): array
+    {
+        $summary = [
+            'schema_version' => 1,
+            'mode' => $execute ? 'execute' : 'dry_run',
+            'generated_at' => now()->toAtomString(),
+            'release_rows_scanned' => 0,
+            'release_rows_backfillable' => 0,
+            'release_rows_backfilled' => 0,
+            'release_rows_skipped' => 0,
+            'backup_roots_scanned' => 0,
+            'backup_roots_backfillable' => 0,
+            'backup_roots_backfilled' => 0,
+            'artifact_files_scanned' => 0,
+            'artifact_blobs_upserted' => 0,
+            'manifests_upserted' => 0,
+            'manifest_files_upserted' => 0,
+            'blobs_upserted' => 0,
+            'missing_physical_sources' => 0,
+            'warnings' => [],
+        ];
+        $processedRoots = [];
+
+        $releases = DB::table('content_pack_releases')
+            ->where('status', 'success')
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get();
+
+        foreach ($releases as $release) {
+            $this->processRelease($release, $execute, $summary, $processedRoots);
+        }
+
+        foreach ($this->releaseStorageLocator->legacyBackupRoots() as $backupRoot) {
+            $normalizedRoot = $this->normalizeRoot($backupRoot);
+            if ($normalizedRoot === '' || isset($processedRoots[$normalizedRoot])) {
+                continue;
+            }
+
+            $this->processBackupRoot($backupRoot, $execute, $summary, $processedRoots);
+        }
+
+        $artifactEntries = $this->collectArtifactEntries();
+        $summary['artifact_files_scanned'] = count($artifactEntries);
+        if ($execute) {
+            foreach ($artifactEntries as $entry) {
+                try {
+                    $bytes = (string) Storage::disk('local')->get($entry['relative_path']);
+                    $this->blobCatalogService->upsertBlob([
+                        'hash' => hash('sha256', $bytes),
+                        'disk' => 'local',
+                        'storage_path' => $this->blobCatalogService->storagePathForHash(hash('sha256', $bytes)),
+                        'size_bytes' => strlen($bytes),
+                        'content_type' => $entry['content_type'],
+                        'encoding' => 'identity',
+                        'ref_count' => 0,
+                        'last_verified_at' => now(),
+                    ]);
+                    $summary['artifact_blobs_upserted']++;
+                    $summary['blobs_upserted']++;
+                } catch (\Throwable $e) {
+                    $this->appendWarning($summary, 'artifact blob catalog failed for '.$entry['relative_path'].': '.$e->getMessage());
+                }
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @param  array<string,bool>  $processedRoots
+     */
+    private function processRelease(object $release, bool $execute, array &$summary, array &$processedRoots): void
+    {
+        $summary['release_rows_scanned']++;
+
+        $source = $this->releaseStorageLocator->resolveReleaseSource($release);
+        if ($source === null) {
+            $summary['release_rows_skipped']++;
+            $summary['missing_physical_sources']++;
+            $this->appendWarning($summary, 'missing physical source for release '.trim((string) ($release->id ?? '')));
+
+            return;
+        }
+
+        $normalizedRoot = $this->normalizeRoot((string) $source['root']);
+        if ($normalizedRoot !== '') {
+            $processedRoots[$normalizedRoot] = true;
+        }
+
+        $summary['release_rows_backfillable']++;
+
+        $manifestMeta = $this->releaseStorageLocator->readManifestMetadataFromRoot($source['root']);
+        $manifestHash = trim((string) ($release->manifest_hash ?? ''));
+        if ($manifestHash === '') {
+            $manifestHash = $manifestMeta['manifest_hash'];
+        }
+
+        $packVersion = $this->derivePackVersion($release, $manifestMeta['decoded']);
+        $sourceCommit = trim((string) ($release->source_commit ?? $release->git_sha ?? ''));
+        $storagePathForPatch = trim((string) ($source['storage_path_for_patch'] ?? ''));
+
+        $patch = [];
+        if (trim((string) ($release->pack_version ?? '')) === '' && $packVersion !== '') {
+            $patch['pack_version'] = $packVersion;
+        }
+        if ($this->isEmptyJsonColumn($release->manifest_json ?? null) && $manifestMeta['raw_json'] !== '') {
+            $patch['manifest_json'] = $manifestMeta['raw_json'];
+        }
+        if (trim((string) ($release->storage_path ?? '')) === '' && $storagePathForPatch !== '') {
+            $patch['storage_path'] = $storagePathForPatch;
+        }
+        if (trim((string) ($release->source_commit ?? '')) === '' && $sourceCommit !== '') {
+            $patch['source_commit'] = $sourceCommit;
+        }
+
+        $compiledFiles = $this->releaseStorageLocator->collectCompiledFilesFromRoot($source['root']);
+        if ($compiledFiles === []) {
+            $summary['release_rows_skipped']++;
+            $summary['missing_physical_sources']++;
+            $this->appendWarning($summary, 'no compiled files found for release '.trim((string) ($release->id ?? '')));
+
+            return;
+        }
+
+        if (! $execute) {
+            return;
+        }
+
+        if ($patch !== []) {
+            DB::table('content_pack_releases')
+                ->where('id', (string) $release->id)
+                ->update($patch);
+        }
+
+        $blobCatalogFailed = false;
+        foreach ($compiledFiles as $file) {
+            try {
+                $this->blobCatalogService->upsertBlob([
+                    'hash' => $file['hash'],
+                    'disk' => 'local',
+                    'storage_path' => $this->blobCatalogService->storagePathForHash($file['hash']),
+                    'size_bytes' => $file['size_bytes'],
+                    'content_type' => $file['content_type'],
+                    'encoding' => 'identity',
+                    'ref_count' => 0,
+                    'last_verified_at' => now(),
+                ]);
+                $summary['blobs_upserted']++;
+            } catch (\Throwable $e) {
+                $blobCatalogFailed = true;
+                $this->appendWarning(
+                    $summary,
+                    'release blob catalog failed for '.trim((string) ($release->id ?? '')).' '.$file['logical_path'].': '.$e->getMessage()
+                );
+            }
+        }
+
+        if ($manifestHash !== '' && ! $blobCatalogFailed) {
+            $existingManifest = $this->manifestCatalogService->findByManifestHash($manifestHash);
+            $manifestStoragePath = trim((string) ($existingManifest?->storage_path ?? ''));
+            if ($manifestStoragePath === '') {
+                $manifestStoragePath = $storagePathForPatch;
+            }
+
+            $manifestFiles = [];
+            foreach ($compiledFiles as $file) {
+                $manifestFiles[] = [
+                    'logical_path' => $file['logical_path'],
+                    'blob_hash' => $file['hash'],
+                    'size_bytes' => $file['size_bytes'],
+                    'role' => $file['role'],
+                    'content_type' => $file['content_type'],
+                    'encoding' => 'identity',
+                    'checksum' => 'sha256:'.$file['hash'],
+                ];
+            }
+
+            try {
+                $this->manifestCatalogService->upsertManifest([
+                    'content_pack_release_id' => $existingManifest?->content_pack_release_id ?: (string) ($release->id ?? ''),
+                    'manifest_hash' => $manifestHash,
+                    'storage_disk' => trim((string) ($existingManifest?->storage_disk ?? '')) !== '' ? (string) $existingManifest->storage_disk : 'local',
+                    'storage_path' => $manifestStoragePath,
+                    'pack_id' => strtoupper(trim((string) ($release->to_pack_id ?? $manifestMeta['pack_id'] ?? ''))),
+                    'pack_version' => $packVersion !== '' ? $packVersion : null,
+                    'compiled_hash' => trim((string) ($release->compiled_hash ?? $manifestMeta['compiled_hash'] ?? '')) ?: null,
+                    'content_hash' => trim((string) ($release->content_hash ?? $manifestMeta['content_hash'] ?? '')) ?: null,
+                    'norms_version' => trim((string) ($release->norms_version ?? $manifestMeta['norms_version'] ?? '')) ?: null,
+                    'source_commit' => $sourceCommit !== '' ? $sourceCommit : null,
+                    'payload_json' => $manifestMeta['decoded'] !== [] ? $manifestMeta['decoded'] : null,
+                ], $manifestFiles);
+                $summary['manifests_upserted']++;
+                $summary['manifest_files_upserted'] += count($manifestFiles);
+            } catch (\Throwable $e) {
+                $this->appendWarning($summary, 'release manifest upsert failed for '.trim((string) ($release->id ?? '')).': '.$e->getMessage());
+            }
+        }
+
+        $summary['release_rows_backfilled']++;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @param  array<string,bool>  $processedRoots
+     */
+    private function processBackupRoot(string $backupRoot, bool $execute, array &$summary, array &$processedRoots): void
+    {
+        $normalizedRoot = $this->normalizeRoot($backupRoot);
+        if ($normalizedRoot === '') {
+            return;
+        }
+
+        $processedRoots[$normalizedRoot] = true;
+        $summary['backup_roots_scanned']++;
+
+        $manifestMeta = $this->releaseStorageLocator->readManifestMetadataFromRoot($backupRoot);
+        $compiledFiles = $this->releaseStorageLocator->collectCompiledFilesFromRoot($backupRoot);
+        if ($compiledFiles === []) {
+            $summary['missing_physical_sources']++;
+            $this->appendWarning($summary, 'no compiled files found for backup root '.$backupRoot);
+
+            return;
+        }
+
+        $summary['backup_roots_backfillable']++;
+
+        if (! $execute) {
+            return;
+        }
+
+        $blobCatalogFailed = false;
+        foreach ($compiledFiles as $file) {
+            try {
+                $this->blobCatalogService->upsertBlob([
+                    'hash' => $file['hash'],
+                    'disk' => 'local',
+                    'storage_path' => $this->blobCatalogService->storagePathForHash($file['hash']),
+                    'size_bytes' => $file['size_bytes'],
+                    'content_type' => $file['content_type'],
+                    'encoding' => 'identity',
+                    'ref_count' => 0,
+                    'last_verified_at' => now(),
+                ]);
+                $summary['blobs_upserted']++;
+            } catch (\Throwable $e) {
+                $blobCatalogFailed = true;
+                $this->appendWarning(
+                    $summary,
+                    'backup blob catalog failed for '.$backupRoot.' '.$file['logical_path'].': '.$e->getMessage()
+                );
+            }
+        }
+
+        $manifestHash = trim((string) ($manifestMeta['manifest_hash'] ?? ''));
+        if ($manifestHash !== '' && ! $blobCatalogFailed) {
+            $existingManifest = $this->manifestCatalogService->findByManifestHash($manifestHash);
+            $manifestStoragePath = trim((string) ($existingManifest?->storage_path ?? ''));
+            if ($manifestStoragePath === '') {
+                $manifestStoragePath = $backupRoot;
+            }
+
+            $backupContext = $this->releaseStorageLocator->backupRootContext($backupRoot);
+            $backupReleaseId = trim((string) ($backupContext['release_id'] ?? ''));
+            if ($backupReleaseId !== '' && ! DB::table('content_pack_releases')->where('id', $backupReleaseId)->exists()) {
+                $backupReleaseId = '';
+            }
+            $manifestFiles = [];
+            foreach ($compiledFiles as $file) {
+                $manifestFiles[] = [
+                    'logical_path' => $file['logical_path'],
+                    'blob_hash' => $file['hash'],
+                    'size_bytes' => $file['size_bytes'],
+                    'role' => $file['role'],
+                    'content_type' => $file['content_type'],
+                    'encoding' => 'identity',
+                    'checksum' => 'sha256:'.$file['hash'],
+                ];
+            }
+
+            try {
+                $this->manifestCatalogService->upsertManifest([
+                    'content_pack_release_id' => $existingManifest?->content_pack_release_id
+                        ?: ($backupReleaseId !== '' ? $backupReleaseId : null),
+                    'manifest_hash' => $manifestHash,
+                    'storage_disk' => trim((string) ($existingManifest?->storage_disk ?? '')) !== '' ? (string) $existingManifest->storage_disk : 'local',
+                    'storage_path' => $manifestStoragePath,
+                    'pack_id' => strtoupper(trim((string) ($manifestMeta['pack_id'] ?? ''))) ?: null,
+                    'pack_version' => trim((string) ($manifestMeta['pack_version'] ?? '')) ?: null,
+                    'compiled_hash' => trim((string) ($manifestMeta['compiled_hash'] ?? '')) ?: null,
+                    'content_hash' => trim((string) ($manifestMeta['content_hash'] ?? '')) ?: null,
+                    'norms_version' => trim((string) ($manifestMeta['norms_version'] ?? '')) ?: null,
+                    'source_commit' => trim((string) ($existingManifest?->source_commit ?? '')) ?: null,
+                    'payload_json' => $manifestMeta['decoded'] !== [] ? $manifestMeta['decoded'] : null,
+                ], $manifestFiles);
+                $summary['manifests_upserted']++;
+                $summary['manifest_files_upserted'] += count($manifestFiles);
+            } catch (\Throwable $e) {
+                $this->appendWarning($summary, 'backup manifest upsert failed for '.$backupRoot.': '.$e->getMessage());
+            }
+        }
+
+        $summary['backup_roots_backfilled']++;
+    }
+
+    /**
+     * @return list<array{relative_path:string,content_type:?string}>
+     */
+    private function collectArtifactEntries(): array
+    {
+        $disk = Storage::disk('local');
+        $entries = [];
+
+        foreach (['artifacts/reports', 'artifacts/pdf', 'reports', 'private/reports'] as $prefix) {
+            foreach ($disk->allFiles($prefix) as $relativePath) {
+                $entries[$relativePath] = [
+                    'relative_path' => $relativePath,
+                    'content_type' => $this->contentTypeForArtifactPath($relativePath),
+                ];
+            }
+        }
+
+        ksort($entries);
+
+        return array_values($entries);
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifest
+     */
+    private function derivePackVersion(object $release, array $manifest): string
+    {
+        $version = trim((string) ($release->pack_version ?? ''));
+        if ($version !== '') {
+            return $version;
+        }
+
+        $version = trim((string) ($manifest['pack_version'] ?? $manifest['content_package_version'] ?? ''));
+        if ($version !== '') {
+            return $version;
+        }
+
+        $toVersionId = trim((string) ($release->to_version_id ?? ''));
+        if ($toVersionId !== '') {
+            $versionRow = DB::table('content_pack_versions')->where('id', $toVersionId)->first();
+            if ($versionRow !== null) {
+                $version = trim((string) ($versionRow->content_package_version ?? ''));
+                if ($version !== '') {
+                    return $version;
+                }
+            }
+        }
+
+        return '';
+    }
+
+    private function contentTypeForArtifactPath(string $relativePath): ?string
+    {
+        $relativePath = strtolower($relativePath);
+
+        return match (true) {
+            str_ends_with($relativePath, '.json') => 'application/json',
+            str_ends_with($relativePath, '.pdf') => 'application/pdf',
+            default => null,
+        };
+    }
+
+    private function isEmptyJsonColumn(mixed $value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        if (is_string($value)) {
+            return trim($value) === '';
+        }
+
+        if (is_array($value)) {
+            return $value === [];
+        }
+
+        return false;
+    }
+
+    private function normalizeRoot(string $root): string
+    {
+        return str_replace('\\', '/', rtrim(trim($root), '/\\'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function appendWarning(array &$summary, string $message): void
+    {
+        if (count($summary['warnings']) < 20) {
+            $summary['warnings'][] = $message;
+        }
+    }
+}

--- a/backend/app/Services/Storage/ReleaseStorageLocator.php
+++ b/backend/app/Services/Storage/ReleaseStorageLocator.php
@@ -1,0 +1,430 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+
+final class ReleaseStorageLocator
+{
+    /**
+     * @var array<string,object|null>
+     */
+    private array $versionCache = [];
+
+    /**
+     * @var array<string,string>
+     */
+    private array $rollbackSourceReleaseCache = [];
+
+    /**
+     * @param  object|array<string,mixed>  $release
+     * @return array{
+     *   root:string,
+     *   compiled_dir:string,
+     *   storage_path_for_patch:string,
+     *   resolved_from:string
+     * }|null
+     */
+    public function resolveReleaseSource(object|array $release): ?array
+    {
+        $storagePath = trim((string) data_get($release, 'storage_path'));
+        if ($storagePath !== '') {
+            foreach ($this->candidateRootsFromStoragePath($storagePath) as $root) {
+                $compiledDir = $this->compiledDirFromRoot($root);
+                if ($compiledDir === null) {
+                    continue;
+                }
+
+                return [
+                    'root' => $root,
+                    'compiled_dir' => $compiledDir,
+                    'storage_path_for_patch' => $storagePath,
+                    'resolved_from' => 'release.storage_path',
+                ];
+            }
+        }
+
+        $action = strtolower(trim((string) data_get($release, 'action')));
+        if ($action === 'publish') {
+            $versionId = trim((string) data_get($release, 'to_version_id'));
+            if ($versionId !== '') {
+                $legacyRoot = $this->legacySourcePackRoot($versionId);
+                $compiledDir = $this->compiledDirFromRoot($legacyRoot);
+                if ($compiledDir !== null) {
+                    return [
+                        'root' => $legacyRoot,
+                        'compiled_dir' => $compiledDir,
+                        'storage_path_for_patch' => $legacyRoot,
+                        'resolved_from' => 'legacy.source_pack',
+                    ];
+                }
+
+                $version = $this->versionRow($versionId);
+                $extractedRelPath = trim((string) ($version?->extracted_rel_path ?? ''));
+                if ($extractedRelPath !== '') {
+                    $extractedRoot = $this->absoluteStorageRoot($extractedRelPath);
+                    $compiledDir = $this->compiledDirFromRoot($extractedRoot);
+                    if ($compiledDir !== null) {
+                        return [
+                            'root' => $extractedRoot,
+                            'compiled_dir' => $compiledDir,
+                            'storage_path_for_patch' => $extractedRoot,
+                            'resolved_from' => 'legacy.extracted_rel_path',
+                        ];
+                    }
+                }
+            }
+        }
+
+        if ($action === 'rollback') {
+            $releaseId = trim((string) data_get($release, 'id'));
+            $sourceReleaseId = $this->rollbackSourceReleaseId($releaseId);
+            if ($sourceReleaseId !== '') {
+                $backupRoot = $this->legacyPreviousPackRoot($sourceReleaseId);
+                $compiledDir = $this->compiledDirFromRoot($backupRoot);
+                if ($compiledDir !== null) {
+                    return [
+                        'root' => $backupRoot,
+                        'compiled_dir' => $compiledDir,
+                        'storage_path_for_patch' => $backupRoot,
+                        'resolved_from' => 'legacy.previous_pack',
+                    ];
+                }
+            }
+        }
+
+        foreach ($this->candidateV2RootsFromRelease($release) as $candidate) {
+            $compiledDir = $this->compiledDirFromRoot($candidate['root']);
+            if ($compiledDir === null) {
+                continue;
+            }
+
+            return [
+                'root' => $candidate['root'],
+                'compiled_dir' => $compiledDir,
+                'storage_path_for_patch' => $candidate['storage_path_for_patch'],
+                'resolved_from' => $candidate['resolved_from'],
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{
+     *   raw_json:string,
+     *   decoded:array<string,mixed>,
+     *   manifest_hash:string,
+     *   pack_id:string,
+     *   pack_version:string,
+     *   compiled_hash:string,
+     *   content_hash:string,
+     *   norms_version:string
+     * }
+     */
+    public function readManifestMetadataFromRoot(string $root): array
+    {
+        $compiledDir = $this->compiledDirFromRoot($root);
+        if ($compiledDir === null) {
+            return [
+                'raw_json' => '',
+                'decoded' => [],
+                'manifest_hash' => '',
+                'pack_id' => '',
+                'pack_version' => '',
+                'compiled_hash' => '',
+                'content_hash' => '',
+                'norms_version' => '',
+            ];
+        }
+
+        $manifestPath = $compiledDir.DIRECTORY_SEPARATOR.'manifest.json';
+        if (! is_file($manifestPath)) {
+            return [
+                'raw_json' => '',
+                'decoded' => [],
+                'manifest_hash' => '',
+                'pack_id' => '',
+                'pack_version' => '',
+                'compiled_hash' => '',
+                'content_hash' => '',
+                'norms_version' => '',
+            ];
+        }
+
+        $rawJson = (string) File::get($manifestPath);
+        $decoded = json_decode($rawJson, true);
+        $decoded = is_array($decoded) ? $decoded : [];
+
+        return [
+            'raw_json' => $rawJson,
+            'decoded' => $decoded,
+            'manifest_hash' => $rawJson !== '' ? hash('sha256', $rawJson) : '',
+            'pack_id' => strtoupper(trim((string) ($decoded['pack_id'] ?? ''))),
+            'pack_version' => trim((string) ($decoded['pack_version'] ?? $decoded['content_package_version'] ?? '')),
+            'compiled_hash' => trim((string) ($decoded['compiled_hash'] ?? '')),
+            'content_hash' => trim((string) ($decoded['content_hash'] ?? '')),
+            'norms_version' => trim((string) ($decoded['norms_version'] ?? '')),
+        ];
+    }
+
+    /**
+     * @return list<array{logical_path:string,hash:string,size_bytes:int,content_type:?string,role:?string}>
+     */
+    public function collectCompiledFilesFromRoot(string $root): array
+    {
+        $compiledDir = $this->compiledDirFromRoot($root);
+        if ($compiledDir === null) {
+            return [];
+        }
+
+        $files = [];
+        foreach (File::allFiles($compiledDir) as $file) {
+            $absolutePath = $file->getPathname();
+            $logicalPath = ltrim(str_replace('\\', '/', substr($absolutePath, strlen(rtrim($root, '/\\')))), '/');
+            $bytes = (string) File::get($absolutePath);
+            $files[] = [
+                'logical_path' => $logicalPath,
+                'hash' => hash('sha256', $bytes),
+                'size_bytes' => strlen($bytes),
+                'content_type' => $this->contentTypeForLogicalPath($logicalPath),
+                'role' => $logicalPath === 'compiled/manifest.json' || $logicalPath === 'manifest.json' ? 'manifest' : null,
+            ];
+        }
+
+        usort($files, static fn (array $left, array $right): int => strcmp($left['logical_path'], $right['logical_path']));
+
+        return $files;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function liveAliasRoots(): array
+    {
+        $packsRoot = rtrim((string) config('content_packs.root', ''), '/\\');
+        if ($packsRoot === '' || ! is_dir($packsRoot)) {
+            return [];
+        }
+
+        $defaultRoot = basename($packsRoot) === 'default'
+            ? $packsRoot
+            : $packsRoot.DIRECTORY_SEPARATOR.'default';
+        if (! is_dir($defaultRoot)) {
+            return [];
+        }
+
+        $roots = [];
+        foreach (File::allFiles($defaultRoot) as $file) {
+            $path = str_replace('\\', '/', $file->getPathname());
+            if (! str_ends_with($path, '/compiled/manifest.json')) {
+                continue;
+            }
+
+            $roots[] = dirname(dirname($path));
+        }
+
+        return array_values(array_unique($roots));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function legacyBackupRoots(): array
+    {
+        $backupsRoot = storage_path('app/private/content_releases/backups');
+        if (! is_dir($backupsRoot)) {
+            return [];
+        }
+
+        $roots = [];
+        foreach (glob($backupsRoot.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR) ?: [] as $releaseRoot) {
+            foreach (['previous_pack', 'current_pack'] as $leaf) {
+                $candidate = $releaseRoot.DIRECTORY_SEPARATOR.$leaf;
+                if ($this->compiledDirFromRoot($candidate) !== null) {
+                    $roots[] = $candidate;
+                }
+            }
+        }
+
+        return array_values(array_unique($roots));
+    }
+
+    /**
+     * @return array{release_id:string,leaf:string}|null
+     */
+    public function backupRootContext(string $root): ?array
+    {
+        $pattern = '#^'.preg_quote(str_replace('\\', '/', storage_path('app/private/content_releases/backups')), '#').'/([^/]+)/(previous_pack|current_pack)$#';
+        $normalizedRoot = str_replace('\\', '/', rtrim($root, '/\\'));
+        if (preg_match($pattern, $normalizedRoot, $matches) !== 1) {
+            return null;
+        }
+
+        return [
+            'release_id' => (string) $matches[1],
+            'leaf' => (string) $matches[2],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function candidateRootsFromStoragePath(string $storagePath): array
+    {
+        $normalized = str_replace('\\', '/', trim($storagePath));
+        if ($normalized === '') {
+            return [];
+        }
+
+        $candidates = [];
+        if (str_starts_with($normalized, '/')) {
+            $candidates[] = rtrim($normalized, '/');
+        } else {
+            $relative = ltrim($normalized, '/');
+            if (str_starts_with($relative, 'app/')) {
+                $relative = substr($relative, 4);
+            }
+            $relative = ltrim($relative, '/');
+            if ($relative !== '') {
+                $candidates[] = rtrim(storage_path('app/'.$relative), '/');
+            }
+
+            if (str_starts_with($relative, 'private/packs_v2/')) {
+                $mirror = 'content_packs_v2/'.substr($relative, strlen('private/packs_v2/'));
+                $candidates[] = rtrim(storage_path('app/'.$mirror), '/');
+            } elseif (str_starts_with($relative, 'content_packs_v2/')) {
+                $mirror = 'private/packs_v2/'.substr($relative, strlen('content_packs_v2/'));
+                $candidates[] = rtrim(storage_path('app/'.$mirror), '/');
+            }
+        }
+
+        return array_values(array_unique(array_filter($candidates, static fn (string $root): bool => $root !== '')));
+    }
+
+    public function compiledDirFromRoot(string $root): ?string
+    {
+        $root = rtrim($root, '/\\');
+        if ($root === '') {
+            return null;
+        }
+
+        $compiledDir = $root.DIRECTORY_SEPARATOR.'compiled';
+        if (is_file($compiledDir.DIRECTORY_SEPARATOR.'manifest.json')) {
+            return $compiledDir;
+        }
+
+        if (is_file($root.DIRECTORY_SEPARATOR.'manifest.json')) {
+            return $root;
+        }
+
+        return null;
+    }
+
+    private function legacySourcePackRoot(string $versionId): string
+    {
+        return storage_path('app/private/content_releases/'.$versionId.'/source_pack');
+    }
+
+    private function legacyPreviousPackRoot(string $sourceReleaseId): string
+    {
+        return storage_path('app/private/content_releases/backups/'.$sourceReleaseId.'/previous_pack');
+    }
+
+    /**
+     * @param  object|array<string,mixed>  $release
+     * @return list<array{root:string,storage_path_for_patch:string,resolved_from:string}>
+     */
+    private function candidateV2RootsFromRelease(object|array $release): array
+    {
+        $releaseId = trim((string) data_get($release, 'id'));
+        $packId = strtoupper(trim((string) data_get($release, 'to_pack_id')));
+        $packVersion = trim((string) data_get($release, 'pack_version'));
+        if ($releaseId === '' || $packId === '' || $packVersion === '') {
+            return [];
+        }
+
+        $primaryRelative = 'private/packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
+        $mirrorRelative = 'content_packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
+
+        return [
+            [
+                'root' => storage_path('app/'.$primaryRelative),
+                'storage_path_for_patch' => $primaryRelative,
+                'resolved_from' => 'v2.primary',
+            ],
+            [
+                'root' => storage_path('app/'.$mirrorRelative),
+                'storage_path_for_patch' => $mirrorRelative,
+                'resolved_from' => 'v2.mirror',
+            ],
+        ];
+    }
+
+    private function versionRow(string $versionId): ?object
+    {
+        if ($versionId === '') {
+            return null;
+        }
+
+        if (array_key_exists($versionId, $this->versionCache)) {
+            return $this->versionCache[$versionId];
+        }
+
+        $this->versionCache[$versionId] = DB::table('content_pack_versions')->where('id', $versionId)->first();
+
+        return $this->versionCache[$versionId];
+    }
+
+    private function rollbackSourceReleaseId(string $releaseId): string
+    {
+        if ($releaseId === '') {
+            return '';
+        }
+
+        if (array_key_exists($releaseId, $this->rollbackSourceReleaseCache)) {
+            return $this->rollbackSourceReleaseCache[$releaseId];
+        }
+
+        $sourceReleaseId = '';
+        $rows = DB::table('audit_logs')
+            ->where('target_type', 'content_pack_release')
+            ->where('target_id', $releaseId)
+            ->orderByDesc('id')
+            ->get();
+
+        foreach ($rows as $row) {
+            $meta = json_decode((string) ($row->meta_json ?? '{}'), true);
+            if (! is_array($meta)) {
+                continue;
+            }
+
+            $sourceReleaseId = trim((string) ($meta['source_release_id'] ?? ''));
+            if ($sourceReleaseId !== '') {
+                break;
+            }
+        }
+
+        $this->rollbackSourceReleaseCache[$releaseId] = $sourceReleaseId;
+
+        return $sourceReleaseId;
+    }
+
+    private function absoluteStorageRoot(string $storagePath): string
+    {
+        $relative = ltrim($storagePath, '/');
+        if (str_starts_with($relative, 'app/')) {
+            $relative = substr($relative, 4);
+        }
+
+        return storage_path('app/'.$relative);
+    }
+
+    private function contentTypeForLogicalPath(string $logicalPath): ?string
+    {
+        return str_ends_with(strtolower($logicalPath), '.json') ? 'application/json' : null;
+    }
+}

--- a/backend/tests/Feature/Storage/StorageBackfillReleaseMetadataCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageBackfillReleaseMetadataCommandTest.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageBackfillReleaseMetadataCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-backfill-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_backfills_historical_release_and_artifact_metadata_idempotently(): void
+    {
+        $publishVersionId = (string) Str::uuid();
+        $publishReleaseId = (string) Str::uuid();
+        $rollbackSourceReleaseId = (string) Str::uuid();
+        $rollbackReleaseId = (string) Str::uuid();
+        $rollbackCurrentReleaseId = (string) Str::uuid();
+        $v2ReleaseId = (string) Str::uuid();
+        $missingReleaseId = (string) Str::uuid();
+
+        $publishRoot = storage_path('app/private/content_releases/'.$publishVersionId.'/source_pack');
+        $publishManifest = $this->createCompiledTree($publishRoot, 'BIG5_OCEAN', 'v1', 'legacy_publish');
+
+        DB::table('content_pack_versions')->insert([
+            'id' => $publishVersionId,
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'pack_id' => 'BIG5_OCEAN',
+            'content_package_version' => 'v1',
+            'dir_version_alias' => 'BIG5-OCEAN-BACKFILL',
+            'source_type' => 'repo',
+            'source_ref' => 'backend/content_packs/BIG5_OCEAN/v1',
+            'sha256' => str_repeat('a', 64),
+            'manifest_json' => json_encode($publishManifest['decoded'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'extracted_rel_path' => 'private/content_releases/'.$publishVersionId.'/source_pack',
+            'created_by' => 'test',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $publishReleaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'BIG5-OCEAN-BACKFILL',
+            'from_version_id' => null,
+            'to_version_id' => $publishVersionId,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $publishManifest['manifest_hash'],
+            'compiled_hash' => $publishManifest['compiled_hash'],
+            'content_hash' => $publishManifest['content_hash'],
+            'norms_version' => $publishManifest['norms_version'],
+            'git_sha' => 'git-publish-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(5),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+
+        $rollbackRoot = storage_path('app/private/content_releases/backups/'.$rollbackSourceReleaseId.'/previous_pack');
+        $rollbackManifest = $this->createCompiledTree($rollbackRoot, 'BIG5_OCEAN', 'v1', 'legacy_rollback');
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $rollbackReleaseId,
+            'action' => 'rollback',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'BIG5-OCEAN-BACKFILL',
+            'from_version_id' => $publishVersionId,
+            'to_version_id' => null,
+            'from_pack_id' => 'BIG5_OCEAN',
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $rollbackManifest['manifest_hash'],
+            'compiled_hash' => $rollbackManifest['compiled_hash'],
+            'content_hash' => $rollbackManifest['content_hash'],
+            'norms_version' => $rollbackManifest['norms_version'],
+            'git_sha' => 'git-rollback-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(4),
+            'updated_at' => now()->subMinutes(4),
+        ]);
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'big5_pack_rollback',
+            'target_type' => 'content_pack_release',
+            'target_id' => $rollbackReleaseId,
+            'meta_json' => json_encode(['source_release_id' => $rollbackSourceReleaseId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test',
+            'request_id' => null,
+            'reason' => 'test',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(4),
+        ]);
+
+        $rollbackCurrentRoot = storage_path('app/private/content_releases/backups/'.$rollbackCurrentReleaseId.'/current_pack');
+        $rollbackCurrentManifest = $this->createCompiledTree($rollbackCurrentRoot, 'BIG5_OCEAN', 'v1', 'legacy_current_pack');
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $rollbackCurrentReleaseId,
+            'action' => 'rollback',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'BIG5-OCEAN-BACKFILL',
+            'from_version_id' => $publishVersionId,
+            'to_version_id' => null,
+            'from_pack_id' => 'BIG5_OCEAN',
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => null,
+            'compiled_hash' => null,
+            'content_hash' => null,
+            'norms_version' => null,
+            'git_sha' => 'git-rollback-current-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(3)->subSeconds(30),
+            'updated_at' => now()->subMinutes(3)->subSeconds(30),
+        ]);
+
+        $v2MirrorRelative = 'content_packs_v2/SDS_20/v1/'.$v2ReleaseId;
+        $v2MirrorRoot = storage_path('app/'.$v2MirrorRelative);
+        $v2Manifest = $this->createCompiledTree($v2MirrorRoot, 'SDS_20', 'v1', 'v2_mirror');
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $v2ReleaseId,
+            'action' => 'packs2_publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'SDS-20-BACKFILL',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'SDS_20',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $v2Manifest['manifest_hash'],
+            'compiled_hash' => $v2Manifest['compiled_hash'],
+            'content_hash' => $v2Manifest['content_hash'],
+            'norms_version' => $v2Manifest['norms_version'],
+            'git_sha' => 'git-v2-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => 'private/packs_v2/SDS_20/v1/'.$v2ReleaseId,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinutes(3),
+        ]);
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $missingReleaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'MISSING-BACKFILL',
+            'from_version_id' => null,
+            'to_version_id' => (string) Str::uuid(),
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => str_repeat('f', 64),
+            'compiled_hash' => str_repeat('e', 64),
+            'content_hash' => str_repeat('d', 64),
+            'norms_version' => '2026Q1',
+            'git_sha' => 'git-missing-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(2),
+            'updated_at' => now()->subMinutes(2),
+        ]);
+
+        Storage::disk('local')->put('artifacts/reports/MBTI/attempt-backfill/report.json', '{"artifact":true}');
+
+        $this->assertSame(0, Artisan::call('storage:backfill-release-metadata', [
+            '--dry-run' => true,
+        ]));
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('release_rows_backfillable=3', $dryRunOutput);
+        $this->assertStringContainsString('artifact_files_scanned=1', $dryRunOutput);
+        $this->assertDatabaseCount('storage_blobs', 0);
+        $this->assertDatabaseCount('content_release_manifests', 0);
+        $this->assertNull(DB::table('content_pack_releases')->where('id', $publishReleaseId)->value('storage_path'));
+
+        $this->assertSame(0, Artisan::call('storage:backfill-release-metadata', [
+            '--execute' => true,
+        ]));
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('release_rows_backfilled=3', $executeOutput);
+
+        $this->assertSame($publishRoot, (string) DB::table('content_pack_releases')->where('id', $publishReleaseId)->value('storage_path'));
+        $this->assertSame('v1', (string) DB::table('content_pack_releases')->where('id', $publishReleaseId)->value('pack_version'));
+        $this->assertSame('git-publish-sha', (string) DB::table('content_pack_releases')->where('id', $publishReleaseId)->value('source_commit'));
+
+        $this->assertSame($rollbackRoot, (string) DB::table('content_pack_releases')->where('id', $rollbackReleaseId)->value('storage_path'));
+        $this->assertSame('v1', (string) DB::table('content_pack_releases')->where('id', $rollbackReleaseId)->value('pack_version'));
+        $this->assertSame('git-rollback-sha', (string) DB::table('content_pack_releases')->where('id', $rollbackReleaseId)->value('source_commit'));
+
+        $this->assertNull(DB::table('content_pack_releases')->where('id', $rollbackCurrentReleaseId)->value('storage_path'));
+        $this->assertDatabaseHas('content_release_manifests', [
+            'manifest_hash' => $rollbackCurrentManifest['manifest_hash'],
+            'content_pack_release_id' => $rollbackCurrentReleaseId,
+            'storage_path' => $rollbackCurrentRoot,
+        ]);
+
+        $this->assertSame('v1', (string) DB::table('content_pack_releases')->where('id', $v2ReleaseId)->value('pack_version'));
+        $this->assertSame('git-v2-sha', (string) DB::table('content_pack_releases')->where('id', $v2ReleaseId)->value('source_commit'));
+
+        $this->assertDatabaseCount('content_release_manifests', 4);
+        $this->assertDatabaseCount('content_release_manifest_files', 8);
+        $this->assertDatabaseCount('storage_blobs', 9);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+
+        $manifestCount = (int) DB::table('content_release_manifests')->count();
+        $manifestFileCount = (int) DB::table('content_release_manifest_files')->count();
+        $blobCount = (int) DB::table('storage_blobs')->count();
+
+        $this->assertSame(0, Artisan::call('storage:backfill-release-metadata', [
+            '--execute' => true,
+        ]));
+        $this->assertSame($manifestCount, (int) DB::table('content_release_manifests')->count());
+        $this->assertSame($manifestFileCount, (int) DB::table('content_release_manifest_files')->count());
+        $this->assertSame($blobCount, (int) DB::table('storage_blobs')->count());
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_backfill_release_metadata')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($audit);
+        $auditMeta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($auditMeta);
+        $this->assertSame('execute', (string) ($auditMeta['mode'] ?? ''));
+        $this->assertSame(5, (int) ($auditMeta['release_rows_scanned'] ?? 0));
+        $this->assertSame(1, (int) ($auditMeta['backup_roots_backfilled'] ?? 0));
+        $this->assertSame(2, (int) ($auditMeta['missing_physical_sources'] ?? 0));
+    }
+
+    /**
+     * @return array{
+     *   decoded:array<string,mixed>,
+     *   manifest_hash:string,
+     *   compiled_hash:string,
+     *   content_hash:string,
+     *   norms_version:string
+     * }
+     */
+    private function createCompiledTree(string $root, string $packId, string $packVersion, string $suffix): array
+    {
+        $compiledDir = $root.'/compiled';
+        File::ensureDirectoryExists($compiledDir);
+
+        $payload = json_encode([
+            'suffix' => $suffix,
+            'pack_id' => $packId,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $payload = is_string($payload) ? $payload : '{}';
+        File::put($compiledDir.'/payload.compiled.json', $payload);
+
+        $compiledHash = hash('sha256', $payload.'|compiled|'.$suffix);
+        $contentHash = hash('sha256', $payload.'|content|'.$suffix);
+        $normsVersion = '2026Q1_'.$suffix;
+        $manifest = [
+            'schema' => 'storage.backfill.test.v1',
+            'pack_id' => $packId,
+            'pack_version' => $packVersion,
+            'content_package_version' => $packVersion,
+            'compiled_hash' => $compiledHash,
+            'content_hash' => $contentHash,
+            'norms_version' => $normsVersion,
+        ];
+        $manifestJson = json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        $manifestJson = is_string($manifestJson) ? $manifestJson : '{}';
+        File::put($compiledDir.'/manifest.json', $manifestJson);
+
+        return [
+            'decoded' => $manifest,
+            'manifest_hash' => hash('sha256', $manifestJson),
+            'compiled_hash' => $compiledHash,
+            'content_hash' => $contentHash,
+            'norms_version' => $normsVersion,
+        ];
+    }
+}

--- a/backend/tests/Feature/Storage/StorageBlobGcCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageBlobGcCommandTest.php
@@ -1,0 +1,392 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\BlobCatalogService;
+use App\Services\Storage\ContentReleaseManifestCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+use Tests\TestCase;
+
+final class StorageBlobGcCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    private string $isolatedPacksRoot;
+
+    private string $originalPacksRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->originalPacksRoot = (string) config('content_packs.root');
+
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-blob-gc-'.Str::uuid();
+        $this->isolatedPacksRoot = sys_get_temp_dir().'/fap-packs-root-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        File::ensureDirectoryExists($this->isolatedPacksRoot);
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('content_packs.root', $this->isolatedPacksRoot);
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        config()->set('content_packs.root', $this->originalPacksRoot);
+        Storage::forgetDisk('local');
+
+        foreach ([$this->isolatedStoragePath, $this->isolatedPacksRoot] as $path) {
+            if (is_dir($path)) {
+                File::deleteDirectory($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_blob_gc_dry_run_builds_conservative_plan_without_planned_deletions(): void
+    {
+        $blobCatalog = app(BlobCatalogService::class);
+        $manifestCatalog = app(ContentReleaseManifestCatalogService::class);
+
+        $activeReleaseId = (string) Str::uuid();
+        $snapshotReleaseId = (string) Str::uuid();
+        $v2ReleaseId = (string) Str::uuid();
+
+        $activeRoot = storage_path('app/private/content_releases/'.Str::uuid().'/source_pack');
+        $activeManifest = $this->createCompiledTree($activeRoot, 'BIG5_OCEAN', 'v1', 'active');
+        $this->catalogRootFiles($blobCatalog, $activeRoot);
+        DB::table('content_pack_releases')->insert([
+            'id' => $activeReleaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'BIG5-GC-ACTIVE',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $activeManifest['manifest_hash'],
+            'compiled_hash' => $activeManifest['compiled_hash'],
+            'content_hash' => $activeManifest['content_hash'],
+            'norms_version' => $activeManifest['norms_version'],
+            'git_sha' => 'git-active',
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode($activeManifest['decoded'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $activeRoot,
+            'source_commit' => 'git-active',
+            'created_at' => now()->subMinutes(5),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+        DB::table('content_pack_activations')->insert([
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'release_id' => $activeReleaseId,
+            'activated_at' => now()->subMinutes(5),
+            'created_at' => now()->subMinutes(5),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+
+        $staleHash = hash('sha256', 'stale-file-map-hash');
+        $blobCatalog->upsertBlob([
+            'hash' => $staleHash,
+            'disk' => 'local',
+            'storage_path' => $blobCatalog->storagePathForHash($staleHash),
+            'size_bytes' => strlen('stale-file-map-hash'),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+            'last_verified_at' => now(),
+        ]);
+        $manifestCatalog->upsertManifest([
+            'content_pack_release_id' => $activeReleaseId,
+            'manifest_hash' => $activeManifest['manifest_hash'],
+            'storage_disk' => 'local',
+            'storage_path' => $activeRoot,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => $activeManifest['compiled_hash'],
+            'content_hash' => $activeManifest['content_hash'],
+            'norms_version' => $activeManifest['norms_version'],
+            'source_commit' => 'git-active',
+            'payload_json' => $activeManifest['decoded'],
+        ], [
+            [
+                'logical_path' => 'compiled/stale.compiled.json',
+                'blob_hash' => $staleHash,
+                'size_bytes' => strlen('stale-file-map-hash'),
+                'role' => null,
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.$staleHash,
+            ],
+        ]);
+
+        $snapshotRoot = storage_path('app/private/content_releases/'.Str::uuid().'/source_pack');
+        $snapshotManifest = $this->createCompiledTree($snapshotRoot, 'BIG5_OCEAN', 'v1', 'snapshot');
+        $this->catalogRootFiles($blobCatalog, $snapshotRoot);
+        DB::table('content_pack_releases')->insert([
+            'id' => $snapshotReleaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'BIG5-GC-SNAPSHOT',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $snapshotManifest['manifest_hash'],
+            'compiled_hash' => $snapshotManifest['compiled_hash'],
+            'content_hash' => $snapshotManifest['content_hash'],
+            'norms_version' => $snapshotManifest['norms_version'],
+            'git_sha' => 'git-snapshot',
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode($snapshotManifest['decoded'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $snapshotRoot,
+            'source_commit' => 'git-snapshot',
+            'created_at' => now()->subMinutes(4),
+            'updated_at' => now()->subMinutes(4),
+        ]);
+        DB::table('content_release_snapshots')->insert([
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'from_content_pack_release_id' => null,
+            'to_content_pack_release_id' => $snapshotReleaseId,
+            'activation_before_release_id' => null,
+            'activation_after_release_id' => $snapshotReleaseId,
+            'reason' => 'test',
+            'created_by' => 'test',
+            'meta_json' => json_encode([], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->subMinutes(4),
+            'updated_at' => now()->subMinutes(4),
+        ]);
+
+        $backupCurrentRoot = storage_path('app/private/content_releases/backups/'.$activeReleaseId.'/current_pack');
+        $backupManifest = $this->createCompiledTree($backupCurrentRoot, 'BIG5_OCEAN', 'v1', 'backup_current');
+        $this->catalogRootFiles($blobCatalog, $backupCurrentRoot);
+
+        $v2MirrorRelative = 'content_packs_v2/SDS_20/v1/'.$v2ReleaseId;
+        $v2MirrorRoot = storage_path('app/'.$v2MirrorRelative);
+        $v2Manifest = $this->createCompiledTree($v2MirrorRoot, 'SDS_20', 'v1', 'v2_mirror');
+        $this->catalogRootFiles($blobCatalog, $v2MirrorRoot);
+        DB::table('content_pack_releases')->insert([
+            'id' => $v2ReleaseId,
+            'action' => 'packs2_publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'SDS-GC',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'SDS_20',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $v2Manifest['manifest_hash'],
+            'compiled_hash' => $v2Manifest['compiled_hash'],
+            'content_hash' => $v2Manifest['content_hash'],
+            'norms_version' => $v2Manifest['norms_version'],
+            'git_sha' => 'git-v2',
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode($v2Manifest['decoded'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => 'private/packs_v2/SDS_20/v1/'.$v2ReleaseId,
+            'source_commit' => 'git-v2',
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinutes(3),
+        ]);
+
+        $liveAliasRoot = $this->isolatedPacksRoot.'/default/CN_MAINLAND/zh-CN/BIG5-LIVE-GC';
+        $liveAliasManifest = $this->createCompiledTree($liveAliasRoot, 'BIG5_OCEAN', 'v1', 'live_alias');
+        $this->catalogRootFiles($blobCatalog, $liveAliasRoot);
+
+        $deprecatedRoot = $this->isolatedPacksRoot.'/_deprecated/MBTI/CN_MAINLAND/BIG5-DEPRECATED-GC';
+        $deprecatedManifest = $this->createCompiledTree($deprecatedRoot, 'BIG5_OCEAN', 'v1', 'deprecated_alias');
+        $this->catalogRootFiles($blobCatalog, $deprecatedRoot);
+
+        Storage::disk('local')->put('artifacts/reports/MBTI/attempt-gc/report.json', '{"artifact":"reachable"}');
+        $artifactHash = hash('sha256', '{"artifact":"reachable"}');
+        $blobCatalog->upsertBlob([
+            'hash' => $artifactHash,
+            'disk' => 'local',
+            'storage_path' => $blobCatalog->storagePathForHash($artifactHash),
+            'size_bytes' => strlen('{"artifact":"reachable"}'),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+            'last_verified_at' => now(),
+        ]);
+
+        $orphanHash = hash('sha256', 'orphan-blob');
+        $blobCatalog->upsertBlob([
+            'hash' => $orphanHash,
+            'disk' => 'local',
+            'storage_path' => $blobCatalog->storagePathForHash($orphanHash),
+            'size_bytes' => strlen('orphan-blob'),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+            'last_verified_at' => now(),
+        ]);
+
+        $this->assertSame(0, Artisan::call('storage:blob-gc', [
+            '--dry-run' => true,
+        ]));
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=planned', $output);
+        $this->assertStringContainsString('planned_deletions=0', $output);
+        $this->assertStringContainsString('dry_run_only=1', $output);
+
+        preg_match('/^plan=(.+)$/m', $output, $matches);
+        $this->assertNotEmpty($matches);
+        $planPath = trim((string) ($matches[1] ?? ''));
+        $this->assertFileExists($planPath);
+
+        $plan = json_decode((string) file_get_contents($planPath), true);
+        $this->assertIsArray($plan);
+        $this->assertSame('storage_blob_gc_plan.v1', (string) ($plan['schema'] ?? ''));
+        $this->assertTrue((bool) data_get($plan, 'planned_deletions.dry_run_only'));
+        $this->assertSame([], data_get($plan, 'planned_deletions.blob_hashes', []));
+
+        $this->assertContains($activeReleaseId, data_get($plan, 'roots.active_release_ids', []));
+        $this->assertContains($snapshotReleaseId, data_get($plan, 'roots.snapshot_release_ids', []));
+        $this->assertContains($backupCurrentRoot, data_get($plan, 'roots.release_storage_paths', []));
+        $this->assertContains($v2MirrorRoot, data_get($plan, 'roots.release_storage_paths', []));
+        $this->assertContains($liveAliasRoot, data_get($plan, 'roots.live_alias_paths', []));
+        $this->assertNotContains($deprecatedRoot, data_get($plan, 'roots.live_alias_paths', []));
+        $this->assertContains('artifacts/reports/MBTI/attempt-gc/report.json', data_get($plan, 'roots.artifact_paths', []));
+
+        $reachable = data_get($plan, 'reachable.blob_hashes', []);
+        $this->assertContains($activeManifest['manifest_hash'], $reachable);
+        $this->assertContains($snapshotManifest['manifest_hash'], $reachable);
+        $this->assertContains($backupManifest['manifest_hash'], $reachable);
+        $this->assertContains($v2Manifest['manifest_hash'], $reachable);
+        $this->assertContains($liveAliasManifest['manifest_hash'], $reachable);
+        $this->assertContains($artifactHash, $reachable);
+        $this->assertContains($staleHash, $reachable);
+        $this->assertNotContains($deprecatedManifest['manifest_hash'], $reachable);
+        $this->assertContains($orphanHash, data_get($plan, 'unreachable.blob_hashes', []));
+        $this->assertContains($deprecatedManifest['manifest_hash'], data_get($plan, 'unreachable.blob_hashes', []));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_blob_gc')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($audit);
+        $auditMeta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($auditMeta);
+        $this->assertSame($planPath, (string) ($auditMeta['plan'] ?? ''));
+        $this->assertTrue((bool) ($auditMeta['dry_run_only'] ?? false));
+    }
+
+    public function test_blob_gc_requires_dry_run_and_does_not_support_execute(): void
+    {
+        $this->artisan('storage:blob-gc')->assertExitCode(1);
+
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The "--execute" option does not exist.');
+
+        Artisan::call('storage:blob-gc', [
+            '--execute' => true,
+        ]);
+    }
+
+    /**
+     * @return array{
+     *   decoded:array<string,mixed>,
+     *   manifest_hash:string,
+     *   compiled_hash:string,
+     *   content_hash:string,
+     *   norms_version:string
+     * }
+     */
+    private function createCompiledTree(string $root, string $packId, string $packVersion, string $suffix): array
+    {
+        $compiledDir = $root.'/compiled';
+        File::ensureDirectoryExists($compiledDir);
+
+        $payload = json_encode([
+            'suffix' => $suffix,
+            'pack_id' => $packId,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $payload = is_string($payload) ? $payload : '{}';
+        File::put($compiledDir.'/payload.compiled.json', $payload);
+
+        $compiledHash = hash('sha256', $payload.'|compiled|'.$suffix);
+        $contentHash = hash('sha256', $payload.'|content|'.$suffix);
+        $normsVersion = '2026Q1_'.$suffix;
+        $manifest = [
+            'schema' => 'storage.gc.test.v1',
+            'pack_id' => $packId,
+            'pack_version' => $packVersion,
+            'content_package_version' => $packVersion,
+            'compiled_hash' => $compiledHash,
+            'content_hash' => $contentHash,
+            'norms_version' => $normsVersion,
+        ];
+        $manifestJson = json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        $manifestJson = is_string($manifestJson) ? $manifestJson : '{}';
+        File::put($compiledDir.'/manifest.json', $manifestJson);
+
+        return [
+            'decoded' => $manifest,
+            'manifest_hash' => hash('sha256', $manifestJson),
+            'compiled_hash' => $compiledHash,
+            'content_hash' => $contentHash,
+            'norms_version' => $normsVersion,
+        ];
+    }
+
+    private function catalogRootFiles(BlobCatalogService $blobCatalogService, string $root): void
+    {
+        foreach (File::allFiles($root.'/compiled') as $file) {
+            $bytes = (string) File::get($file->getPathname());
+            $hash = hash('sha256', $bytes);
+            $blobCatalogService->upsertBlob([
+                'hash' => $hash,
+                'disk' => 'local',
+                'storage_path' => $blobCatalogService->storagePathForHash($hash),
+                'size_bytes' => strlen($bytes),
+                'content_type' => str_ends_with($file->getFilename(), '.json') ? 'application/json' : null,
+                'encoding' => 'identity',
+                'ref_count' => 0,
+                'last_verified_at' => now(),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements PR-14 only: historical rollout metadata backfill plus a conservative blob reachability / GC dry-run plan.

The scope stays deliberately narrow and low-risk:

- adds an idempotent historical metadata backfill command
- adds a dry-run-only blob GC planner command
- does not change runtime readers
- does not change legacy publish / rollback success paths
- does not change V2 publish / resolver / materialization runtime behavior
- does not add destructive delete
- does not wire scheduler execution
- does not expand into PR-15 hot/cold storage or object-store offload

## Root cause

After PR-13D through PR-13G, new writes could already produce rollout metadata, but historical content releases and artifacts were still only partially cataloged.

That left two practical gaps:

1. old release/artifact bytes were not fully represented in:
   - `storage_blobs`
   - `content_release_manifests`
   - `content_release_manifest_files`
2. there was no auditable, conservative reachability planner for rollout GC

Without those two pieces, storage rollout could not safely answer:

- which historical bytes are already covered by metadata
- which bytes are still reachable from active releases / snapshots / legacy backup trees / live alias fallback roots / canonical artifacts
- what a future GC phase would even be allowed to consider

## What this PR adds

### 1. `storage:backfill-release-metadata`

New command:

- `php artisan storage:backfill-release-metadata --dry-run`
- `php artisan storage:backfill-release-metadata --execute`

The command enforces exactly one mode.

Behavior:

- `--dry-run`: scan only, print summary, write audit
- `--execute`: idempotent DB upserts only, no file moves, no file deletes, no runtime path changes

Backfill coverage:

- successful legacy publish release rows
- successful legacy rollback release rows
- V2 release rows using primary/mirror fallback
- legacy backup roots including:
  - `previous_pack`
  - `current_pack`
- artifact files under canonical and compatible legacy locations

Backfill source-of-truth is always physical-tree-first and never metadata-first.

Priority:

1. existing release `storage_path` when it resolves to a real physical tree
2. legacy `source_pack`
3. legacy rollback `previous_pack`
4. V2 primary/mirror fallback
5. backup roots for metadata-only coverage
6. canonical / compatible legacy artifact paths for artifact blob rows

The command backfills, when derivable:

- `content_pack_releases.pack_version`
- `content_pack_releases.manifest_json`
- `content_pack_releases.storage_path`
- `content_pack_releases.source_commit`
- `content_release_manifests`
- `content_release_manifest_files`
- `storage_blobs`

Important safety rules preserved:

- no file deletion
- no runtime file rewrite
- no physical `private/blobs/**` creation
- additive-only file-map semantics remain intact
- existing release-row values are not overwritten when already populated

### 2. `storage:blob-gc --dry-run`

New command:

- `php artisan storage:blob-gc --dry-run`

This PR intentionally does **not** implement `--execute`.

Behavior:

- computes a conservative root set
- computes reachable vs candidate-unreachable blob hashes
- writes a JSON plan under `storage/app/private/gc_plans`
- prints a summary to stdout
- writes an audit row

Plan schema:

- `storage_blob_gc_plan.v1`

Plan payload includes:

- `schema`
- `generated_at`
- `summary`
- `roots`
- `reachable`
- `unreachable`
- `planned_deletions`
- `bytes`

`planned_deletions` is intentionally empty in PR-14 and marked `dry_run_only=true`.

## Conservative root set in this PR

The planner roots all of the following:

- active release ids from `content_pack_activations`
- release ids referenced by `content_release_snapshots`
- successful `content_pack_releases` that still resolve to physical trees
- legacy backup trees:
  - `previous_pack`
  - `current_pack`
- V2 physical roots with primary/mirror fallback
- live alias fallback roots under `content_packages/default/**`
- canonical artifact paths under `artifacts/reports/**` and `artifacts/pdf/**`
- compatible legacy artifact paths when canonical copies do not exist

The planner also conservatively expands reachability through manifest file-map edges, but does **not** treat file-map rows as exact delete truth.

## Important follow-up fixes included in this branch

During review, two P1 gaps were closed before opening this PR:

1. backup metadata backfill now covers `current_pack`, not just `previous_pack`
2. live alias root discovery is restricted to `content_packages/default/**` and no longer scans the entire `content_packages` tree

A small FK-safety fix was also added for backup-root manifest upserts:

- if a backup directory name looks like a release id but no matching `content_pack_releases` row exists, the manifest row is still recorded with `content_pack_release_id = null` instead of failing on a foreign-key insert

## Why this PR stops at dry-run

PR-14 is intentionally plan-first.

It does **not** implement destructive rollout GC because:

- historical coverage is still being proven incrementally
- `storage_blobs.ref_count` is not a trustworthy live reachability counter
- manifest file maps are additive-only and therefore conservative, not exact delete truth
- runtime still depends on legacy backup semantics, V2 fallback semantics, and live alias fallback semantics

So this PR only gets us to:

- historical metadata backfill
- auditable reachability computation
- conservative GC plans
- dry-run verification

## Tests

New focused coverage:

- `tests/Feature/Storage/StorageBackfillReleaseMetadataCommandTest.php`
- `tests/Feature/Storage/StorageBlobGcCommandTest.php`

These tests lock:

- legacy publish backfill from `source_pack`
- legacy rollback backfill from `previous_pack`
- metadata-only coverage for `current_pack`
- V2 backfill with mirror fallback when primary is absent
- idempotent repeat execution
- missing-source skip behavior
- no physical `private/blobs/**` creation
- active/snapshot/backup/V2/live-alias/artifact roots in the GC plan
- exclusion of `_deprecated` from live alias roots
- conservative treatment of stale manifest file-map edges
- no `storage:blob-gc --execute` support in PR-14

Existing storage/content rollout tests were also re-run and kept green.

## Commands run

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php -l app/Console/Commands/StorageBackfillReleaseMetadata.php
php -l app/Console/Commands/StorageBlobGc.php
php -l app/Services/Storage/ReleaseStorageLocator.php
php -l app/Services/Storage/ReleaseMetadataBackfillService.php
php -l app/Services/Storage/BlobReachabilityService.php
php -l tests/Feature/Storage/StorageBackfillReleaseMetadataCommandTest.php
php -l tests/Feature/Storage/StorageBlobGcCommandTest.php

./vendor/bin/pint \
  app/Console/Commands/StorageBackfillReleaseMetadata.php \
  app/Console/Commands/StorageBlobGc.php \
  app/Services/Storage/ReleaseStorageLocator.php \
  app/Services/Storage/ReleaseMetadataBackfillService.php \
  app/Services/Storage/BlobReachabilityService.php \
  tests/Feature/Storage/StorageBackfillReleaseMetadataCommandTest.php \
  tests/Feature/Storage/StorageBlobGcCommandTest.php

vendor/bin/phpunit \
  tests/Feature/Storage/StorageBackfillReleaseMetadataCommandTest.php \
  tests/Feature/Storage/StorageBlobGcCommandTest.php \
  tests/Feature/Storage/BlobCatalogServiceTest.php \
  tests/Feature/Storage/ContentReleaseManifestCatalogServiceTest.php \
  tests/Feature/Storage/ContentReleaseSnapshotCatalogServiceTest.php \
  tests/Feature/Content/Packs2MetadataDualWriteTest.php \
  tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php

php artisan migrate
php artisan route:list > /tmp/pr14_route_list.txt

php artisan storage:backfill-release-metadata --dry-run
php artisan storage:backfill-release-metadata --execute
php artisan storage:blob-gc --dry-run

php artisan serve --host=127.0.0.1 --port=18081
curl -i http://127.0.0.1:18081/api/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
```

## Validation

- focused storage/content suite: `OK (14 tests, 192 assertions)`
- `php artisan migrate`: `Nothing to migrate.`
- `storage:backfill-release-metadata --execute`: passed
- `storage:blob-gc --dry-run`: passed and wrote a plan file under `storage/app/private/gc_plans`
- `curl -i http://127.0.0.1:18081/api/healthz`: `HTTP/1.1 200 OK`

## Known baseline failure unchanged

`bash backend/scripts/ci_verify_mbti.sh` still fails on the existing content-package self-check baseline:

- `report_dynamic_sections.json :: missing manifest.schemas mapping (asset=dynamic_sections)`

This PR does not touch `content_packages/**` intentionally and does not attempt to fix that out-of-scope baseline issue.
