### PR TITLE
[codex] Ship MBTI PR-8C user state deepening (backend)

### DIFF
--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -654,7 +654,7 @@ final class MbtiResultPersonalizationService
         }
 
         return $this->userStateOrchestrationService->withBaseline([
-            'schema_version' => 'mbti.personalization.phase8b.v1',
+            'schema_version' => 'mbti.personalization.phase8c.v1',
             'locale' => $locale,
             'type_code' => $typeCode,
             'identity' => $identity,

--- a/backend/app/Services/Mbti/MbtiUserStateOrchestrationService.php
+++ b/backend/app/Services/Mbti/MbtiUserStateOrchestrationService.php
@@ -9,6 +9,21 @@ use Illuminate\Support\Facades\DB;
 final class MbtiUserStateOrchestrationService
 {
     /**
+     * @var list<string>
+     */
+    private const POSITIVE_FEEDBACK_VALUES = ['accurate', 'helpful_action'];
+
+    /**
+     * @var list<string>
+     */
+    private const MIXED_FEEDBACK_VALUES = ['mixed', 'not_now'];
+
+    /**
+     * @var list<string>
+     */
+    private const NEGATIVE_FEEDBACK_VALUES = ['unclear'];
+
+    /**
      * @var array<string, list<string>>
      */
     private const CHAPTER_SECTIONS = [
@@ -134,16 +149,7 @@ final class MbtiUserStateOrchestrationService
             return [];
         }
 
-        $userState = [
-            'is_first_view' => true,
-            'is_revisit' => false,
-            'has_unlock' => $hasUnlock,
-            'has_feedback' => false,
-            'has_share' => false,
-            'has_action_engagement' => false,
-        ];
-
-        return $this->mergeAuthority($personalization, $userState);
+        return $this->mergeAuthority($personalization, $this->buildBaselineUserState($hasUnlock));
     }
 
     /**
@@ -160,19 +166,41 @@ final class MbtiUserStateOrchestrationService
             return $this->withBaseline($personalization, $hasUnlock);
         }
 
-        $isRevisit = $this->attemptHasAnyEvent($orgId, $attemptId, ['result_view', 'report_view']);
-        $hasFeedback = $this->attemptHasAnyEvent($orgId, $attemptId, ['accuracy_feedback']);
-        $hasShare = $this->attemptHasAnyEvent($orgId, $attemptId, ['share_result']) || $this->attemptHasShareRow($attemptId);
-        $hasActionEngagement = $this->attemptHasActionEngagement($orgId, $attemptId);
+        $eventRows = $this->fetchAttemptEvents($orgId, $attemptId);
+        $isRevisit = $this->eventRowsContainAny($eventRows, ['result_view', 'report_view']);
+        $hasFeedback = $this->eventRowsContainAny($eventRows, ['accuracy_feedback']);
+        $hasShare = $this->eventRowsContainAny($eventRows, ['share_result']) || $this->attemptHasShareRow($attemptId);
+        $hasActionEngagement = $this->eventRowsContainActionEngagement($eventRows);
+        $feedbackSentiment = $this->resolveFeedbackSentiment($eventRows);
+        $feedbackCoverage = $this->resolveFeedbackCoverage($eventRows);
+        $actionCompletionTendency = $this->resolveActionCompletionTendency(
+            $eventRows,
+            $isRevisit,
+            $hasUnlock
+        );
+        $lastDeepReadSection = $this->resolveLastDeepReadSection($eventRows);
+        $currentIntentCluster = $this->resolveCurrentIntentCluster(
+            $eventRows,
+            $hasUnlock,
+            $feedbackSentiment,
+            $feedbackCoverage,
+            $actionCompletionTendency,
+            $lastDeepReadSection,
+            $hasActionEngagement
+        );
 
-        $userState = [
+        $userState = array_merge($this->buildBaselineUserState($hasUnlock), [
             'is_first_view' => ! $isRevisit,
             'is_revisit' => $isRevisit,
-            'has_unlock' => $hasUnlock,
             'has_feedback' => $hasFeedback,
             'has_share' => $hasShare,
             'has_action_engagement' => $hasActionEngagement,
-        ];
+            'feedback_sentiment' => $feedbackSentiment,
+            'feedback_coverage' => $feedbackCoverage,
+            'action_completion_tendency' => $actionCompletionTendency,
+            'last_deep_read_section' => $lastDeepReadSection,
+            'current_intent_cluster' => $currentIntentCluster,
+        ]);
 
         return $this->mergeAuthority($personalization, $userState);
     }
@@ -189,12 +217,14 @@ final class MbtiUserStateOrchestrationService
         $orderedRecommendationKeys = $this->resolveOrderedRecommendationKeys(
             $personalization,
             $primaryFocusKey,
-            $secondaryFocusKeys
+            $secondaryFocusKeys,
+            $userState
         );
         $orderedActionKeys = $this->resolveOrderedActionKeys(
             $personalization,
             $primaryFocusKey,
-            $secondaryFocusKeys
+            $secondaryFocusKeys,
+            $userState
         );
         $continuity = $this->resolveContinuity($personalization, $userState, $primaryFocusKey, $secondaryFocusKeys);
 
@@ -204,7 +234,7 @@ final class MbtiUserStateOrchestrationService
                 'ordered_section_keys' => $this->resolveOrderedSectionKeys($primaryFocusKey, $secondaryFocusKeys),
                 'primary_focus_key' => $primaryFocusKey,
                 'secondary_focus_keys' => $secondaryFocusKeys,
-                'cta_priority_keys' => $this->resolveCtaPriorityKeys($userState),
+                'cta_priority_keys' => $this->resolveCtaPriorityKeys($userState, $primaryFocusKey),
             ],
             'ordered_recommendation_keys' => $orderedRecommendationKeys,
             'ordered_action_keys' => $orderedActionKeys,
@@ -214,6 +244,26 @@ final class MbtiUserStateOrchestrationService
             'action_focus_key' => (string) ($orderedActionKeys[0] ?? ''),
             'continuity' => $continuity,
         ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildBaselineUserState(bool $hasUnlock): array
+    {
+        return [
+            'is_first_view' => true,
+            'is_revisit' => false,
+            'has_unlock' => $hasUnlock,
+            'has_feedback' => false,
+            'has_share' => false,
+            'has_action_engagement' => false,
+            'feedback_sentiment' => 'none',
+            'feedback_coverage' => 'none',
+            'action_completion_tendency' => 'idle',
+            'last_deep_read_section' => '',
+            'current_intent_cluster' => 'default',
+        ];
     }
 
     /**
@@ -243,12 +293,53 @@ final class MbtiUserStateOrchestrationService
      */
     private function resolvePrimaryFocusKey(array $personalization, array $userState): string
     {
+        $feedbackSentiment = trim((string) ($userState['feedback_sentiment'] ?? ''));
+        $feedbackCoverage = trim((string) ($userState['feedback_coverage'] ?? ''));
+        $actionCompletionTendency = trim((string) ($userState['action_completion_tendency'] ?? ''));
+        $lastDeepReadSection = trim((string) ($userState['last_deep_read_section'] ?? ''));
+        $currentIntentCluster = trim((string) ($userState['current_intent_cluster'] ?? ''));
+        $hasUnlock = (bool) ($userState['has_unlock'] ?? false);
+
+        if (
+            in_array($feedbackSentiment, ['negative', 'mixed'], true)
+            && in_array($feedbackCoverage, ['scene_only', 'explainability_only', 'mixed'], true)
+        ) {
+            if ($this->isKnownSectionKey($lastDeepReadSection) && $this->isClarifySection($lastDeepReadSection)) {
+                return $lastDeepReadSection;
+            }
+
+            return 'traits.close_call_axes';
+        }
+
+        if ($currentIntentCluster === 'career_move') {
+            return $hasUnlock ? 'career.work_experiments' : 'career.next_step';
+        }
+
+        if ($currentIntentCluster === 'relationship_tuning') {
+            return 'relationships.try_this_week';
+        }
+
+        if (
+            $currentIntentCluster === 'action_activation'
+            && in_array($actionCompletionTendency, ['repeatable', 'committed'], true)
+        ) {
+            if ($this->isKnownSectionKey($lastDeepReadSection) && in_array($lastDeepReadSection, self::ACTION_SECTION_KEYS, true)) {
+                return $lastDeepReadSection;
+            }
+
+            return $hasUnlock ? 'career.work_experiments' : 'growth.weekly_experiments';
+        }
+
+        if ($currentIntentCluster === 'deep_reading' && $this->isKnownSectionKey($lastDeepReadSection)) {
+            return $lastDeepReadSection;
+        }
+
         if (($userState['has_feedback'] ?? false) && $this->isLowConfidencePath($personalization)) {
             return 'growth.stability_confidence';
         }
 
         if (($userState['is_revisit'] ?? false) === false) {
-            return ($userState['has_unlock'] ?? false) ? 'career.next_step' : 'growth.next_actions';
+            return $hasUnlock ? 'career.next_step' : 'growth.next_actions';
         }
 
         if ($userState['has_action_engagement'] ?? false) {
@@ -264,7 +355,34 @@ final class MbtiUserStateOrchestrationService
      */
     private function resolveSecondaryFocusKeys(string $primaryFocusKey, array $userState): array
     {
-        $candidates = ($userState['is_revisit'] ?? false) ? self::SECTION_FOCUS_REVISIT : self::SECTION_FOCUS_FIRST_VIEW;
+        $candidates = [];
+        $currentIntentCluster = trim((string) ($userState['current_intent_cluster'] ?? ''));
+        $lastDeepReadSection = trim((string) ($userState['last_deep_read_section'] ?? ''));
+
+        if ($this->isKnownSectionKey($lastDeepReadSection) && $lastDeepReadSection !== $primaryFocusKey) {
+            $candidates[] = $lastDeepReadSection;
+        }
+
+        $intentCandidates = match ($currentIntentCluster) {
+            'career_move' => ['career.next_step', 'growth.weekly_experiments', 'relationships.try_this_week'],
+            'relationship_tuning' => ['relationships.communication_style', 'growth.watchouts', 'career.work_experiments'],
+            'clarify_type' => ['traits.adjacent_type_contrast', 'growth.stability_confidence', 'career.work_experiments'],
+            'action_activation' => ['growth.weekly_experiments', 'career.work_experiments', 'relationships.try_this_week'],
+            'deep_reading' => ['career.work_experiments', 'traits.close_call_axes', 'growth.watchouts'],
+            default => [],
+        };
+
+        foreach ($intentCandidates as $candidate) {
+            if ($this->isKnownSectionKey($candidate)) {
+                $candidates[] = $candidate;
+            }
+        }
+
+        $fallbackCandidates = ($userState['is_revisit'] ?? false) ? self::SECTION_FOCUS_REVISIT : self::SECTION_FOCUS_FIRST_VIEW;
+        foreach ($fallbackCandidates as $candidate) {
+            $candidates[] = $candidate;
+        }
+
         $selected = [];
 
         foreach ($candidates as $candidate) {
@@ -316,13 +434,37 @@ final class MbtiUserStateOrchestrationService
      * @param  array<string, bool>  $userState
      * @return list<string>
      */
-    private function resolveCtaPriorityKeys(array $userState): array
+    private function resolveCtaPriorityKeys(array $userState, string $primaryFocusKey): array
     {
         $hasUnlock = (bool) ($userState['has_unlock'] ?? false);
         $isRevisit = (bool) ($userState['is_revisit'] ?? false);
         $hasFeedback = (bool) ($userState['has_feedback'] ?? false);
         $hasShare = (bool) ($userState['has_share'] ?? false);
         $hasActionEngagement = (bool) ($userState['has_action_engagement'] ?? false);
+        $feedbackSentiment = trim((string) ($userState['feedback_sentiment'] ?? ''));
+        $actionCompletionTendency = trim((string) ($userState['action_completion_tendency'] ?? ''));
+        $currentIntentCluster = trim((string) ($userState['current_intent_cluster'] ?? ''));
+
+        if ($currentIntentCluster === 'career_move' || str_starts_with($primaryFocusKey, 'career.')) {
+            return $hasUnlock
+                ? ['career_bridge', 'workspace_lite', 'share_result']
+                : ['career_bridge', 'unlock_full_report', 'share_result'];
+        }
+
+        if ($currentIntentCluster === 'clarify_type' || in_array($feedbackSentiment, ['negative', 'mixed'], true)) {
+            return $hasUnlock
+                ? ['workspace_lite', 'career_bridge', 'share_result']
+                : ['unlock_full_report', 'share_result', 'career_bridge'];
+        }
+
+        if (
+            $currentIntentCluster === 'action_activation'
+            && in_array($actionCompletionTendency, ['repeatable', 'committed'], true)
+        ) {
+            return $hasUnlock
+                ? ['workspace_lite', 'career_bridge', 'share_result']
+                : ['career_bridge', 'unlock_full_report', 'share_result'];
+        }
 
         if (! $hasUnlock) {
             if ($isRevisit && ($hasFeedback || $hasShare)) {
@@ -347,7 +489,8 @@ final class MbtiUserStateOrchestrationService
     private function resolveOrderedRecommendationKeys(
         array $personalization,
         string $primaryFocusKey,
-        array $secondaryFocusKeys
+        array $secondaryFocusKeys,
+        array $userState
     ): array {
         $candidates = $this->normalizeRecommendationCandidates(
             (array) ($personalization['recommended_read_candidates'] ?? [])
@@ -357,7 +500,7 @@ final class MbtiUserStateOrchestrationService
             return [];
         }
 
-        $primaryThemes = $this->resolveRecommendationThemesForFocus($primaryFocusKey);
+        $primaryThemes = $this->resolveRecommendationThemesForState($primaryFocusKey, $userState);
         $secondaryThemes = [];
 
         foreach ($secondaryFocusKeys as $secondaryFocusKey) {
@@ -399,9 +542,10 @@ final class MbtiUserStateOrchestrationService
     private function resolveOrderedActionKeys(
         array $personalization,
         string $primaryFocusKey,
-        array $secondaryFocusKeys
+        array $secondaryFocusKeys,
+        array $userState
     ): array {
-        $orderedFields = $this->resolveActionFieldOrder($primaryFocusKey, $secondaryFocusKeys);
+        $orderedFields = $this->resolveActionFieldOrder($primaryFocusKey, $secondaryFocusKeys, $userState);
         $ordered = [];
 
         foreach ($orderedFields as $field) {
@@ -418,9 +562,27 @@ final class MbtiUserStateOrchestrationService
      * @param  list<string>  $secondaryFocusKeys
      * @return list<string>
      */
-    private function resolveActionFieldOrder(string $primaryFocusKey, array $secondaryFocusKeys): array
+    private function resolveActionFieldOrder(string $primaryFocusKey, array $secondaryFocusKeys, array $userState): array
     {
         $ordered = [];
+        $currentIntentCluster = trim((string) ($userState['current_intent_cluster'] ?? ''));
+        $actionCompletionTendency = trim((string) ($userState['action_completion_tendency'] ?? ''));
+
+        $intentHints = match ($currentIntentCluster) {
+            'career_move' => ['work_experiment_keys', 'weekly_action_keys'],
+            'relationship_tuning' => ['relationship_action_keys', 'weekly_action_keys'],
+            'clarify_type' => ['watchout_keys', 'weekly_action_keys'],
+            'action_activation' => in_array($actionCompletionTendency, ['repeatable', 'committed'], true)
+                ? ['work_experiment_keys', 'weekly_action_keys', 'relationship_action_keys']
+                : ['weekly_action_keys', 'watchout_keys'],
+            default => [],
+        };
+
+        foreach ($intentHints as $field) {
+            if (! in_array($field, $ordered, true)) {
+                $ordered[] = $field;
+            }
+        }
 
         foreach ($this->resolvePrimaryActionFieldHints($primaryFocusKey) as $field) {
             if (! in_array($field, $ordered, true)) {
@@ -521,6 +683,41 @@ final class MbtiUserStateOrchestrationService
             str_starts_with($focusKey, 'traits.') => ['explainability', 'growth'],
             default => ['action', 'growth', 'career'],
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $userState
+     * @return list<string>
+     */
+    private function resolveRecommendationThemesForState(string $focusKey, array $userState): array
+    {
+        $currentIntentCluster = trim((string) ($userState['current_intent_cluster'] ?? ''));
+        $feedbackSentiment = trim((string) ($userState['feedback_sentiment'] ?? ''));
+        $feedbackCoverage = trim((string) ($userState['feedback_coverage'] ?? ''));
+
+        if ($currentIntentCluster === 'career_move') {
+            return ['career', 'work', 'action'];
+        }
+
+        if ($currentIntentCluster === 'relationship_tuning') {
+            return ['relationship', 'communication', 'action'];
+        }
+
+        if (
+            $currentIntentCluster === 'clarify_type'
+            || (
+                in_array($feedbackSentiment, ['negative', 'mixed'], true)
+                && in_array($feedbackCoverage, ['scene_only', 'explainability_only', 'mixed'], true)
+            )
+        ) {
+            return ['explainability', 'stability', 'growth'];
+        }
+
+        if ($currentIntentCluster === 'action_activation') {
+            return ['action', 'growth', 'career'];
+        }
+
+        return $this->resolveRecommendationThemesForFocus($focusKey);
     }
 
     /**
@@ -789,22 +986,392 @@ final class MbtiUserStateOrchestrationService
             ->exists();
     }
 
-    private function attemptHasActionEngagement(int $orgId, string $attemptId): bool
+    /**
+     * @return list<array{event_code:string, meta:array<string, mixed>}>
+     */
+    private function fetchAttemptEvents(int $orgId, string $attemptId): array
     {
         $rows = DB::table('events')
             ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId)
-            ->where('event_code', 'ui_card_interaction')
             ->orderByDesc('occurred_at')
-            ->limit(25)
-            ->pluck('meta_json');
+            ->limit(50)
+            ->get(['event_code', 'meta_json']);
 
-        foreach ($rows as $rawMeta) {
-            $meta = $this->normalizeMetaJson($rawMeta);
+        $events = [];
+
+        foreach ($rows as $row) {
+            $eventCode = trim((string) ($row->event_code ?? ''));
+            if ($eventCode === '') {
+                continue;
+            }
+
+            $events[] = [
+                'event_code' => $eventCode,
+                'meta' => $this->normalizeMetaJson($row->meta_json ?? null),
+            ];
+        }
+
+        return $events;
+    }
+
+    /**
+     * @param  list<array{event_code:string, meta:array<string, mixed>}>  $eventRows
+     * @param  list<string>  $eventCodes
+     */
+    private function eventRowsContainAny(array $eventRows, array $eventCodes): bool
+    {
+        if ($eventCodes === []) {
+            return false;
+        }
+
+        foreach ($eventRows as $row) {
+            if (in_array($row['event_code'], $eventCodes, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array{event_code:string, meta:array<string, mixed>}>  $eventRows
+     */
+    private function eventRowsContainActionEngagement(array $eventRows): bool
+    {
+        foreach ($eventRows as $row) {
+            if ($row['event_code'] !== 'ui_card_interaction') {
+                continue;
+            }
+
+            $meta = $row['meta'];
             $sectionKey = trim((string) ($meta['sectionKey'] ?? $meta['section_key'] ?? ''));
             $actionKey = trim((string) ($meta['actionKey'] ?? $meta['action_key'] ?? ''));
 
             if ($actionKey !== '' || in_array($sectionKey, self::ACTION_SECTION_KEYS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array{event_code:string, meta:array<string, mixed>}>  $eventRows
+     */
+    private function resolveFeedbackSentiment(array $eventRows): string
+    {
+        $hasPositive = false;
+        $hasMixed = false;
+        $hasNegative = false;
+
+        foreach ($eventRows as $row) {
+            if ($row['event_code'] !== 'accuracy_feedback') {
+                continue;
+            }
+
+            $feedback = trim((string) ($row['meta']['feedback'] ?? ''));
+            if (in_array($feedback, self::POSITIVE_FEEDBACK_VALUES, true)) {
+                $hasPositive = true;
+                continue;
+            }
+
+            if (in_array($feedback, self::MIXED_FEEDBACK_VALUES, true)) {
+                $hasMixed = true;
+                continue;
+            }
+
+            if (in_array($feedback, self::NEGATIVE_FEEDBACK_VALUES, true)) {
+                $hasNegative = true;
+            }
+        }
+
+        if (! $hasPositive && ! $hasMixed && ! $hasNegative) {
+            return 'none';
+        }
+
+        if ($hasNegative && ! $hasPositive && ! $hasMixed) {
+            return 'negative';
+        }
+
+        if ($hasNegative || $hasMixed) {
+            return 'mixed';
+        }
+
+        return 'positive';
+    }
+
+    /**
+     * @param  list<array{event_code:string, meta:array<string, mixed>}>  $eventRows
+     */
+    private function resolveFeedbackCoverage(array $eventRows): string
+    {
+        $categories = [];
+
+        foreach ($eventRows as $row) {
+            if ($row['event_code'] !== 'accuracy_feedback') {
+                continue;
+            }
+
+            $sectionKey = trim((string) ($row['meta']['sectionKey'] ?? $row['meta']['section_key'] ?? ''));
+            $category = $this->categorizeFeedbackSection($sectionKey);
+            if ($category !== '' && ! in_array($category, $categories, true)) {
+                $categories[] = $category;
+            }
+        }
+
+        if ($categories === []) {
+            return 'none';
+        }
+
+        if (count($categories) === 1) {
+            return $categories[0] . '_only';
+        }
+
+        return 'mixed';
+    }
+
+    /**
+     * @param  list<array{event_code:string, meta:array<string, mixed>}>  $eventRows
+     */
+    private function resolveActionCompletionTendency(array $eventRows, bool $isRevisit, bool $hasUnlock): string
+    {
+        $actionInteractionCount = 0;
+        $positiveActionFeedback = false;
+        $hasCommerceIntent = false;
+
+        foreach ($eventRows as $row) {
+            $eventCode = $row['event_code'];
+            $meta = $row['meta'];
+
+            if (in_array($eventCode, ['click_unlock', 'create_order'], true)) {
+                $hasCommerceIntent = true;
+            }
+
+            if ($eventCode === 'accuracy_feedback') {
+                $feedback = trim((string) ($meta['feedback'] ?? ''));
+                $sectionKey = trim((string) ($meta['sectionKey'] ?? $meta['section_key'] ?? ''));
+                if ($feedback === 'helpful_action' || in_array($sectionKey, self::ACTION_SECTION_KEYS, true)) {
+                    $positiveActionFeedback = true;
+                }
+            }
+
+            if ($eventCode !== 'ui_card_interaction') {
+                continue;
+            }
+
+            $sectionKey = trim((string) ($meta['sectionKey'] ?? $meta['section_key'] ?? ''));
+            $actionKey = trim((string) ($meta['actionKey'] ?? $meta['action_key'] ?? ''));
+            if ($actionKey !== '' || in_array($sectionKey, self::ACTION_SECTION_KEYS, true)) {
+                $actionInteractionCount++;
+            }
+        }
+
+        if ($hasCommerceIntent && ($actionInteractionCount > 0 || $positiveActionFeedback)) {
+            return 'committed';
+        }
+
+        if (
+            $actionInteractionCount >= 2
+            || ($isRevisit && $actionInteractionCount >= 1)
+            || ($positiveActionFeedback && $actionInteractionCount >= 1)
+        ) {
+            return 'repeatable';
+        }
+
+        if ($actionInteractionCount >= 1 || $positiveActionFeedback) {
+            return 'warming_up';
+        }
+
+        return $hasUnlock ? 'available' : 'idle';
+    }
+
+    /**
+     * @param  list<array{event_code:string, meta:array<string, mixed>}>  $eventRows
+     */
+    private function resolveLastDeepReadSection(array $eventRows): string
+    {
+        foreach ($eventRows as $row) {
+            if ($row['event_code'] !== 'ui_card_interaction') {
+                continue;
+            }
+
+            $interaction = trim((string) ($row['meta']['interaction'] ?? ''));
+            $sectionKey = trim((string) ($row['meta']['sectionKey'] ?? $row['meta']['section_key'] ?? ''));
+            if ($sectionKey !== '' && $interaction === 'dwell_2500ms') {
+                return $sectionKey;
+            }
+        }
+
+        foreach ($eventRows as $row) {
+            if ($row['event_code'] !== 'ui_card_interaction') {
+                continue;
+            }
+
+            $sectionKey = trim((string) ($row['meta']['sectionKey'] ?? $row['meta']['section_key'] ?? ''));
+            if ($sectionKey !== '') {
+                return $sectionKey;
+            }
+        }
+
+        foreach ($eventRows as $row) {
+            if ($row['event_code'] !== 'accuracy_feedback') {
+                continue;
+            }
+
+            $sectionKey = trim((string) ($row['meta']['sectionKey'] ?? $row['meta']['section_key'] ?? ''));
+            if ($sectionKey !== '') {
+                return $sectionKey;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  list<array{event_code:string, meta:array<string, mixed>}>  $eventRows
+     */
+    private function resolveCurrentIntentCluster(
+        array $eventRows,
+        bool $hasUnlock,
+        string $feedbackSentiment,
+        string $feedbackCoverage,
+        string $actionCompletionTendency,
+        string $lastDeepReadSection,
+        bool $hasActionEngagement
+    ): string {
+        foreach ($eventRows as $row) {
+            $eventCode = $row['event_code'];
+            $meta = $row['meta'];
+            $sectionKey = trim((string) ($meta['sectionKey'] ?? $meta['section_key'] ?? ''));
+            $actionKey = trim((string) ($meta['actionKey'] ?? $meta['action_key'] ?? ''));
+            $ctaKey = trim((string) ($meta['ctaKey'] ?? $meta['cta_key'] ?? ''));
+            $continueTarget = trim((string) ($meta['continueTarget'] ?? $meta['continue_target'] ?? ''));
+            $recommendationKey = trim((string) ($meta['recommendationKey'] ?? $meta['recommendation_key'] ?? ''));
+
+            if (in_array($eventCode, ['click_unlock', 'create_order'], true)) {
+                return 'unlock_readiness';
+            }
+
+            if ($eventCode === 'share_result') {
+                return 'continuity_return';
+            }
+
+            if ($eventCode === 'accuracy_feedback') {
+                return in_array($this->categorizeFeedbackSection($sectionKey), ['action', 'career'], true)
+                    ? 'action_activation'
+                    : 'clarify_type';
+            }
+
+            if ($eventCode !== 'ui_card_interaction') {
+                continue;
+            }
+
+            if ($ctaKey === 'career_bridge' || $continueTarget === 'career_recommendation') {
+                return 'career_move';
+            }
+
+            if ($ctaKey === 'workspace_lite' || str_starts_with($continueTarget, 'history_') || $continueTarget === 'share_take_flow') {
+                return 'continuity_return';
+            }
+
+            if ($recommendationKey !== '' || $continueTarget === 'recommended_read') {
+                return 'deep_reading';
+            }
+
+            if ($actionKey !== '' || in_array($sectionKey, self::ACTION_SECTION_KEYS, true)) {
+                return 'action_activation';
+            }
+
+            if (str_starts_with($sectionKey, 'career.')) {
+                return 'career_move';
+            }
+
+            if (str_starts_with($sectionKey, 'relationships.')) {
+                return 'relationship_tuning';
+            }
+
+            if ($this->isClarifySection($sectionKey) || $sectionKey === 'scene_fingerprint') {
+                return 'clarify_type';
+            }
+        }
+
+        if (
+            in_array($feedbackSentiment, ['negative', 'mixed'], true)
+            && in_array($feedbackCoverage, ['scene_only', 'explainability_only', 'mixed'], true)
+        ) {
+            return 'clarify_type';
+        }
+
+        if ($this->isKnownSectionKey($lastDeepReadSection)) {
+            if (str_starts_with($lastDeepReadSection, 'career.')) {
+                return 'career_move';
+            }
+
+            if (str_starts_with($lastDeepReadSection, 'relationships.')) {
+                return 'relationship_tuning';
+            }
+
+            if ($this->isClarifySection($lastDeepReadSection)) {
+                return 'clarify_type';
+            }
+        }
+
+        if ($hasActionEngagement || in_array($actionCompletionTendency, ['repeatable', 'committed'], true)) {
+            return 'action_activation';
+        }
+
+        return $hasUnlock ? 'default' : 'unlock_readiness';
+    }
+
+    private function categorizeFeedbackSection(string $sectionKey): string
+    {
+        if ($sectionKey === '') {
+            return '';
+        }
+
+        if ($sectionKey === 'scene_fingerprint') {
+            return 'scene';
+        }
+
+        if ($this->isClarifySection($sectionKey)) {
+            return 'explainability';
+        }
+
+        if (in_array($sectionKey, self::ACTION_SECTION_KEYS, true)) {
+            return 'action';
+        }
+
+        if (str_starts_with($sectionKey, 'career.')) {
+            return 'career';
+        }
+
+        if (str_starts_with($sectionKey, 'relationships.')) {
+            return 'relationship';
+        }
+
+        if (str_starts_with($sectionKey, 'growth.')) {
+            return 'growth';
+        }
+
+        return '';
+    }
+
+    private function isClarifySection(string $sectionKey): bool
+    {
+        return $sectionKey === 'scene_fingerprint'
+            || $sectionKey === 'growth.stability_confidence'
+            || str_starts_with($sectionKey, 'traits.');
+    }
+
+    private function isKnownSectionKey(string $sectionKey): bool
+    {
+        if ($sectionKey === '') {
+            return false;
+        }
+
+        foreach (self::CHAPTER_SECTIONS as $sections) {
+            if (in_array($sectionKey, $sections, true)) {
                 return true;
             }
         }

--- a/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+++ b/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
@@ -96,7 +96,7 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
 
         $this->assertTrue((bool) ($payload['ok'] ?? false));
         $this->assertSame(
-            'mbti.personalization.phase8b.v1',
+            'mbti.personalization.phase8c.v1',
             data_get($payload, 'report._meta.personalization.schema_version')
         );
         $this->assertSame(
@@ -104,7 +104,7 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             data_get($payload, 'report._meta.personalization.engine_version')
         );
         $this->assertSame(
-            'phase8b.v1',
+            'phase8c.v1',
             data_get($payload, 'report._meta.personalization.dynamic_sections_version')
         );
         $this->assertIsArray(data_get($payload, 'report._meta.personalization.ordered_recommendation_keys'));
@@ -121,6 +121,11 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
                 'has_feedback' => false,
                 'has_share' => false,
                 'has_action_engagement' => false,
+                'feedback_sentiment' => 'none',
+                'feedback_coverage' => 'none',
+                'action_completion_tendency' => 'idle',
+                'last_deep_read_section' => '',
+                'current_intent_cluster' => 'default',
             ],
             data_get($payload, 'report._meta.personalization.user_state')
         );
@@ -348,11 +353,11 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             ->first(static fn (array $section): bool => (string) ($section['key'] ?? '') === 'relationships.try_this_week');
 
         $this->assertSame(
-            'mbti.personalization.phase8b.v1',
+            'mbti.personalization.phase8c.v1',
             data_get($projection, '_meta.personalization.schema_version')
         );
         $this->assertSame(
-            'phase8b.v1',
+            'phase8c.v1',
             data_get($projection, '_meta.personalization.dynamic_sections_version')
         );
         $this->assertSame(

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -43,8 +43,8 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertSame('INTJ-A', (string) ($meta['type_code'] ?? ''));
             $this->assertSame('A', (string) ($meta['identity'] ?? ''));
             $this->assertSame('report_phase4a_contract', (string) ($meta['engine_version'] ?? ''));
-            $this->assertSame('mbti.personalization.phase8b.v1', (string) ($meta['schema_version'] ?? ''));
-            $this->assertSame('phase8b.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
+            $this->assertSame('mbti.personalization.phase8c.v1', (string) ($meta['schema_version'] ?? ''));
+            $this->assertSame('phase8c.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
             $this->assertIsArray($meta['axis_bands'] ?? null);
             $this->assertSame('boundary', (string) (($meta['axis_bands']['EI'] ?? '')));
             $this->assertSame('boundary', (string) (($meta['axis_bands']['AT'] ?? '')));
@@ -116,36 +116,49 @@ class MbtiResultTelemetryContractTest extends TestCase
         $this->assertSame($eventMeta['report_view']['relationship_action_keys'] ?? null, $eventMeta['result_view']['relationship_action_keys'] ?? null);
         $this->assertSame($eventMeta['report_view']['work_experiment_keys'] ?? null, $eventMeta['result_view']['work_experiment_keys'] ?? null);
         $this->assertSame($eventMeta['report_view']['watchout_keys'] ?? null, $eventMeta['result_view']['watchout_keys'] ?? null);
-        $this->assertSame($eventMeta['report_view']['ordered_action_keys'] ?? null, $eventMeta['result_view']['ordered_action_keys'] ?? null);
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.is_first_view'));
         $this->assertSame(false, data_get($eventMeta, 'result_view.user_state.is_revisit'));
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.has_share'));
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.has_feedback'));
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.has_action_engagement'));
+        $this->assertSame('negative', data_get($eventMeta, 'result_view.user_state.feedback_sentiment'));
+        $this->assertSame('explainability_only', data_get($eventMeta, 'result_view.user_state.feedback_coverage'));
+        $this->assertSame('warming_up', data_get($eventMeta, 'result_view.user_state.action_completion_tendency'));
+        $this->assertSame('traits.close_call_axes', data_get($eventMeta, 'result_view.user_state.last_deep_read_section'));
+        $this->assertSame('action_activation', data_get($eventMeta, 'result_view.user_state.current_intent_cluster'));
         $this->assertSame(false, data_get($eventMeta, 'report_view.user_state.is_first_view'));
         $this->assertSame(true, data_get($eventMeta, 'report_view.user_state.is_revisit'));
+        $this->assertSame('negative', data_get($eventMeta, 'report_view.user_state.feedback_sentiment'));
+        $this->assertSame('explainability_only', data_get($eventMeta, 'report_view.user_state.feedback_coverage'));
+        $this->assertSame('repeatable', data_get($eventMeta, 'report_view.user_state.action_completion_tendency'));
+        $this->assertSame('traits.close_call_axes', data_get($eventMeta, 'report_view.user_state.last_deep_read_section'));
+        $this->assertSame('action_activation', data_get($eventMeta, 'report_view.user_state.current_intent_cluster'));
         $this->assertSame(
-            'growth.stability_confidence',
+            'traits.close_call_axes',
             data_get($eventMeta, 'result_view.orchestration.primary_focus_key')
         );
         $this->assertSame(
-            'growth.stability_confidence',
+            'traits.close_call_axes',
             data_get($eventMeta, 'report_view.orchestration.primary_focus_key')
         );
         $this->assertSame(
-            ['unlock_full_report', 'career_bridge', 'share_result'],
+            ['unlock_full_report', 'share_result', 'career_bridge'],
             data_get($eventMeta, 'result_view.orchestration.cta_priority_keys')
+        );
+        $this->assertSame(
+            ['unlock_full_report', 'share_result', 'career_bridge'],
+            data_get($eventMeta, 'report_view.orchestration.cta_priority_keys')
         );
         $this->assertIsArray(data_get($eventMeta, 'result_view.ordered_recommendation_keys', []));
         $this->assertIsArray(data_get($eventMeta, 'result_view.recommendation_priority_keys', []));
-        $this->assertIsString((string) data_get($eventMeta, 'result_view.reading_focus_key', ''));
-        $this->assertIsString((string) data_get($eventMeta, 'result_view.action_focus_key', ''));
+        $this->assertSame('weekly_action.theme.protect_energy_lane', data_get($eventMeta, 'result_view.action_focus_key'));
+        $this->assertSame('work_experiment.theme.protect_energy_lane', data_get($eventMeta, 'report_view.action_focus_key'));
         $this->assertSame(
-            'growth.stability_confidence',
+            'traits.close_call_axes',
             data_get($eventMeta, 'result_view.continuity.carryover_focus_key')
         );
         $this->assertSame(
-            'growth.stability_confidence',
+            'traits.close_call_axes',
             data_get($eventMeta, 'report_view.continuity.carryover_focus_key')
         );
         $this->assertSame(
@@ -157,30 +170,29 @@ class MbtiResultTelemetryContractTest extends TestCase
             data_get($eventMeta, 'report_view.continuity.carryover_reason')
         );
         $this->assertSame(
-            ['growth.stability_confidence', 'traits.close_call_axes', 'traits.adjacent_type_contrast'],
+            ['traits.close_call_axes', 'growth.weekly_experiments', 'career.work_experiments'],
             data_get($eventMeta, 'result_view.continuity.recommended_resume_keys')
         );
         $this->assertSame(
-            ['growth.stability_confidence', 'career.work_experiments', 'relationships.try_this_week'],
+            ['traits.close_call_axes', 'growth.weekly_experiments', 'career.work_experiments'],
             data_get($eventMeta, 'report_view.continuity.recommended_resume_keys')
         );
         $this->assertSame(
-            ['stability', 'explainability'],
+            ['explainability', 'growth', 'work'],
             data_get($eventMeta, 'result_view.continuity.carryover_scene_keys')
         );
         $this->assertSame(
-            ['stability', 'work', 'decision'],
+            ['explainability', 'growth', 'work'],
             data_get($eventMeta, 'report_view.continuity.carryover_scene_keys')
         );
         $this->assertSame(
-            ['watchout.stability.context_sensitive'],
+            ['weekly_action.theme.protect_energy_lane', 'work_experiment.theme.protect_energy_lane'],
             data_get($eventMeta, 'result_view.continuity.carryover_action_keys')
         );
         $this->assertSame(
             [
-                'watchout.stability.context_sensitive',
+                'weekly_action.theme.protect_energy_lane',
                 'work_experiment.theme.protect_energy_lane',
-                'relationship_action.theme.protect_energy_lane',
             ],
             data_get($eventMeta, 'report_view.continuity.carryover_action_keys')
         );
@@ -334,8 +346,25 @@ class MbtiResultTelemetryContractTest extends TestCase
                 'event_name' => 'accuracy_feedback',
                 'org_id' => 0,
                 'attempt_id' => $attemptId,
-                'meta_json' => json_encode(['sectionKey' => 'growth.stability_confidence'], JSON_UNESCAPED_UNICODE),
+                'meta_json' => json_encode([
+                    'sectionKey' => 'growth.stability_confidence',
+                    'feedback' => 'unclear',
+                ], JSON_UNESCAPED_UNICODE),
                 'occurred_at' => now()->subMinutes(10),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 0,
+                'attempt_id' => $attemptId,
+                'meta_json' => json_encode([
+                    'sectionKey' => 'traits.close_call_axes',
+                    'interaction' => 'dwell_2500ms',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(9),
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
@@ -348,8 +377,9 @@ class MbtiResultTelemetryContractTest extends TestCase
                 'meta_json' => json_encode([
                     'sectionKey' => 'growth.next_actions',
                     'actionKey' => 'weekly_action.theme.name_decision_rule',
+                    'interaction' => 'click',
                 ], JSON_UNESCAPED_UNICODE),
-                'occurred_at' => now()->subMinutes(9),
+                'occurred_at' => now()->subMinutes(8),
                 'created_at' => now(),
                 'updated_at' => now(),
             ],

--- a/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
@@ -86,14 +86,14 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
 
         $this->assertSame('ENFP-T', $clear['type_code']);
         $this->assertSame('T', $clear['identity']);
-        $this->assertSame('mbti.personalization.phase8b.v1', $clear['schema_version']);
+        $this->assertSame('mbti.personalization.phase8c.v1', $clear['schema_version']);
         $this->assertSame('clear', data_get($clear, 'axis_bands.EI'));
         $this->assertSame('strong', data_get($strong, 'axis_bands.EI'));
         $this->assertSame(false, data_get($clear, 'boundary_flags.EI'));
         $this->assertSame(false, data_get($strong, 'boundary_flags.EI'));
         $this->assertSame('MBTI.cn-mainland.zh-CN.v0.3', $clear['pack_id']);
         $this->assertSame('report_phase4a_contract', $clear['engine_version']);
-        $this->assertSame('phase8b.v1', $clear['dynamic_sections_version']);
+        $this->assertSame('phase8c.v1', $clear['dynamic_sections_version']);
         $this->assertSame(
             [
                 'is_first_view' => true,
@@ -102,6 +102,11 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
                 'has_feedback' => false,
                 'has_share' => false,
                 'has_action_engagement' => false,
+                'feedback_sentiment' => 'none',
+                'feedback_coverage' => 'none',
+                'action_completion_tendency' => 'idle',
+                'last_deep_read_section' => '',
+                'current_intent_cluster' => 'default',
             ],
             data_get($clear, 'user_state')
         );

--- a/backend/tests/Unit/Services/Mbti/MbtiUserStateOrchestrationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiUserStateOrchestrationServiceTest.php
@@ -47,8 +47,25 @@ final class MbtiUserStateOrchestrationServiceTest extends TestCase
                 'event_name' => 'accuracy_feedback',
                 'org_id' => 7,
                 'attempt_id' => 'attempt-phase7b',
-                'meta_json' => json_encode(['sectionKey' => 'growth.stability_confidence'], JSON_UNESCAPED_UNICODE),
+                'meta_json' => json_encode([
+                    'sectionKey' => 'growth.stability_confidence',
+                    'feedback' => 'unclear',
+                ], JSON_UNESCAPED_UNICODE),
                 'occurred_at' => now()->subMinutes(4),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-phase7b',
+                'meta_json' => json_encode([
+                    'sectionKey' => 'traits.close_call_axes',
+                    'interaction' => 'dwell_2500ms',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(3),
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
@@ -61,8 +78,9 @@ final class MbtiUserStateOrchestrationServiceTest extends TestCase
                 'meta_json' => json_encode([
                     'sectionKey' => 'growth.next_actions',
                     'actionKey' => 'weekly_action.theme.name_decision_rule',
+                    'interaction' => 'click',
                 ], JSON_UNESCAPED_UNICODE),
-                'occurred_at' => now()->subMinutes(3),
+                'occurred_at' => now()->subMinutes(2),
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
@@ -94,38 +112,236 @@ final class MbtiUserStateOrchestrationServiceTest extends TestCase
                 'has_feedback' => true,
                 'has_share' => true,
                 'has_action_engagement' => true,
+                'feedback_sentiment' => 'negative',
+                'feedback_coverage' => 'explainability_only',
+                'action_completion_tendency' => 'repeatable',
+                'last_deep_read_section' => 'traits.close_call_axes',
+                'current_intent_cluster' => 'action_activation',
             ],
             data_get($effective, 'user_state')
         );
-        $this->assertSame('growth.stability_confidence', data_get($effective, 'orchestration.primary_focus_key'));
+        $this->assertSame('traits.close_call_axes', data_get($effective, 'orchestration.primary_focus_key'));
         $this->assertSame(
-            ['career_bridge', 'workspace_lite', 'share_result'],
+            ['workspace_lite', 'career_bridge', 'share_result'],
             data_get($effective, 'orchestration.cta_priority_keys')
         );
         $this->assertSame(
-            ['read-action', 'read-career', 'read-relationship', 'read-explain'],
+            ['read-action', 'read-relationship', 'read-explain', 'read-career'],
             data_get($effective, 'ordered_recommendation_keys')
         );
         $this->assertSame('read-action', data_get($effective, 'reading_focus_key'));
         $this->assertSame(
-            ['career.work_experiments', 'relationships.try_this_week'],
+            ['growth.weekly_experiments', 'career.work_experiments'],
             data_get($effective, 'orchestration.secondary_focus_keys')
         );
-        $this->assertSame('watchout.stability.context_sensitive', data_get($effective, 'action_focus_key'));
+        $this->assertSame('work_experiment.theme.name_decision_rule', data_get($effective, 'action_focus_key'));
+        $this->assertSame(
+            [
+                'work_experiment.theme.name_decision_rule',
+                'weekly_action.theme.name_decision_rule',
+                'relationship_action.theme.name_decision_rule',
+                'watchout.stability.context_sensitive',
+            ],
+            data_get($effective, 'ordered_action_keys')
+        );
         $this->assertContains('work_experiment.theme.name_decision_rule', data_get($effective, 'ordered_action_keys', []));
         $this->assertContains('relationship_action.theme.name_decision_rule', data_get($effective, 'ordered_action_keys', []));
-        $this->assertSame('growth.stability_confidence', data_get($effective, 'continuity.carryover_focus_key'));
+        $this->assertSame('traits.close_call_axes', data_get($effective, 'continuity.carryover_focus_key'));
         $this->assertSame('resume_action_loop', data_get($effective, 'continuity.carryover_reason'));
         $this->assertSame(
-            ['growth.stability_confidence', 'career.work_experiments', 'relationships.try_this_week'],
+            ['traits.close_call_axes', 'growth.weekly_experiments', 'career.work_experiments'],
             data_get($effective, 'continuity.recommended_resume_keys')
         );
         $this->assertSame(
-            ['stability', 'work', 'decision'],
+            ['explainability', 'growth', 'work'],
             data_get($effective, 'continuity.carryover_scene_keys')
         );
-        $this->assertContains('watchout.stability.context_sensitive', data_get($effective, 'continuity.carryover_action_keys', []));
+        $this->assertContains('weekly_action.theme.name_decision_rule', data_get($effective, 'continuity.carryover_action_keys', []));
         $this->assertContains('work_experiment.theme.name_decision_rule', data_get($effective, 'continuity.carryover_action_keys', []));
+    }
+
+    public function test_overlay_effective_changes_focus_ordering_when_deepened_user_state_signals_shift(): void
+    {
+        $personalization = app(MbtiResultPersonalizationService::class)->buildForReportPayload(
+            $this->reportPayload(),
+            [
+                'type_code' => 'ENFP-T',
+                'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'dir_version' => 'MBTI-CN-v0.3',
+                'locale' => 'zh-CN',
+                'engine_version' => 'report_phase4a_contract',
+                'has_unlock' => true,
+            ]
+        );
+
+        DB::table('events')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'result_view',
+                'event_name' => 'result_view',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-clarify',
+                'meta_json' => json_encode(['attempt_id' => 'attempt-clarify'], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(6),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'accuracy_feedback',
+                'event_name' => 'accuracy_feedback',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-clarify',
+                'meta_json' => json_encode([
+                    'sectionKey' => 'growth.stability_confidence',
+                    'feedback' => 'unclear',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(5),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-clarify',
+                'meta_json' => json_encode([
+                    'sectionKey' => 'traits.close_call_axes',
+                    'interaction' => 'dwell_2500ms',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(4),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-clarify',
+                'meta_json' => json_encode([
+                    'sectionKey' => 'growth.next_actions',
+                    'actionKey' => 'weekly_action.theme.name_decision_rule',
+                    'interaction' => 'click',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(3),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'result_view',
+                'event_name' => 'result_view',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-career',
+                'meta_json' => json_encode(['attempt_id' => 'attempt-career'], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(6),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'accuracy_feedback',
+                'event_name' => 'accuracy_feedback',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-career',
+                'meta_json' => json_encode([
+                    'sectionKey' => 'growth.stability_confidence',
+                    'feedback' => 'accurate',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(5),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-career',
+                'meta_json' => json_encode([
+                    'sectionKey' => 'career.work_experiments',
+                    'actionKey' => 'work_experiment.theme.name_decision_rule',
+                    'interaction' => 'click',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(4),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 7,
+                'attempt_id' => 'attempt-career',
+                'meta_json' => json_encode([
+                    'ctaKey' => 'career_bridge',
+                    'continueTarget' => 'career_recommendation',
+                    'interaction' => 'click_cta',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(3),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        DB::table('shares')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'attempt_id' => 'attempt-clarify',
+                'anon_id' => 'anon-clarify',
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v0.3',
+                'content_package_version' => 'v0.3',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'attempt_id' => 'attempt-career',
+                'anon_id' => 'anon-career',
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v0.3',
+                'content_package_version' => 'v0.3',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $service = app(MbtiUserStateOrchestrationService::class);
+        $clarify = $service->overlayEffective($personalization, 7, 'attempt-clarify', true);
+        $career = $service->overlayEffective($personalization, 7, 'attempt-career', true);
+
+        $this->assertSame(true, data_get($clarify, 'user_state.has_feedback'));
+        $this->assertSame(true, data_get($career, 'user_state.has_feedback'));
+        $this->assertSame(true, data_get($clarify, 'user_state.has_share'));
+        $this->assertSame(true, data_get($career, 'user_state.has_share'));
+        $this->assertSame('negative', data_get($clarify, 'user_state.feedback_sentiment'));
+        $this->assertSame('positive', data_get($career, 'user_state.feedback_sentiment'));
+        $this->assertSame('traits.close_call_axes', data_get($clarify, 'user_state.last_deep_read_section'));
+        $this->assertSame('career_move', data_get($career, 'user_state.current_intent_cluster'));
+        $this->assertSame('traits.close_call_axes', data_get($clarify, 'orchestration.primary_focus_key'));
+        $this->assertSame('career.work_experiments', data_get($career, 'orchestration.primary_focus_key'));
+        $this->assertSame(
+            ['workspace_lite', 'career_bridge', 'share_result'],
+            data_get($clarify, 'orchestration.cta_priority_keys')
+        );
+        $this->assertSame(
+            ['career_bridge', 'workspace_lite', 'share_result'],
+            data_get($career, 'orchestration.cta_priority_keys')
+        );
+        $this->assertSame('read-action', data_get($clarify, 'reading_focus_key'));
+        $this->assertSame('read-career', data_get($career, 'reading_focus_key'));
+        $this->assertSame('work_experiment.theme.name_decision_rule', data_get($career, 'action_focus_key'));
+        $this->assertNotSame(
+            data_get($clarify, 'ordered_recommendation_keys'),
+            data_get($career, 'ordered_recommendation_keys')
+        );
+        $this->assertSame(
+            'work_experiment.theme.name_decision_rule',
+            data_get($clarify, 'action_focus_key')
+        );
     }
 
     /**

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
@@ -1,6 +1,6 @@
 {
     "schema": "fap.mbti.dynamic_sections.v1",
-    "version": "phase8b.v1",
+    "version": "phase8c.v1",
   "labels": {
     "block_kinds": {
       "type_skeleton": "类型骨架",


### PR DESCRIPTION
## Summary

This PR ships the backend half of MBTI PR-8C: user state deepening.

The MBTI result stack already had strong authority for:

- strength-layered variants
- scene fingerprint and boundary deepening
- explainability and borderline contrast
- action plan and guided next steps
- user-state-aware ordering
- cross-page continuity and focus carryover
- recommendation / reading / action / CTA orchestration

What was still missing was a deeper operating state layer.

This PR closes that gap by upgrading MBTI user state from a basic read/revisit/unlock layer into a stronger authority that can drive focus selection, recommendation ordering, CTA priority, and continuity more reliably.

## Problem

Before this change, the backend could already derive first-view vs revisit, unlock state, feedback presence, share state, and basic action engagement.

But it still could not formally express deeper operating signals such as:

- `feedback_sentiment`
- `feedback_coverage`
- `action_completion_tendency`
- `last_deep_read_section`
- `current_intent_cluster`

That meant orchestration was working, but it still had to make important decisions without a sufficiently rich user-state layer.

## Root cause

The existing authority chain already had enough signal in the event history and read-time overlay path to support deeper state, but those signals were not being normalized into the formal MBTI personalization contract.

As a result:

- orchestration had less context than it could have had
- continuity and recommendation systems had a weaker state base than intended
- telemetry could not segment key MBTI events with the deeper state that actually explains user intent

## Fix

This PR introduces a deepened MBTI user-state authority and makes it part of the existing single-authority pipeline.

It adds and persists these fields through personalization, projection, report, snapshot metadata, and read-time telemetry:

- `feedback_sentiment`
- `feedback_coverage`
- `action_completion_tendency`
- `last_deep_read_section`
- `current_intent_cluster`

Implementation highlights:

- `MbtiUserStateOrchestrationService` now derives the deeper state from existing read/interaction/feedback/share/order signals
- orchestration logic now consumes the deeper state when resolving focus, recommendation order, action order, and CTA priority
- the metadata boundary is bumped to `mbti.personalization.phase8c.v1` / `phase8c.v1`
- targeted backend tests now lock the visible state-driven ordering differences

This keeps the architecture intact:

- no migration
- no new dependency
- no second authority path
- no payment / CMS / AIC / career-system rewrite

## User impact

After this PR, MBTI user state is no longer just good enough for basic revisit logic.

The backend can now distinguish whether the current user is:

- still clarifying the type
- already moving into action activation
- showing career intent
- staying shallow vs reading deeply
- responding positively or negatively to the current explanation layer

That gives later phases a much stronger base for orchestration, CTA ranking, recommendation ordering, and carryover.

## Validation

I ran:

- `php artisan test tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php tests/Unit/Services/Mbti/MbtiUserStateOrchestrationServiceTest.php tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php tests/Feature/V0_3/MbtiResultTelemetryContractTest.php`

All passed:

- 10 tests passed
- 448 assertions

## Scope note

This PR intentionally excludes unrelated local dirty changes already present in the repo, especially:

- `backend/app/Console/Commands/PacksPublish.php`
- `backend/app/Console/Commands/PacksRollback.php`
- `backend/content_packs/BIG5_OCEAN/v1/compiled/*`
- `backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php`

Only the MBTI PR-8C backend files are included.
