### PR TITLE
[codex] unblock mbti verify and refresh openapi snapshot

### DIFF
--- a/backend/app/Services/Experiments/ExperimentAssigner.php
+++ b/backend/app/Services/Experiments/ExperimentAssigner.php
@@ -2,10 +2,8 @@
 
 namespace App\Services\Experiments;
 
-use App\Models\ExperimentAssignment;
 use App\Support\StableBucket;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 class ExperimentAssigner
 {
@@ -41,7 +39,7 @@ class ExperimentAssigner
 
     public function attachUserId(int $orgId, string $anonId, int $userId): int
     {
-        if (!\App\Support\SchemaBaseline::hasTable('experiment_assignments')) {
+        if (! \App\Support\SchemaBaseline::hasTable('experiment_assignments')) {
             return 0;
         }
 
@@ -71,7 +69,7 @@ class ExperimentAssigner
     private function assignOne(string $experimentKey, $config, int $orgId, ?string $anonId, ?int $userId): ?string
     {
         $experimentKey = trim($experimentKey);
-        if ($experimentKey === '' || !is_array($config)) {
+        if ($experimentKey === '' || ! is_array($config)) {
             return null;
         }
 
@@ -97,11 +95,11 @@ class ExperimentAssigner
         }
 
         $variants = $config['variants'] ?? [];
-        if (!is_array($variants) || $variants === []) {
+        if (! is_array($variants) || $variants === []) {
             return null;
         }
 
-        $subjectKey = $userId !== null ? 'user:' . $userId : 'anon:' . $anonId;
+        $subjectKey = $userId !== null ? 'user:'.$userId : 'anon:'.$anonId;
         $variant = $this->pickVariant($variants, $subjectKey, $orgId, $experimentKey);
         if ($variant === null) {
             return null;
@@ -130,7 +128,7 @@ class ExperimentAssigner
 
     private function activeExperimentsFromRegistry(int $orgId): array
     {
-        if (!\App\Support\SchemaBaseline::hasTable('experiments_registry')) {
+        if (! \App\Support\SchemaBaseline::hasTable('experiments_registry')) {
             return [];
         }
 
@@ -171,16 +169,16 @@ class ExperimentAssigner
     private function activeExperimentsFromConfig(): array
     {
         $configs = config('fap_experiments.experiments', []);
-        if (!is_array($configs)) {
+        if (! is_array($configs)) {
             return [];
         }
 
         $active = [];
         foreach ($configs as $key => $config) {
-            if (!is_array($config)) {
+            if (! is_array($config)) {
                 continue;
             }
-            if (!($config['is_active'] ?? false)) {
+            if (! ($config['is_active'] ?? false)) {
                 continue;
             }
             $active[$key] = $config;
@@ -198,14 +196,14 @@ class ExperimentAssigner
             }
         }
 
-        if (!is_array($payload)) {
+        if (! is_array($payload)) {
             return [];
         }
 
         $normalized = [];
         foreach ($payload as $variant => $weight) {
             $variantKey = trim((string) $variant);
-            if ($variantKey === '' || !is_numeric($weight)) {
+            if ($variantKey === '' || ! is_numeric($weight)) {
                 continue;
             }
 
@@ -220,10 +218,10 @@ class ExperimentAssigner
         return $normalized;
     }
 
-    private function findExisting(string $experimentKey, int $orgId, ?int $userId, string $anonId): ?ExperimentAssignment
+    private function findExisting(string $experimentKey, int $orgId, ?int $userId, string $anonId): ?object
     {
         if ($userId !== null) {
-            $row = ExperimentAssignment::query()
+            $row = DB::table('experiment_assignments')
                 ->where('org_id', $orgId)
                 ->where('user_id', $userId)
                 ->where('experiment_key', $experimentKey)
@@ -234,7 +232,7 @@ class ExperimentAssigner
             }
         }
 
-        return ExperimentAssignment::query()
+        return DB::table('experiment_assignments')
             ->where('org_id', $orgId)
             ->where('anon_id', $anonId)
             ->where('experiment_key', $experimentKey)
@@ -258,12 +256,12 @@ class ExperimentAssigner
             return null;
         }
 
-        $bucket = StableBucket::bucket($subjectKey . '|' . $orgId . '|' . $experimentKey . '|' . $this->salt, 100);
+        $bucket = StableBucket::bucket($subjectKey.'|'.$orgId.'|'.$experimentKey.'|'.$this->salt, 100);
         $target = $bucket % $total;
 
         $cursor = 0;
         foreach ($variants as $variant => $weight) {
-            if (!is_numeric($weight)) {
+            if (! is_numeric($weight)) {
                 continue;
             }
             $w = (int) round((float) $weight);

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -576,6 +576,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
                 ]
             }
@@ -598,6 +599,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:id",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
                 ]
@@ -621,6 +623,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:id",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
                 ]
@@ -1034,6 +1037,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1056,6 +1060,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1078,6 +1083,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1100,6 +1106,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1122,6 +1129,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1144,6 +1152,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1166,6 +1175,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1188,6 +1198,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1210,6 +1221,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1232,6 +1244,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1254,6 +1267,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext",
                     "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
                 ]
             }
@@ -1275,7 +1289,8 @@
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
-                    "App\\Http\\Middleware\\ResolveOrgContext"
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext"
                 ]
             }
         },
@@ -1296,7 +1311,8 @@
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
-                    "App\\Http\\Middleware\\ResolveOrgContext"
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext"
                 ]
             }
         },
@@ -1317,7 +1333,8 @@
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\FmTokenAuth",
-                    "App\\Http\\Middleware\\ResolveOrgContext"
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireTenantContext"
                 ]
             }
         },

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -36,7 +36,7 @@ class MbtiResultTelemetryContractTest extends TestCase
         $eventMeta = [];
         foreach (['result_view', 'report_view'] as $eventCode) {
             $event = $this->findLatestEventByAttempt($eventCode, $attemptId);
-            $this->assertNotNull($event, 'missing event row: ' . $eventCode);
+            $this->assertNotNull($event, 'missing event row: '.$eventCode);
 
             $meta = json_decode((string) ($event->meta_json ?? '{}'), true) ?: [];
             $eventMeta[$eventCode] = $meta;
@@ -198,9 +198,46 @@ class MbtiResultTelemetryContractTest extends TestCase
         );
     }
 
