### PR TITLE
[codex] Ship MBTI PR-8E edge read path and replay performance (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -13,6 +13,7 @@ use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
 use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Mbti\MbtiPublicProjectionService;
+use App\Services\Mbti\MbtiReadModelContractService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Mbti\MbtiUserStateOrchestrationService;
 use App\Services\Observability\ClinicalComboTelemetry;
@@ -41,6 +42,7 @@ class AttemptReadController extends Controller
         private MbtiPublicProjectionService $mbtiPublicProjectionService,
         private MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private MbtiUserStateOrchestrationService $mbtiUserStateOrchestrationService,
+        private MbtiReadModelContractService $mbtiReadModelContractService,
         private MbtiAccessHubBuilder $mbtiAccessHubBuilder,
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
@@ -346,6 +348,10 @@ class AttemptReadController extends Controller
 
         if ($effectiveMbtiPersonalization !== []) {
             $responsePayload = $this->applyMbtiPersonalizationToEnvelope($responsePayload, $effectiveMbtiPersonalization);
+            $readContract = data_get($responsePayload, 'report._meta.personalization.read_contract_v1');
+            if (is_array($readContract)) {
+                $responsePayload['mbti_read_contract_v1'] = $readContract;
+            }
         }
 
         $mbtiEventMeta = $scaleCode === 'MBTI'
@@ -662,7 +668,11 @@ class AttemptReadController extends Controller
 
         if (is_array(data_get($reportEnvelope, 'report'))) {
             $reportMeta = is_array(data_get($reportEnvelope, 'report._meta')) ? data_get($reportEnvelope, 'report._meta') : [];
-            $reportMeta['personalization'] = $personalization;
+            $canonicalPersonalization = is_array($reportMeta['personalization'] ?? null) ? $reportMeta['personalization'] : [];
+            $reportMeta['personalization'] = $this->mbtiReadModelContractService->applyOverlayPatch(
+                $canonicalPersonalization,
+                $personalization
+            );
             data_set($reportEnvelope, 'report._meta', $reportMeta);
         }
 
@@ -670,7 +680,13 @@ class AttemptReadController extends Controller
             $projectionMeta = is_array(data_get($reportEnvelope, 'mbti_public_projection_v1._meta'))
                 ? data_get($reportEnvelope, 'mbti_public_projection_v1._meta')
                 : [];
-            $projectionMeta['personalization'] = $personalization;
+            $canonicalPersonalization = is_array($projectionMeta['personalization'] ?? null)
+                ? $projectionMeta['personalization']
+                : [];
+            $projectionMeta['personalization'] = $this->mbtiReadModelContractService->applyOverlayPatch(
+                $canonicalPersonalization,
+                $personalization
+            );
             data_set($reportEnvelope, 'mbti_public_projection_v1._meta', $projectionMeta);
         }
 

