### PR TITLE
[codex] add remote blob location metadata and copy-only offload

### DIFF
--- a/backend/app/Console/Commands/StorageBlobOffload.php
+++ b/backend/app/Console/Commands/StorageBlobOffload.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\BlobOffloadService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageBlobOffload extends Command
+{
+    protected $signature = 'storage:blob-offload
+        {--dry-run : Build an offload plan only}
+        {--execute : Upload blobs copy-only using a generated or supplied plan}
+        {--disk= : Target disk, defaults to storage_rollout.blob_offload_disk}
+        {--plan= : Existing offload plan path for execute mode}';
+
+    protected $description = 'Copy rollout blobs to a remote location and record verified location metadata without changing runtime readers.';
+
+    public function __construct(
+        private readonly BlobOffloadService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $disk = trim((string) ($this->option('disk') ?? ''));
+        if ($disk === '') {
+            $disk = trim((string) config('storage_rollout.blob_offload_disk', 'local'));
+        }
+
+        try {
+            $this->ensureTargetDiskIsRemote($disk);
+
+            if ($dryRun) {
+                $plan = $this->service->buildPlan($disk);
+                $planPath = $this->persistPlan($plan);
+                $this->emitDryRunOutput($disk, $planPath, $plan);
+                $this->recordAudit('planned', $disk, $planPath, $plan, [
+                    'uploaded_count' => 0,
+                    'verified_count' => 0,
+                    'failed_count' => 0,
+                    'bytes' => 0,
+                ]);
+
+                return self::SUCCESS;
+            }
+
+            $this->ensureExecuteDiskConfigured($disk);
+
+            $planPath = trim((string) ($this->option('plan') ?? ''));
+            if ($planPath !== '') {
+                $planPath = $this->resolvePlanPath($planPath);
+                $plan = $this->readPlan($planPath);
+                $planDisk = trim((string) ($plan['disk'] ?? ''));
+                if ($planDisk !== '' && $planDisk !== $disk) {
+                    $this->error('plan disk mismatch: '.$planDisk.' != '.$disk);
+
+                    return self::FAILURE;
+                }
+            } else {
+                $plan = $this->service->buildPlan($disk);
+                $planPath = $this->persistPlan($plan);
+            }
+
+            $result = $this->service->executePlan($plan);
+            $this->emitExecuteOutput($disk, $planPath, $plan, $result);
+            $this->recordAudit('executed', $disk, $planPath, $plan, $result);
+
+            return (int) ($result['failed_count'] ?? 0) > 0 ? self::FAILURE : self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function ensureTargetDiskIsRemote(string $disk): void
+    {
+        $driver = trim((string) config('filesystems.disks.'.$disk.'.driver', ''));
+        if ($driver === '') {
+            throw new \RuntimeException('offload disk is not configured: filesystems.disks.'.$disk.' is missing.');
+        }
+
+        if ($driver === 'local') {
+            throw new \RuntimeException('blob offload target disk must be remote: local disks are not allowed.');
+        }
+    }
+
+    private function ensureExecuteDiskConfigured(string $disk): void
+    {
+        $driver = trim((string) config('filesystems.disks.'.$disk.'.driver', ''));
+        if ($driver !== 's3') {
+            return;
+        }
+
+        $bucket = trim((string) config('filesystems.disks.'.$disk.'.bucket', ''));
+        if ($bucket === '') {
+            throw new \RuntimeException('s3 offload disk is not configured: filesystems.disks.'.$disk.'.bucket is empty.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function persistPlan(array $plan): string
+    {
+        $planDir = storage_path('app/private/offload_plans');
+        File::ensureDirectoryExists($planDir);
+
+        $planPath = $planDir.DIRECTORY_SEPARATOR.now()->format('Ymd_His').'_blob_offload_'.substr(bin2hex(random_bytes(4)), 0, 8).'.json';
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode blob offload plan json.');
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        return $planPath;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readPlan(string $planPath): array
+    {
+        if (! is_file($planPath)) {
+            throw new \RuntimeException('plan not found: '.$planPath);
+        }
+
+        $decoded = json_decode((string) File::get($planPath), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('invalid offload plan json: '.$planPath);
+        }
+
+        $expectedSchema = (string) config('storage_rollout.blob_offload_plan_schema_version', 'storage_blob_offload_plan.v1');
+        if ((string) ($decoded['schema'] ?? '') !== $expectedSchema) {
+            throw new \RuntimeException('plan schema mismatch.');
+        }
+
+        return $decoded;
+    }
+
+    private function resolvePlanPath(string $planOption): string
+    {
+        if (str_starts_with($planOption, DIRECTORY_SEPARATOR)) {
+            return $planOption;
+        }
+
+        $basePathCandidate = base_path($planOption);
+        if (is_file($basePathCandidate)) {
+            return $basePathCandidate;
+        }
+
+        return storage_path('app/private/'.ltrim($planOption, '/\\'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function emitDryRunOutput(string $disk, string $planPath, array $plan): void
+    {
+        $summary = is_array($plan['summary'] ?? null) ? $plan['summary'] : [];
+
+        $this->line('status=planned');
+        $this->line('disk='.$disk);
+        $this->line('plan='.$planPath);
+        $this->line('candidate_count='.(int) ($summary['candidate_count'] ?? 0));
+        $this->line('skipped_count='.(int) ($summary['skipped_count'] ?? 0));
+        $this->line('bytes='.(int) ($summary['bytes'] ?? 0));
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @param  array<string,mixed>  $result
+     */
+    private function emitExecuteOutput(string $disk, string $planPath, array $plan, array $result): void
+    {
+        $summary = is_array($plan['summary'] ?? null) ? $plan['summary'] : [];
+
+        $this->line('status=executed');
+        $this->line('disk='.$disk);
+        $this->line('plan='.$planPath);
+        $this->line('candidate_count='.(int) ($summary['candidate_count'] ?? 0));
+        $this->line('uploaded_count='.(int) ($result['uploaded_count'] ?? 0));
+        $this->line('verified_count='.(int) ($result['verified_count'] ?? 0));
+        $this->line('skipped_count='.(int) ($result['skipped_count'] ?? 0));
+        $this->line('failed_count='.(int) ($result['failed_count'] ?? 0));
+        $this->line('bytes='.(int) ($result['bytes'] ?? 0));
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @param  array<string,mixed>  $result
+     */
+    private function recordAudit(string $mode, string $disk, string $planPath, array $plan, array $result): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $summary = is_array($plan['summary'] ?? null) ? $plan['summary'] : [];
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_blob_offload',
+            'target_type' => 'storage',
+            'target_id' => 'blob_offload',
+            'meta_json' => json_encode([
+                'schema' => $plan['schema'] ?? null,
+                'mode' => $mode,
+                'disk' => $disk,
+                'plan' => $planPath,
+                'candidate_count' => (int) ($summary['candidate_count'] ?? 0),
+                'skipped_count' => $mode === 'planned'
+                    ? (int) ($summary['skipped_count'] ?? 0)
+                    : (int) ($result['skipped_count'] ?? 0),
+                'bytes' => $mode === 'planned'
+                    ? (int) ($summary['bytes'] ?? 0)
+                    : (int) ($result['bytes'] ?? 0),
+                'uploaded_count' => (int) ($result['uploaded_count'] ?? 0),
+                'verified_count' => (int) ($result['verified_count'] ?? 0),
+                'failed_count' => (int) ($result['failed_count'] ?? 0),
+                'warnings' => $result['warnings'] ?? [],
+                'copy_only' => true,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_blob_offload',
+            'request_id' => null,
+            'reason' => 'blob_offload_copy_only',
+            'result' => (int) ($result['failed_count'] ?? 0) > 0 ? 'failed' : 'success',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/app/Models/StorageBlobLocation.php
+++ b/backend/app/Models/StorageBlobLocation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StorageBlobLocation extends Model
+{
+    protected $table = 'storage_blob_locations';
+
+    protected $fillable = [
+        'blob_hash',
+        'disk',
+        'storage_path',
+        'location_kind',
+        'size_bytes',
+        'checksum',
+        'etag',
+        'storage_class',
+        'verified_at',
+        'meta_json',
+    ];
+
+    protected $casts = [
+        'size_bytes' => 'integer',
+        'verified_at' => 'datetime',
+        'meta_json' => 'array',
+    ];
+}

--- a/backend/app/Services/Storage/BlobOffloadService.php
+++ b/backend/app/Services/Storage/BlobOffloadService.php
@@ -1,0 +1,703 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\StorageBlobLocation;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
+final class BlobOffloadService
+{
+    private const LOCATION_KIND_REMOTE_COPY = 'remote_copy';
+
+    public function __construct(
+        private readonly ArtifactStore $artifactStore,
+        private readonly BlobCatalogService $blobCatalogService,
+        private readonly BlobReachabilityService $blobReachabilityService,
+        private readonly ReleaseStorageLocator $releaseStorageLocator,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildPlan(string $disk): array
+    {
+        $disk = $this->normalizeDisk($disk);
+        $sourceMap = $this->collectSourceMap();
+
+        $candidates = [];
+        $skipped = [];
+        $candidateBytes = 0;
+        $skippedBytes = 0;
+
+        $reachableHashes = $this->reachableBlobHashes();
+        $catalogedBlobs = DB::table('storage_blobs')
+            ->when(
+                $reachableHashes !== [],
+                static fn ($query) => $query->whereIn('hash', $reachableHashes),
+                static fn ($query) => $query->whereRaw('1 = 0')
+            )
+            ->orderBy('hash')
+            ->get();
+
+        foreach ($catalogedBlobs as $blob) {
+            $hash = strtolower(trim((string) ($blob->hash ?? '')));
+            if (! $this->isValidHash($hash)) {
+                continue;
+            }
+
+            $remotePath = $this->remotePathForHash($hash);
+            $sizeBytes = max(0, (int) ($blob->size_bytes ?? 0));
+            $contentType = trim((string) ($blob->content_type ?? ''));
+            $existingLocation = StorageBlobLocation::query()
+                ->where('blob_hash', $hash)
+                ->where('disk', $disk)
+                ->where('storage_path', $remotePath)
+                ->first();
+
+            if ($existingLocation !== null) {
+                $skipped[] = [
+                    'blob_hash' => $hash,
+                    'reason' => 'already_offloaded',
+                    'size_bytes' => $sizeBytes,
+                    'remote_path' => $remotePath,
+                    'source_kind' => null,
+                    'source_path' => null,
+                ];
+                $skippedBytes += $sizeBytes;
+
+                continue;
+            }
+
+            $source = $sourceMap[$hash] ?? null;
+            if ($source === null) {
+                $skipped[] = [
+                    'blob_hash' => $hash,
+                    'reason' => 'no_source',
+                    'size_bytes' => $sizeBytes,
+                    'remote_path' => $remotePath,
+                    'source_kind' => null,
+                    'source_path' => null,
+                ];
+                $skippedBytes += $sizeBytes;
+
+                continue;
+            }
+
+            if ((string) ($source['source_kind'] ?? '') === 'live_alias') {
+                $skipped[] = [
+                    'blob_hash' => $hash,
+                    'reason' => 'live_alias_only_source',
+                    'size_bytes' => $sizeBytes,
+                    'remote_path' => $remotePath,
+                    'source_kind' => 'live_alias',
+                    'source_path' => (string) ($source['source_path'] ?? ''),
+                ];
+                $skippedBytes += $sizeBytes;
+
+                continue;
+            }
+
+            $candidates[] = [
+                'blob_hash' => $hash,
+                'remote_path' => $remotePath,
+                'size_bytes' => $sizeBytes,
+                'content_type' => $contentType !== '' ? $contentType : ($source['content_type'] ?? null),
+                'source_kind' => (string) ($source['source_kind'] ?? ''),
+                'source_path' => (string) ($source['source_path'] ?? ''),
+                'source_root' => (string) ($source['source_root'] ?? ''),
+                'source_relative_path' => (string) ($source['source_relative_path'] ?? ''),
+                'storage_class' => $this->storageClass(),
+            ];
+            $candidateBytes += $sizeBytes;
+        }
+
+        usort($candidates, static fn (array $a, array $b): int => strcmp((string) $a['blob_hash'], (string) $b['blob_hash']));
+        usort($skipped, static fn (array $a, array $b): int => strcmp((string) $a['blob_hash'], (string) $b['blob_hash']));
+
+        return [
+            'schema' => (string) config('storage_rollout.blob_offload_plan_schema_version', 'storage_blob_offload_plan.v1'),
+            'generated_at' => now()->toAtomString(),
+            'disk' => $disk,
+            'summary' => [
+                'candidate_count' => count($candidates),
+                'skipped_count' => count($skipped),
+                'bytes' => $candidateBytes,
+                'candidate_bytes' => $candidateBytes,
+                'skipped_bytes' => $skippedBytes,
+            ],
+            'candidates' => $candidates,
+            'skipped' => $skipped,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    public function executePlan(array $plan): array
+    {
+        $disk = $this->normalizeDisk((string) ($plan['disk'] ?? ''));
+        $remoteDisk = Storage::disk($disk);
+        $driver = trim((string) config('filesystems.disks.'.$disk.'.driver', ''));
+
+        $summary = [
+            'uploaded_count' => 0,
+            'verified_count' => 0,
+            'skipped_count' => 0,
+            'failed_count' => 0,
+            'bytes' => 0,
+            'uploaded_bytes' => 0,
+            'warnings' => [],
+        ];
+
+        $candidates = is_array($plan['candidates'] ?? null) ? $plan['candidates'] : [];
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $hash = strtolower(trim((string) ($candidate['blob_hash'] ?? '')));
+            $sourcePath = trim((string) ($candidate['source_path'] ?? ''));
+            $remotePath = trim((string) ($candidate['remote_path'] ?? ''));
+            $expectedSize = max(0, (int) ($candidate['size_bytes'] ?? 0));
+            $sourceKind = trim((string) ($candidate['source_kind'] ?? ''));
+
+            if (! $this->isValidHash($hash) || $sourcePath === '' || $remotePath === '') {
+                $summary['failed_count']++;
+                $this->appendWarning($summary, 'invalid offload candidate '.json_encode($candidate, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+                continue;
+            }
+
+            if (! is_file($sourcePath)) {
+                $summary['failed_count']++;
+                $this->appendWarning($summary, 'source file missing for '.$hash.': '.$sourcePath);
+
+                continue;
+            }
+
+            $bytes = (string) File::get($sourcePath);
+            if (hash('sha256', $bytes) !== $hash) {
+                $summary['failed_count']++;
+                $this->appendWarning($summary, 'source hash mismatch for '.$hash.' from '.$sourcePath);
+
+                continue;
+            }
+
+            if ($remoteDisk->exists($remotePath)) {
+                $verified = $this->verifyRemoteObject($remoteDisk, $remotePath, $hash, $expectedSize);
+                if (! ($verified['ok'] ?? false)) {
+                    $summary['failed_count']++;
+                    $this->appendWarning($summary, 'remote verify failed for existing object '.$remotePath);
+
+                    continue;
+                }
+
+                $this->upsertLocation($hash, $disk, $remotePath, $verified, $sourceKind, $sourcePath, $driver);
+                $summary['verified_count']++;
+                $summary['skipped_count']++;
+
+                continue;
+            }
+
+            try {
+                $options = [];
+                if ($driver === 's3' && $this->storageClass() !== null) {
+                    $options['StorageClass'] = $this->storageClass();
+                }
+
+                if ($options === []) {
+                    $remoteDisk->put($remotePath, $bytes);
+                } else {
+                    $remoteDisk->put($remotePath, $bytes, $options);
+                }
+            } catch (\Throwable $e) {
+                $summary['failed_count']++;
+                $this->appendWarning($summary, 'upload failed for '.$hash.' -> '.$remotePath.': '.$e->getMessage());
+
+                continue;
+            }
+
+            $verified = $this->verifyRemoteObject($remoteDisk, $remotePath, $hash, $expectedSize);
+            if (! ($verified['ok'] ?? false)) {
+                $summary['failed_count']++;
+                $this->appendWarning($summary, 'remote verify failed after upload for '.$hash.' -> '.$remotePath);
+
+                continue;
+            }
+
+            $this->upsertLocation($hash, $disk, $remotePath, $verified, $sourceKind, $sourcePath, $driver);
+            $summary['uploaded_count']++;
+            $summary['verified_count']++;
+            $summary['bytes'] += (int) ($verified['size_bytes'] ?? 0);
+            $summary['uploaded_bytes'] += (int) ($verified['size_bytes'] ?? 0);
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function collectSourceMap(): array
+    {
+        $sourceMap = [];
+
+        foreach ($this->artifactSourceEntries() as $entry) {
+            $this->registerSource($sourceMap, $entry);
+        }
+
+        foreach ($this->releaseRows() as $release) {
+            $source = $this->releaseStorageLocator->resolveReleaseSource($release);
+            if ($source === null) {
+                continue;
+            }
+
+            $root = (string) ($source['root'] ?? '');
+            $resolvedFrom = $this->sourceKindForResolvedSource($source);
+            foreach ($this->releaseStorageLocator->collectCompiledFilesFromRoot($root) as $file) {
+                $logicalPath = (string) ($file['logical_path'] ?? '');
+                $sourcePath = $this->absolutePathFromRoot($root, $logicalPath);
+                if (! is_file($sourcePath)) {
+                    continue;
+                }
+
+                $this->registerSource($sourceMap, [
+                    'blob_hash' => (string) ($file['hash'] ?? ''),
+                    'source_kind' => $resolvedFrom,
+                    'source_path' => $sourcePath,
+                    'source_root' => $root,
+                    'source_relative_path' => $logicalPath,
+                    'content_type' => $file['content_type'] ?? null,
+                    'priority' => 30,
+                ]);
+            }
+        }
+
+        foreach ($this->releaseStorageLocator->legacyBackupRoots() as $root) {
+            foreach ($this->releaseStorageLocator->collectCompiledFilesFromRoot($root) as $file) {
+                $logicalPath = (string) ($file['logical_path'] ?? '');
+                $sourcePath = $this->absolutePathFromRoot($root, $logicalPath);
+                if (! is_file($sourcePath)) {
+                    continue;
+                }
+
+                $this->registerSource($sourceMap, [
+                    'blob_hash' => (string) ($file['hash'] ?? ''),
+                    'source_kind' => 'backup',
+                    'source_path' => $sourcePath,
+                    'source_root' => $root,
+                    'source_relative_path' => $logicalPath,
+                    'content_type' => $file['content_type'] ?? null,
+                    'priority' => 40,
+                ]);
+            }
+        }
+
+        foreach ($this->releaseStorageLocator->liveAliasRoots() as $root) {
+            foreach ($this->releaseStorageLocator->collectCompiledFilesFromRoot($root) as $file) {
+                $logicalPath = (string) ($file['logical_path'] ?? '');
+                $sourcePath = $this->absolutePathFromRoot($root, $logicalPath);
+                if (! is_file($sourcePath)) {
+                    continue;
+                }
+
+                $this->registerSource($sourceMap, [
+                    'blob_hash' => (string) ($file['hash'] ?? ''),
+                    'source_kind' => 'live_alias',
+                    'source_path' => $sourcePath,
+                    'source_root' => $root,
+                    'source_relative_path' => $logicalPath,
+                    'content_type' => $file['content_type'] ?? null,
+                    'priority' => 90,
+                ]);
+            }
+        }
+
+        return $sourceMap;
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function releaseRows(): array
+    {
+        return DB::table('content_pack_releases')
+            ->where(function ($query): void {
+                $query->where('status', 'success')
+                    ->orWhereIn('id', $this->activeReleaseIds())
+                    ->orWhereIn('id', $this->snapshotReleaseIds());
+            })
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get()
+            ->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function activeReleaseIds(): array
+    {
+        return DB::table('content_pack_activations')
+            ->pluck('release_id')
+            ->filter(static fn (mixed $value): bool => trim((string) $value) !== '')
+            ->map(static fn (mixed $value): string => trim((string) $value))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function snapshotReleaseIds(): array
+    {
+        $columns = [
+            'from_content_pack_release_id',
+            'to_content_pack_release_id',
+            'activation_before_release_id',
+            'activation_after_release_id',
+        ];
+
+        $ids = [];
+        foreach (DB::table('content_release_snapshots')->get($columns) as $row) {
+            foreach ($columns as $column) {
+                $value = trim((string) ($row->{$column} ?? ''));
+                if ($value !== '') {
+                    $ids[$value] = true;
+                }
+            }
+        }
+
+        return array_keys($ids);
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function artifactSourceEntries(): array
+    {
+        $disk = Storage::disk('local');
+        $entries = [];
+
+        foreach ($disk->allFiles('artifacts/reports') as $relativePath) {
+            $this->pushArtifactEntry($entries, $relativePath, 'artifact_canonical', 10);
+        }
+        foreach ($disk->allFiles('artifacts/pdf') as $relativePath) {
+            $this->pushArtifactEntry($entries, $relativePath, 'artifact_canonical', 10);
+        }
+
+        foreach (['reports', 'private/reports'] as $prefix) {
+            foreach ($disk->allFiles($prefix) as $relativePath) {
+                if (! $this->shouldTreatLegacyArtifactAsRoot($relativePath)) {
+                    continue;
+                }
+
+                $this->pushArtifactEntry($entries, $relativePath, 'artifact_legacy', 20);
+            }
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $entries
+     */
+    private function pushArtifactEntry(array &$entries, string $relativePath, string $sourceKind, int $priority): void
+    {
+        $absolutePath = storage_path('app/private/'.ltrim($relativePath, '/'));
+        if (! is_file($absolutePath)) {
+            return;
+        }
+
+        $bytes = (string) Storage::disk('local')->get($relativePath);
+        $entries[] = [
+            'blob_hash' => hash('sha256', $bytes),
+            'source_kind' => $sourceKind,
+            'source_path' => $absolutePath,
+            'source_root' => dirname($absolutePath),
+            'source_relative_path' => $relativePath,
+            'content_type' => $this->contentTypeForArtifactPath($relativePath),
+            'priority' => $priority,
+        ];
+    }
+
+    /**
+     * @param  array<string,array<string,mixed>>  $sourceMap
+     * @param  array<string,mixed>  $entry
+     */
+    private function registerSource(array &$sourceMap, array $entry): void
+    {
+        $hash = strtolower(trim((string) ($entry['blob_hash'] ?? '')));
+        if (! $this->isValidHash($hash)) {
+            return;
+        }
+
+        $priority = (int) ($entry['priority'] ?? PHP_INT_MAX);
+        if (isset($sourceMap[$hash]) && $priority >= (int) ($sourceMap[$hash]['priority'] ?? PHP_INT_MAX)) {
+            return;
+        }
+
+        $entry['priority'] = $priority;
+        $entry['blob_hash'] = $hash;
+        $sourceMap[$hash] = $entry;
+    }
+
+    /**
+     * @param  mixed  $remoteDisk
+     * @return array<string,mixed>
+     */
+    private function verifyRemoteObject($remoteDisk, string $remotePath, string $expectedHash, int $expectedSize): array
+    {
+        try {
+            if (! $remoteDisk->exists($remotePath)) {
+                return ['ok' => false];
+            }
+
+            $bytes = $remoteDisk->get($remotePath);
+            if (! is_string($bytes)) {
+                return ['ok' => false];
+            }
+
+            $verifiedHash = hash('sha256', $bytes);
+            $verifiedSize = strlen($bytes);
+            if ($verifiedHash !== $expectedHash) {
+                return ['ok' => false];
+            }
+            if ($expectedSize > 0 && $verifiedSize !== $expectedSize) {
+                return ['ok' => false];
+            }
+
+            return [
+                'ok' => true,
+                'size_bytes' => $verifiedSize,
+                'checksum' => 'sha256:'.$verifiedHash,
+                'etag' => $this->bestEffortRemoteChecksum($remoteDisk, $remotePath),
+                'storage_class' => $this->storageClass(),
+                'verified_hash' => $verifiedHash,
+            ];
+        } catch (\Throwable) {
+            return ['ok' => false];
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $verified
+     */
+    private function upsertLocation(
+        string $hash,
+        string $disk,
+        string $remotePath,
+        array $verified,
+        string $sourceKind,
+        string $sourcePath,
+        string $driver,
+    ): void {
+        StorageBlobLocation::query()->updateOrCreate(
+            [
+                'blob_hash' => $hash,
+                'disk' => $disk,
+                'storage_path' => $remotePath,
+            ],
+            [
+                'location_kind' => self::LOCATION_KIND_REMOTE_COPY,
+                'size_bytes' => (int) ($verified['size_bytes'] ?? 0),
+                'checksum' => $verified['checksum'] ?? null,
+                'etag' => $verified['etag'] ?? null,
+                'storage_class' => $verified['storage_class'] ?? $this->storageClass(),
+                'verified_at' => now(),
+                'meta_json' => [
+                    'driver' => $driver,
+                    'source_kind' => $sourceKind,
+                    'source_path' => $sourcePath,
+                    'verified_checksum_sha256' => (string) ($verified['verified_hash'] ?? ''),
+                    'requested_storage_class' => $this->storageClass(),
+                    'bucket' => $this->diskConfigValue($disk, 'bucket'),
+                    'region' => $this->diskConfigValue($disk, 'region'),
+                    'endpoint' => $this->diskConfigValue($disk, 'endpoint'),
+                    'url' => $this->diskConfigValue($disk, 'url'),
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function reachableBlobHashes(): array
+    {
+        $plan = $this->blobReachabilityService->buildPlan();
+        $hashes = data_get($plan, 'reachable.blob_hashes', []);
+        if (! is_array($hashes)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($hashes as $hash) {
+            $hash = strtolower(trim((string) $hash));
+            if ($this->isValidHash($hash)) {
+                $normalized[$hash] = true;
+            }
+        }
+
+        return array_keys($normalized);
+    }
+
+    private function diskConfigValue(string $disk, string $key): ?string
+    {
+        $value = trim((string) config('filesystems.disks.'.$disk.'.'.$key, ''));
+
+        return $value !== '' ? $value : null;
+    }
+
+    private function remotePathForHash(string $hash): string
+    {
+        $prefix = trim((string) config('storage_rollout.blob_offload_prefix', 'rollout/blobs'), '/');
+        $suffix = 'sha256/'.substr($hash, 0, 2).'/'.$hash;
+
+        return $prefix === '' ? $suffix : $prefix.'/'.$suffix;
+    }
+
+    /**
+     * @param  array<string,mixed>  $source
+     */
+    private function sourceKindForResolvedSource(array $source): string
+    {
+        $resolvedFrom = str_replace('.', '_', trim((string) ($source['resolved_from'] ?? 'release')));
+        if ($resolvedFrom === '') {
+            $resolvedFrom = 'release';
+        }
+
+        if ($resolvedFrom !== 'release_storage_path') {
+            return $resolvedFrom;
+        }
+
+        $storagePath = str_replace('\\', '/', trim((string) ($source['storage_path_for_patch'] ?? '')));
+        $root = str_replace('\\', '/', trim((string) ($source['root'] ?? '')));
+
+        if (str_contains($storagePath, 'private/packs_v2/') && str_contains($root, '/app/content_packs_v2/')) {
+            return 'v2_mirror';
+        }
+
+        if (str_contains($storagePath, 'content_packs_v2/') && str_contains($root, '/app/private/packs_v2/')) {
+            return 'v2_primary';
+        }
+
+        return $resolvedFrom;
+    }
+
+    private function absolutePathFromRoot(string $root, string $logicalPath): string
+    {
+        return rtrim($root, '/\\').DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, ltrim($logicalPath, '/'));
+    }
+
+    private function shouldTreatLegacyArtifactAsRoot(string $relativePath): bool
+    {
+        $canonicalTarget = $this->canonicalArtifactTargetForLegacyPath($relativePath);
+        if ($canonicalTarget === null) {
+            return true;
+        }
+
+        return ! Storage::disk('local')->exists($canonicalTarget);
+    }
+
+    private function canonicalArtifactTargetForLegacyPath(string $relativePath): ?string
+    {
+        if (preg_match('#^(?:private/)?reports/([^/]+)/report\.json$#', $relativePath, $matches) === 1) {
+            return $this->artifactStore->reportCanonicalPath('MBTI', (string) $matches[1]);
+        }
+
+        if (preg_match('#^(?:private/)?reports/([^/]+)/([^/]+)/report\.json$#', $relativePath, $matches) === 1) {
+            return $this->artifactStore->reportCanonicalPath((string) $matches[1], (string) $matches[2]);
+        }
+
+        if (preg_match('#^(?:private/)?reports/([^/]+)/([^/]+)/([^/]+)/report_(free|full)\.pdf$#i', $relativePath, $matches) === 1) {
+            return $this->artifactStore->pdfCanonicalPath(
+                (string) $matches[1],
+                (string) $matches[2],
+                (string) $matches[3],
+                strtolower((string) $matches[4]),
+            );
+        }
+
+        if (preg_match('#^(?:private/)?reports/big5/([^/]+)/report_(free|full)\.pdf$#i', $relativePath) === 1) {
+            return null;
+        }
+
+        return null;
+    }
+
+    private function contentTypeForArtifactPath(string $relativePath): ?string
+    {
+        $relativePath = strtolower($relativePath);
+
+        return match (true) {
+            str_ends_with($relativePath, '.json') => 'application/json',
+            str_ends_with($relativePath, '.pdf') => 'application/pdf',
+            default => null,
+        };
+    }
+
+    /**
+     * @param  mixed  $remoteDisk
+     */
+    private function bestEffortRemoteChecksum($remoteDisk, string $remotePath): ?string
+    {
+        if (! method_exists($remoteDisk, 'checksum')) {
+            return null;
+        }
+
+        try {
+            $checksum = $remoteDisk->checksum($remotePath);
+
+            return is_string($checksum) && $checksum !== '' ? $checksum : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function normalizeDisk(string $disk): string
+    {
+        $disk = trim($disk);
+        if ($disk === '') {
+            $disk = trim((string) config('storage_rollout.blob_offload_disk', 'local'));
+        }
+
+        if ($disk === '') {
+            throw new \InvalidArgumentException('blob offload disk is required');
+        }
+
+        return $disk;
+    }
+
+    private function storageClass(): ?string
+    {
+        $storageClass = trim((string) config('storage_rollout.blob_offload_storage_class', ''));
+
+        return $storageClass !== '' ? $storageClass : null;
+    }
+
+    private function isValidHash(string $hash): bool
+    {
+        return preg_match('/^[a-f0-9]{64}$/', $hash) === 1;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function appendWarning(array &$summary, string $message): void
+    {
+        if (! isset($summary['warnings']) || ! is_array($summary['warnings'])) {
+            $summary['warnings'] = [];
+        }
+
+        if (count($summary['warnings']) < 20) {
+            $summary['warnings'][] = $message;
+        }
+    }
+}

--- a/backend/config/storage_rollout.php
+++ b/backend/config/storage_rollout.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 return [
     'manifest_schema_version' => 'storage_manifest.v1',
     'snapshot_schema_version' => 'storage_snapshot.v1',
+    'blob_offload_plan_schema_version' => 'storage_blob_offload_plan.v1',
     'blob_catalog_enabled' => false,
     'manifest_catalog_enabled' => false,
     'snapshot_catalog_enabled' => false,
     'artifact_dual_write_enabled' => false,
     'content_pack_v2_dual_write_enabled' => false,
     'resolver_materialization_enabled' => false,
+    'blob_offload_disk' => env('STORAGE_BLOB_OFFLOAD_DISK', 's3'),
+    'blob_offload_prefix' => env('STORAGE_BLOB_OFFLOAD_PREFIX', 'rollout/blobs'),
+    'blob_offload_storage_class' => env('STORAGE_BLOB_OFFLOAD_STORAGE_CLASS'),
 ];

--- a/backend/database/migrations/2026_03_20_060000_create_storage_blob_locations_table.php
+++ b/backend/database/migrations/2026_03_20_060000_create_storage_blob_locations_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('storage_blob_locations')) {
+            return;
+        }
+
+        Schema::create('storage_blob_locations', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->char('blob_hash', 64);
+            $table->string('disk', 32);
+            $table->string('storage_path', 1024);
+            $table->string('location_kind', 32)->default('remote_copy');
+            $table->unsignedBigInteger('size_bytes')->default(0);
+            $table->string('checksum', 128)->nullable();
+            $table->string('etag', 256)->nullable();
+            $table->string('storage_class', 64)->nullable();
+            $table->timestamp('verified_at')->nullable();
+            $table->json('meta_json')->nullable();
+            $table->timestamps();
+
+            $table->unique(['disk', 'storage_path'], 'sbl_disk_path_uq');
+            $table->index(['blob_hash'], 'sbl_blob_hash_idx');
+            $table->index(['verified_at'], 'sbl_verified_idx');
+            $table->foreign('blob_hash', 'sbl_blob_hash_fk')
+                ->references('hash')
+                ->on('storage_blobs')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Storage/StorageBlobOffloadCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageBlobOffloadCommandTest.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Models\StorageBlobLocation;
+use App\Services\Storage\BlobCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageBlobOffloadCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    private string $isolatedPacksRoot;
+
+    private string $originalPacksRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->originalPacksRoot = (string) config('content_packs.root');
+
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-blob-offload-'.Str::uuid();
+        $this->isolatedPacksRoot = sys_get_temp_dir().'/fap-packs-offload-root-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        File::ensureDirectoryExists($this->isolatedPacksRoot);
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('content_packs.root', $this->isolatedPacksRoot);
+        config()->set('storage_rollout.blob_offload_prefix', 'rollout/blobs');
+        config()->set('storage_rollout.blob_offload_storage_class', 'STANDARD_IA');
+        config()->set('storage_rollout.blob_offload_disk', 's3');
+        config()->set('filesystems.disks.s3.bucket', 'test-offload-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.example.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        config()->set('content_packs.root', $this->originalPacksRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        foreach ([$this->isolatedStoragePath, $this->isolatedPacksRoot] as $path) {
+            if (is_dir($path)) {
+                File::deleteDirectory($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_blob_offload_builds_plan_and_executes_copy_only_with_source_fallback_and_idempotency(): void
+    {
+        $blobCatalog = app(BlobCatalogService::class);
+
+        $releaseId = (string) Str::uuid();
+        $releaseRoot = storage_path('app/private/content_releases/'.Str::uuid().'/source_pack');
+        $releaseManifest = $this->createCompiledTree($releaseRoot, 'BIG5_OCEAN', 'v1', 'release_source');
+        $this->catalogRootFiles($blobCatalog, $releaseRoot);
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'BIG5-OFFLOAD',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $releaseManifest['manifest_hash'],
+            'compiled_hash' => $releaseManifest['compiled_hash'],
+            'content_hash' => $releaseManifest['content_hash'],
+            'norms_version' => $releaseManifest['norms_version'],
+            'git_sha' => 'git-release',
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode($releaseManifest['decoded'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $releaseRoot,
+            'source_commit' => 'git-release',
+            'created_at' => now()->subMinutes(5),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+        DB::table('content_pack_activations')->insert([
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'release_id' => $releaseId,
+            'activated_at' => now()->subMinutes(5),
+            'created_at' => now()->subMinutes(5),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+
+        $backupRoot = storage_path('app/private/content_releases/backups/'.Str::uuid().'/current_pack');
+        $backupManifest = $this->createCompiledTree($backupRoot, 'BIG5_OCEAN', 'v1', 'backup_current');
+        $this->catalogRootFiles($blobCatalog, $backupRoot);
+
+        $v2ReleaseId = (string) Str::uuid();
+        $v2MirrorRoot = storage_path('app/content_packs_v2/SDS_20/v1/'.$v2ReleaseId);
+        $v2Manifest = $this->createCompiledTree($v2MirrorRoot, 'SDS_20', 'v1', 'v2_mirror');
+        $this->catalogRootFiles($blobCatalog, $v2MirrorRoot);
+        DB::table('content_pack_releases')->insert([
+            'id' => $v2ReleaseId,
+            'action' => 'packs2_publish',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v1',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'SDS_20',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $v2Manifest['manifest_hash'],
+            'compiled_hash' => $v2Manifest['compiled_hash'],
+            'content_hash' => $v2Manifest['content_hash'],
+            'norms_version' => $v2Manifest['norms_version'],
+            'git_sha' => 'git-v2',
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode($v2Manifest['decoded'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => 'private/packs_v2/SDS_20/v1/'.$v2ReleaseId,
+            'source_commit' => 'git-v2',
+            'created_at' => now()->subMinutes(4),
+            'updated_at' => now()->subMinutes(4),
+        ]);
+
+        Storage::disk('local')->put('artifacts/reports/MBTI/attempt-offload/report.json', '{"artifact":"canonical"}');
+        $artifactBytes = (string) Storage::disk('local')->get('artifacts/reports/MBTI/attempt-offload/report.json');
+        $artifactHash = hash('sha256', $artifactBytes);
+        $blobCatalog->upsertBlob([
+            'hash' => $artifactHash,
+            'disk' => 'local',
+            'storage_path' => $blobCatalog->storagePathForHash($artifactHash),
+            'size_bytes' => strlen($artifactBytes),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+            'last_verified_at' => now(),
+        ]);
+
+        $unreachableHash = str_repeat('f', 64);
+        $blobCatalog->upsertBlob([
+            'hash' => $unreachableHash,
+            'disk' => 'local',
+            'storage_path' => $blobCatalog->storagePathForHash($unreachableHash),
+            'size_bytes' => 123,
+            'content_type' => 'application/octet-stream',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+            'last_verified_at' => now(),
+        ]);
+
+        $liveAliasRoot = $this->isolatedPacksRoot.'/default/CN_MAINLAND/zh-CN/BIG5-LIVE-OFFLOAD';
+        $liveAliasManifest = $this->createCompiledTree($liveAliasRoot, 'BIG5_OCEAN', 'v1', 'live_alias_only');
+        $this->catalogRootFiles($blobCatalog, $liveAliasRoot);
+
+        $this->assertSame(0, Artisan::call('storage:blob-offload', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('disk=s3', $dryRunOutput);
+        $this->assertStringContainsString('candidate_count=7', $dryRunOutput);
+        $this->assertStringContainsString('skipped_count=2', $dryRunOutput);
+
+        $planPath = $this->extractPlanPath($dryRunOutput);
+        $this->assertFileExists($planPath);
+        $plan = json_decode((string) file_get_contents($planPath), true);
+        $this->assertIsArray($plan);
+        $this->assertSame('storage_blob_offload_plan.v1', (string) ($plan['schema'] ?? ''));
+        $this->assertSame('s3', (string) ($plan['disk'] ?? ''));
+        $this->assertCount(7, (array) ($plan['candidates'] ?? []));
+        $this->assertCount(2, (array) ($plan['skipped'] ?? []));
+        $this->assertContains('live_alias_only_source', array_column((array) ($plan['skipped'] ?? []), 'reason'));
+
+        $this->assertSame(0, Artisan::call('storage:blob-offload', [
+            '--execute' => true,
+            '--disk' => 's3',
+        ]));
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('disk=s3', $executeOutput);
+        $this->assertStringContainsString('uploaded_count=7', $executeOutput);
+        $this->assertStringContainsString('failed_count=0', $executeOutput);
+
+        $this->assertSame(7, StorageBlobLocation::query()->count());
+
+        $releaseRemotePath = $this->remotePathForHash($releaseManifest['manifest_hash']);
+        $backupRemotePath = $this->remotePathForHash($backupManifest['manifest_hash']);
+        $v2RemotePath = $this->remotePathForHash($v2Manifest['manifest_hash']);
+        $artifactRemotePath = $this->remotePathForHash($artifactHash);
+
+        $this->assertTrue(Storage::disk('s3')->exists($releaseRemotePath));
+        $this->assertTrue(Storage::disk('s3')->exists($backupRemotePath));
+        $this->assertTrue(Storage::disk('s3')->exists($v2RemotePath));
+        $this->assertTrue(Storage::disk('s3')->exists($artifactRemotePath));
+
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $releaseManifest['manifest_hash'],
+            'disk' => 's3',
+            'storage_path' => $releaseRemotePath,
+            'location_kind' => 'remote_copy',
+            'storage_class' => 'STANDARD_IA',
+        ]);
+        $location = StorageBlobLocation::query()
+            ->where('blob_hash', $v2Manifest['manifest_hash'])
+            ->where('disk', 's3')
+            ->where('storage_path', $v2RemotePath)
+            ->first();
+        $this->assertNotNull($location);
+        $this->assertSame('sha256:'.$v2Manifest['manifest_hash'], (string) ($location->checksum ?? ''));
+        $this->assertNotNull($location->verified_at);
+        $this->assertSame('v2_mirror', data_get($location->meta_json, 'source_kind'));
+        $this->assertSame('test-offload-bucket', data_get($location->meta_json, 'bucket'));
+        $this->assertSame('ap-guangzhou', data_get($location->meta_json, 'region'));
+        $this->assertSame('https://cos.example.test', data_get($location->meta_json, 'endpoint'));
+
+        $artifactLocation = StorageBlobLocation::query()
+            ->where('blob_hash', $artifactHash)
+            ->where('disk', 's3')
+            ->where('storage_path', $artifactRemotePath)
+            ->first();
+        $this->assertNotNull($artifactLocation);
+        $this->assertSame('artifact_canonical', data_get($artifactLocation->meta_json, 'source_kind'));
+
+        $this->assertFalse(Storage::disk('s3')->exists($this->remotePathForHash($liveAliasManifest['manifest_hash'])));
+        $this->assertDatabaseMissing('storage_blob_locations', [
+            'blob_hash' => $unreachableHash,
+            'disk' => 's3',
+        ]);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/offload'));
+
+        $this->assertSame(0, Artisan::call('storage:blob-offload', [
+            '--execute' => true,
+            '--disk' => 's3',
+        ]));
+        $secondExecuteOutput = Artisan::output();
+        $this->assertStringContainsString('uploaded_count=0', $secondExecuteOutput);
+        $this->assertStringContainsString('failed_count=0', $secondExecuteOutput);
+        $this->assertSame(7, StorageBlobLocation::query()->count());
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_blob_offload')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($audit);
+        $auditMeta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($auditMeta);
+        $this->assertSame('executed', (string) ($auditMeta['mode'] ?? ''));
+        $this->assertSame('s3', (string) ($auditMeta['disk'] ?? ''));
+        $this->assertTrue((bool) ($auditMeta['copy_only'] ?? false));
+    }
+
+    public function test_blob_offload_requires_exactly_one_mode(): void
+    {
+        $this->artisan('storage:blob-offload')->assertExitCode(1);
+        $this->artisan('storage:blob-offload --dry-run --execute')->assertExitCode(1);
+    }
+
+    public function test_blob_offload_rejects_local_target_disk(): void
+    {
+        config()->set('storage_rollout.blob_offload_disk', 'local');
+
+        $this->artisan('storage:blob-offload --dry-run')
+            ->expectsOutputToContain('blob offload target disk must be remote: local disks are not allowed.')
+            ->assertExitCode(1);
+    }
+
+    private function extractPlanPath(string $output): string
+    {
+        preg_match('/^plan=(.+)$/m', $output, $matches);
+
+        return trim((string) ($matches[1] ?? ''));
+    }
+
+    /**
+     * @return array{
+     *   decoded:array<string,mixed>,
+     *   manifest_hash:string,
+     *   compiled_hash:string,
+     *   content_hash:string,
+     *   norms_version:string
+     * }
+     */
+    private function createCompiledTree(string $root, string $packId, string $packVersion, string $suffix): array
+    {
+        $compiledDir = $root.'/compiled';
+        File::ensureDirectoryExists($compiledDir);
+
+        $payload = json_encode([
+            'suffix' => $suffix,
+            'pack_id' => $packId,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $payload = is_string($payload) ? $payload : '{}';
+        File::put($compiledDir.'/payload.compiled.json', $payload);
+
+        $compiledHash = hash('sha256', $payload.'|compiled|'.$suffix);
+        $contentHash = hash('sha256', $payload.'|content|'.$suffix);
+        $normsVersion = '2026Q1_'.$suffix;
+        $manifest = [
+            'schema' => 'storage.offload.test.v1',
+            'pack_id' => $packId,
+            'pack_version' => $packVersion,
+            'content_package_version' => $packVersion,
+            'compiled_hash' => $compiledHash,
+            'content_hash' => $contentHash,
+            'norms_version' => $normsVersion,
+        ];
+        $manifestJson = json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        $manifestJson = is_string($manifestJson) ? $manifestJson : '{}';
+        File::put($compiledDir.'/manifest.json', $manifestJson);
+
+        return [
+            'decoded' => $manifest,
+            'manifest_hash' => hash('sha256', $manifestJson),
+            'compiled_hash' => $compiledHash,
+            'content_hash' => $contentHash,
+            'norms_version' => $normsVersion,
+        ];
+    }
+
+    private function catalogRootFiles(BlobCatalogService $blobCatalog, string $root): void
+    {
+        foreach (File::allFiles($root.'/compiled') as $file) {
+            $bytes = (string) File::get($file->getPathname());
+            $hash = hash('sha256', $bytes);
+            $blobCatalog->upsertBlob([
+                'hash' => $hash,
+                'disk' => 'local',
+                'storage_path' => $blobCatalog->storagePathForHash($hash),
+                'size_bytes' => strlen($bytes),
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'ref_count' => 0,
+                'last_verified_at' => now(),
+            ]);
+        }
+    }
+
+    private function remotePathForHash(string $hash): string
+    {
+        return 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements PR-15 in the low-risk shape only: additive remote location metadata plus copy-only blob offload.

The scope stays intentionally narrow:

- add an additive `storage_blob_locations` schema
- add `storage:blob-offload` with `--dry-run` and `--execute`
- upload from real local source-of-bytes
- verify remote objects before recording location metadata
- keep runtime readers local
- do not add delete
- do not add scheduler automation
- do not add remote-read cutover

## Root cause

After PR-14, the repo could already:

- catalog new blob metadata
- backfill historical metadata
- compute conservative reachability
- generate GC dry-run plans

But rollout blobs still had no first-class concept of verified remote copies.

That left two practical gaps:

1. `storage_blobs` could identify a blob hash, but it could not safely represent multiple locations for the same blob.
2. There was no plan-first command to upload reachable blobs to remote storage without changing runtime readers or deleting local bytes.

## What this PR adds

### 1. Additive remote location schema

This PR adds `storage_blob_locations`.

Each row records a verified remote copy of a blob and includes:

- `blob_hash`
- `disk`
- `storage_path`
- `location_kind`
- `size_bytes`
- `checksum`
- `etag`
- `storage_class`
- `verified_at`
- `meta_json`

The schema is additive and does not change existing runtime readers.

### 2. `storage:blob-offload`

This PR adds:

- `php artisan storage:blob-offload --dry-run`
- `php artisan storage:blob-offload --execute`
- optional `--disk=...`
- optional `--plan=...`

Behavior:

- `--dry-run` builds an offload plan and writes it to `storage/app/private/offload_plans`
- `--execute` performs copy-only upload using a generated or supplied plan
- execute never deletes local data
- execute never updates runtime reader paths
- execute writes an audit row with `copy_only=true`

### 3. Source-of-bytes stays physical-tree-first

Offload bytes are read from real local sources, not from any synthetic blob tree.

Priority is conservative:

1. canonical artifact files
2. immutable/resolved release roots
3. legacy backup roots
4. live alias roots are visible in planning, but execute skips blobs whose only source is a live alias path

### 4. Review fixes included before opening PR

This branch also closes the follow-up review findings on the first implementation:

- local disks are now rejected as offload targets
- candidate selection is restricted to the conservative reachable blob set from PR-14
- remote verify metadata now persists bucket / region / endpoint / url so a location row remains auditable even if disk config later changes

## Safety boundaries preserved

This PR does **not** change:

- legacy publish / rollback success paths
- ContentPackV2 publish / resolver / materialization runtime contract
- ArtifactStore canonical-first / legacy-fallback reader order
- BigFiveOps route / stdout / audit contract
- StoragePrune delete semantics
- runtime content reads

This PR does **not** add:

- local delete
- scheduler automation
- remote-first reads
- remote-read cutover

## Tests

New focused coverage:

- `tests/Feature/Storage/StorageBlobOffloadCommandTest.php`

The focused test locks:

- dry-run / execute command contract
- copy-only idempotent upload
- release / backup / V2 mirror / artifact source fallback
- local target disk rejection
- unreachable blobs are not offloaded
- live-alias-only sources are skipped
- verified remote metadata is persisted
- no new runtime local path side effects are created

Existing rollout/storage tests were re-run and stayed green.

## Commands run

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php -l app/Console/Commands/StorageBlobOffload.php
php -l app/Services/Storage/BlobOffloadService.php
php -l app/Models/StorageBlobLocation.php
php -l database/migrations/2026_03_20_060000_create_storage_blob_locations_table.php
php -l tests/Feature/Storage/StorageBlobOffloadCommandTest.php
php -l config/storage_rollout.php

./vendor/bin/pint \
  app/Console/Commands/StorageBlobOffload.php \
  app/Services/Storage/BlobOffloadService.php \
  app/Models/StorageBlobLocation.php \
  database/migrations/2026_03_20_060000_create_storage_blob_locations_table.php \
  config/storage_rollout.php \
  tests/Feature/Storage/StorageBlobOffloadCommandTest.php

php artisan migrate

vendor/bin/phpunit \
  tests/Feature/Storage/StorageBlobOffloadCommandTest.php \
  tests/Feature/Storage/BlobCatalogServiceTest.php \
  tests/Feature/Storage/StorageBackfillReleaseMetadataCommandTest.php \
  tests/Feature/Storage/StorageBlobGcCommandTest.php \
  tests/Feature/Content/Packs2MetadataDualWriteTest.php \
  tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php

php artisan storage:blob-offload --dry-run
php artisan storage:blob-offload --execute
php artisan storage:blob-offload --dry-run --disk=s3
php artisan storage:blob-offload --execute --disk=s3

php artisan route:list > /tmp/pr15_route_list.txt
php artisan serve --host=127.0.0.1 --port=18081
curl -i http://127.0.0.1:18081/api/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
```

## Validation

- focused suite: `OK (14 tests, 224 assertions)`
- `php artisan migrate`: `Nothing to migrate.`
- `php artisan storage:blob-offload --dry-run`: passed
- `php artisan storage:blob-offload --dry-run --disk=s3`: passed
- `php artisan storage:blob-offload --execute --disk=s3`: fails fast with a clear config guard when `filesystems.disks.s3.bucket` is empty
- `curl -i http://127.0.0.1:18081/api/healthz`: `HTTP/1.1 200 OK`

## Known baseline / workspace issue unchanged

`bash backend/scripts/ci_verify_mbti.sh` is still red in the current workspace, and the live failure here is:

- `ORG_CONTEXT_MISSING`

This PR does not touch that area and does not attempt to fix it.