+    public function test_mbti_report_view_records_experiments_in_public_context_without_org_scope_failures(): void
+    {
+        $this->seedScales();
+        Config::set('fap_experiments.experiments', [
+            'PR23_STICKY_BUCKET' => [
+                'is_active' => true,
+                'variants' => [
+                    'control' => 50,
+                    'variant_a' => 50,
+                ],
+            ],
+        ]);
+
+        $anonId = 'mbti_report_experiment_anon';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+
+        $reportResponse = $this->invokeController('report', $attemptId, $anonId);
+        $this->assertSame(200, $reportResponse->getStatusCode());
+
+        $event = $this->findLatestEventByAttempt('report_view', $attemptId);
+        $this->assertNotNull($event);
+        $experiments = json_decode((string) ($event->experiments_json ?? '{}'), true) ?: [];
+        $this->assertArrayHasKey('PR23_STICKY_BUCKET', $experiments);
+
+        $assignment = DB::table('experiment_assignments')
+            ->where('org_id', 0)
+            ->where('anon_id', $anonId)
+            ->where('experiment_key', 'PR23_STICKY_BUCKET')
+            ->first();
+
+        $this->assertNotNull($assignment);
+        $this->assertSame(
+            (string) data_get($experiments, 'PR23_STICKY_BUCKET'),
+            (string) ($assignment->variant ?? '')
+        );
+    }
+
     private function seedScales(): void
     {
-        (new ScaleRegistrySeeder())->run();
+        (new ScaleRegistrySeeder)->run();
     }
 
     private function createMbtiAttemptWithResult(string $anonId): string
@@ -289,7 +326,7 @@ class MbtiResultTelemetryContractTest extends TestCase
 
     private function invokeController(string $method, string $attemptId, string $anonId): \Illuminate\Http\JsonResponse
     {
-        $path = "/api/v0.3/attempts/{$attemptId}/" . ($method === 'report' ? 'report' : 'result');
+        $path = "/api/v0.3/attempts/{$attemptId}/".($method === 'report' ? 'report' : 'result');
         $request = Request::create($path, 'GET');
         $request->headers->set('X-Anon-Id', $anonId);
         $request->attributes->set('anon_id', $anonId);
@@ -331,7 +368,7 @@ class MbtiResultTelemetryContractTest extends TestCase
                     return;
                 }
 
