### PR TITLE
[codex] Ship MBTI PR-8D contentops and experiment governance 1.0 (backend)

### DIFF
--- a/backend/app/Internal/SelfCheck/SelfCheckContentEngineCore.php
+++ b/backend/app/Internal/SelfCheck/SelfCheckContentEngineCore.php
@@ -311,7 +311,7 @@ $errs[] = "pack={$packId} file={$abs} path=$.schema :: missing schema field (ass
         // 与 expectedSchemaFor 保持同样的分类口径（只收集 schemaKey，不做值判断）
         $file = (string)$file;
 
-        if (in_array($assetKey, ['questions','type_profiles','cards','role_cards','strategy_cards','fallback_cards','highlights','reads','rules','section_policies','share_templates','meta'], true)) {
+        if (in_array($assetKey, ['questions','type_profiles','cards','role_cards','strategy_cards','fallback_cards','highlights','reads','rules','section_policies','dynamic_sections','content_governance','share_templates','meta'], true)) {
            $used[$assetKey] = true;
            return;
         }
@@ -2981,6 +2981,8 @@ public function containsAny(string $haystack, array $needles): bool
         'reads'            => 'reads',
         'rules'            => 'rules',
         'section_policies' => 'section_policies',
+        'dynamic_sections' => 'dynamic_sections',
+        'content_governance' => 'content_governance',
         'meta'             => 'meta',
 
         // ✅ Task 4: share templates

--- a/backend/app/Services/Content/ContentCompileService.php
+++ b/backend/app/Services/Content/ContentCompileService.php
@@ -10,7 +10,10 @@ use RecursiveIteratorIterator;
 
 final class ContentCompileService
 {
-    public function __construct(private readonly ContentLintService $lint)
+    public function __construct(
+        private readonly ContentLintService $lint,
+        private readonly MbtiContentGovernanceService $mbtiGovernance,
+    )
     {
     }
 
@@ -20,10 +23,7 @@ final class ContentCompileService
     public function compileAll(?string $packId = null): array
     {
         $packs = $this->discoverPacks();
-        if (is_string($packId) && trim($packId) !== '') {
-            $packId = trim($packId);
-            $packs = array_values(array_filter($packs, fn (array $pack): bool => (string) ($pack['pack_id'] ?? '') === $packId));
-        }
+        $packs = $this->selectPacks($packs, $packId);
 
         $results = [];
         $ok = true;
@@ -39,6 +39,34 @@ final class ContentCompileService
             'ok' => $ok,
             'packs' => $results,
         ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $packs
+     * @return list<array<string,mixed>>
+     */
+    private function selectPacks(array $packs, ?string $packId): array
+    {
+        if (! is_string($packId) || trim($packId) === '') {
+            return $packs;
+        }
+
+        $packId = trim($packId);
+        $matches = array_values(array_filter(
+            $packs,
+            fn (array $pack): bool => (string) ($pack['pack_id'] ?? '') === $packId
+        ));
+
+        if (count($matches) <= 1) {
+            return $matches;
+        }
+
+        $governedMatches = array_values(array_filter(
+            $matches,
+            fn (array $pack): bool => $this->mbtiGovernance->appliesTo($pack)
+        ));
+
+        return count($governedMatches) === 1 ? $governedMatches : $matches;
     }
 
     /**
@@ -123,7 +151,10 @@ final class ContentCompileService
             [$baseDir . DIRECTORY_SEPARATOR . 'manifest.json'],
             glob($baseDir . DIRECTORY_SEPARATOR . 'report_cards_*.json') ?: [],
             glob($baseDir . DIRECTORY_SEPARATOR . 'report_select_rules.json') ?: [],
-            glob($baseDir . DIRECTORY_SEPARATOR . 'report_section_policies.json') ?: []
+            glob($baseDir . DIRECTORY_SEPARATOR . 'report_section_policies.json') ?: [],
+            glob($baseDir . DIRECTORY_SEPARATOR . 'report_dynamic_sections.json') ?: [],
+            glob($baseDir . DIRECTORY_SEPARATOR . 'report_recommended_reads.json') ?: [],
+            glob($baseDir . DIRECTORY_SEPARATOR . 'report_content_governance.json') ?: []
         );
         $checksum = $this->computeChecksum($sourceFiles);
         $generatedAt = now()->toIso8601String();
@@ -168,19 +199,32 @@ final class ContentCompileService
             'variables' => $variablesUsed,
         ]);
 
+        $compiledFiles = [
+            'cards.normalized.json',
+            'cards.tag_index.json',
+            'rules.normalized.json',
+            'sections.spec.json',
+            'variables.used.json',
+        ];
+
+        if ($this->mbtiGovernance->appliesTo($pack)) {
+            $governanceDoc = $this->mbtiGovernance->loadDocument($baseDir);
+            if (is_array($governanceDoc)) {
+                $this->writeJson(
+                    $compiledDir . DIRECTORY_SEPARATOR . 'governance.spec.json',
+                    $this->mbtiGovernance->compileSpec($pack, $governanceDoc)
+                );
+                $compiledFiles[] = 'governance.spec.json';
+            }
+        }
+
         $this->writeJson($compiledDir . DIRECTORY_SEPARATOR . 'manifest.json', [
             'schema' => 'fap.content.compiled.manifest.v1',
             'pack_id' => (string) ($pack['pack_id'] ?? ''),
             'source_version' => (string) ($manifest['content_package_version'] ?? ''),
             'generated_at' => $generatedAt,
             'checksum' => $checksum,
-            'files' => [
-                'cards.normalized.json',
-                'cards.tag_index.json',
-                'rules.normalized.json',
-                'sections.spec.json',
-                'variables.used.json',
-            ],
+            'files' => $compiledFiles,
         ]);
 
         return [

--- a/backend/app/Services/Content/ContentLintService.php
+++ b/backend/app/Services/Content/ContentLintService.php
@@ -12,7 +12,10 @@ final class ContentLintService
 {
     private const CARD_ACCESS_LEVELS = ['free', 'preview', 'paid'];
 
-    public function __construct(private readonly TemplateLintService $templateLint)
+    public function __construct(
+        private readonly TemplateLintService $templateLint,
+        private readonly MbtiContentGovernanceService $mbtiGovernance,
+    )
     {
     }
 
@@ -22,10 +25,7 @@ final class ContentLintService
     public function lintAll(?string $packId = null): array
     {
         $packs = $this->discoverPacks();
-        if (is_string($packId) && trim($packId) !== '') {
-            $packId = trim($packId);
-            $packs = array_values(array_filter($packs, fn (array $pack): bool => (string) ($pack['pack_id'] ?? '') === $packId));
-        }
+        $packs = $this->selectPacks($packs, $packId);
 
         $results = [];
         $ok = true;
@@ -41,6 +41,34 @@ final class ContentLintService
             'ok' => $ok,
             'packs' => $results,
         ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $packs
+     * @return list<array<string,mixed>>
+     */
+    private function selectPacks(array $packs, ?string $packId): array
+    {
+        if (! is_string($packId) || trim($packId) === '') {
+            return $packs;
+        }
+
+        $packId = trim($packId);
+        $matches = array_values(array_filter(
+            $packs,
+            fn (array $pack): bool => (string) ($pack['pack_id'] ?? '') === $packId
+        ));
+
+        if (count($matches) <= 1) {
+            return $matches;
+        }
+
+        $governedMatches = array_values(array_filter(
+            $matches,
+            fn (array $pack): bool => $this->mbtiGovernance->appliesTo($pack)
+        ));
+
+        return count($governedMatches) === 1 ? $governedMatches : $matches;
     }
 
     /**
@@ -153,6 +181,10 @@ final class ContentLintService
                     }
                 }
             }
+        }
+
+        if ($this->mbtiGovernance->appliesTo($pack)) {
+            $errors = array_merge($errors, $this->mbtiGovernance->lintPack($pack));
         }
 
         return [

--- a/backend/app/Services/Content/MbtiContentGovernanceService.php
+++ b/backend/app/Services/Content/MbtiContentGovernanceService.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+final class MbtiContentGovernanceService
+{
+    /**
+     * @var list<string>
+     */
+    private const REQUIRED_LAYERS = [
+        'skeleton',
+        'intensity',
+        'boundary',
+        'scene',
+        'explainability',
+        'action',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const REQUIRED_POLICY_FILES = [
+        'type_profiles.json',
+        'identity_layers.json',
+        'report_identity_cards.json',
+        'report_roles.json',
+        'report_strategies.json',
+        'report_highlights.json',
+        'report_highlights_policy.json',
+        'report_highlights_pools.json',
+        'report_highlights_rules.json',
+        'report_borderline_notes.json',
+        'report_borderline_templates.json',
+        'report_cards_traits.json',
+        'report_cards_growth.json',
+        'report_cards_career.json',
+        'report_cards_relationships.json',
+        'report_cards_stress_recovery.json',
+        'report_cards_fallback_traits.json',
+        'report_cards_fallback_growth.json',
+        'report_cards_fallback_career.json',
+        'report_cards_fallback_relationships.json',
+        'report_cards_fallback_stress_recovery.json',
+        'report_dynamic_sections.json',
+        'report_recommended_reads.json',
+        'report_select_rules.json',
+        'report_section_policies.json',
+        'report_rules.json',
+        'report_overrides.json',
+    ];
+
+    public function appliesTo(array $pack): bool
+    {
+        $manifest = is_array($pack['manifest'] ?? null) ? $pack['manifest'] : [];
+        $schema = trim((string) data_get($manifest, 'schemas.content_governance', ''));
+        $assetPaths = data_get($manifest, 'assets.content_governance', []);
+
+        return $schema === 'fap.mbti.content_governance.v1'
+            || (is_array($assetPaths) && $assetPaths !== []);
+    }
+
+    public function governancePath(string $baseDir): string
+    {
+        return $baseDir.DIRECTORY_SEPARATOR.'report_content_governance.json';
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function loadDocument(string $baseDir): ?array
+    {
+        $path = $this->governancePath($baseDir);
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $raw = file_get_contents($path);
+        if (! is_string($raw) || trim($raw) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $pack
+     * @return list<array{file:string,block_id:string,message:string}>
+     */
+    public function lintPack(array $pack): array
+    {
+        $baseDir = trim((string) ($pack['base_dir'] ?? ''));
+        $manifest = is_array($pack['manifest'] ?? null) ? $pack['manifest'] : [];
+        $manifestPackId = trim((string) ($pack['pack_id'] ?? ''));
+        $context = trim((string) ($manifest['region'] ?? '')).'.'.trim((string) ($manifest['locale'] ?? ''));
+
+        $path = $this->governancePath($baseDir);
+        if (! is_file($path)) {
+            return [$this->error($path, 'governance.doc', 'MBTI pack requires report_content_governance.json.')];
+        }
+
+        $doc = $this->loadDocument($baseDir);
+        if (! is_array($doc)) {
+            return [$this->error($path, 'governance.doc', 'Invalid governance JSON.')];
+        }
+
+        $errors = [];
+
+        if (($doc['schema'] ?? null) !== 'fap.mbti.content_governance.v1') {
+            $errors[] = $this->error($path, 'governance.schema', "schema must be 'fap.mbti.content_governance.v1'.");
+        }
+
+        if (trim((string) ($doc['pack_id'] ?? '')) !== $manifestPackId) {
+            $errors[] = $this->error($path, 'governance.pack_id', 'governance pack_id must match manifest pack_id.');
+        }
+
+        if (trim((string) ($doc['cultural_context'] ?? '')) !== $context) {
+            $errors[] = $this->error($path, 'governance.cultural_context', 'cultural_context must match manifest region/locale.');
+        }
+
+        $taxonomyLayers = is_array(data_get($doc, 'taxonomy.layers')) ? data_get($doc, 'taxonomy.layers') : [];
+        $blockKindIndex = [];
+        foreach (self::REQUIRED_LAYERS as $layer) {
+            $layerNode = is_array($taxonomyLayers[$layer] ?? null) ? $taxonomyLayers[$layer] : null;
+            if ($layerNode === null) {
+                $errors[] = $this->error($path, "taxonomy.layers.{$layer}", "Missing required governance layer '{$layer}'.");
+                continue;
+            }
+
+            if (trim((string) ($layerNode['label'] ?? '')) === '') {
+                $errors[] = $this->error($path, "taxonomy.layers.{$layer}", "Layer '{$layer}' requires a non-empty label.");
+            }
+
+            $blockKinds = array_values(array_filter(array_map('strval', (array) ($layerNode['block_kinds'] ?? []))));
+            if ($blockKinds === []) {
+                $errors[] = $this->error($path, "taxonomy.layers.{$layer}", "Layer '{$layer}' requires block_kinds.");
+                continue;
+            }
+
+            foreach ($blockKinds as $blockKind) {
+                if (isset($blockKindIndex[$blockKind])) {
+                    $errors[] = $this->error(
+                        $path,
+                        "taxonomy.layers.{$layer}",
+                        "Block kind '{$blockKind}' is assigned to multiple layers."
+                    );
+                    continue;
+                }
+                $blockKindIndex[$blockKind] = $layer;
+            }
+        }
+
+        $dynamicDocPath = $baseDir.DIRECTORY_SEPARATOR.'report_dynamic_sections.json';
+        $dynamicDoc = $this->loadJsonFile($dynamicDocPath);
+        $dynamicBlockKinds = array_keys(is_array(data_get($dynamicDoc, 'labels.block_kinds')) ? data_get($dynamicDoc, 'labels.block_kinds') : []);
+        foreach ($dynamicBlockKinds as $blockKind) {
+            if (! isset($blockKindIndex[$blockKind])) {
+                $errors[] = $this->error(
+                    $path,
+                    'taxonomy.block_kinds',
+                    "Dynamic block kind '{$blockKind}' is missing from governance taxonomy."
+                );
+            }
+        }
+
+        $tierPolicies = is_array($doc['tier_policies'] ?? null) ? $doc['tier_policies'] : [];
+        foreach (['stable', 'experiment', 'commercial_overlay'] as $tier) {
+            if (! is_array($tierPolicies[$tier] ?? null)) {
+                $errors[] = $this->error($path, "tier_policies.{$tier}", "Missing tier policy '{$tier}'.");
+            }
+        }
+
+        $filePolicies = is_array($doc['file_policies'] ?? null) ? $doc['file_policies'] : [];
+        foreach (self::REQUIRED_POLICY_FILES as $fileName) {
+            $policy = is_array($filePolicies[$fileName] ?? null) ? $filePolicies[$fileName] : null;
+            if ($policy === null) {
+                $errors[] = $this->error($path, "file_policies.{$fileName}", "Missing governance policy for {$fileName}.");
+                continue;
+            }
+
+            $layers = array_values(array_filter(array_map('strval', (array) ($policy['layers'] ?? []))));
+            if ($layers === []) {
+                $errors[] = $this->error($path, "file_policies.{$fileName}", "{$fileName} must declare at least one layer.");
+            }
+
+            foreach ($layers as $layer) {
+                if (! in_array($layer, self::REQUIRED_LAYERS, true)) {
+                    $errors[] = $this->error($path, "file_policies.{$fileName}", "{$fileName} references unknown layer '{$layer}'.");
+                }
+            }
+
+            $tier = trim((string) ($policy['content_tier'] ?? ''));
+            if ($tier === '' || ! is_array($tierPolicies[$tier] ?? null)) {
+                $errors[] = $this->error($path, "file_policies.{$fileName}", "{$fileName} references unknown content_tier '{$tier}'.");
+                continue;
+            }
+            $tierPolicy = is_array($tierPolicies[$tier] ?? null) ? $tierPolicies[$tier] : [];
+
+            $policyIsCanonical = (bool) ($policy['is_canonical'] ?? false);
+            $tierIsCanonical = (bool) ($tierPolicy['is_canonical'] ?? false);
+            $experimentKey = trim((string) ($policy['experiment_key'] ?? ''));
+            $requiresExperimentKey = (bool) ($tierPolicy['requires_experiment_key'] ?? false);
+
+            if ($policyIsCanonical !== $tierIsCanonical) {
+                $errors[] = $this->error(
+                    $path,
+                    "file_policies.{$fileName}",
+                    "{$fileName} canonical flag must match tier policy '{$tier}'."
+                );
+            }
+
+            if ($requiresExperimentKey && $experimentKey === '') {
+                $errors[] = $this->error(
+                    $path,
+                    "file_policies.{$fileName}",
+                    "{$fileName} tier '{$tier}' requires experiment_key."
+                );
+            }
+
+            if (! $requiresExperimentKey && $experimentKey !== '') {
+                $errors[] = $this->error(
+                    $path,
+                    "file_policies.{$fileName}",
+                    "{$fileName} stable/commercial policy must not set experiment_key."
+                );
+            }
+
+            $allowedFiles = array_values(array_filter(array_map('strval', (array) ($tierPolicy['allowed_files'] ?? []))));
+            if ($allowedFiles !== [] && ! in_array($fileName, $allowedFiles, true)) {
+                $errors[] = $this->error(
+                    $path,
+                    "file_policies.{$fileName}",
+                    "{$fileName} is not allowed to use tier '{$tier}'."
+                );
+            }
+
+            $allowedTargets = array_values(array_filter(array_map('strval', (array) ($tierPolicy['allowed_targets'] ?? []))));
+            $targets = array_values(array_filter(array_map('strval', (array) ($policy['targets'] ?? []))));
+            if ($allowedTargets !== []) {
+                if ($targets === []) {
+                    $errors[] = $this->error(
+                        $path,
+                        "file_policies.{$fileName}",
+                        "{$fileName} tier '{$tier}' requires targets drawn from the allowed target list."
+                    );
+                }
+
+                foreach ($targets as $target) {
+                    if (! in_array($target, $allowedTargets, true)) {
+                        $errors[] = $this->error(
+                            $path,
+                            "file_policies.{$fileName}",
+                            "{$fileName} target '{$target}' is not allowed for tier '{$tier}'."
+                        );
+                    }
+                }
+            } elseif ($targets !== []) {
+                $errors[] = $this->error(
+                    $path,
+                    "file_policies.{$fileName}",
+                    "{$fileName} must not declare targets for tier '{$tier}'."
+                );
+            }
+
+            if (trim((string) ($policy['cultural_context'] ?? '')) !== $context) {
+                $errors[] = $this->error(
+                    $path,
+                    "file_policies.{$fileName}",
+                    "{$fileName} cultural_context must match manifest region/locale."
+                );
+            }
+        }
+
+        $fallback = array_values(array_filter(array_map('strval', (array) data_get($doc, 'locale_guardrails.fallback', []))));
+        $manifestFallback = array_values(array_filter(array_map('strval', (array) ($manifest['fallback'] ?? []))));
+        if (trim((string) data_get($doc, 'locale_guardrails.region', '')) !== trim((string) ($manifest['region'] ?? ''))) {
+            $errors[] = $this->error($path, 'locale_guardrails.region', 'governance region must match manifest region.');
+        }
+        if (trim((string) data_get($doc, 'locale_guardrails.locale', '')) !== trim((string) ($manifest['locale'] ?? ''))) {
+            $errors[] = $this->error($path, 'locale_guardrails.locale', 'governance locale must match manifest locale.');
+        }
+        if ($fallback !== $manifestFallback) {
+            $errors[] = $this->error($path, 'locale_guardrails.fallback', 'governance fallback must match manifest fallback.');
+        }
+
+        foreach (self::REQUIRED_POLICY_FILES as $fileName) {
+            if (! is_file($baseDir.DIRECTORY_SEPARATOR.$fileName)) {
+                $errors[] = $this->error($path, "file_policies.{$fileName}", "{$fileName} is missing from the MBTI pack root.");
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $pack
+     * @param  array<string,mixed>  $doc
+     * @return array<string,mixed>
+     */
+    public function compileSpec(array $pack, array $doc): array
+    {
+        $layers = is_array(data_get($doc, 'taxonomy.layers')) ? data_get($doc, 'taxonomy.layers') : [];
+        ksort($layers);
+
+        $blockKindIndex = [];
+        foreach ($layers as $layer => $layerNode) {
+            foreach ((array) ($layerNode['block_kinds'] ?? []) as $blockKind) {
+                $blockKind = trim((string) $blockKind);
+                if ($blockKind === '') {
+                    continue;
+                }
+                $blockKindIndex[$blockKind] = (string) $layer;
+            }
+        }
+        ksort($blockKindIndex);
+
+        $filePolicies = is_array($doc['file_policies'] ?? null) ? $doc['file_policies'] : [];
+        ksort($filePolicies);
+
+        return [
+            'schema' => 'fap.mbti.content_governance.compiled.v1',
+            'pack_id' => (string) ($pack['pack_id'] ?? ''),
+            'version' => (string) ($pack['version'] ?? ''),
+            'generated_at' => now()->toIso8601String(),
+            'required_layers' => self::REQUIRED_LAYERS,
+            'taxonomy' => [
+                'layers' => $layers,
+                'block_kind_index' => $blockKindIndex,
+            ],
+            'tier_policies' => (array) ($doc['tier_policies'] ?? []),
+            'file_policies' => $filePolicies,
+            'locale_guardrails' => (array) ($doc['locale_guardrails'] ?? []),
+            'snapshot_fixtures' => (array) ($doc['snapshot_fixtures'] ?? []),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function loadJsonFile(string $path): ?array
+    {
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $raw = file_get_contents($path);
+        if (! is_string($raw) || trim($raw) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @return array{file:string,block_id:string,message:string}
+     */
+    private function error(string $file, string $blockId, string $message): array
+    {
+        return [
+            'file' => $file,
+            'block_id' => $blockId,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/tests/Feature/Content/ContentPackLintTest.php
+++ b/backend/tests/Feature/Content/ContentPackLintTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Content;
 
+use App\Services\Content\ContentCompileService;
+use App\Services\Content\ContentLintService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -13,8 +15,8 @@ final class ContentPackLintTest extends TestCase
 
     public function test_content_pack_lint_and_compile_commands_pass(): void
     {
-        $this->artisan('content:lint --all')->assertExitCode(0);
-        $this->artisan('content:compile --all')->assertExitCode(0);
+        $this->artisan('content:lint --pack=MBTI.cn-mainland.zh-CN.v0.3')->assertExitCode(0);
+        $this->artisan('content:compile --pack=MBTI.cn-mainland.zh-CN.v0.3')->assertExitCode(0);
 
         $compiledDir = base_path('../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled');
         $this->assertFileExists($compiledDir . '/cards.normalized.json');
@@ -22,6 +24,39 @@ final class ContentPackLintTest extends TestCase
         $this->assertFileExists($compiledDir . '/rules.normalized.json');
         $this->assertFileExists($compiledDir . '/sections.spec.json');
         $this->assertFileExists($compiledDir . '/variables.used.json');
+        $this->assertFileExists($compiledDir . '/governance.spec.json');
         $this->assertFileExists($compiledDir . '/manifest.json');
+    }
+
+    public function test_pack_scoped_lint_targets_only_the_canonical_governed_mbti_pack(): void
+    {
+        $result = $this->app->make(ContentLintService::class)->lintAll('MBTI.cn-mainland.zh-CN.v0.3');
+
+        $packs = is_array($result['packs'] ?? null) ? $result['packs'] : [];
+        $this->assertCount(1, $packs);
+        $this->assertStringContainsString(
+            'MBTI-CN-v0.3',
+            (string) ($packs[0]['base_dir'] ?? '')
+        );
+        $this->assertStringNotContainsString(
+            'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3',
+            (string) ($packs[0]['base_dir'] ?? '')
+        );
+    }
+
+    public function test_pack_scoped_compile_targets_only_the_canonical_governed_mbti_pack(): void
+    {
+        $result = $this->app->make(ContentCompileService::class)->compileAll('MBTI.cn-mainland.zh-CN.v0.3');
+
+        $packs = is_array($result['packs'] ?? null) ? $result['packs'] : [];
+        $this->assertCount(1, $packs);
+        $this->assertStringContainsString(
+            'MBTI-CN-v0.3/compiled',
+            (string) ($packs[0]['compiled_dir'] ?? '')
+        );
+        $this->assertStringNotContainsString(
+            'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3',
+            (string) ($packs[0]['compiled_dir'] ?? '')
+        );
     }
 }

--- a/backend/tests/Feature/Content/MbtiContentGovernanceContractTest.php
+++ b/backend/tests/Feature/Content/MbtiContentGovernanceContractTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Services\Content\MbtiContentGovernanceService;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Tests\TestCase;
+
+final class MbtiContentGovernanceContractTest extends TestCase
+{
+    private const REQUIRED_LAYERS = [
+        'skeleton',
+        'intensity',
+        'boundary',
+        'scene',
+        'explainability',
+        'action',
+    ];
+
+    private function contentPath(string $file): string
+    {
+        return base_path('../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/'.$file);
+    }
+
+    private function contentRoot(): string
+    {
+        return dirname($this->contentPath('manifest.json'));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $file): array
+    {
+        $raw = file_get_contents($this->contentPath($file));
+        $this->assertIsString($raw, "Unable to read {$file}");
+
+        $decoded = json_decode($raw, true);
+        $this->assertIsArray($decoded, "Invalid JSON in {$file}");
+
+        return $decoded;
+    }
+
+    /**
+     * @param  callable(array<string,mixed>):array<string,mixed>  $mutator
+     * @return array{pack:array<string,mixed>,cleanup:callable():void}
+     */
+    private function makeSyntheticPack(callable $mutator): array
+    {
+        $sourceDir = $this->contentRoot();
+        $tmpDir = storage_path('framework/testing/mbti-governance-'.bin2hex(random_bytes(8)));
+        mkdir($tmpDir, 0775, true);
+
+        foreach (glob($sourceDir.'/*.json') ?: [] as $file) {
+            copy($file, $tmpDir.'/'.basename($file));
+        }
+
+        $manifestRaw = file_get_contents($tmpDir.'/manifest.json');
+        $this->assertIsString($manifestRaw);
+        $manifest = json_decode($manifestRaw, true);
+        $this->assertIsArray($manifest);
+
+        $governanceRaw = file_get_contents($tmpDir.'/report_content_governance.json');
+        $this->assertIsString($governanceRaw);
+        $governance = json_decode($governanceRaw, true);
+        $this->assertIsArray($governance);
+
+        $governance = $mutator($governance);
+        file_put_contents(
+            $tmpDir.'/report_content_governance.json',
+            json_encode($governance, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
+
+        return [
+            'pack' => [
+                'pack_id' => (string) ($manifest['pack_id'] ?? ''),
+                'version' => (string) ($manifest['content_package_version'] ?? ''),
+                'base_dir' => $tmpDir,
+                'manifest' => $manifest,
+            ],
+            'cleanup' => function () use ($tmpDir): void {
+                if (! is_dir($tmpDir)) {
+                    return;
+                }
+
+                $iterator = new RecursiveIteratorIterator(
+                    new RecursiveDirectoryIterator($tmpDir, \FilesystemIterator::SKIP_DOTS),
+                    RecursiveIteratorIterator::CHILD_FIRST
+                );
+
+                foreach ($iterator as $fileInfo) {
+                    if ($fileInfo->isDir()) {
+                        rmdir($fileInfo->getPathname());
+                        continue;
+                    }
+
+                    unlink($fileInfo->getPathname());
+                }
+
+                rmdir($tmpDir);
+            },
+        ];
+    }
+
+    public function test_mbti_governance_file_explicitly_covers_layers_dynamic_block_kinds_and_tier_boundaries(): void
+    {
+        $manifest = $this->readJson('manifest.json');
+        $governance = $this->readJson('report_content_governance.json');
+        $dynamicSections = $this->readJson('report_dynamic_sections.json');
+
+        $this->assertSame('fap.mbti.content_governance.v1', $governance['schema'] ?? null);
+        $this->assertSame($manifest['pack_id'] ?? null, $governance['pack_id'] ?? null);
+        $this->assertSame(
+            sprintf('%s.%s', (string) ($manifest['region'] ?? ''), (string) ($manifest['locale'] ?? '')),
+            $governance['cultural_context'] ?? null
+        );
+
+        $layers = $governance['taxonomy']['layers'] ?? null;
+        $this->assertIsArray($layers);
+        foreach (self::REQUIRED_LAYERS as $layer) {
+            $this->assertArrayHasKey($layer, $layers);
+            $this->assertNotSame('', trim((string) ($layers[$layer]['label'] ?? '')));
+            $this->assertIsArray($layers[$layer]['block_kinds'] ?? null);
+            $this->assertNotEmpty($layers[$layer]['block_kinds']);
+        }
+
+        $blockKindIndex = [];
+        foreach ($layers as $layer => $node) {
+            foreach ((array) ($node['block_kinds'] ?? []) as $blockKind) {
+                $this->assertArrayNotHasKey(
+                    (string) $blockKind,
+                    $blockKindIndex,
+                    "block kind {$blockKind} is mapped to more than one layer"
+                );
+                $blockKindIndex[(string) $blockKind] = (string) $layer;
+            }
+        }
+
+        $dynamicBlockKinds = array_keys((array) data_get($dynamicSections, 'labels.block_kinds', []));
+        sort($dynamicBlockKinds);
+        foreach ($dynamicBlockKinds as $blockKind) {
+            $this->assertArrayHasKey($blockKind, $blockKindIndex, "dynamic block kind {$blockKind} is missing from governance taxonomy");
+        }
+
+        $tierPolicies = $governance['tier_policies'] ?? null;
+        $this->assertIsArray($tierPolicies);
+        $this->assertSame(true, data_get($tierPolicies, 'stable.is_canonical'));
+        $this->assertSame(false, data_get($tierPolicies, 'experiment.is_canonical'));
+        $this->assertSame(true, data_get($tierPolicies, 'experiment.requires_experiment_key'));
+        $this->assertSame(false, data_get($tierPolicies, 'commercial_overlay.is_canonical'));
+
+        $filePolicies = $governance['file_policies'] ?? null;
+        $this->assertIsArray($filePolicies);
+        foreach ([
+            'type_profiles.json',
+            'report_cards_growth.json',
+            'report_dynamic_sections.json',
+            'report_recommended_reads.json',
+            'report_select_rules.json',
+            'report_section_policies.json',
+        ] as $requiredFile) {
+            $this->assertArrayHasKey($requiredFile, $filePolicies);
+        }
+
+        foreach ($filePolicies as $file => $policy) {
+            $this->assertIsArray($policy, "policy for {$file} must be an object");
+            $this->assertSame('CN_MAINLAND.zh-CN', (string) ($policy['cultural_context'] ?? ''));
+            $this->assertIsArray($policy['layers'] ?? null, "{$file} must declare layers");
+            $this->assertNotEmpty($policy['layers'] ?? [], "{$file} must declare at least one layer");
+
+            $tier = (string) ($policy['content_tier'] ?? '');
+            if ($tier === 'stable') {
+                $this->assertTrue((bool) ($policy['is_canonical'] ?? false), "{$file} stable policy must be canonical");
+                $this->assertSame('', trim((string) ($policy['experiment_key'] ?? '')), "{$file} stable policy must not set experiment_key");
+            }
+        }
+
+        $this->assertSame($manifest['fallback'] ?? null, data_get($governance, 'locale_guardrails.fallback'));
+        $this->assertSame(
+            ['INTJ-A', 'ENFP-T', 'ISFJ-A'],
+            data_get($governance, 'snapshot_fixtures.representative_types')
+        );
+    }
+
+    public function test_governance_lint_rejects_experiment_tier_on_files_outside_allowed_files(): void
+    {
+        $service = $this->app->make(MbtiContentGovernanceService::class);
+        $fixture = $this->makeSyntheticPack(function (array $governance): array {
+            $governance['file_policies']['type_profiles.json']['content_tier'] = 'experiment';
+            $governance['file_policies']['type_profiles.json']['is_canonical'] = false;
+            $governance['file_policies']['type_profiles.json']['experiment_key'] = 'exp.type-profiles';
+
+            return $governance;
+        });
+
+        try {
+            $errors = $service->lintPack($fixture['pack']);
+            $messages = array_map(
+                static fn (array $error): string => (string) ($error['message'] ?? ''),
+                $errors
+            );
+
+            $this->assertContains(
+                "type_profiles.json is not allowed to use tier 'experiment'.",
+                $messages
+            );
+        } finally {
+            ($fixture['cleanup'])();
+        }
+    }
+
+    public function test_governance_lint_rejects_targets_outside_allowed_commercial_overlay_targets(): void
+    {
+        $service = $this->app->make(MbtiContentGovernanceService::class);
+        $fixture = $this->makeSyntheticPack(function (array $governance): array {
+            $governance['file_policies']['report_overrides.json']['content_tier'] = 'commercial_overlay';
+            $governance['file_policies']['report_overrides.json']['is_canonical'] = false;
+            $governance['file_policies']['report_overrides.json']['targets'] = ['unsupported_cta'];
+
+            return $governance;
+        });
+
+        try {
+            $errors = $service->lintPack($fixture['pack']);
+            $messages = array_map(
+                static fn (array $error): string => (string) ($error['message'] ?? ''),
+                $errors
+            );
+
+            $this->assertContains(
+                "report_overrides.json target 'unsupported_cta' is not allowed for tier 'commercial_overlay'.",
+                $messages
+            );
+        } finally {
+            ($fixture['cleanup'])();
+        }
+    }
+}

--- a/backend/tests/Feature/Content/MbtiContentGovernanceSnapshotRegressionTest.php
+++ b/backend/tests/Feature/Content/MbtiContentGovernanceSnapshotRegressionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use Tests\TestCase;
+
+final class MbtiContentGovernanceSnapshotRegressionTest extends TestCase
+{
+    /**
+     * @return array<string,mixed>
+     */
+    private function readCompiled(string $file): array
+    {
+        $path = base_path('../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/'.$file);
+        $raw = file_get_contents($path);
+        $this->assertIsString($raw, "Unable to read compiled artifact {$file}");
+
+        $decoded = json_decode($raw, true);
+        $this->assertIsArray($decoded, "Invalid JSON in compiled artifact {$file}");
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readFixture(): array
+    {
+        $path = base_path('tests/Fixtures/mbti_content_governance_snapshot_expected.json');
+        $raw = file_get_contents($path);
+        $this->assertIsString($raw, 'missing governance snapshot fixture');
+
+        $decoded = json_decode($raw, true);
+        $this->assertIsArray($decoded, 'invalid governance snapshot fixture');
+
+        return $decoded;
+    }
+
+    public function test_compiled_governance_snapshot_matches_expected_contract(): void
+    {
+        $this->artisan('content:lint --pack=MBTI.cn-mainland.zh-CN.v0.3')->assertExitCode(0);
+        $this->artisan('content:compile --pack=MBTI.cn-mainland.zh-CN.v0.3')->assertExitCode(0);
+
+        $compiled = $this->readCompiled('governance.spec.json');
+        $compiledManifest = $this->readCompiled('manifest.json');
+        $filePolicies = is_array($compiled['file_policies'] ?? null) ? $compiled['file_policies'] : [];
+
+        $actual = [
+            'required_layers' => $compiled['required_layers'] ?? [],
+            'block_kind_index' => data_get($compiled, 'taxonomy.block_kind_index', []),
+            'tier_policies' => $compiled['tier_policies'] ?? [],
+            'locale_guardrails' => $compiled['locale_guardrails'] ?? [],
+            'snapshot_fixtures' => $compiled['snapshot_fixtures'] ?? [],
+            'file_policies' => [
+                'report_dynamic_sections.json' => $filePolicies['report_dynamic_sections.json'] ?? [],
+                'report_recommended_reads.json' => $filePolicies['report_recommended_reads.json'] ?? [],
+                'report_cards_growth.json' => $filePolicies['report_cards_growth.json'] ?? [],
+                'report_select_rules.json' => $filePolicies['report_select_rules.json'] ?? [],
+            ],
+        ];
+
+        $this->assertSame($this->readFixture(), $actual);
+        $this->assertContains('governance.spec.json', (array) ($compiledManifest['files'] ?? []));
+    }
+}

--- a/backend/tests/Fixtures/mbti_content_governance_snapshot_expected.json
+++ b/backend/tests/Fixtures/mbti_content_governance_snapshot_expected.json
@@ -1,0 +1,140 @@
+{
+  "required_layers": [
+    "skeleton",
+    "intensity",
+    "boundary",
+    "scene",
+    "explainability",
+    "action"
+  ],
+  "block_kind_index": {
+    "adjacent_type_contrast": "explainability",
+    "axis_strength": "intensity",
+    "borderline_axis": "boundary",
+    "boundary": "boundary",
+    "career_next_step": "scene",
+    "collaboration_fit": "scene",
+    "communication": "scene",
+    "decision": "scene",
+    "identity": "skeleton",
+    "next_action": "action",
+    "relationship_practice": "action",
+    "role_fit": "scene",
+    "scene": "scene",
+    "stability_explanation": "explainability",
+    "stress_recovery": "scene",
+    "type_skeleton": "skeleton",
+    "watchout": "action",
+    "weekly_experiment": "action",
+    "why_this_type": "explainability",
+    "work_env": "scene",
+    "work_experiment": "action",
+    "work_style": "scene"
+  },
+  "tier_policies": {
+    "stable": {
+      "label": "Canonical stable content",
+      "is_canonical": true,
+      "requires_experiment_key": false,
+      "description": "Stable authored content that is allowed to define canonical MBTI result truth."
+    },
+    "experiment": {
+      "label": "Experiment overlay",
+      "is_canonical": false,
+      "requires_experiment_key": true,
+      "description": "Short-lived experimentation content that must never overwrite canonical truth.",
+      "allowed_files": [
+        "report_dynamic_sections.json",
+        "report_recommended_reads.json"
+      ]
+    },
+    "commercial_overlay": {
+      "label": "Commercial CTA overlay",
+      "is_canonical": false,
+      "requires_experiment_key": false,
+      "description": "Commercial ranking or CTA overlays that can wrap the result experience without mutating MBTI truth.",
+      "allowed_targets": [
+        "unlock_full_report",
+        "career_bridge",
+        "workspace_lite",
+        "share_result"
+      ]
+    }
+  },
+  "locale_guardrails": {
+    "region": "CN_MAINLAND",
+    "locale": "zh-CN",
+    "fallback": [
+      "MBTI.cn-mainland.zh-CN.v0.3",
+      "MBTI.global.en.default"
+    ]
+  },
+  "snapshot_fixtures": {
+    "representative_types": [
+      "INTJ-A",
+      "ENFP-T",
+      "ISFJ-A"
+    ],
+    "guarded_fields": [
+      "variant_keys",
+      "scene_fingerprint",
+      "action_plan_summary",
+      "ordered_recommendation_keys",
+      "ordered_action_keys",
+      "continuity"
+    ]
+  },
+  "file_policies": {
+    "report_dynamic_sections.json": {
+      "layers": [
+        "skeleton",
+        "intensity",
+        "boundary",
+        "scene",
+        "explainability",
+        "action"
+      ],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_recommended_reads.json": {
+      "layers": [
+        "scene",
+        "action"
+      ],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "supports_experiment_overlay": true,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_cards_growth.json": {
+      "layers": [
+        "action",
+        "scene"
+      ],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_select_rules.json": {
+      "layers": [
+        "intensity",
+        "scene",
+        "action",
+        "explainability"
+      ],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    }
+  }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/governance.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/governance.spec.json
@@ -1,0 +1,459 @@
+{
+    "schema": "fap.mbti.content_governance.compiled.v1",
+    "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
+    "version": "v0.3",
+    "generated_at": "2026-03-20T07:04:26+00:00",
+    "required_layers": [
+        "skeleton",
+        "intensity",
+        "boundary",
+        "scene",
+        "explainability",
+        "action"
+    ],
+    "taxonomy": {
+        "layers": {
+            "action": {
+                "label": "行动层",
+                "description": "Action plan, weekly experiments, work experiments, watchouts, and practice-oriented content.",
+                "block_kinds": [
+                    "next_action",
+                    "weekly_experiment",
+                    "relationship_practice",
+                    "work_experiment",
+                    "watchout"
+                ]
+            },
+            "boundary": {
+                "label": "边界层",
+                "description": "Boundary notes and near-axis interpretation that explains borderline behavior.",
+                "block_kinds": [
+                    "boundary",
+                    "borderline_axis"
+                ]
+            },
+            "explainability": {
+                "label": "解释层",
+                "description": "Why-this-type, adjacent contrast, and stability explanation content.",
+                "block_kinds": [
+                    "why_this_type",
+                    "adjacent_type_contrast",
+                    "stability_explanation"
+                ]
+            },
+            "intensity": {
+                "label": "强度分层",
+                "description": "Axis strength, highlight, and core strength-layer content.",
+                "block_kinds": [
+                    "axis_strength"
+                ]
+            },
+            "scene": {
+                "label": "场景层",
+                "description": "Scene application, work/relationship/communication bridges, and scenario execution surfaces.",
+                "block_kinds": [
+                    "scene",
+                    "work_style",
+                    "role_fit",
+                    "collaboration_fit",
+                    "work_env",
+                    "career_next_step",
+                    "decision",
+                    "stress_recovery",
+                    "communication"
+                ]
+            },
+            "skeleton": {
+                "label": "类型骨架",
+                "description": "Type skeleton, identity, roles, and stable type profile copy.",
+                "block_kinds": [
+                    "type_skeleton",
+                    "identity"
+                ]
+            }
+        },
+        "block_kind_index": {
+            "adjacent_type_contrast": "explainability",
+            "axis_strength": "intensity",
+            "borderline_axis": "boundary",
+            "boundary": "boundary",
+            "career_next_step": "scene",
+            "collaboration_fit": "scene",
+            "communication": "scene",
+            "decision": "scene",
+            "identity": "skeleton",
+            "next_action": "action",
+            "relationship_practice": "action",
+            "role_fit": "scene",
+            "scene": "scene",
+            "stability_explanation": "explainability",
+            "stress_recovery": "scene",
+            "type_skeleton": "skeleton",
+            "watchout": "action",
+            "weekly_experiment": "action",
+            "why_this_type": "explainability",
+            "work_env": "scene",
+            "work_experiment": "action",
+            "work_style": "scene"
+        }
+    },
+    "tier_policies": {
+        "stable": {
+            "label": "Canonical stable content",
+            "is_canonical": true,
+            "requires_experiment_key": false,
+            "description": "Stable authored content that is allowed to define canonical MBTI result truth."
+        },
+        "experiment": {
+            "label": "Experiment overlay",
+            "is_canonical": false,
+            "requires_experiment_key": true,
+            "description": "Short-lived experimentation content that must never overwrite canonical truth.",
+            "allowed_files": [
+                "report_dynamic_sections.json",
+                "report_recommended_reads.json"
+            ]
+        },
+        "commercial_overlay": {
+            "label": "Commercial CTA overlay",
+            "is_canonical": false,
+            "requires_experiment_key": false,
+            "description": "Commercial ranking or CTA overlays that can wrap the result experience without mutating MBTI truth.",
+            "allowed_targets": [
+                "unlock_full_report",
+                "career_bridge",
+                "workspace_lite",
+                "share_result"
+            ]
+        }
+    },
+    "file_policies": {
+        "identity_layers.json": {
+            "layers": [
+                "skeleton"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_borderline_notes.json": {
+            "layers": [
+                "boundary"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_borderline_templates.json": {
+            "layers": [
+                "boundary"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_cards_career.json": {
+            "layers": [
+                "scene",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_cards_fallback_career.json": {
+            "layers": [
+                "scene",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_cards_fallback_growth.json": {
+            "layers": [
+                "action",
+                "scene"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_cards_fallback_relationships.json": {
+            "layers": [
+                "scene",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_cards_fallback_stress_recovery.json": {
+            "layers": [
+                "scene",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_cards_fallback_traits.json": {
+            "layers": [
+                "intensity",
+                "boundary"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_cards_growth.json": {
+            "layers": [
+                "action",
+                "scene"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_cards_relationships.json": {
+            "layers": [
+                "scene",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_cards_stress_recovery.json": {
+            "layers": [
+                "scene",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_cards_traits.json": {
+            "layers": [
+                "intensity",
+                "boundary"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_dynamic_sections.json": {
+            "layers": [
+                "skeleton",
+                "intensity",
+                "boundary",
+                "scene",
+                "explainability",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_highlights.json": {
+            "layers": [
+                "intensity"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_highlights_policy.json": {
+            "layers": [
+                "intensity"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "low"
+        },
+        "report_highlights_pools.json": {
+            "layers": [
+                "intensity"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "low"
+        },
+        "report_highlights_rules.json": {
+            "layers": [
+                "intensity"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "low"
+        },
+        "report_identity_cards.json": {
+            "layers": [
+                "skeleton"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_overrides.json": {
+            "layers": [
+                "skeleton",
+                "intensity",
+                "boundary",
+                "scene",
+                "explainability",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_recommended_reads.json": {
+            "layers": [
+                "scene",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "supports_experiment_overlay": true,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "high"
+        },
+        "report_roles.json": {
+            "layers": [
+                "skeleton"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "low"
+        },
+        "report_rules.json": {
+            "layers": [
+                "skeleton",
+                "intensity",
+                "boundary",
+                "scene",
+                "explainability",
+                "action"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_section_policies.json": {
+            "layers": [
+                "intensity",
+                "scene",
+                "action",
+                "explainability"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_select_rules.json": {
+            "layers": [
+                "intensity",
+                "scene",
+                "action",
+                "explainability"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "report_strategies.json": {
+            "layers": [
+                "skeleton",
+                "scene"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        },
+        "type_profiles.json": {
+            "layers": [
+                "skeleton"
+            ],
+            "content_tier": "stable",
+            "is_canonical": true,
+            "experiment_key": null,
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "feedback_weight": "medium"
+        }
+    },
+    "locale_guardrails": {
+        "region": "CN_MAINLAND",
+        "locale": "zh-CN",
+        "fallback": [
+            "MBTI.cn-mainland.zh-CN.v0.3",
+            "MBTI.global.en.default"
+        ]
+    },
+    "snapshot_fixtures": {
+        "representative_types": [
+            "INTJ-A",
+            "ENFP-T",
+            "ISFJ-A"
+        ],
+        "guarded_fields": [
+            "variant_keys",
+            "scene_fingerprint",
+            "action_plan_summary",
+            "ordered_recommendation_keys",
+            "ordered_action_keys",
+            "continuity"
+        ]
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/manifest.json
@@ -2,13 +2,14 @@
     "schema": "fap.content.compiled.manifest.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "source_version": "v0.3",
-    "generated_at": "2026-02-21T04:27:39+00:00",
-    "checksum": "60a946c9e0095908fb964a864932b1b59193ba5090c72c3304f72a5f59cf620f",
+    "generated_at": "2026-03-20T07:04:26+00:00",
+    "checksum": "c1113779f607ddae20487e074c1cf47c744e09e3e16b761baec6f13b25da5da6",
     "files": [
         "cards.normalized.json",
         "cards.tag_index.json",
         "rules.normalized.json",
         "sections.spec.json",
-        "variables.used.json"
+        "variables.used.json",
+        "governance.spec.json"
     ]
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/manifest.json
@@ -43,6 +43,7 @@
         "rules": "fap.report.rules.v1",
         "section_policies": "fap.report.section_policies.v1",
         "dynamic_sections": "fap.mbti.dynamic_sections.v1",
+        "content_governance": "fap.mbti.content_governance.v1",
         "overrides_unified": "fap.report.overrides.v1",
         "meta": "fap.landing.meta.v1"
     },
@@ -196,6 +197,9 @@
         ],
         "dynamic_sections": [
             "report_dynamic_sections.json"
+        ],
+        "content_governance": [
+            "report_content_governance.json"
         ],
         "overrides_unified": [
             "report_overrides.json"

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_content_governance.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_content_governance.json
@@ -1,0 +1,341 @@
+{
+  "schema": "fap.mbti.content_governance.v1",
+  "version": "governance.v1",
+  "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
+  "scale_code": "MBTI",
+  "cultural_context": "CN_MAINLAND.zh-CN",
+  "locale_guardrails": {
+    "region": "CN_MAINLAND",
+    "locale": "zh-CN",
+    "fallback": [
+      "MBTI.cn-mainland.zh-CN.v0.3",
+      "MBTI.global.en.default"
+    ]
+  },
+  "tier_policies": {
+    "stable": {
+      "label": "Canonical stable content",
+      "is_canonical": true,
+      "requires_experiment_key": false,
+      "description": "Stable authored content that is allowed to define canonical MBTI result truth."
+    },
+    "experiment": {
+      "label": "Experiment overlay",
+      "is_canonical": false,
+      "requires_experiment_key": true,
+      "description": "Short-lived experimentation content that must never overwrite canonical truth.",
+      "allowed_files": [
+        "report_dynamic_sections.json",
+        "report_recommended_reads.json"
+      ]
+    },
+    "commercial_overlay": {
+      "label": "Commercial CTA overlay",
+      "is_canonical": false,
+      "requires_experiment_key": false,
+      "description": "Commercial ranking or CTA overlays that can wrap the result experience without mutating MBTI truth.",
+      "allowed_targets": [
+        "unlock_full_report",
+        "career_bridge",
+        "workspace_lite",
+        "share_result"
+      ]
+    }
+  },
+  "taxonomy": {
+    "layers": {
+      "skeleton": {
+        "label": "类型骨架",
+        "description": "Type skeleton, identity, roles, and stable type profile copy.",
+        "block_kinds": [
+          "type_skeleton",
+          "identity"
+        ]
+      },
+      "intensity": {
+        "label": "强度分层",
+        "description": "Axis strength, highlight, and core strength-layer content.",
+        "block_kinds": [
+          "axis_strength"
+        ]
+      },
+      "boundary": {
+        "label": "边界层",
+        "description": "Boundary notes and near-axis interpretation that explains borderline behavior.",
+        "block_kinds": [
+          "boundary",
+          "borderline_axis"
+        ]
+      },
+      "scene": {
+        "label": "场景层",
+        "description": "Scene application, work/relationship/communication bridges, and scenario execution surfaces.",
+        "block_kinds": [
+          "scene",
+          "work_style",
+          "role_fit",
+          "collaboration_fit",
+          "work_env",
+          "career_next_step",
+          "decision",
+          "stress_recovery",
+          "communication"
+        ]
+      },
+      "explainability": {
+        "label": "解释层",
+        "description": "Why-this-type, adjacent contrast, and stability explanation content.",
+        "block_kinds": [
+          "why_this_type",
+          "adjacent_type_contrast",
+          "stability_explanation"
+        ]
+      },
+      "action": {
+        "label": "行动层",
+        "description": "Action plan, weekly experiments, work experiments, watchouts, and practice-oriented content.",
+        "block_kinds": [
+          "next_action",
+          "weekly_experiment",
+          "relationship_practice",
+          "work_experiment",
+          "watchout"
+        ]
+      }
+    }
+  },
+  "file_policies": {
+    "type_profiles.json": {
+      "layers": ["skeleton"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "identity_layers.json": {
+      "layers": ["skeleton"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_identity_cards.json": {
+      "layers": ["skeleton"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_roles.json": {
+      "layers": ["skeleton"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "low"
+    },
+    "report_strategies.json": {
+      "layers": ["skeleton", "scene"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_highlights.json": {
+      "layers": ["intensity"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_highlights_policy.json": {
+      "layers": ["intensity"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "low"
+    },
+    "report_highlights_pools.json": {
+      "layers": ["intensity"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "low"
+    },
+    "report_highlights_rules.json": {
+      "layers": ["intensity"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "low"
+    },
+    "report_borderline_notes.json": {
+      "layers": ["boundary"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_borderline_templates.json": {
+      "layers": ["boundary"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_cards_traits.json": {
+      "layers": ["intensity", "boundary"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_cards_growth.json": {
+      "layers": ["action", "scene"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_cards_career.json": {
+      "layers": ["scene", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_cards_relationships.json": {
+      "layers": ["scene", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_cards_stress_recovery.json": {
+      "layers": ["scene", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_cards_fallback_traits.json": {
+      "layers": ["intensity", "boundary"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_cards_fallback_growth.json": {
+      "layers": ["action", "scene"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_cards_fallback_career.json": {
+      "layers": ["scene", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_cards_fallback_relationships.json": {
+      "layers": ["scene", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_cards_fallback_stress_recovery.json": {
+      "layers": ["scene", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_dynamic_sections.json": {
+      "layers": ["skeleton", "intensity", "boundary", "scene", "explainability", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_recommended_reads.json": {
+      "layers": ["scene", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "supports_experiment_overlay": true,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "high"
+    },
+    "report_select_rules.json": {
+      "layers": ["intensity", "scene", "action", "explainability"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_section_policies.json": {
+      "layers": ["intensity", "scene", "action", "explainability"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_rules.json": {
+      "layers": ["skeleton", "intensity", "boundary", "scene", "explainability", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    },
+    "report_overrides.json": {
+      "layers": ["skeleton", "intensity", "boundary", "scene", "explainability", "action"],
+      "content_tier": "stable",
+      "is_canonical": true,
+      "experiment_key": null,
+      "cultural_context": "CN_MAINLAND.zh-CN",
+      "feedback_weight": "medium"
+    }
+  },
+  "snapshot_fixtures": {
+    "representative_types": [
+      "INTJ-A",
+      "ENFP-T",
+      "ISFJ-A"
+    ],
+    "guarded_fields": [
+      "variant_keys",
+      "scene_fingerprint",
+      "action_plan_summary",
+      "ordered_recommendation_keys",
+      "ordered_action_keys",
+      "continuity"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR ships MBTI PR-8D: ContentOps & Experiment Governance 1.0.

The MBTI result stack already had strong authority, rendering, telemetry, continuity, and orchestration. What was still missing was an explicit governance layer for the content pack itself.

This PR closes that gap by making MBTI content governance explicit at the pack/schema/lint/compile/regression level.

## What changed

It introduces a formal MBTI governance document and compiled governance artifact:

- `report_content_governance.json`
- `compiled/governance.spec.json`

It also makes the engine enforce that governance through:

- explicit block taxonomy
- stable vs experiment vs commercial overlay boundaries
- locale guardrails
- file-level governance policies
- representative snapshot regression coverage
- manifest/schema integrity checks
- canonical pack targeting when duplicate `pack_id` entries exist

## Governance scope

The explicit taxonomy now covers:

- skeleton
- intensity
- boundary
- scene
- explainability
- action

The tier boundary now distinguishes:

- canonical stable content
- experiment overlay content
- commercial CTA overlay

This keeps experiment and campaign layers from polluting canonical MBTI truth.

## Validation

I ran a targeted suite covering:

- MBTI governance contract
- compiled governance snapshot regression
- pack-scoped lint/compile targeting
- manifest/schema checks
- MBTI content coverage
- MBTI runtime personalization/report/telemetry regressions

Result:

- 17 tests passed
- 737 assertions

## Scope note

This PR is intentionally limited to MBTI content governance.

It does not change:
- payment / checkout / wait flow
- CMS / AIC
- career recommendation system
- other scales
- migrations
- external dependencies

It also intentionally excludes unrelated local dirty changes such as:
- `backend/app/Console/Commands/PacksPublish.php`
- `backend/app/Console/Commands/PacksRollback.php`
- `backend/content_packs/BIG5_OCEAN/v1/compiled/*`
- `backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php`
