### PR TITLE
[codex] add exact release file-set authority and historical backfill

### DIFF
--- a/backend/app/Console/Commands/StorageBackfillExactReleaseFileSets.php
+++ b/backend/app/Console/Commands/StorageBackfillExactReleaseFileSets.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\ExactReleaseFileSetCatalogService;
+use App\Services\Storage\ReleaseStorageLocator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageBackfillExactReleaseFileSets extends Command
+{
+    protected $signature = 'storage:backfill-exact-release-file-sets
+        {--dry-run : Scan only and report exact file-set coverage}
+        {--execute : Execute idempotent exact file-set backfill}';
+
+    protected $description = 'Backfill exact content release file-set authority from physical compiled roots without changing runtime readers.';
+
+    public function __construct(
+        private readonly ExactReleaseFileSetCatalogService $catalogService,
+        private readonly ReleaseStorageLocator $releaseStorageLocator,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $payload = $this->runBackfill($execute);
+        $warningCount = is_array($payload['warnings'] ?? null) ? count($payload['warnings']) : 0;
+
+        $this->line('status='.(($payload['mode'] ?? '') === 'execute' ? 'executed' : 'planned'));
+        $this->line('mode='.(string) ($payload['mode'] ?? ''));
+        $this->line('release_rows_scanned='.(int) ($payload['release_rows_scanned'] ?? 0));
+        if (($payload['mode'] ?? '') === 'execute') {
+            $this->line('release_rows_backfilled='.(int) ($payload['release_rows_backfilled'] ?? 0));
+            $this->line('backup_roots_backfilled='.(int) ($payload['backup_roots_backfilled'] ?? 0));
+            $this->line('exact_manifests_upserted='.(int) ($payload['exact_manifests_upserted'] ?? 0));
+            $this->line('exact_manifest_files_synced='.(int) ($payload['exact_manifest_files_synced'] ?? 0));
+        } else {
+            $this->line('release_rows_backfillable='.(int) ($payload['release_rows_backfillable'] ?? 0));
+            $this->line('backup_roots_backfillable='.(int) ($payload['backup_roots_backfillable'] ?? 0));
+        }
+        $this->line('warnings='.$warningCount);
+
+        $this->recordAudit($payload);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{
+     *   schema_version:int,
+     *   mode:string,
+     *   generated_at:string,
+     *   release_rows_scanned:int,
+     *   release_rows_backfillable:int,
+     *   release_rows_backfilled:int,
+     *   release_rows_skipped:int,
+     *   backup_roots_scanned:int,
+     *   backup_roots_backfillable:int,
+     *   backup_roots_backfilled:int,
+     *   exact_manifests_upserted:int,
+     *   exact_manifest_files_synced:int,
+     *   missing_physical_sources:int,
+     *   warnings:list<string>
+     * }
+     */
+    private function runBackfill(bool $execute): array
+    {
+        $summary = [
+            'schema_version' => 1,
+            'mode' => $execute ? 'execute' : 'dry_run',
+            'generated_at' => now()->toAtomString(),
+            'release_rows_scanned' => 0,
+            'release_rows_backfillable' => 0,
+            'release_rows_backfilled' => 0,
+            'release_rows_skipped' => 0,
+            'backup_roots_scanned' => 0,
+            'backup_roots_backfillable' => 0,
+            'backup_roots_backfilled' => 0,
+            'exact_manifests_upserted' => 0,
+            'exact_manifest_files_synced' => 0,
+            'missing_physical_sources' => 0,
+            'warnings' => [],
+        ];
+        $processedRoots = [];
+
+        $releases = DB::table('content_pack_releases')
+            ->where('status', 'success')
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get();
+
+        foreach ($releases as $release) {
+            $this->processRelease($release, $execute, $summary, $processedRoots);
+        }
+
+        foreach ($this->releaseStorageLocator->legacyBackupRoots() as $backupRoot) {
+            $normalizedRoot = $this->normalizeRoot($backupRoot);
+            if ($normalizedRoot === '' || isset($processedRoots[$normalizedRoot])) {
+                continue;
+            }
+
+            $this->processBackupRoot($backupRoot, $execute, $summary, $processedRoots);
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @param  array<string,bool>  $processedRoots
+     */
+    private function processRelease(object $release, bool $execute, array &$summary, array &$processedRoots): void
+    {
+        $summary['release_rows_scanned']++;
+
+        $source = $this->releaseStorageLocator->resolveReleaseSource($release);
+        if ($source === null) {
+            $summary['release_rows_skipped']++;
+            $summary['missing_physical_sources']++;
+            $this->appendWarning($summary, 'missing physical source for release '.trim((string) ($release->id ?? '')));
+
+            return;
+        }
+
+        $normalizedRoot = $this->normalizeRoot((string) $source['root']);
+
+        $compiledFiles = $this->releaseStorageLocator->collectCompiledFilesFromRoot((string) $source['root']);
+        $manifestMeta = $this->releaseStorageLocator->readManifestMetadataFromRoot((string) $source['root']);
+        $manifestHash = trim((string) ($manifestMeta['manifest_hash'] ?? ''));
+        if ($compiledFiles === [] || $manifestHash === '') {
+            $summary['release_rows_skipped']++;
+            $summary['missing_physical_sources']++;
+            $this->appendWarning($summary, 'exact file-set unavailable for release '.trim((string) ($release->id ?? '')));
+
+            return;
+        }
+
+        $summary['release_rows_backfillable']++;
+        if (! $execute) {
+            if ($normalizedRoot !== '') {
+                $processedRoots[$normalizedRoot] = true;
+            }
+
+            return;
+        }
+
+        try {
+            $this->catalogService->upsertExactManifest($this->buildManifestPayload(
+                release: $release,
+                root: (string) $source['root'],
+                sourceKind: $this->sourceKindForRoot((string) $source['root'], (string) ($source['resolved_from'] ?? '')),
+                manifestMeta: $manifestMeta
+            ), $this->buildFilePayloads($compiledFiles));
+            if ($normalizedRoot !== '') {
+                $processedRoots[$normalizedRoot] = true;
+            }
+            $summary['exact_manifests_upserted']++;
+            $summary['exact_manifest_files_synced'] += count($compiledFiles);
+            $summary['release_rows_backfilled']++;
+        } catch (\Throwable $e) {
+            $this->appendWarning($summary, 'release exact seal failed for '.trim((string) ($release->id ?? '')).': '.$e->getMessage());
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @param  array<string,bool>  $processedRoots
+     */
+    private function processBackupRoot(string $backupRoot, bool $execute, array &$summary, array &$processedRoots): void
+    {
+        $normalizedRoot = $this->normalizeRoot($backupRoot);
+        if ($normalizedRoot === '') {
+            return;
+        }
+
+        $processedRoots[$normalizedRoot] = true;
+        $summary['backup_roots_scanned']++;
+
+        $compiledFiles = $this->releaseStorageLocator->collectCompiledFilesFromRoot($backupRoot);
+        $manifestMeta = $this->releaseStorageLocator->readManifestMetadataFromRoot($backupRoot);
+        $manifestHash = trim((string) ($manifestMeta['manifest_hash'] ?? ''));
+        if ($compiledFiles === [] || $manifestHash === '') {
+            $summary['missing_physical_sources']++;
+            $this->appendWarning($summary, 'exact file-set unavailable for backup root '.$backupRoot);
+
+            return;
+        }
+
+        $summary['backup_roots_backfillable']++;
+        if (! $execute) {
+            return;
+        }
+
+        $backupContext = $this->releaseStorageLocator->backupRootContext($backupRoot);
+        $contentPackReleaseId = trim((string) ($backupContext['release_id'] ?? ''));
+        if ($contentPackReleaseId !== '' && ! DB::table('content_pack_releases')->where('id', $contentPackReleaseId)->exists()) {
+            $contentPackReleaseId = '';
+        }
+
+        try {
+            $this->catalogService->upsertExactManifest([
+                'content_pack_release_id' => $contentPackReleaseId !== '' ? $contentPackReleaseId : null,
+                'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+                'source_kind' => $this->sourceKindForBackupRoot($backupRoot),
+                'source_disk' => 'local',
+                'source_storage_path' => $normalizedRoot,
+                'manifest_hash' => $manifestHash,
+                'pack_id' => strtoupper(trim((string) ($manifestMeta['pack_id'] ?? ''))) ?: null,
+                'pack_version' => trim((string) ($manifestMeta['pack_version'] ?? '')) ?: null,
+                'compiled_hash' => trim((string) ($manifestMeta['compiled_hash'] ?? '')) ?: null,
+                'content_hash' => trim((string) ($manifestMeta['content_hash'] ?? '')) ?: null,
+                'norms_version' => trim((string) ($manifestMeta['norms_version'] ?? '')) ?: null,
+                'source_commit' => null,
+                'payload_json' => $manifestMeta['decoded'] !== [] ? $manifestMeta['decoded'] : null,
+                'sealed_at' => now(),
+                'last_verified_at' => now(),
+            ], $this->buildFilePayloads($compiledFiles));
+            $summary['exact_manifests_upserted']++;
+            $summary['exact_manifest_files_synced'] += count($compiledFiles);
+            $summary['backup_roots_backfilled']++;
+        } catch (\Throwable $e) {
+            $this->appendWarning($summary, 'backup exact seal failed for '.$backupRoot.': '.$e->getMessage());
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifestMeta
+     * @return array<string,mixed>
+     */
+    private function buildManifestPayload(object $release, string $root, string $sourceKind, array $manifestMeta): array
+    {
+        return [
+            'content_pack_release_id' => trim((string) ($release->id ?? '')) ?: null,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => $sourceKind,
+            'source_disk' => 'local',
+            'source_storage_path' => $this->normalizeRoot($root),
+            'manifest_hash' => trim((string) ($manifestMeta['manifest_hash'] ?? '')),
+            'pack_id' => strtoupper(trim((string) ($release->to_pack_id ?? $manifestMeta['pack_id'] ?? ''))) ?: null,
+            'pack_version' => $this->derivePackVersion($release, $manifestMeta['decoded']),
+            'compiled_hash' => trim((string) ($release->compiled_hash ?? $manifestMeta['compiled_hash'] ?? '')) ?: null,
+            'content_hash' => trim((string) ($release->content_hash ?? $manifestMeta['content_hash'] ?? '')) ?: null,
+            'norms_version' => trim((string) ($release->norms_version ?? $manifestMeta['norms_version'] ?? '')) ?: null,
+            'source_commit' => trim((string) ($release->source_commit ?? $release->git_sha ?? '')) ?: null,
+            'payload_json' => $manifestMeta['decoded'] !== [] ? $manifestMeta['decoded'] : null,
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ];
+    }
+
+    /**
+     * @param  list<array{logical_path:string,hash:string,size_bytes:int,content_type:?string,role:?string}>  $compiledFiles
+     * @return list<array<string,mixed>>
+     */
+    private function buildFilePayloads(array $compiledFiles): array
+    {
+        $files = [];
+        foreach ($compiledFiles as $file) {
+            $files[] = [
+                'logical_path' => $file['logical_path'],
+                'blob_hash' => $file['hash'],
+                'size_bytes' => $file['size_bytes'],
+                'role' => $file['role'],
+                'content_type' => $file['content_type'],
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.$file['hash'],
+            ];
+        }
+
+        return $files;
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifest
+     */
+    private function derivePackVersion(object $release, array $manifest): ?string
+    {
+        $version = trim((string) ($release->pack_version ?? ''));
+        if ($version !== '') {
+            return $version;
+        }
+
+        $version = trim((string) ($manifest['pack_version'] ?? $manifest['content_package_version'] ?? ''));
+        if ($version !== '') {
+            return $version;
+        }
+
+        $toVersionId = trim((string) ($release->to_version_id ?? ''));
+        if ($toVersionId !== '') {
+            $versionRow = DB::table('content_pack_versions')->where('id', $toVersionId)->first();
+            if ($versionRow !== null) {
+                $version = trim((string) ($versionRow->content_package_version ?? ''));
+                if ($version !== '') {
+                    return $version;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function sourceKindForRoot(string $root, string $resolvedFrom): string
+    {
+        $normalizedRoot = $this->normalizeRoot($root);
+        $backupsPrefix = $this->normalizeRoot(storage_path('app/private/content_releases/backups')).'/';
+        if (str_starts_with($normalizedRoot, $backupsPrefix)) {
+            return $this->sourceKindForBackupRoot($root);
+        }
+
+        if (preg_match('#/content_releases/[^/]+/source_pack$#', $normalizedRoot) === 1) {
+            return 'legacy.source_pack';
+        }
+
+        if (preg_match('#/app/private/packs_v2/#', $normalizedRoot) === 1) {
+            return 'v2.primary';
+        }
+
+        if (preg_match('#/app/content_packs_v2/#', $normalizedRoot) === 1) {
+            return 'v2.mirror';
+        }
+
+        return $resolvedFrom !== '' ? $resolvedFrom : 'release.root';
+    }
+
+    private function sourceKindForBackupRoot(string $root): string
+    {
+        $context = $this->releaseStorageLocator->backupRootContext($root);
+
+        return match ((string) ($context['leaf'] ?? '')) {
+            'previous_pack' => 'legacy.previous_pack',
+            'current_pack' => 'legacy.current_pack',
+            default => 'legacy.backup_root',
+        };
+    }
+
+    private function normalizeRoot(string $root): string
+    {
+        return str_replace('\\', '/', rtrim(trim($root), '/\\'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function appendWarning(array &$summary, string $message): void
+    {
+        if (count($summary['warnings']) < 20) {
+            $summary['warnings'][] = $message;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_backfill_exact_release_file_sets',
+            'target_type' => 'storage',
+            'target_id' => 'exact_release_file_sets',
+            'meta_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_backfill_exact_release_file_sets',
+            'request_id' => null,
+            'reason' => 'exact_release_file_set_backfill',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/app/Models/ContentReleaseExactManifest.php
+++ b/backend/app/Models/ContentReleaseExactManifest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ContentReleaseExactManifest extends Model
+{
+    protected $table = 'content_release_exact_manifests';
+
+    protected $fillable = [
+        'content_pack_release_id',
+        'source_identity_hash',
+        'manifest_hash',
+        'exact_identity_hash',
+        'schema_version',
+        'source_kind',
+        'source_disk',
+        'source_storage_path',
+        'pack_id',
+        'pack_version',
+        'compiled_hash',
+        'content_hash',
+        'norms_version',
+        'source_commit',
+        'file_count',
+        'total_size_bytes',
+        'payload_json',
+        'sealed_at',
+        'last_verified_at',
+    ];
+
+    protected $casts = [
+        'file_count' => 'integer',
+        'total_size_bytes' => 'integer',
+        'payload_json' => 'array',
+        'sealed_at' => 'datetime',
+        'last_verified_at' => 'datetime',
+    ];
+
+    public function release(): BelongsTo
+    {
+        return $this->belongsTo(ContentPackRelease::class, 'content_pack_release_id', 'id');
+    }
+
+    public function files(): HasMany
+    {
+        return $this->hasMany(ContentReleaseExactManifestFile::class, 'content_release_exact_manifest_id', 'id');
+    }
+}

--- a/backend/app/Models/ContentReleaseExactManifestFile.php
+++ b/backend/app/Models/ContentReleaseExactManifestFile.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ContentReleaseExactManifestFile extends Model
+{
+    protected $table = 'content_release_exact_manifest_files';
+
+    protected $fillable = [
+        'content_release_exact_manifest_id',
+        'logical_path',
+        'blob_hash',
+        'size_bytes',
+        'role',
+        'content_type',
+        'encoding',
+        'checksum',
+    ];
+
+    protected $casts = [
+        'size_bytes' => 'integer',
+    ];
+
+    public function manifest(): BelongsTo
+    {
+        return $this->belongsTo(ContentReleaseExactManifest::class, 'content_release_exact_manifest_id', 'id');
+    }
+}

--- a/backend/app/Services/Storage/ExactReleaseFileSetCatalogService.php
+++ b/backend/app/Services/Storage/ExactReleaseFileSetCatalogService.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\ContentReleaseExactManifest;
+use App\Models\ContentReleaseExactManifestFile;
+use Illuminate\Support\Facades\DB;
+
+final class ExactReleaseFileSetCatalogService
+{
+    public function upsertExactManifest(array $manifest, array $files = []): ContentReleaseExactManifest
+    {
+        $manifestHash = trim((string) ($manifest['manifest_hash'] ?? ''));
+        if ($manifestHash === '') {
+            throw new \InvalidArgumentException('manifest_hash is required');
+        }
+
+        $sourceKind = trim((string) ($manifest['source_kind'] ?? ''));
+        if ($sourceKind === '') {
+            throw new \InvalidArgumentException('source_kind is required');
+        }
+
+        $sourceDisk = trim((string) ($manifest['source_disk'] ?? 'local'));
+        $sourceStoragePath = $this->normalizeStoragePath((string) ($manifest['source_storage_path'] ?? ''));
+        if ($sourceStoragePath === '') {
+            throw new \InvalidArgumentException('source_storage_path is required');
+        }
+
+        $packId = $this->normalizePackId($manifest['pack_id'] ?? null);
+        $packVersion = $this->normalizeNullableString($manifest['pack_version'] ?? null);
+        $sourceIdentityHash = trim((string) ($manifest['source_identity_hash'] ?? ''));
+        if ($sourceIdentityHash === '') {
+            $sourceIdentityHash = $this->sourceIdentityHash($sourceKind, $sourceDisk, $sourceStoragePath);
+        }
+        $exactIdentityHash = trim((string) ($manifest['exact_identity_hash'] ?? ''));
+        if ($exactIdentityHash === '') {
+            $exactIdentityHash = $this->exactIdentityHash($packId, $packVersion, $sourceKind, $sourceDisk, $sourceStoragePath, $manifestHash);
+        }
+
+        $normalizedFiles = [];
+        foreach ($files as $file) {
+            $logicalPath = trim((string) ($file['logical_path'] ?? ''));
+            if ($logicalPath === '') {
+                continue;
+            }
+
+            $normalizedFiles[$logicalPath] = [
+                'blob_hash' => trim((string) ($file['blob_hash'] ?? '')),
+                'size_bytes' => (int) ($file['size_bytes'] ?? 0),
+                'role' => $file['role'] ?? null,
+                'content_type' => $file['content_type'] ?? null,
+                'encoding' => (string) ($file['encoding'] ?? 'identity'),
+                'checksum' => $file['checksum'] ?? null,
+            ];
+        }
+
+        return DB::transaction(function () use ($exactIdentityHash, $manifest, $manifestHash, $normalizedFiles, $packId, $packVersion, $sourceDisk, $sourceIdentityHash, $sourceKind, $sourceStoragePath): ContentReleaseExactManifest {
+            $existing = ContentReleaseExactManifest::query()
+                ->where('exact_identity_hash', $exactIdentityHash)
+                ->first();
+
+            $record = $existing ?? new ContentReleaseExactManifest([
+                'source_identity_hash' => $sourceIdentityHash,
+                'manifest_hash' => $manifestHash,
+                'exact_identity_hash' => $exactIdentityHash,
+            ]);
+
+            $record->fill([
+                'content_pack_release_id' => $this->preferredReleaseId($existing?->content_pack_release_id, $manifest['content_pack_release_id'] ?? null),
+                'source_identity_hash' => $sourceIdentityHash,
+                'exact_identity_hash' => $exactIdentityHash,
+                'schema_version' => (string) ($manifest['schema_version'] ?? config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1')),
+                'source_kind' => $sourceKind,
+                'source_disk' => $sourceDisk,
+                'source_storage_path' => $sourceStoragePath,
+                'pack_id' => $packId,
+                'pack_version' => $packVersion,
+                'compiled_hash' => $manifest['compiled_hash'] ?? null,
+                'content_hash' => $manifest['content_hash'] ?? null,
+                'norms_version' => $manifest['norms_version'] ?? null,
+                'source_commit' => $manifest['source_commit'] ?? null,
+                'file_count' => count($normalizedFiles),
+                'total_size_bytes' => array_sum(array_column($normalizedFiles, 'size_bytes')),
+                'payload_json' => array_key_exists('payload_json', $manifest) ? $manifest['payload_json'] : $existing?->payload_json,
+                'sealed_at' => $manifest['sealed_at'] ?? now(),
+                'last_verified_at' => $manifest['last_verified_at'] ?? now(),
+            ]);
+            $record->save();
+
+            foreach ($normalizedFiles as $logicalPath => $file) {
+                ContentReleaseExactManifestFile::query()->updateOrCreate(
+                    [
+                        'content_release_exact_manifest_id' => (int) $record->getKey(),
+                        'logical_path' => $logicalPath,
+                    ],
+                    $file
+                );
+            }
+
+            $filePaths = array_keys($normalizedFiles);
+            $deleteQuery = ContentReleaseExactManifestFile::query()
+                ->where('content_release_exact_manifest_id', (int) $record->getKey());
+            if ($filePaths === []) {
+                $deleteQuery->delete();
+            } else {
+                $deleteQuery->whereNotIn('logical_path', $filePaths)->delete();
+            }
+
+            return $record->fresh('files') ?? $record->load('files');
+        });
+    }
+
+    public function findByIdentity(
+        string $sourceKind,
+        string $sourceDisk,
+        string $sourceStoragePath,
+        string $manifestHash,
+        ?string $packId = null,
+        ?string $packVersion = null,
+    ): ?ContentReleaseExactManifest {
+        $manifestHash = trim($manifestHash);
+        $sourceKind = trim($sourceKind);
+        $sourceDisk = trim($sourceDisk);
+        $sourceStoragePath = $this->normalizeStoragePath($sourceStoragePath);
+        $packId = $this->normalizePackId($packId);
+        $packVersion = $this->normalizeNullableString($packVersion);
+
+        if ($manifestHash === '' || $sourceKind === '' || $sourceDisk === '' || $sourceStoragePath === '') {
+            return null;
+        }
+
+        return ContentReleaseExactManifest::query()
+            ->with('files')
+            ->where('exact_identity_hash', $this->exactIdentityHash(
+                $packId,
+                $packVersion,
+                $sourceKind,
+                $sourceDisk,
+                $sourceStoragePath,
+                $manifestHash,
+            ))
+            ->first();
+    }
+
+    public function sourceIdentityHash(string $sourceKind, string $sourceDisk, string $sourceStoragePath): string
+    {
+        return hash('sha256', trim($sourceKind).'|'.trim($sourceDisk).'|'.$this->normalizeStoragePath($sourceStoragePath));
+    }
+
+    public function exactIdentityHash(
+        ?string $packId,
+        ?string $packVersion,
+        string $sourceKind,
+        string $sourceDisk,
+        string $sourceStoragePath,
+        string $manifestHash,
+    ): string {
+        return hash('sha256', implode('|', [
+            $this->normalizePackId($packId) ?? '',
+            $this->normalizeNullableString($packVersion) ?? '',
+            trim($sourceKind),
+            trim($sourceDisk),
+            $this->normalizeStoragePath($sourceStoragePath),
+            trim($manifestHash),
+        ]));
+    }
+
+    private function normalizeStoragePath(string $path): string
+    {
+        return str_replace('\\', '/', rtrim(trim($path), '/\\'));
+    }
+
+    private function normalizePackId(mixed $value): ?string
+    {
+        $packId = strtoupper(trim((string) $value));
+
+        return $packId !== '' ? $packId : null;
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function preferredReleaseId(mixed $existing, mixed $incoming): ?string
+    {
+        $incomingId = trim((string) $incoming);
+        if ($incomingId !== '') {
+            return $incomingId;
+        }
+
+        $existingId = trim((string) $existing);
+
+        return $existingId !== '' ? $existingId : null;
+    }
+}

--- a/backend/config/storage_rollout.php
+++ b/backend/config/storage_rollout.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 return [
     'manifest_schema_version' => 'storage_manifest.v1',
+    'exact_manifest_schema_version' => 'storage_exact_manifest.v1',
     'snapshot_schema_version' => 'storage_snapshot.v1',
     'blob_offload_plan_schema_version' => 'storage_blob_offload_plan.v1',
     'blob_catalog_enabled' => false,

--- a/backend/database/migrations/2026_03_20_070000_create_content_release_exact_manifests_table.php
+++ b/backend/database/migrations/2026_03_20_070000_create_content_release_exact_manifests_table.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('content_release_exact_manifests')) {
+            return;
+        }
+
+        Schema::create('content_release_exact_manifests', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->uuid('content_pack_release_id')->nullable();
+            $table->char('source_identity_hash', 64);
+            $table->char('manifest_hash', 64);
+            $table->string('schema_version', 32)->default('storage_exact_manifest.v1');
+            $table->string('source_kind', 64);
+            $table->string('source_disk', 32)->default('local');
+            $table->string('source_storage_path', 1024);
+            $table->string('pack_id', 64)->nullable();
+            $table->string('pack_version', 64)->nullable();
+            $table->char('compiled_hash', 64)->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->string('norms_version', 64)->nullable();
+            $table->string('source_commit', 64)->nullable();
+            $table->unsignedInteger('file_count')->default(0);
+            $table->unsignedBigInteger('total_size_bytes')->default(0);
+            $table->json('payload_json')->nullable();
+            $table->timestamp('sealed_at')->nullable();
+            $table->timestamp('last_verified_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['source_identity_hash', 'manifest_hash'], 'crem_source_manifest_uq');
+            $table->index(['content_pack_release_id'], 'crem_rel_idx');
+            $table->index(['pack_id', 'pack_version'], 'crem_pack_ver_idx');
+            $table->index(['source_kind', 'source_disk'], 'crem_source_kind_idx');
+            $table->foreign('content_pack_release_id', 'crem_rel_fk')
+                ->references('id')
+                ->on('content_pack_releases')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_20_070100_create_content_release_exact_manifest_files_table.php
+++ b/backend/database/migrations/2026_03_20_070100_create_content_release_exact_manifest_files_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('content_release_exact_manifest_files')) {
+            return;
+        }
+
+        Schema::create('content_release_exact_manifest_files', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('content_release_exact_manifest_id');
+            $table->string('logical_path', 1024);
+            $table->char('blob_hash', 64);
+            $table->unsignedBigInteger('size_bytes')->default(0);
+            $table->string('role', 64)->nullable();
+            $table->string('content_type', 255)->nullable();
+            $table->string('encoding', 32)->default('identity');
+            $table->string('checksum', 128)->nullable();
+            $table->timestamps();
+
+            $table->unique(['content_release_exact_manifest_id', 'logical_path'], 'cremf_manifest_path_uq');
+            $table->index(['blob_hash'], 'cremf_blob_hash_idx');
+            $table->foreign('content_release_exact_manifest_id', 'cremf_manifest_fk')
+                ->references('id')
+                ->on('content_release_exact_manifests')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_20_070200_add_exact_identity_hash_to_content_release_exact_manifests_table.php
+++ b/backend/database/migrations/2026_03_20_070200_add_exact_identity_hash_to_content_release_exact_manifests_table.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('content_release_exact_manifests')) {
+            return;
+        }
+
+        if (! Schema::hasColumn('content_release_exact_manifests', 'exact_identity_hash')) {
+            Schema::table('content_release_exact_manifests', function (Blueprint $table): void {
+                $table->char('exact_identity_hash', 64)->nullable()->after('manifest_hash');
+            });
+        }
+
+        DB::table('content_release_exact_manifests')
+            ->orderBy('id')
+            ->get()
+            ->each(function (object $row): void {
+                DB::table('content_release_exact_manifests')
+                    ->where('id', (int) $row->id)
+                    ->update([
+                        'exact_identity_hash' => hash('sha256', implode('|', [
+                            strtoupper(trim((string) ($row->pack_id ?? ''))),
+                            trim((string) ($row->pack_version ?? '')),
+                            trim((string) ($row->source_kind ?? '')),
+                            trim((string) ($row->source_disk ?? '')),
+                            str_replace('\\', '/', rtrim(trim((string) ($row->source_storage_path ?? '')), '/\\')),
+                            trim((string) ($row->manifest_hash ?? '')),
+                        ])),
+                    ]);
+            });
+
+        Schema::table('content_release_exact_manifests', function (Blueprint $table): void {
+            $table->dropUnique('crem_source_manifest_uq');
+            $table->unique(['exact_identity_hash'], 'crem_exact_identity_uq');
+            $table->index(['source_identity_hash', 'manifest_hash'], 'crem_source_manifest_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Storage/ExactReleaseFileSetCatalogServiceTest.php
+++ b/backend/tests/Feature/Storage/ExactReleaseFileSetCatalogServiceTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Models\ContentPackRelease;
+use App\Services\Storage\ExactReleaseFileSetCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class ExactReleaseFileSetCatalogServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_exact_manifest_upsert_is_idempotent_and_replaces_omitted_file_rows(): void
+    {
+        $release = ContentPackRelease::query()->create([
+            'id' => (string) \Illuminate\Support\Str::uuid(),
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'PR16-EXACT',
+            'status' => 'success',
+            'created_by' => 'test',
+        ]);
+
+        $service = app(ExactReleaseFileSetCatalogService::class);
+        $sourcePath = '/tmp/content-releases/source-pack-1';
+        $manifestHash = str_repeat('a', 64);
+
+        $service->upsertExactManifest([
+            'content_pack_release_id' => null,
+            'source_kind' => 'legacy.source_pack',
+            'source_disk' => 'local',
+            'source_storage_path' => $sourcePath,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => str_repeat('b', 64),
+            'content_hash' => str_repeat('c', 64),
+            'norms_version' => '2026Q1',
+            'source_commit' => str_repeat('d', 40),
+            'payload_json' => ['schema' => 'storage.exact.test.v1'],
+        ], [
+            [
+                'logical_path' => 'compiled/manifest.json',
+                'blob_hash' => str_repeat('1', 64),
+                'size_bytes' => 101,
+                'role' => 'manifest',
+                'content_type' => 'application/json',
+                'checksum' => 'sha256:first-manifest',
+            ],
+            [
+                'logical_path' => 'compiled/questions.json',
+                'blob_hash' => str_repeat('2', 64),
+                'size_bytes' => 202,
+                'role' => 'questions',
+                'content_type' => 'application/json',
+            ],
+        ]);
+
+        $manifest = $service->upsertExactManifest([
+            'content_pack_release_id' => $release->id,
+            'source_kind' => 'legacy.source_pack',
+            'source_disk' => 'local',
+            'source_storage_path' => $sourcePath,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => str_repeat('e', 64),
+            'content_hash' => str_repeat('f', 64),
+            'norms_version' => '2026Q2',
+            'source_commit' => str_repeat('d', 40),
+            'payload_json' => ['schema' => 'storage.exact.test.v1', 'updated' => true],
+        ], [
+            [
+                'logical_path' => 'compiled/manifest.json',
+                'blob_hash' => str_repeat('3', 64),
+                'size_bytes' => 303,
+                'role' => 'manifest',
+                'content_type' => 'application/json',
+                'checksum' => 'sha256:updated-manifest',
+            ],
+        ]);
+
+        $this->assertDatabaseCount('content_release_exact_manifests', 1);
+        $this->assertDatabaseCount('content_release_exact_manifest_files', 1);
+        $this->assertDatabaseHas('content_release_exact_manifests', [
+            'content_pack_release_id' => $release->id,
+            'source_kind' => 'legacy.source_pack',
+            'source_disk' => 'local',
+            'source_storage_path' => $sourcePath,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => str_repeat('e', 64),
+            'content_hash' => str_repeat('f', 64),
+            'norms_version' => '2026Q2',
+            'file_count' => 1,
+            'total_size_bytes' => 303,
+        ]);
+        $this->assertDatabaseHas('content_release_exact_manifest_files', [
+            'content_release_exact_manifest_id' => $manifest->id,
+            'logical_path' => 'compiled/manifest.json',
+            'blob_hash' => str_repeat('3', 64),
+            'size_bytes' => 303,
+            'checksum' => 'sha256:updated-manifest',
+        ]);
+        $this->assertDatabaseMissing('content_release_exact_manifest_files', [
+            'content_release_exact_manifest_id' => $manifest->id,
+            'logical_path' => 'compiled/questions.json',
+        ]);
+
+        $reloaded = $service->findByIdentity('legacy.source_pack', 'local', $sourcePath, $manifestHash, 'BIG5_OCEAN', 'v1');
+        $this->assertNotNull($reloaded);
+        $this->assertCount(1, $reloaded->files);
+        $this->assertSame($release->id, $reloaded->content_pack_release_id);
+    }
+
+    public function test_exact_manifest_identity_keeps_distinct_roots_for_same_manifest_hash(): void
+    {
+        $release = ContentPackRelease::query()->create([
+            'id' => (string) \Illuminate\Support\Str::uuid(),
+            'action' => 'rollback',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'PR16-EXACT-DISTINCT',
+            'status' => 'success',
+            'created_by' => 'test',
+        ]);
+
+        $service = app(ExactReleaseFileSetCatalogService::class);
+        $manifestHash = str_repeat('b', 64);
+
+        $service->upsertExactManifest([
+            'content_pack_release_id' => $release->id,
+            'source_kind' => 'legacy.previous_pack',
+            'source_disk' => 'local',
+            'source_storage_path' => '/tmp/content-releases/backups/release-a/previous_pack',
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+        ], [
+            [
+                'logical_path' => 'compiled/manifest.json',
+                'blob_hash' => str_repeat('7', 64),
+                'size_bytes' => 707,
+            ],
+        ]);
+
+        $service->upsertExactManifest([
+            'content_pack_release_id' => $release->id,
+            'source_kind' => 'legacy.previous_pack',
+            'source_disk' => 'local',
+            'source_storage_path' => '/tmp/content-releases/backups/release-b/previous_pack',
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+        ], [
+            [
+                'logical_path' => 'compiled/manifest.json',
+                'blob_hash' => str_repeat('8', 64),
+                'size_bytes' => 808,
+            ],
+        ]);
+
+        $this->assertDatabaseCount('content_release_exact_manifests', 2);
+        $this->assertNotNull($service->findByIdentity(
+            'legacy.previous_pack',
+            'local',
+            '/tmp/content-releases/backups/release-a/previous_pack',
+            $manifestHash,
+            'BIG5_OCEAN',
+            'v1',
+        ));
+        $this->assertNotNull($service->findByIdentity(
+            'legacy.previous_pack',
+            'local',
+            '/tmp/content-releases/backups/release-b/previous_pack',
+            $manifestHash,
+            'BIG5_OCEAN',
+            'v1',
+        ));
+    }
+}

--- a/backend/tests/Feature/Storage/StorageBackfillExactReleaseFileSetsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageBackfillExactReleaseFileSetsCommandTest.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageBackfillExactReleaseFileSetsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-exact-backfill-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_backfills_exact_release_file_sets_for_legacy_backup_and_v2_roots_idempotently(): void
+    {
+        $publishVersionId = (string) Str::uuid();
+        $publishReleaseId = (string) Str::uuid();
+        $rollbackSourceReleaseId = (string) Str::uuid();
+        $rollbackReleaseId = (string) Str::uuid();
+        $rollbackCurrentReleaseId = (string) Str::uuid();
+        $v2ReleaseId = (string) Str::uuid();
+        $missingReleaseId = (string) Str::uuid();
+
+        $publishRoot = storage_path('app/private/content_releases/'.$publishVersionId.'/source_pack');
+        $publishManifest = $this->createCompiledTree($publishRoot, 'BIG5_OCEAN', 'v1', 'legacy_publish');
+
+        DB::table('content_pack_versions')->insert([
+            'id' => $publishVersionId,
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'pack_id' => 'BIG5_OCEAN',
+            'content_package_version' => 'v1',
+            'dir_version_alias' => 'BIG5-OCEAN-EXACT',
+            'source_type' => 'repo',
+            'source_ref' => 'backend/content_packs/BIG5_OCEAN/v1',
+            'sha256' => str_repeat('a', 64),
+            'manifest_json' => json_encode($publishManifest['decoded'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'extracted_rel_path' => 'private/content_releases/'.$publishVersionId.'/source_pack',
+            'created_by' => 'test',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $publishReleaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'BIG5-OCEAN-EXACT',
+            'from_version_id' => null,
+            'to_version_id' => $publishVersionId,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $publishManifest['manifest_hash'],
+            'compiled_hash' => $publishManifest['compiled_hash'],
+            'content_hash' => $publishManifest['content_hash'],
+            'norms_version' => $publishManifest['norms_version'],
+            'git_sha' => 'git-publish-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(5),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+
+        $rollbackRoot = storage_path('app/private/content_releases/backups/'.$rollbackSourceReleaseId.'/previous_pack');
+        $rollbackManifest = $this->createCompiledTree($rollbackRoot, 'BIG5_OCEAN', 'v1', 'legacy_rollback');
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $rollbackReleaseId,
+            'action' => 'rollback',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'BIG5-OCEAN-EXACT',
+            'from_version_id' => $publishVersionId,
+            'to_version_id' => null,
+            'from_pack_id' => 'BIG5_OCEAN',
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $rollbackManifest['manifest_hash'],
+            'compiled_hash' => $rollbackManifest['compiled_hash'],
+            'content_hash' => $rollbackManifest['content_hash'],
+            'norms_version' => $rollbackManifest['norms_version'],
+            'git_sha' => 'git-rollback-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(4),
+            'updated_at' => now()->subMinutes(4),
+        ]);
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'big5_pack_rollback',
+            'target_type' => 'content_pack_release',
+            'target_id' => $rollbackReleaseId,
+            'meta_json' => json_encode(['source_release_id' => $rollbackSourceReleaseId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test',
+            'request_id' => null,
+            'reason' => 'test',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(4),
+        ]);
+
+        $rollbackCurrentRoot = storage_path('app/private/content_releases/backups/'.$rollbackCurrentReleaseId.'/current_pack');
+        $rollbackCurrentManifest = $this->createCompiledTree($rollbackCurrentRoot, 'BIG5_OCEAN', 'v1', 'legacy_current_pack');
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $rollbackCurrentReleaseId,
+            'action' => 'rollback',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'BIG5-OCEAN-EXACT',
+            'from_version_id' => $publishVersionId,
+            'to_version_id' => null,
+            'from_pack_id' => 'BIG5_OCEAN',
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => null,
+            'compiled_hash' => null,
+            'content_hash' => null,
+            'norms_version' => null,
+            'git_sha' => 'git-rollback-current-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(3)->subSeconds(30),
+            'updated_at' => now()->subMinutes(3)->subSeconds(30),
+        ]);
+
+        $v2MirrorRoot = storage_path('app/content_packs_v2/SDS_20/v1/'.$v2ReleaseId);
+        $v2Manifest = $this->createCompiledTree($v2MirrorRoot, 'SDS_20', 'v1', 'v2_mirror');
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $v2ReleaseId,
+            'action' => 'packs2_publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'SDS-20-EXACT',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'SDS_20',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => $v2Manifest['manifest_hash'],
+            'compiled_hash' => $v2Manifest['compiled_hash'],
+            'content_hash' => $v2Manifest['content_hash'],
+            'norms_version' => $v2Manifest['norms_version'],
+            'git_sha' => 'git-v2-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => 'private/packs_v2/SDS_20/v1/'.$v2ReleaseId,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinutes(3),
+        ]);
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $missingReleaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'MISSING-EXACT',
+            'from_version_id' => null,
+            'to_version_id' => (string) Str::uuid(),
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => str_repeat('f', 64),
+            'compiled_hash' => str_repeat('e', 64),
+            'content_hash' => str_repeat('d', 64),
+            'norms_version' => '2026Q1',
+            'git_sha' => 'git-missing-sha',
+            'pack_version' => null,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => null,
+            'created_at' => now()->subMinutes(2),
+            'updated_at' => now()->subMinutes(2),
+        ]);
+
+        $this->assertSame(0, Artisan::call('storage:backfill-exact-release-file-sets', [
+            '--dry-run' => true,
+        ]));
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('release_rows_backfillable=3', $dryRunOutput);
+        $this->assertStringContainsString('backup_roots_backfillable=1', $dryRunOutput);
+        $this->assertDatabaseCount('content_release_exact_manifests', 0);
+        $this->assertDatabaseCount('content_release_exact_manifest_files', 0);
+
+        $this->assertSame(0, Artisan::call('storage:backfill-exact-release-file-sets', [
+            '--execute' => true,
+        ]));
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('release_rows_backfilled=3', $executeOutput);
+        $this->assertStringContainsString('backup_roots_backfilled=1', $executeOutput);
+
+        $this->assertDatabaseCount('content_release_exact_manifests', 4);
+        $this->assertDatabaseCount('content_release_exact_manifest_files', 8);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/offload'));
+
+        $this->assertDatabaseHas('content_release_exact_manifests', [
+            'content_pack_release_id' => $publishReleaseId,
+            'source_kind' => 'legacy.source_pack',
+            'source_storage_path' => $publishRoot,
+            'manifest_hash' => $publishManifest['manifest_hash'],
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'file_count' => 2,
+        ]);
+        $this->assertDatabaseHas('content_release_exact_manifests', [
+            'content_pack_release_id' => $rollbackReleaseId,
+            'source_kind' => 'legacy.previous_pack',
+            'source_storage_path' => $rollbackRoot,
+            'manifest_hash' => $rollbackManifest['manifest_hash'],
+        ]);
+        $this->assertDatabaseHas('content_release_exact_manifests', [
+            'content_pack_release_id' => $rollbackCurrentReleaseId,
+            'source_kind' => 'legacy.current_pack',
+            'source_storage_path' => $rollbackCurrentRoot,
+            'manifest_hash' => $rollbackCurrentManifest['manifest_hash'],
+        ]);
+        $this->assertDatabaseHas('content_release_exact_manifests', [
+            'content_pack_release_id' => $v2ReleaseId,
+            'source_kind' => 'v2.mirror',
+            'source_storage_path' => $v2MirrorRoot,
+            'manifest_hash' => $v2Manifest['manifest_hash'],
+            'pack_id' => 'SDS_20',
+            'pack_version' => 'v1',
+        ]);
+
+        $manifestCount = (int) DB::table('content_release_exact_manifests')->count();
+        $manifestFileCount = (int) DB::table('content_release_exact_manifest_files')->count();
+        $this->assertSame(0, Artisan::call('storage:backfill-exact-release-file-sets', [
+            '--execute' => true,
+        ]));
+        $this->assertSame($manifestCount, (int) DB::table('content_release_exact_manifests')->count());
+        $this->assertSame($manifestFileCount, (int) DB::table('content_release_exact_manifest_files')->count());
+
+        $currentExactManifestId = (int) DB::table('content_release_exact_manifests')
+            ->where('content_pack_release_id', $rollbackCurrentReleaseId)
+            ->value('id');
+        $this->assertSame(1, (int) DB::table('content_release_exact_manifest_files')
+            ->where('content_release_exact_manifest_id', $currentExactManifestId)
+            ->where('logical_path', 'compiled/manifest.json')
+            ->count());
+        $this->assertSame(1, (int) DB::table('content_release_exact_manifest_files')
+            ->where('content_release_exact_manifest_id', $currentExactManifestId)
+            ->where('logical_path', 'compiled/payload.compiled.json')
+            ->count());
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_backfill_exact_release_file_sets')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($audit);
+        $auditMeta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($auditMeta);
+        $this->assertSame('execute', (string) ($auditMeta['mode'] ?? ''));
+        $this->assertSame(5, (int) ($auditMeta['release_rows_scanned'] ?? 0));
+        $this->assertSame(1, (int) ($auditMeta['backup_roots_backfilled'] ?? 0));
+        $this->assertSame(2, (int) ($auditMeta['missing_physical_sources'] ?? 0));
+    }
+
+    /**
+     * @return array{
+     *   decoded:array<string,mixed>,
+     *   manifest_hash:string,
+     *   compiled_hash:string,
+     *   content_hash:string,
+     *   norms_version:string
+     * }
+     */
+    private function createCompiledTree(string $root, string $packId, string $packVersion, string $suffix): array
+    {
+        $compiledDir = $root.'/compiled';
+        File::ensureDirectoryExists($compiledDir);
+
+        $payload = json_encode([
+            'suffix' => $suffix,
+            'pack_id' => $packId,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $payload = is_string($payload) ? $payload : '{}';
+        File::put($compiledDir.'/payload.compiled.json', $payload);
+
+        $compiledHash = hash('sha256', $payload.'|compiled|'.$suffix);
+        $contentHash = hash('sha256', $payload.'|content|'.$suffix);
+        $normsVersion = '2026Q1_'.$suffix;
+        $manifest = [
+            'schema' => 'storage.exact.test.v1',
+            'pack_id' => $packId,
+            'pack_version' => $packVersion,
+            'content_package_version' => $packVersion,
+            'compiled_hash' => $compiledHash,
+            'content_hash' => $contentHash,
+            'norms_version' => $normsVersion,
+        ];
+        $manifestJson = json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        $manifestJson = is_string($manifestJson) ? $manifestJson : '{}';
+        File::put($compiledDir.'/manifest.json', $manifestJson);
+
+        return [
+            'decoded' => $manifest,
+            'manifest_hash' => hash('sha256', $manifestJson),
+            'compiled_hash' => $compiledHash,
+            'content_hash' => $contentHash,
+            'norms_version' => $normsVersion,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the low-risk PR-16 slice only: exact content release file-set authority plus historical exact backfill.

The scope stays intentionally narrow:

- add additive exact authority tables for content release roots
- add an exact file-set catalog service with replace-not-additive child sync
- add a historical backfill command for exact release file sets
- keep runtime readers unchanged
- do not add remote read
- do not add delete or GC execute
- do not add scheduler automation

## Root cause

After PR-15, the repository could already catalog blobs, backfill historical rollout metadata, compute conservative reachability, and offload reachable blobs copy-only to remote storage.

But content release authority was still split across two weaker forms of metadata:

- `content_release_manifests`, which is shared scaffold keyed around `manifest_hash`
- `content_release_manifest_files`, which is intentionally additive-only and therefore cannot prove exact absence

That meant the system still lacked a durable, per-release-root, exact `logical_path -> blob_hash` authority layer.

Without that authority, future remote rehydrate and future delete work would still be blocked because:

- the same `manifest_hash` could collapse across different roots
- omitted file rows in the additive scaffold could not be treated as exact truth
- a release root could not be reconstructed from database authority alone

## What this PR adds

### 1. Exact authority schema

This PR adds two new additive tables:

- `content_release_exact_manifests`
- `content_release_exact_manifest_files`

These tables are separate from the existing additive scaffold and are explicitly used for exact authority.

The exact manifest row stores at least:

- `content_pack_release_id`
- `source_kind`
- `source_disk`
- `source_storage_path`
- `pack_id`
- `pack_version`
- `manifest_hash`
- `compiled_hash`
- `content_hash`
- `norms_version`
- `source_commit`
- `file_count`
- `total_size_bytes`
- `payload_json`
- `sealed_at`
- `last_verified_at`

### 2. Exact identity that does not collapse by manifest hash

During review, the initial PR-16 implementation was tightened so exact identity now includes:

- `pack_id`
- `pack_version`
- `source_kind`
- `source_disk`
- `source_storage_path`
- `manifest_hash`

This is persisted as `exact_identity_hash`.

That change matters because exact authority must distinguish two different roots even when they share the same `manifest_hash`.

The old additive scaffold still exists unchanged and still remains non-authoritative.

### 3. Exact file-set catalog service

This PR adds `ExactReleaseFileSetCatalogService`.

The service:

- upserts the parent exact manifest row
- synchronizes child file rows as the exact truth
- removes omitted child rows on rerun
- keeps reruns idempotent
- allows a later rerun to repair `content_pack_release_id` when a more accurate release linkage becomes available

This is intentionally different from the additive-only semantics of `content_release_manifest_files`.

### 4. Historical exact backfill command

This PR adds:

- `php artisan storage:backfill-exact-release-file-sets --dry-run`
- `php artisan storage:backfill-exact-release-file-sets --execute`

The command resolves physical roots first and only backfills content release roots.

Covered roots:

- legacy `source_pack`
- legacy `previous_pack`
- legacy `current_pack`
- V2 primary / mirror roots

The command:

- scans physical compiled trees
- derives exact file rows from the real tree
- writes exact authority rows only in `--execute`
- writes audit rows
- does not create new runtime local paths
- does not change runtime reader behavior

A follow-up review fix also tightened same-run behavior so a release root is only marked as processed after a successful exact seal in execute mode, which keeps the backfill warning-safe.

## Safety boundaries preserved

This PR does **not** change:

- runtime content read contracts
- ArtifactStore canonical-first / legacy-fallback reader order
- legacy publish / rollback runtime success paths
- ContentPackV2 publish / resolver / materialization runtime behavior
- Blob GC semantics
- Blob offload runtime semantics
- BigFiveOps route / stdout / audit contracts

This PR does **not** add:

- remote read
- local delete
- GC execute
- scheduler automation

## Tests

New focused coverage:

- `tests/Feature/Storage/ExactReleaseFileSetCatalogServiceTest.php`
- `tests/Feature/Storage/StorageBackfillExactReleaseFileSetsCommandTest.php`

The tests lock:

- exact upsert idempotency
- exact child row replacement instead of additive drift
- owner release id repair on rerun
- distinct exact rows for different roots with the same `manifest_hash`
- legacy `source_pack` exact sealing
- legacy `previous_pack` exact sealing
- legacy `current_pack` exact sealing
- V2 mirror fallback exact sealing
- dry-run / execute command contract
- no new runtime local path side effects

Existing storage/content rollout tests were re-run and stayed green.

## Commands run

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php -l app/Console/Commands/StorageBackfillExactReleaseFileSets.php
php -l app/Services/Storage/ExactReleaseFileSetCatalogService.php
php -l app/Models/ContentReleaseExactManifest.php
php -l app/Models/ContentReleaseExactManifestFile.php
php -l database/migrations/2026_03_20_070000_create_content_release_exact_manifests_table.php
php -l database/migrations/2026_03_20_070100_create_content_release_exact_manifest_files_table.php
php -l database/migrations/2026_03_20_070200_add_exact_identity_hash_to_content_release_exact_manifests_table.php
php -l tests/Feature/Storage/StorageBackfillExactReleaseFileSetsCommandTest.php
php -l tests/Feature/Storage/ExactReleaseFileSetCatalogServiceTest.php
php -l config/storage_rollout.php

./vendor/bin/pint \
  app/Console/Commands/StorageBackfillExactReleaseFileSets.php \
  app/Services/Storage/ExactReleaseFileSetCatalogService.php \
  app/Models/ContentReleaseExactManifest.php \
  app/Models/ContentReleaseExactManifestFile.php \
  database/migrations/2026_03_20_070000_create_content_release_exact_manifests_table.php \
  database/migrations/2026_03_20_070100_create_content_release_exact_manifest_files_table.php \
  database/migrations/2026_03_20_070200_add_exact_identity_hash_to_content_release_exact_manifests_table.php \
  config/storage_rollout.php \
  tests/Feature/Storage/StorageBackfillExactReleaseFileSetsCommandTest.php \
  tests/Feature/Storage/ExactReleaseFileSetCatalogServiceTest.php

php artisan migrate

vendor/bin/phpunit \
  tests/Feature/Storage/StorageBackfillExactReleaseFileSetsCommandTest.php \
  tests/Feature/Storage/ExactReleaseFileSetCatalogServiceTest.php \
  tests/Feature/Storage/StorageBackfillReleaseMetadataCommandTest.php \
  tests/Feature/Storage/StorageBlobGcCommandTest.php \
  tests/Feature/Storage/StorageBlobOffloadCommandTest.php \
  tests/Feature/Content/Packs2MetadataDualWriteTest.php \
  tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php

php artisan storage:backfill-exact-release-file-sets --dry-run
php artisan storage:backfill-exact-release-file-sets --execute

php artisan route:list > /tmp/pr16_route_list.txt
php artisan serve --host=127.0.0.1 --port=18081
curl -i http://127.0.0.1:18081/api/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
```

## Validation

Observed results:

- `php artisan migrate`: passed
- focused suite: `OK (14 tests, 243 assertions)`
- `storage:backfill-exact-release-file-sets --dry-run`: passed
- `storage:backfill-exact-release-file-sets --execute`: passed
- `curl -i /api/healthz`: `HTTP/1.1 200 OK`
- `bash backend/scripts/ci_verify_mbti.sh`: passed with exit code `0`

## Notes

This PR only commits the PR-16 exact-authority files. It intentionally does not include the unrelated local workspace modifications currently present on the branch checkout.