-                $inner->orWhereRaw('meta_json like ?', ['%"attempt_id":"' . $attemptId . '"%']);
+                $inner->orWhereRaw('meta_json like ?', ['%"attempt_id":"'.$attemptId.'"%']);
             });
 
         return $query->orderByDesc('occurred_at')->first();


### PR DESCRIPTION
## Summary

This PR unblocks the MBTI CI chain by fixing the public experiment-assignment lookup path and refreshing the checked-in OpenAPI snapshot.

The scope is intentionally narrow:

- fix the `ORG_CONTEXT_MISSING` failure in the public MBTI result/report telemetry path
- add focused coverage so the public report flow keeps recording experiment assignments without depending on request tenant scope
- refresh `backend/docs/contracts/openapi.snapshot.json` so the OpenAPI diff gate matches the current route middleware stack

It does not change route wiring, migrations, middleware registration, runtime read contracts, or content package behavior.

## Root cause

Two independent CI blockers were present.

### 1. Public report telemetry was still hitting tenant-scoped assignment lookup

`ExperimentAssigner::findExisting()` already received an explicit `org_id`, but it queried through `ExperimentAssignment::query()`, which still applied the model tenant scope.

In public report/result flows there is no request tenant context, so this path could throw `ORG_CONTEXT_MISSING` while trying to record experiment metadata for telemetry.

That broke `ci_verify_mbti.sh` in the report path even though the flow already had enough explicit identifiers (`org_id`, `anon_id`, `experiment_key`) to resolve the assignment safely.

### 2. The OpenAPI snapshot was stale

`backend/docs/contracts/openapi.snapshot.json` no longer matched the route middleware stack on `main`, specifically because routes now include `App\\Http\\Middleware\\RequireTenantContext` in the exported middleware list.

That caused the OpenAPI diff gate to fail even after the report flow itself was fixed.

## Fix

### 1. Make experiment assignment lookup explicit instead of scope-dependent

`ExperimentAssigner::findExisting()` now uses explicit `DB::table('experiment_assignments')` queries keyed by:

- `org_id`
- `user_id` or `anon_id`
- `experiment_key`

This keeps the lookup bound to the explicit inputs passed by the service and removes the accidental dependency on request tenant scope in public report/result flows.

### 2. Add regression coverage for public-context experiment telemetry

`MbtiResultTelemetryContractTest` now locks that:

- MBTI `report` still returns `200` in public context
- `report_view` records experiment metadata
- the sticky `experiment_assignments` row is created for the public anon flow
- the flow no longer fails on `ORG_CONTEXT_MISSING`

### 3. Refresh the OpenAPI snapshot

The checked-in snapshot was regenerated from the current route state so the OpenAPI diff gate reflects the actual middleware chain on `main`.

## Files changed

- `backend/app/Services/Experiments/ExperimentAssigner.php`
- `backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php`
- `backend/docs/contracts/openapi.snapshot.json`

## Validation

These checks were run against the same diff in the main workspace before packaging the PR branch:

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan route:list > /tmp/openapi_gate_route_list.txt
php artisan migrate
bash scripts/export_openapi.sh --check
php artisan test --filter MbtiResultTelemetryContractTest --stop-on-failure
php artisan test --filter EventExperimentsJsonTest --stop-on-failure
php artisan test --filter OpenApiDiffTest --stop-on-failure
php artisan serve --host=127.0.0.1 --port=18081
curl -i http://127.0.0.1:18081/api/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
```

Observed results:

- `bash scripts/export_openapi.sh --check`: passed
- `OpenApiDiffTest`: passed
- `MbtiResultTelemetryContractTest`: passed
- `EventExperimentsJsonTest`: passed
- `curl /api/healthz`: `HTTP/1.1 200 OK`
- `bash backend/scripts/ci_verify_mbti.sh`: passed end-to-end with exit code `0`

## Notes

This PR only commits the CI unblock files. It does not include the many unrelated local workspace changes currently present on the main checkout.