--- a/backend/app/Services/Mbti/MbtiReadModelContractService.php
+++ b/backend/app/Services/Mbti/MbtiReadModelContractService.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti;
+
+final class MbtiReadModelContractService
+{
+    private const VERSION = 'mbti.read_contract.v1';
+
+    /**
+     * @var list<string>
+     */
+    private const OVERLAY_PERSONALIZATION_FIELDS = [
+        'user_state',
+        'orchestration',
+        'ordered_recommendation_keys',
+        'ordered_action_keys',
+        'recommendation_priority_keys',
+        'action_priority_keys',
+        'reading_focus_key',
+        'action_focus_key',
+        'continuity',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const CANONICAL_SURFACE_FIELDS = [
+        'report.summary',
+        'report.profile',
+        'report.identity_card',
+        'report.layers',
+        'report.sections',
+        'report.recommended_reads',
+        'report.highlights',
+        'mbti_public_summary_v1',
+        'mbti_public_projection_v1.summary_card',
+        'mbti_public_projection_v1.profile',
+        'mbti_public_projection_v1.dimensions',
+        'mbti_public_projection_v1.sections',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const CACHEABLE_FIELDS = [
+        'report',
+        'report.summary',
+        'report.profile',
+        'report.identity_card',
+        'report.layers',
+        'report.sections',
+        'report.recommended_reads',
+        'report.highlights',
+        'mbti_public_summary_v1',
+        'mbti_public_projection_v1',
+        'mbti_public_projection_v1.summary_card',
+        'mbti_public_projection_v1.profile',
+        'mbti_public_projection_v1.dimensions',
+        'mbti_public_projection_v1.sections',
+        'mbti_read_contract_v1',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const TELEMETRY_PARITY_FIELDS = [
+        'user_state',
+        'orchestration.primary_focus_key',
+        'orchestration.secondary_focus_keys',
+        'orchestration.cta_priority_keys',
+        'continuity.carryover_focus_key',
+        'continuity.carryover_reason',
+        'continuity.recommended_resume_keys',
+        'ordered_recommendation_keys',
+        'ordered_action_keys',
+        'recommendation_priority_keys',
+        'action_priority_keys',
+        'reading_focus_key',
+        'action_focus_key',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @return array<string, mixed>
+     */
+    public function attachContract(array $personalization): array
+    {
+        if ($personalization === []) {
+            return [];
+        }
+
+        $personalization['read_contract_v1'] = $this->buildContract($personalization);
+
+        return $personalization;
+    }
+
+    /**
+     * @param  array<string, mixed>  $canonicalPersonalization
+     * @param  array<string, mixed>  $effectivePersonalization
+     * @return array<string, mixed>
+     */
+    public function applyOverlayPatch(array $canonicalPersonalization, array $effectivePersonalization): array
+    {
+        if ($canonicalPersonalization === []) {
+            return $this->attachContract($effectivePersonalization);
+        }
+
+        $patched = $canonicalPersonalization;
+
+        foreach (self::OVERLAY_PERSONALIZATION_FIELDS as $field) {
+            if (! array_key_exists($field, $effectivePersonalization)) {
+                continue;
+            }
+
+            $patched[$field] = $effectivePersonalization[$field];
+        }
+
+        return $this->attachContract($patched);
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @return array<string, mixed>
+     */
+    public function buildContract(array $personalization): array
+    {
+        $canonicalPersonalizationFields = array_values(array_filter(
+            array_keys($personalization),
+            static fn (string $field): bool => $field !== 'read_contract_v1'
+                && ! in_array($field, self::OVERLAY_PERSONALIZATION_FIELDS, true)
+        ));
+
+        $nonCacheableFields = [];
+        foreach (self::OVERLAY_PERSONALIZATION_FIELDS as $field) {
+            $nonCacheableFields[] = "report._meta.personalization.{$field}";
+            $nonCacheableFields[] = "mbti_public_projection_v1._meta.personalization.{$field}";
+        }
+
+        return [
+            'version' => self::VERSION,
+            'canonical_read_model' => [
+                'personalization_fields' => $canonicalPersonalizationFields,
+                'surface_fields' => self::CANONICAL_SURFACE_FIELDS,
+                'sources' => [
+                    'report_snapshot',
+                    'report_projection',
+                ],
+            ],
+            'overlay_patch' => [
+                'personalization_fields' => self::OVERLAY_PERSONALIZATION_FIELDS,
+                'surface_fields' => $nonCacheableFields,
+                'sources' => [
+                    'attempt_access',
+                    'attempt_events',
+                    'share_rows',
+                ],
+            ],
+            'cacheable_fields' => self::CACHEABLE_FIELDS,
+            'non_cacheable_fields' => $nonCacheableFields,
+            'telemetry_parity_fields' => self::TELEMETRY_PARITY_FIELDS,
+        ];
+    }
+}

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -567,6 +567,7 @@ final class MbtiResultPersonalizationService
     public function __construct(
         private readonly ContentPacksIndex $packsIndex,
         private readonly MbtiUserStateOrchestrationService $userStateOrchestrationService,
+        private readonly MbtiReadModelContractService $readModelContractService,
     ) {
     }
 
@@ -653,44 +654,46 @@ final class MbtiResultPersonalizationService
             $variantKeys[$sectionKey] = (string) ($variant['variant_key'] ?? '');
         }
 
-        return $this->userStateOrchestrationService->withBaseline([
-            'schema_version' => 'mbti.personalization.phase8c.v1',
-            'locale' => $locale,
-            'type_code' => $typeCode,
-            'identity' => $identity,
-            'axis_vector' => $axisVector,
-            'axis_bands' => $axisBands,
-            'boundary_flags' => $boundaryFlags,
-            'dominant_axes' => $dominantAxes,
-            'scene_fingerprint' => $sceneFingerprint,
-            'explainability_summary' => $explainabilityAuthority['explainability_summary'],
-            'close_call_axes' => $explainabilityAuthority['close_call_axes'],
-            'neighbor_type_keys' => $explainabilityAuthority['neighbor_type_keys'],
-            'contrast_keys' => $explainabilityAuthority['contrast_keys'],
-            'confidence_or_stability_keys' => $explainabilityAuthority['confidence_or_stability_keys'],
-            'work_style_keys' => array_values((array) data_get($sceneFingerprint, 'work.style_keys', [])),
-            'relationship_style_keys' => array_values((array) data_get($sceneFingerprint, 'relationships.style_keys', [])),
-            'decision_style_keys' => array_values((array) data_get($sceneFingerprint, 'decision.style_keys', [])),
-            'stress_recovery_keys' => array_values((array) data_get($sceneFingerprint, 'stress_recovery.style_keys', [])),
-            'communication_style_keys' => array_values((array) data_get($sceneFingerprint, 'communication.style_keys', [])),
-            'work_style_summary' => $careerBridgeAuthority['work_style_summary'],
-            'role_fit_keys' => $careerBridgeAuthority['role_fit_keys'],
-            'collaboration_fit_keys' => $careerBridgeAuthority['collaboration_fit_keys'],
-            'work_env_preference_keys' => $careerBridgeAuthority['work_env_preference_keys'],
-            'career_next_step_keys' => $careerBridgeAuthority['career_next_step_keys'],
-            'action_plan_summary' => $actionAuthority['action_plan_summary'],
-            'weekly_action_keys' => $actionAuthority['weekly_action_keys'],
-            'relationship_action_keys' => $actionAuthority['relationship_action_keys'],
-            'work_experiment_keys' => $actionAuthority['work_experiment_keys'],
-            'watchout_keys' => $actionAuthority['watchout_keys'],
-            'recommended_read_candidates' => $this->extractRecommendationCandidates($reportPayload),
-            'variant_keys' => $variantKeys,
-            'sections' => $sectionVariants,
-            'pack_id' => trim((string) ($context['pack_id'] ?? data_get($reportPayload, 'versions.content_pack_id', ''))),
-            'engine_version' => trim((string) ($context['engine_version'] ?? data_get($reportPayload, 'versions.engine', ''))),
-            'content_package_dir' => trim((string) ($context['dir_version'] ?? data_get($reportPayload, 'versions.dir_version', ''))),
-            'dynamic_sections_version' => trim((string) ($dynamicDoc['version'] ?? '')),
-        ], (bool) ($context['has_unlock'] ?? false));
+        return $this->readModelContractService->attachContract(
+            $this->userStateOrchestrationService->withBaseline([
+                'schema_version' => 'mbti.personalization.phase8c.v1',
+                'locale' => $locale,
+                'type_code' => $typeCode,
+                'identity' => $identity,
+                'axis_vector' => $axisVector,
+                'axis_bands' => $axisBands,
+                'boundary_flags' => $boundaryFlags,
+                'dominant_axes' => $dominantAxes,
+                'scene_fingerprint' => $sceneFingerprint,
+                'explainability_summary' => $explainabilityAuthority['explainability_summary'],
+                'close_call_axes' => $explainabilityAuthority['close_call_axes'],
+                'neighbor_type_keys' => $explainabilityAuthority['neighbor_type_keys'],
+                'contrast_keys' => $explainabilityAuthority['contrast_keys'],
+                'confidence_or_stability_keys' => $explainabilityAuthority['confidence_or_stability_keys'],
+                'work_style_keys' => array_values((array) data_get($sceneFingerprint, 'work.style_keys', [])),
+                'relationship_style_keys' => array_values((array) data_get($sceneFingerprint, 'relationships.style_keys', [])),
+                'decision_style_keys' => array_values((array) data_get($sceneFingerprint, 'decision.style_keys', [])),
+                'stress_recovery_keys' => array_values((array) data_get($sceneFingerprint, 'stress_recovery.style_keys', [])),
+                'communication_style_keys' => array_values((array) data_get($sceneFingerprint, 'communication.style_keys', [])),
+                'work_style_summary' => $careerBridgeAuthority['work_style_summary'],
+                'role_fit_keys' => $careerBridgeAuthority['role_fit_keys'],
+                'collaboration_fit_keys' => $careerBridgeAuthority['collaboration_fit_keys'],
+                'work_env_preference_keys' => $careerBridgeAuthority['work_env_preference_keys'],
+                'career_next_step_keys' => $careerBridgeAuthority['career_next_step_keys'],
+                'action_plan_summary' => $actionAuthority['action_plan_summary'],
+                'weekly_action_keys' => $actionAuthority['weekly_action_keys'],
+                'relationship_action_keys' => $actionAuthority['relationship_action_keys'],
+                'work_experiment_keys' => $actionAuthority['work_experiment_keys'],
+                'watchout_keys' => $actionAuthority['watchout_keys'],
+                'recommended_read_candidates' => $this->extractRecommendationCandidates($reportPayload),
+                'variant_keys' => $variantKeys,
+                'sections' => $sectionVariants,
+                'pack_id' => trim((string) ($context['pack_id'] ?? data_get($reportPayload, 'versions.content_pack_id', ''))),
+                'engine_version' => trim((string) ($context['engine_version'] ?? data_get($reportPayload, 'versions.engine', ''))),
+                'content_package_dir' => trim((string) ($context['dir_version'] ?? data_get($reportPayload, 'versions.dir_version', ''))),
+                'dynamic_sections_version' => trim((string) ($dynamicDoc['version'] ?? '')),
+            ], (bool) ($context['has_unlock'] ?? false))
+        );
     }
 
     /**

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -636,6 +636,9 @@ class ShareService
         $resolvedShareId = trim((string) $shareId);
         $locale = (string) ($summary['locale'] ?? 'zh-CN');
         $compareEnabled = strtoupper((string) ($summary['scale_code'] ?? '')) === 'MBTI';
+        $readContract = is_array(data_get($publicSafeReport, '_meta.personalization.read_contract_v1'))
+            ? data_get($publicSafeReport, '_meta.personalization.read_contract_v1')
+            : null;
         $payload = [
             'share_id' => $resolvedShareId !== '' ? $resolvedShareId : null,
             'share_url' => $resolvedShareId !== '' ? $this->buildLocalizedShareUrl($resolvedShareId, $locale) : null,
@@ -662,6 +665,10 @@ class ShareService
                 ? $this->resolveCompareCtaLabel($locale)
                 : null,
         ];
+
+        if (is_array($readContract)) {
+            $payload['mbti_read_contract_v1'] = $readContract;
+        }
 
         if ($compareEnabled) {
             $payload['mbti_public_summary_v1'] = $this->mbtiPublicSummaryV1Builder->buildFromSharePayload(

--- a/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+++ b/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
@@ -114,6 +114,14 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
         $this->assertIsString((string) data_get($payload, 'report._meta.personalization.reading_focus_key', ''));
         $this->assertIsString((string) data_get($payload, 'report._meta.personalization.action_focus_key', ''));
         $this->assertSame(
+            'mbti.read_contract.v1',
+            data_get($payload, 'report._meta.personalization.read_contract_v1.version')
+        );
+        $this->assertContains(
+            'user_state',
+            data_get($payload, 'report._meta.personalization.read_contract_v1.overlay_patch.personalization_fields', [])
+        );
+        $this->assertSame(
             [
                 'is_first_view' => true,
                 'is_revisit' => false,
@@ -359,6 +367,10 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
         $this->assertSame(
             'phase8c.v1',
             data_get($projection, '_meta.personalization.dynamic_sections_version')
+        );
+        $this->assertSame(
+            data_get($roundTrippedReport, '_meta.personalization.read_contract_v1'),
+            data_get($projection, '_meta.personalization.read_contract_v1')
         );
         $this->assertSame(
             data_get($roundTrippedReport, '_meta.personalization.ordered_recommendation_keys'),

--- a/backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Http\Controllers\API\V0_3\AttemptReadController;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Report\Composer\ReportComposeContext;
+use App\Services\Report\Composer\ReportPayloadAssembler;
+use App\Support\OrgContext;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiReadPathParityContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_report_read_keeps_canonical_fields_stable_and_limits_overlay_to_contract_fields(): void
+    {
+        $this->seedScales();
+        Config::set('fap_experiments.experiments', []);
+
+        $anonId = 'mbti_read_path_parity_anon';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $attempt = Attempt::query()->findOrFail($attemptId);
+        $result = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
+
+        $canonicalPayload = app(ReportPayloadAssembler::class)->assemble(
+            ReportComposeContext::fromAttempt($attempt, $result, [
+                'org_id' => 0,
+                'variant' => 'free',
+                'report_access_level' => 'free',
+                'modules_allowed' => [],
+                'modules_preview' => [],
+                'persist' => false,
+                'strict' => false,
+                'explain' => false,
+            ])
+        );
+
+        $this->assertTrue((bool) ($canonicalPayload['ok'] ?? false));
+        $canonicalPersonalization = (array) data_get($canonicalPayload, 'report._meta.personalization', []);
+        $this->assertSame('mbti.read_contract.v1', data_get($canonicalPersonalization, 'read_contract_v1.version'));
+
+        $this->seedOverlaySignals($attemptId, $anonId);
+        $response = $this->invokeController('report', $attemptId, $anonId);
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $effectiveReportPersonalization = (array) $response->getData(true)['report']['_meta']['personalization'];
+        $effectiveProjectionPersonalization = (array) $response->getData(true)['mbti_public_projection_v1']['_meta']['personalization'];
+        $readContract = (array) data_get($effectiveReportPersonalization, 'read_contract_v1', []);
+
+        $this->assertSame('mbti.read_contract.v1', $readContract['version'] ?? null);
+        $this->assertSame($readContract, (array) ($response->getData(true)['mbti_read_contract_v1'] ?? []));
+
+        foreach ((array) data_get($readContract, 'canonical_read_model.personalization_fields', []) as $field) {
+            $this->assertSame(
+                data_get($canonicalPersonalization, $field),
+                data_get($effectiveReportPersonalization, $field),
+                'canonical field drifted during read overlay: '.$field
+            );
+        }
+
+        foreach (array_merge(
+            (array) data_get($readContract, 'canonical_read_model.personalization_fields', []),
+            (array) data_get($readContract, 'overlay_patch.personalization_fields', [])
+        ) as $field) {
+            $this->assertSame(
+                data_get($effectiveReportPersonalization, $field),
+                data_get($effectiveProjectionPersonalization, $field),
+                'report/projection parity mismatch: '.$field
+            );
+        }
+
+        $this->assertSame(false, data_get($canonicalPersonalization, 'user_state.has_feedback'));
+        $this->assertSame(true, data_get($effectiveReportPersonalization, 'user_state.has_feedback'));
+        $this->assertSame(true, data_get($effectiveReportPersonalization, 'user_state.has_share'));
+        $this->assertSame(true, data_get($effectiveReportPersonalization, 'user_state.has_action_engagement'));
+        $this->assertContains(
+            'report._meta.personalization.user_state',
+            (array) data_get($readContract, 'non_cacheable_fields', [])
+        );
+        $this->assertContains(
+            'mbti_public_projection_v1._meta.personalization.continuity',
+            (array) data_get($readContract, 'non_cacheable_fields', [])
+        );
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_code_v2' => 'MBTI',
+            'scale_uid' => 'mbti',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI',
+            'scale_uid' => 'mbti',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'raw_score' => 0,
+                'final_score' => 0,
+                'breakdown_json' => [],
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'report_phase4a_contract',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function invokeController(string $method, string $attemptId, string $anonId): \Illuminate\Http\JsonResponse
+    {
+        $path = "/api/v0.3/attempts/{$attemptId}/" . ($method === 'report' ? 'report' : 'result');
+        $request = Request::create($path, 'GET');
+        $request->headers->set('X-Anon-Id', $anonId);
+        $request->attributes->set('anon_id', $anonId);
+        $request->attributes->set('org_context_resolved', true);
+        $request->attributes->set('org_context_kind', OrgContext::KIND_PUBLIC);
+
+        $this->app->instance('request', $request);
+        app(OrgContext::class)->set(0, null, 'public', $anonId, OrgContext::KIND_PUBLIC);
+
+        /** @var AttemptReadController $controller */
+        $controller = app(AttemptReadController::class);
+
+        return $controller->{$method}($request, $attemptId);
+    }
+
+    private function seedOverlaySignals(string $attemptId, string $anonId): void
+    {
+        DB::table('events')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'accuracy_feedback',
+                'event_name' => 'accuracy_feedback',
+                'org_id' => 0,
+                'attempt_id' => $attemptId,
+                'meta_json' => json_encode([
+                    'sectionKey' => 'growth.stability_confidence',
+                    'feedback' => 'unclear',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(10),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 0,
+                'attempt_id' => $attemptId,
+                'meta_json' => json_encode([
+                    'sectionKey' => 'traits.close_call_axes',
+                    'interaction' => 'dwell_2500ms',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(9),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'ui_card_interaction',
+                'event_name' => 'ui_card_interaction',
+                'org_id' => 0,
+                'attempt_id' => $attemptId,
+                'meta_json' => json_encode([
+                    'sectionKey' => 'growth.next_actions',
+                    'actionKey' => 'weekly_action.theme.name_decision_rule',
+                    'interaction' => 'click',
+                ], JSON_UNESCAPED_UNICODE),
+                'occurred_at' => now()->subMinutes(8),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        DB::table('shares')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'v0.3',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -70,6 +70,8 @@ final class ShareSummaryContractTest extends TestCase
         $this->assertSame('growth.next_actions', $response->json('mbti_continuity_v1.carryover_focus_key'));
         $this->assertSame('unlock_to_continue_focus', $response->json('mbti_continuity_v1.carryover_reason'));
         $this->assertSame(['growth.next_actions', 'traits.close_call_axes', 'traits.adjacent_type_contrast'], $response->json('mbti_continuity_v1.recommended_resume_keys'));
+        $this->assertSame('mbti.read_contract.v1', $response->json('mbti_read_contract_v1.version'));
+        $this->assertContains('report._meta.personalization.user_state', $response->json('mbti_read_contract_v1.non_cacheable_fields'));
         $this->assertSame($response->json('type_code'), $response->json('mbti_public_projection_v1.display_type'));
         $this->assertSame($response->json('type_name'), $response->json('mbti_public_projection_v1.profile.type_name'));
         $this->assertSame($response->json('dimensions'), $response->json('mbti_public_projection_v1.dimensions'));
@@ -135,6 +137,7 @@ final class ShareSummaryContractTest extends TestCase
             'dimensions',
             'primary_cta_label',
             'primary_cta_path',
+            'mbti_read_contract_v1',
             'mbti_continuity_v1',
             'mbti_public_summary_v1',
             'mbti_public_projection_v1',

--- a/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mbti;
+
+use App\Services\Mbti\MbtiReadModelContractService;
+use Tests\TestCase;
+
+final class MbtiReadModelContractServiceTest extends TestCase
+{
+    public function test_build_contract_exposes_canonical_overlay_and_cache_boundaries(): void
+    {
+        $service = app(MbtiReadModelContractService::class);
+
+        $contract = $service->buildContract([
+            'schema_version' => 'mbti.personalization.phase8c.v1',
+            'identity' => 'A',
+            'variant_keys' => ['overview' => 'overview:clear'],
+            'scene_fingerprint' => ['work' => ['style_key' => 'work.primary.EI.E.clear']],
+            'user_state' => ['is_first_view' => true],
+            'orchestration' => ['primary_focus_key' => 'growth.next_actions'],
+            'continuity' => ['carryover_focus_key' => 'growth.next_actions'],
+            'ordered_recommendation_keys' => ['read-action'],
+            'reading_focus_key' => 'read-action',
+        ]);
+
+        $this->assertSame('mbti.read_contract.v1', $contract['version']);
+        $this->assertContains('identity', $contract['canonical_read_model']['personalization_fields']);
+        $this->assertContains('variant_keys', $contract['canonical_read_model']['personalization_fields']);
+        $this->assertNotContains('user_state', $contract['canonical_read_model']['personalization_fields']);
+        $this->assertSame(
+            [
+                'user_state',
+                'orchestration',
+                'ordered_recommendation_keys',
+                'ordered_action_keys',
+                'recommendation_priority_keys',
+                'action_priority_keys',
+                'reading_focus_key',
+                'action_focus_key',
+                'continuity',
+            ],
+            $contract['overlay_patch']['personalization_fields']
+        );
+        $this->assertContains('report.sections', $contract['cacheable_fields']);
+        $this->assertContains('report._meta.personalization.user_state', $contract['non_cacheable_fields']);
+        $this->assertContains('mbti_public_projection_v1._meta.personalization.continuity', $contract['non_cacheable_fields']);
+        $this->assertContains('user_state', $contract['telemetry_parity_fields']);
+        $this->assertContains('continuity.carryover_focus_key', $contract['telemetry_parity_fields']);
+    }
+
+    public function test_apply_overlay_patch_preserves_canonical_fields_and_replaces_only_overlay_fields(): void
+    {
+        $service = app(MbtiReadModelContractService::class);
+
+        $canonical = [
+            'identity' => 'A',
+            'action_plan_summary' => 'Canonical summary',
+            'user_state' => ['is_first_view' => true],
+            'orchestration' => ['primary_focus_key' => 'growth.next_actions'],
+            'continuity' => ['carryover_focus_key' => 'growth.next_actions'],
+            'ordered_recommendation_keys' => ['read-action'],
+        ];
+
+        $effective = [
+            'identity' => 'T',
+            'action_plan_summary' => 'Overlay must not rewrite canonical text',
+            'user_state' => ['is_first_view' => false, 'is_revisit' => true],
+            'orchestration' => ['primary_focus_key' => 'traits.close_call_axes'],
+            'continuity' => ['carryover_focus_key' => 'traits.close_call_axes'],
+            'ordered_recommendation_keys' => ['read-explain'],
+        ];
+
+        $merged = $service->applyOverlayPatch($canonical, $effective);
+
+        $this->assertSame('A', $merged['identity']);
+        $this->assertSame('Canonical summary', $merged['action_plan_summary']);
+        $this->assertSame(['is_first_view' => false, 'is_revisit' => true], $merged['user_state']);
+        $this->assertSame(['primary_focus_key' => 'traits.close_call_axes'], $merged['orchestration']);
+        $this->assertSame(['carryover_focus_key' => 'traits.close_call_axes'], $merged['continuity']);
+        $this->assertSame(['read-explain'], $merged['ordered_recommendation_keys']);
+        $this->assertSame('mbti.read_contract.v1', data_get($merged, 'read_contract_v1.version'));
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of MBTI PR-8E: edge read path and replay performance.

The MBTI stack already had strong authority for result explanation, continuity, recommendation/action orchestration, deepened user state, and content governance. What was still missing was a hardened read-path contract that explicitly defines what is canonical, what can be overlaid at read time, and what must stay non-cacheable.

This PR closes that gap by introducing a formal MBTI read-model contract and applying read-time personalization as a constrained overlay patch instead of an implicit overwrite.

## Problem

Before this change, the MBTI read path was already powerful, but its boundary rules were still too implicit.

That created several risks:

- canonical result fields and read-time overlay fields were not explicitly separated
- report/projection/share surfaces could drift in how they exposed replay metadata
- telemetry parity relied on convention instead of a formal contract
- future cache/replay work had no concrete contract to lock against

The result was a system that mostly behaved correctly, but whose replay and overlay guarantees were not yet explicit enough for long-term scale.

## Root Cause

The repo already had the ingredients needed for a clean solution:

- canonical snapshot/report/projection authority
- read-time user-state/orchestration/continuity overlays
- share/public-safe read paths

What was missing was a dedicated service that would formalize:

- canonical personalization fields
- overlay personalization fields
- cacheable surface fields
- non-cacheable surface fields
- telemetry parity fields

Without that contract, read-time behavior stayed partially implicit and harder to audit.

## Fix

This PR introduces `MbtiReadModelContractService` and formalizes `mbti.read_contract.v1`.

The contract now explicitly defines:

- `canonical_read_model`
- `overlay_patch`
- `cacheable_fields`
- `non_cacheable_fields`
- `telemetry_parity_fields`

The read path now applies effective MBTI personalization as a constrained overlay patch on top of canonical report/projection personalization, instead of replacing the whole personalization envelope.

This keeps canonical result truth stable while allowing read-time state/order/carryover fields to update safely.

The contract is also surfaced on both:

- report reads via top-level `mbti_read_contract_v1`
- share/public-safe reads via top-level `mbti_read_contract_v1`

To lock this behavior down, the PR adds targeted parity and unit coverage that checks:

- canonical fields do not drift during overlay
- report/projection personalization stay aligned after overlay
- read-contract metadata is exposed on report/share payloads
- cacheability and telemetry parity boundaries remain explicit

## User Impact

This is an infrastructure-heavy PR, but it directly improves stability and debuggability.

After this change:

- canonical MBTI result truth is harder to accidentally mutate at read time
- read overlays are more auditable
- share/report surfaces have a clearer replay contract
- future cache and replay work can build on an explicit boundary instead of inference

## Validation

I ran:

- `php artisan test tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php tests/Feature/V0_3/MbtiReadPathParityContractTest.php tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php tests/Feature/V0_3/MbtiResultTelemetryContractTest.php tests/Feature/V0_3/ShareSummaryContractTest.php`

All passed:

- 8 tests passed
- 516 assertions

## Scope Note

This PR is intentionally limited to MBTI read-path contract, parity, and replay correctness on the backend.

It does not change payment/checkout, CMS/AIC, other scales, or require migration or new dependencies.

It also intentionally excludes unrelated local dirty changes already present in the repo, especially:

- `backend/app/Console/Commands/PacksPublish.php`
- `backend/app/Console/Commands/PacksRollback.php`
- `backend/app/Services/Experiments/ExperimentAssigner.php`
- `backend/content_packs/BIG5_OCEAN/v1/compiled/*`
- `backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php`
