### PR TITLE
[codex] Ship Big Five PR-9A result engine foundation (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -11,6 +11,7 @@ use App\Repositories\Report\ReportAccessActor;
 use App\Repositories\Report\ReportSubjectRepository;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
+use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Mbti\MbtiPrivacyConsentContractService;
 use App\Services\Mbti\MbtiPublicProjectionService;
@@ -40,6 +41,7 @@ class AttemptReadController extends Controller
         private AttemptSubmissionService $attemptSubmissionService,
         private ReportGatekeeper $reportGatekeeper,
         private ReportPdfDocumentService $reportPdfDocumentService,
+        private BigFivePublicProjectionService $bigFivePublicProjectionService,
         private MbtiPrivacyConsentContractService $mbtiPrivacyConsentContractService,
         private MbtiPublicProjectionService $mbtiPublicProjectionService,
         private MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
@@ -197,8 +199,18 @@ class AttemptReadController extends Controller
             $compatScoresPct = [];
         }
 
+        $big5Projection = $scaleCode === 'BIG5_OCEAN'
+            ? $this->bigFivePublicProjectionService->buildFromResult(
+                $result,
+                (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
+            )
+            : [];
+
         $mbtiEventMeta = $scaleCode === 'MBTI'
             ? $this->resolveMbtiResultViewEventMeta($request, $result, $attempt, $attemptId)
+            : [];
+        $big5EventMeta = $scaleCode === 'BIG5_OCEAN'
+            ? $this->resolveBigFiveEventMetaFromProjection($big5Projection)
             : [];
 
         $request->merge(['attempt_id' => $attemptId]);
@@ -209,9 +221,10 @@ class AttemptReadController extends Controller
             'type_code' => (string) ($result->type_code ?? ''),
             'attempt_id' => $attemptId,
             ...$mbtiEventMeta,
+            ...$big5EventMeta,
         ]);
 
-        return response()->json([
+        $responsePayload = [
             'ok' => true,
             'attempt_id' => $attemptId,
             'type_code' => $compatTypeCode,
@@ -229,7 +242,12 @@ class AttemptReadController extends Controller
                 'scoring_spec_version' => $scoringSpecVersion,
                 'report_engine_version' => $reportEngineVersion,
             ],
-        ]);
+        ];
+        if ($big5Projection !== []) {
+            $responsePayload['big5_public_projection_v1'] = $big5Projection;
+        }
+
+        return response()->json($responsePayload);
     }
 
     /**
@@ -337,6 +355,17 @@ class AttemptReadController extends Controller
                 $userId !== null ? (string) $userId : null,
                 $anonId
             );
+        } elseif ($scaleCode === 'BIG5_OCEAN') {
+            $projection = data_get($responsePayload, 'report._meta.big5_public_projection_v1');
+            if (! is_array($projection)) {
+                $projection = $this->bigFivePublicProjectionService->buildFromResult(
+                    $result,
+                    (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')),
+                    strtolower(trim((string) ($gate['variant'] ?? 'free'))),
+                    (bool) ($gate['locked'] ?? false)
+                );
+            }
+            $responsePayload['big5_public_projection_v1'] = $projection;
         }
 
         $effectiveMbtiPersonalization = $scaleCode === 'MBTI'
@@ -363,6 +392,9 @@ class AttemptReadController extends Controller
         $mbtiEventMeta = $scaleCode === 'MBTI'
             ? $this->mbtiTelemetryMetaFromPersonalization($effectiveMbtiPersonalization)
             : [];
+        $big5EventMeta = $scaleCode === 'BIG5_OCEAN'
+            ? $this->resolveBigFiveEventMetaFromProjection(is_array($responsePayload['big5_public_projection_v1'] ?? null) ? $responsePayload['big5_public_projection_v1'] : [])
+            : [];
 
         $request->merge(['attempt_id' => (string) $attempt->id]);
         $this->eventRecorder->recordFromRequest($request, 'report_view', $this->resolveUserId($request), [
@@ -373,6 +405,7 @@ class AttemptReadController extends Controller
             'attempt_id' => (string) $attempt->id,
             'locked' => (bool) ($gate['locked'] ?? false),
             ...$mbtiEventMeta,
+            ...$big5EventMeta,
         ]);
 
         return response()->json($responsePayload);
@@ -525,6 +558,32 @@ class AttemptReadController extends Controller
                 ! ((bool) data_get($reportEnvelope, 'locked', false))
             )
         );
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @return array<string,mixed>
+     */
+    private function resolveBigFiveEventMetaFromProjection(array $projection): array
+    {
+        $traitBands = is_array($projection['trait_bands'] ?? null) ? $projection['trait_bands'] : [];
+        $dominantTraits = is_array($projection['dominant_traits'] ?? null) ? $projection['dominant_traits'] : [];
+        $sceneFingerprint = is_array($projection['scene_fingerprint'] ?? null) ? $projection['scene_fingerprint'] : [];
+        $variantKeys = is_array($projection['variant_keys'] ?? null) ? $projection['variant_keys'] : [];
+        $orderedSectionKeys = is_array($projection['ordered_section_keys'] ?? null) ? $projection['ordered_section_keys'] : [];
+
+        return array_filter([
+            'trait_bands' => $traitBands,
+            'dominant_traits' => array_values(array_filter(array_map(
+                static fn (mixed $trait): string => is_array($trait) ? trim((string) ($trait['key'] ?? '')) : '',
+                $dominantTraits
+            ))),
+            'scene_fingerprint' => $sceneFingerprint,
+            'variant_keys' => array_values(array_filter(array_map('strval', $variantKeys))),
+            'ordered_section_keys' => array_values(array_filter(array_map('strval', $orderedSectionKeys))),
+        ], static function (mixed $value): bool {
+            return is_array($value) ? $value !== [] : $value !== null;
+        });
     }
 
     /**

--- a/backend/app/Services/BigFive/BigFivePublicProjectionService.php
+++ b/backend/app/Services/BigFive/BigFivePublicProjectionService.php
@@ -1,0 +1,564 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive;
+
+use App\Models\Result;
+
+final class BigFivePublicProjectionService
+{
+    private const DOMAIN_ORDER = ['O', 'C', 'E', 'A', 'N'];
+
+    /**
+     * @var array<string,array{en:string,zh:string}>
+     */
+    private const TRAIT_LABELS = [
+        'O' => ['en' => 'Openness', 'zh' => '开放性'],
+        'C' => ['en' => 'Conscientiousness', 'zh' => '尽责性'],
+        'E' => ['en' => 'Extraversion', 'zh' => '外向性'],
+        'A' => ['en' => 'Agreeableness', 'zh' => '宜人性'],
+        'N' => ['en' => 'Neuroticism', 'zh' => '情绪性'],
+    ];
+
+    /**
+     * @var array<string,array<string,array{en:string,zh:string}>>
+     */
+    private const BAND_LABELS = [
+        'low' => [
+            'O' => ['en' => 'grounded', 'zh' => '更务实'],
+            'C' => ['en' => 'adaptive', 'zh' => '更灵活'],
+            'E' => ['en' => 'reserved', 'zh' => '更克制'],
+            'A' => ['en' => 'direct', 'zh' => '更直接'],
+            'N' => ['en' => 'steady', 'zh' => '更稳定'],
+        ],
+        'mid' => [
+            'O' => ['en' => 'balanced', 'zh' => '相对平衡'],
+            'C' => ['en' => 'balanced', 'zh' => '相对平衡'],
+            'E' => ['en' => 'balanced', 'zh' => '相对平衡'],
+            'A' => ['en' => 'balanced', 'zh' => '相对平衡'],
+            'N' => ['en' => 'responsive', 'zh' => '相对敏感'],
+        ],
+        'high' => [
+            'O' => ['en' => 'exploratory', 'zh' => '更探索'],
+            'C' => ['en' => 'structured', 'zh' => '更有序'],
+            'E' => ['en' => 'expressive', 'zh' => '更外放'],
+            'A' => ['en' => 'harmonizing', 'zh' => '更体谅'],
+            'N' => ['en' => 'sensitive', 'zh' => '更敏感'],
+        ],
+    ];
+
+    /**
+     * @var array<string,array{en:string,zh:string}>
+     */
+    private const PROFILE_LABELS = [
+        'profile:resilient' => ['en' => 'Resilient profile', 'zh' => '韧性画像'],
+        'profile:overcontrolled' => ['en' => 'Overcontrolled profile', 'zh' => '高约束画像'],
+        'profile:undercontrolled' => ['en' => 'Undercontrolled profile', 'zh' => '低约束画像'],
+        'profile:explorer' => ['en' => 'Explorer profile', 'zh' => '探索者画像'],
+        'profile:steady_operator' => ['en' => 'Steady operator profile', 'zh' => '稳态执行画像'],
+    ];
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildFromResult(Result $result, string $locale, ?string $variant = null, ?bool $locked = null): array
+    {
+        return $this->build($this->extractScoreResult($result), $locale, $variant, $locked);
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @return array<string,mixed>
+     */
+    public function build(array $scoreResult, string $locale, ?string $variant = null, ?bool $locked = null): array
+    {
+        $locale = $this->normalizeLocale($locale);
+        $domainsMean = is_array(data_get($scoreResult, 'raw_scores.domains_mean')) ? data_get($scoreResult, 'raw_scores.domains_mean') : [];
+        $domainsPercentile = is_array(data_get($scoreResult, 'scores_0_100.domains_percentile')) ? data_get($scoreResult, 'scores_0_100.domains_percentile') : [];
+        $domainBuckets = is_array(data_get($scoreResult, 'facts.domain_buckets')) ? data_get($scoreResult, 'facts.domain_buckets') : [];
+        $topStrengthFacets = array_values(array_filter(array_map('strval', is_array(data_get($scoreResult, 'facts.top_strength_facets')) ? data_get($scoreResult, 'facts.top_strength_facets') : [])));
+        $topGrowthFacets = array_values(array_filter(array_map('strval', is_array(data_get($scoreResult, 'facts.top_growth_facets')) ? data_get($scoreResult, 'facts.top_growth_facets') : [])));
+        $tags = array_values(array_filter(array_map('strval', is_array($scoreResult['tags'] ?? null) ? $scoreResult['tags'] : [])));
+
+        $traitVector = [];
+        foreach (self::DOMAIN_ORDER as $trait) {
+            $band = strtolower(trim((string) ($domainBuckets[$trait] ?? 'mid')));
+            if (! in_array($band, ['low', 'mid', 'high'], true)) {
+                $band = 'mid';
+            }
+
+            $traitVector[] = [
+                'key' => $trait,
+                'label' => $this->traitLabel($trait, $locale),
+                'mean' => round((float) ($domainsMean[$trait] ?? 0.0), 2),
+                'percentile' => (int) ($domainsPercentile[$trait] ?? 0),
+                'band' => $band,
+                'band_label' => $this->bandLabel($trait, $band, $locale),
+            ];
+        }
+
+        $traitBands = [];
+        foreach ($traitVector as $trait) {
+            $traitBands[(string) $trait['key']] = (string) $trait['band'];
+        }
+
+        $rankedTraits = $traitVector;
+        usort($rankedTraits, fn (array $a, array $b): int => $this->compareTraitsByPercentile($a, $b, true));
+
+        $dominantTraits = array_values(array_map(
+            fn (array $trait, int $index): array => [
+                'key' => (string) $trait['key'],
+                'label' => (string) $trait['label'],
+                'percentile' => (int) $trait['percentile'],
+                'band' => (string) $trait['band'],
+                'rank' => $index + 1,
+            ],
+            array_slice($rankedTraits, 0, 3),
+            array_keys(array_slice($rankedTraits, 0, 3))
+        ));
+
+        $variantKeys = $this->buildVariantKeys($tags, $traitBands);
+        $sceneFingerprint = $this->buildSceneFingerprint($traitBands);
+        $explainabilitySummary = $this->buildExplainabilitySummary($dominantTraits, $topStrengthFacets, $variantKeys, $locale);
+        $actionPlanSummary = $this->buildActionPlanSummary($traitVector, $topGrowthFacets, $locale);
+        $sections = $this->buildSections(
+            $traitVector,
+            $dominantTraits,
+            $sceneFingerprint,
+            $variantKeys,
+            $explainabilitySummary,
+            $actionPlanSummary,
+            $locale
+        );
+
+        $projection = [
+            'schema_version' => 'big5.public_projection.v1',
+            'trait_vector' => $traitVector,
+            'trait_bands' => $traitBands,
+            'dominant_traits' => $dominantTraits,
+            'variant_keys' => $variantKeys,
+            'scene_fingerprint' => $sceneFingerprint,
+            'explainability_summary' => $explainabilitySummary,
+            'action_plan_summary' => $actionPlanSummary,
+            'ordered_section_keys' => array_values(array_map(
+                static fn (array $section): string => (string) ($section['key'] ?? ''),
+                $sections
+            )),
+            'sections' => $sections,
+            '_meta' => array_filter([
+                'scale_code' => 'BIG5_OCEAN',
+                'engine_version' => (string) ($scoreResult['engine_version'] ?? ''),
+                'variant' => $variant,
+                'locked' => $locked,
+            ], static fn ($value): bool => $value !== null && $value !== ''),
+        ];
+
+        return $projection;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractScoreResult(Result $result): array
+    {
+        $resultJson = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $candidates = [
+            $result->normed_json,
+            $resultJson['normed_json'] ?? null,
+            data_get($resultJson, 'breakdown_json.score_result'),
+            data_get($resultJson, 'axis_scores_json.score_result'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh' : 'en';
+    }
+
+    /**
+     * @param  array<string,mixed>  $left
+     * @param  array<string,mixed>  $right
+     */
+    private function compareTraitsByPercentile(array $left, array $right, bool $descending): int
+    {
+        $leftPercentile = (int) ($left['percentile'] ?? 0);
+        $rightPercentile = (int) ($right['percentile'] ?? 0);
+
+        $percentileComparison = $descending
+            ? ($rightPercentile <=> $leftPercentile)
+            : ($leftPercentile <=> $rightPercentile);
+
+        if ($percentileComparison !== 0) {
+            return $percentileComparison;
+        }
+
+        return $this->domainOrderIndex((string) ($left['key'] ?? ''))
+            <=> $this->domainOrderIndex((string) ($right['key'] ?? ''));
+    }
+
+    private function domainOrderIndex(string $trait): int
+    {
+        $index = array_search($trait, self::DOMAIN_ORDER, true);
+
+        return $index === false ? count(self::DOMAIN_ORDER) : (int) $index;
+    }
+
+    private function traitLabel(string $trait, string $locale): string
+    {
+        return self::TRAIT_LABELS[$trait][$locale] ?? $trait;
+    }
+
+    private function bandLabel(string $trait, string $band, string $locale): string
+    {
+        return self::BAND_LABELS[$band][$trait][$locale] ?? $band;
+    }
+
+    /**
+     * @param  list<string>  $tags
+     * @param  array<string,string>  $traitBands
+     * @return list<string>
+     */
+    private function buildVariantKeys(array $tags, array $traitBands): array
+    {
+        $variantKeys = [];
+        foreach ($tags as $tag) {
+            if (str_starts_with($tag, 'profile:') || str_starts_with($tag, 'big5:')) {
+                $variantKeys[$tag] = true;
+            }
+        }
+
+        foreach (self::DOMAIN_ORDER as $trait) {
+            $band = strtolower((string) ($traitBands[$trait] ?? 'mid'));
+            $variantKeys['band:'.strtolower($trait).'.'.$band] = true;
+        }
+
+        return array_keys($variantKeys);
+    }
+
+    /**
+     * @param  array<string,string>  $traitBands
+     * @return array<string,string>
+     */
+    private function buildSceneFingerprint(array $traitBands): array
+    {
+        return [
+            'novelty' => match ($traitBands['O'] ?? 'mid') {
+                'high' => 'exploratory',
+                'low' => 'grounded',
+                default => 'balanced',
+            },
+            'structure' => match ($traitBands['C'] ?? 'mid') {
+                'high' => 'structured',
+                'low' => 'adaptive',
+                default => 'balanced',
+            },
+            'social_energy' => match ($traitBands['E'] ?? 'mid') {
+                'high' => 'outward',
+                'low' => 'reserved',
+                default => 'balanced',
+            },
+            'cooperation' => match ($traitBands['A'] ?? 'mid') {
+                'high' => 'harmonizing',
+                'low' => 'direct',
+                default => 'balanced',
+            },
+            'stress_posture' => match ($traitBands['N'] ?? 'mid') {
+                'high' => 'sensitive',
+                'low' => 'steady',
+                default => 'responsive',
+            },
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $dominantTraits
+     * @param  list<string>  $topStrengthFacets
+     * @param  list<string>  $variantKeys
+     * @return array<string,mixed>
+     */
+    private function buildExplainabilitySummary(array $dominantTraits, array $topStrengthFacets, array $variantKeys, string $locale): array
+    {
+        $primary = $dominantTraits[0] ?? ['label' => $locale === 'zh' ? '当前人格' : 'Current profile'];
+        $secondary = $dominantTraits[1] ?? null;
+        $profileTags = array_values(array_filter($variantKeys, static fn (string $key): bool => str_starts_with($key, 'profile:')));
+
+        $headline = $locale === 'zh'
+            ? sprintf('这次画像主要由%s驱动。', (string) ($primary['label'] ?? '你的主维度'))
+            : sprintf('This profile is primarily driven by %s.', (string) ($primary['label'] ?? 'your leading trait'));
+
+        $reasons = [];
+        $reasons[] = $locale === 'zh'
+            ? sprintf('%s位于第 %d 百分位，形成了这次结果的第一主轴。', (string) ($primary['label'] ?? ''), (int) ($primary['percentile'] ?? 0))
+            : sprintf('%s sits at percentile %d, making it the strongest axis in this read.', (string) ($primary['label'] ?? ''), (int) ($primary['percentile'] ?? 0));
+
+        if (is_array($secondary)) {
+            $reasons[] = $locale === 'zh'
+                ? sprintf('%s作为第二主轴，解释了你在不同场景中的稳定表现。', (string) ($secondary['label'] ?? '第二主维度'))
+                : sprintf('%s acts as the secondary axis that stabilizes this profile across scenes.', (string) ($secondary['label'] ?? 'the secondary trait'));
+        }
+
+        if ($topStrengthFacets !== []) {
+            $reasons[] = $locale === 'zh'
+                ? sprintf('高分刻面集中在 %s，说明这不是单点波动，而是有结构的特征组合。', implode(' / ', array_slice($topStrengthFacets, 0, 3)))
+                : sprintf('Top facets cluster around %s, suggesting a structured pattern rather than a one-off spike.', implode(' / ', array_slice($topStrengthFacets, 0, 3)));
+        }
+
+        if ($profileTags !== []) {
+            $reasons[] = $locale === 'zh'
+                ? sprintf('当前命中的 profile tag 为 %s。', implode('、', array_map(fn (string $tag): string => $this->profileTagLabel($tag, $locale), $profileTags)))
+                : sprintf('The current profile tags resolve to %s.', implode(', ', array_map(fn (string $tag): string => $this->profileTagLabel($tag, $locale), $profileTags)));
+        }
+
+        return [
+            'headline' => $headline,
+            'reasons' => $reasons,
+            'top_strength_facets' => array_slice($topStrengthFacets, 0, 3),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $traitVector
+     * @param  list<string>  $topGrowthFacets
+     * @return array<string,mixed>
+     */
+    private function buildActionPlanSummary(array $traitVector, array $topGrowthFacets, string $locale): array
+    {
+        $reverse = $traitVector;
+        usort($reverse, fn (array $a, array $b): int => $this->compareTraitsByPercentile($a, $b, false));
+        $focus = $reverse[0] ?? null;
+        $focusKey = (string) ($focus['key'] ?? 'C');
+        $focusLabel = (string) ($focus['label'] ?? $focusKey);
+
+        $actions = match ($focusKey) {
+            'O' => $locale === 'zh'
+                ? ['每周给自己一次低风险的新刺激。', '把探索想法落成一页记录，避免只停在灵感。', '在新项目里先验证一个最小假设。']
+                : ['Add one low-risk novelty exposure each week.', 'Turn exploratory ideas into one-page notes.', 'Test one smallest viable hypothesis before scaling.'],
+            'C' => $locale === 'zh'
+                ? ['先搭一个最小稳定系统，而不是追求完美流程。', '把重复动作固定到同一个时间窗口。', '每周只追一项能看见进度的目标。']
+                : ['Build one minimal reliable system before optimizing.', 'Anchor repetitive work to the same time window.', 'Track one visible weekly goal instead of many.'],
+            'E' => $locale === 'zh'
+                ? ['把反馈节点提前，而不是等到最后统一收集。', '刻意保留一段对外连接的时间。', '在关键沟通前先写清一句核心诉求。']
+                : ['Move feedback checkpoints earlier.', 'Reserve a deliberate outward-connection window.', 'Write one clear communication ask before key conversations.'],
+            'A' => $locale === 'zh'
+                ? ['把边界说清楚，避免靠猜测维持关系。', '在分歧里先确认目标一致，再谈做法。', '把“我不同意”的表达练成固定句式。']
+                : ['State boundaries explicitly instead of implying them.', 'Confirm shared goals before debating method.', 'Practice a reusable sentence for disagreement.'],
+            'N' => $locale === 'zh'
+                ? ['先固定一个恢复动作，再谈更大的改变。', '把高压时最常见的触发点写出来。', '在任务切换前留出三分钟过渡。']
+                : ['Lock in one recovery ritual before larger changes.', 'Write down your most common pressure triggers.', 'Leave a three-minute transition before task switching.'],
+            default => [],
+        };
+
+        $headline = $locale === 'zh'
+            ? sprintf('当前最值得优先经营的是 %s。', $focusLabel)
+            : sprintf('The best near-term growth lever is %s.', $focusLabel);
+
+        return [
+            'headline' => $headline,
+            'focus_trait' => $focusKey,
+            'focus_trait_label' => $focusLabel,
+            'actions' => $actions,
+            'top_growth_facets' => array_slice($topGrowthFacets, 0, 3),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $traitVector
+     * @param  list<array<string,mixed>>  $dominantTraits
+     * @param  array<string,string>  $sceneFingerprint
+     * @param  list<string>  $variantKeys
+     * @param  array<string,mixed>  $explainabilitySummary
+     * @param  array<string,mixed>  $actionPlanSummary
+     * @return list<array<string,mixed>>
+     */
+    private function buildSections(
+        array $traitVector,
+        array $dominantTraits,
+        array $sceneFingerprint,
+        array $variantKeys,
+        array $explainabilitySummary,
+        array $actionPlanSummary,
+        string $locale
+    ): array {
+        $primary = $dominantTraits[0] ?? null;
+        $secondary = $dominantTraits[1] ?? null;
+        $primaryLabel = (string) ($primary['label'] ?? ($locale === 'zh' ? '当前主维度' : 'the leading trait'));
+        $secondaryLabel = (string) ($secondary['label'] ?? ($locale === 'zh' ? '第二主维度' : 'the secondary trait'));
+
+        $traitBullets = array_map(
+            fn (array $trait): string => $locale === 'zh'
+                ? sprintf('%s：第 %d 百分位，当前更偏 %s。', (string) $trait['label'], (int) $trait['percentile'], (string) $trait['band_label'])
+                : sprintf('%s: percentile %d, currently leaning %s.', (string) $trait['label'], (int) $trait['percentile'], (string) $trait['band_label']),
+            $traitVector
+        );
+
+        return [
+            [
+                'key' => 'traits.overview',
+                'title' => $locale === 'zh' ? '人格总览' : 'Traits Overview',
+                'access_level' => 'free',
+                'module_code' => 'big5_core',
+                'blocks' => [
+                    [
+                        'kind' => 'paragraph',
+                        'title' => $locale === 'zh' ? '这份 Big Five 画像的主轴' : 'The main axis of this Big Five read',
+                        'body' => $locale === 'zh'
+                            ? sprintf('你这次的画像主要由%s和%s共同决定。它不是一句标签，而是五维组合的结果。', $primaryLabel, $secondaryLabel)
+                            : sprintf('This read is primarily shaped by %s and %s. It is a five-trait combination, not a single label.', $primaryLabel, $secondaryLabel),
+                    ],
+                    [
+                        'kind' => 'bullets',
+                        'title' => $locale === 'zh' ? '五维带宽' : 'Trait bands',
+                        'body' => implode("\n", $traitBullets),
+                    ],
+                ],
+            ],
+            [
+                'key' => 'traits.why_this_profile',
+                'title' => $locale === 'zh' ? '为什么会是这个画像' : 'Why This Profile',
+                'access_level' => 'free',
+                'module_code' => 'big5_core',
+                'blocks' => [
+                    [
+                        'kind' => 'paragraph',
+                        'title' => $locale === 'zh' ? '解释主线' : 'Explainability thread',
+                        'body' => (string) ($explainabilitySummary['headline'] ?? ''),
+                        'tags' => array_map(fn (string $key): string => $this->profileTagLabel($key, $locale), array_values(array_filter($variantKeys, static fn (string $key): bool => str_starts_with($key, 'profile:')))),
+                    ],
+                    [
+                        'kind' => 'bullets',
+                        'title' => $locale === 'zh' ? '为什么会命中这组特征' : 'Why this combination resolves',
+                        'body' => implode("\n", array_map('strval', is_array($explainabilitySummary['reasons'] ?? null) ? $explainabilitySummary['reasons'] : [])),
+                    ],
+                ],
+            ],
+            [
+                'key' => 'relationships.interpersonal_style',
+                'title' => $locale === 'zh' ? '关系与互动风格' : 'Interpersonal Style',
+                'access_level' => 'paid',
+                'module_code' => 'big5_full',
+                'blocks' => [
+                    [
+                        'kind' => 'paragraph',
+                        'title' => $locale === 'zh' ? '互动场景画像' : 'Relationship scene fingerprint',
+                        'body' => $locale === 'zh'
+                            ? sprintf('在互动里，你更偏%s的社交能量、%s的合作方式，以及%s的压力姿态。', $this->sceneLabel($sceneFingerprint['social_energy'] ?? 'balanced', $locale), $this->sceneLabel($sceneFingerprint['cooperation'] ?? 'balanced', $locale), $this->sceneLabel($sceneFingerprint['stress_posture'] ?? 'responsive', $locale))
+                            : sprintf('In relationships, you lean toward %s social energy, %s cooperation, and a %s stress posture.', $this->sceneLabel($sceneFingerprint['social_energy'] ?? 'balanced', $locale), $this->sceneLabel($sceneFingerprint['cooperation'] ?? 'balanced', $locale), $this->sceneLabel($sceneFingerprint['stress_posture'] ?? 'responsive', $locale)),
+                    ],
+                    [
+                        'kind' => 'bullets',
+                        'title' => $locale === 'zh' ? '关系提示' : 'Relationship cues',
+                        'body' => implode("\n", $this->relationshipCues($sceneFingerprint, $locale)),
+                    ],
+                ],
+            ],
+            [
+                'key' => 'career.work_style',
+                'title' => $locale === 'zh' ? '工作风格与场景' : 'Work Style',
+                'access_level' => 'paid',
+                'module_code' => 'big5_full',
+                'blocks' => [
+                    [
+                        'kind' => 'paragraph',
+                        'title' => $locale === 'zh' ? '工作场景指纹' : 'Work scene fingerprint',
+                        'body' => $locale === 'zh'
+                            ? sprintf('工作上，你更适合%s的变化、%s的结构，以及%s的对外节奏。', $this->sceneLabel($sceneFingerprint['novelty'] ?? 'balanced', $locale), $this->sceneLabel($sceneFingerprint['structure'] ?? 'balanced', $locale), $this->sceneLabel($sceneFingerprint['social_energy'] ?? 'balanced', $locale))
+                            : sprintf('At work, you fit %s change, %s structure, and a %s outward rhythm.', $this->sceneLabel($sceneFingerprint['novelty'] ?? 'balanced', $locale), $this->sceneLabel($sceneFingerprint['structure'] ?? 'balanced', $locale), $this->sceneLabel($sceneFingerprint['social_energy'] ?? 'balanced', $locale)),
+                    ],
+                    [
+                        'kind' => 'bullets',
+                        'title' => $locale === 'zh' ? '工作提示' : 'Work cues',
+                        'body' => implode("\n", $this->workCues($sceneFingerprint, $locale)),
+                    ],
+                ],
+            ],
+            [
+                'key' => 'growth.next_actions',
+                'title' => $locale === 'zh' ? '成长与下一步动作' : 'Next Actions',
+                'access_level' => 'paid',
+                'module_code' => 'big5_action_plan',
+                'blocks' => [
+                    [
+                        'kind' => 'paragraph',
+                        'title' => $locale === 'zh' ? '接下来优先修什么' : 'What to work on next',
+                        'body' => (string) ($actionPlanSummary['headline'] ?? ''),
+                    ],
+                    [
+                        'kind' => 'bullets',
+                        'title' => $locale === 'zh' ? '行动建议' : 'Action plan',
+                        'body' => implode("\n", array_map('strval', is_array($actionPlanSummary['actions'] ?? null) ? $actionPlanSummary['actions'] : [])),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function profileTagLabel(string $tag, string $locale): string
+    {
+        return self::PROFILE_LABELS[$tag][$locale] ?? $tag;
+    }
+
+    private function sceneLabel(string $value, string $locale): string
+    {
+        return match ($value) {
+            'exploratory' => $locale === 'zh' ? '更探索' : 'more exploratory',
+            'grounded' => $locale === 'zh' ? '更务实' : 'more grounded',
+            'structured' => $locale === 'zh' ? '更有序' : 'more structured',
+            'adaptive' => $locale === 'zh' ? '更灵活' : 'more adaptive',
+            'outward' => $locale === 'zh' ? '更外放' : 'more outward',
+            'reserved' => $locale === 'zh' ? '更克制' : 'more reserved',
+            'harmonizing' => $locale === 'zh' ? '更体谅' : 'more harmonizing',
+            'direct' => $locale === 'zh' ? '更直接' : 'more direct',
+            'sensitive' => $locale === 'zh' ? '更敏感' : 'more sensitive',
+            'steady' => $locale === 'zh' ? '更稳定' : 'more steady',
+            'responsive' => $locale === 'zh' ? '相对敏感' : 'responsive',
+            default => $locale === 'zh' ? '相对平衡' : 'balanced',
+        };
+    }
+
+    /**
+     * @param  array<string,string>  $sceneFingerprint
+     * @return list<string>
+     */
+    private function relationshipCues(array $sceneFingerprint, string $locale): array
+    {
+        return [
+            $locale === 'zh'
+                ? sprintf('在关系里，你通常更偏%s地处理互动。', $this->sceneLabel($sceneFingerprint['social_energy'] ?? 'balanced', $locale))
+                : sprintf('In relationships, you tend to handle interaction in a %s way.', $this->sceneLabel($sceneFingerprint['social_energy'] ?? 'balanced', $locale)),
+            $locale === 'zh'
+                ? sprintf('遇到分歧时，你更可能用%s的方式推进沟通。', $this->sceneLabel($sceneFingerprint['cooperation'] ?? 'balanced', $locale))
+                : sprintf('During conflict, you are more likely to communicate in a %s mode.', $this->sceneLabel($sceneFingerprint['cooperation'] ?? 'balanced', $locale)),
+            $locale === 'zh'
+                ? sprintf('压力上来时，关系体验会呈现%s的姿态。', $this->sceneLabel($sceneFingerprint['stress_posture'] ?? 'responsive', $locale))
+                : sprintf('Under pressure, your relationship posture becomes more %s.', $this->sceneLabel($sceneFingerprint['stress_posture'] ?? 'responsive', $locale)),
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $sceneFingerprint
+     * @return list<string>
+     */
+    private function workCues(array $sceneFingerprint, string $locale): array
+    {
+        return [
+            $locale === 'zh'
+                ? sprintf('面对变化时，你更适合%s的节奏。', $this->sceneLabel($sceneFingerprint['novelty'] ?? 'balanced', $locale))
+                : sprintf('When handling change, you fit a %s pace.', $this->sceneLabel($sceneFingerprint['novelty'] ?? 'balanced', $locale)),
+            $locale === 'zh'
+                ? sprintf('执行任务时，你更习惯%s的结构。', $this->sceneLabel($sceneFingerprint['structure'] ?? 'balanced', $locale))
+                : sprintf('When executing work, you tend to prefer a %s structure.', $this->sceneLabel($sceneFingerprint['structure'] ?? 'balanced', $locale)),
+            $locale === 'zh'
+                ? sprintf('协作节奏上，你通常会选择%s的对外方式。', $this->sceneLabel($sceneFingerprint['social_energy'] ?? 'balanced', $locale))
+                : sprintf('In collaboration, you usually prefer a %s outward rhythm.', $this->sceneLabel($sceneFingerprint['social_energy'] ?? 'balanced', $locale)),
+        ];
+    }
+}

--- a/backend/app/Services/Report/BigFiveReportComposer.php
+++ b/backend/app/Services/Report/BigFiveReportComposer.php
@@ -6,6 +6,7 @@ namespace App\Services\Report;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\Content\BigFivePackLoader;
 use App\Services\Observability\BigFiveTelemetry;
 use App\Services\Template\TemplateContext;
@@ -28,6 +29,7 @@ final class BigFiveReportComposer
         private readonly BigFivePackLoader $packLoader,
         private readonly TemplateEngine $templateEngine,
         private readonly BigFiveTelemetry $bigFiveTelemetry,
+        private readonly BigFivePublicProjectionService $bigFivePublicProjectionService,
     ) {}
 
     /**
@@ -120,6 +122,15 @@ final class BigFiveReportComposer
         }
 
         $locked = $variant === ReportAccess::VARIANT_FREE;
+        $publicProjection = $this->bigFivePublicProjectionService->build(
+            $scoreResult,
+            $locale,
+            $variant,
+            $locked
+        );
+        $foundationSections = is_array($publicProjection['sections'] ?? null) ? $publicProjection['sections'] : [];
+        $sections = array_merge($foundationSections, $sections);
+
         $this->bigFiveTelemetry->recordReportComposed(
             (int) ($attempt->org_id ?? 0),
             $this->numericUserId($attempt->user_id ?? null),
@@ -152,6 +163,9 @@ final class BigFiveReportComposer
                 ],
                 'quality' => [
                     'level' => (string) ($scoreResult['quality']['level'] ?? 'D'),
+                ],
+                '_meta' => [
+                    'big5_public_projection_v1' => $publicProjection,
                 ],
                 'generated_at' => now()->toISOString(),
             ],

--- a/backend/tests/Feature/Content/BigFiveReportBlocksContractTest.php
+++ b/backend/tests/Feature/Content/BigFiveReportBlocksContractTest.php
@@ -90,7 +90,24 @@ final class BigFiveReportBlocksContractTest extends TestCase
         $this->assertTrue((bool) ($free['ok'] ?? false));
         $freeSections = (array) data_get($free, 'report.sections', []);
         $freeKeys = array_values(array_map(static fn (array $s): string => (string) ($s['key'] ?? ''), $freeSections));
-        $this->assertSame(['disclaimer_top', 'summary', 'domains_overview', 'disclaimer'], $freeKeys);
+        $this->assertSame(
+            [
+                'traits.overview',
+                'traits.why_this_profile',
+                'relationships.interpersonal_style',
+                'career.work_style',
+                'growth.next_actions',
+                'disclaimer_top',
+                'summary',
+                'domains_overview',
+                'disclaimer',
+            ],
+            $freeKeys
+        );
+        $this->assertSame('paid', (string) data_get($freeSections, '2.access_level'));
+        $this->assertSame('paid', (string) data_get($freeSections, '3.access_level'));
+        $this->assertSame('paid', (string) data_get($freeSections, '4.access_level'));
+        $this->assertSame('big5.public_projection.v1', (string) data_get($free, 'report._meta.big5_public_projection_v1.schema_version'));
 
         $full = $composer->composeVariant($attempt, $result, ReportAccess::VARIANT_FULL, [
             'modules_allowed' => [
@@ -103,9 +120,24 @@ final class BigFiveReportBlocksContractTest extends TestCase
         $fullSections = (array) data_get($full, 'report.sections', []);
         $fullKeys = array_values(array_map(static fn (array $s): string => (string) ($s['key'] ?? ''), $fullSections));
         $this->assertSame(
-            ['disclaimer_top', 'summary', 'domains_overview', 'facet_table', 'top_facets', 'facets_deepdive', 'action_plan', 'disclaimer'],
+            [
+                'traits.overview',
+                'traits.why_this_profile',
+                'relationships.interpersonal_style',
+                'career.work_style',
+                'growth.next_actions',
+                'disclaimer_top',
+                'summary',
+                'domains_overview',
+                'facet_table',
+                'top_facets',
+                'facets_deepdive',
+                'action_plan',
+                'disclaimer',
+            ],
             $fullKeys
         );
+        $this->assertSame('big5.public_projection.v1', (string) data_get($full, 'report._meta.big5_public_projection_v1.schema_version'));
 
         $sectionMap = [];
         foreach ($fullSections as $section) {

--- a/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Services\Assessment\Scorers\BigFiveScorerV3;
+use App\Services\Content\BigFivePackLoader;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BigFiveResultEngineFoundationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_big5_result_and_report_read_paths_expose_projection_foundation_and_telemetry_meta(): void
+    {
+        $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
+        $this->artisan('norms:import --scale=BIG5_OCEAN --csv=resources/norms/big5/big5_norm_stats_seed.csv --activate=1')
+            ->assertExitCode(0);
+        (new ScaleRegistrySeeder())->run();
+
+        $anonId = 'anon_big5_foundation';
+        $attemptId = $this->seedAttempt($anonId);
+        $this->seedResult($attemptId);
+        $token = $this->issueAnonToken($anonId);
+
+        $resultResponse = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $resultResponse->assertOk();
+        $resultResponse->assertJsonPath('big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
+        $resultResponse->assertJsonPath('big5_public_projection_v1.ordered_section_keys.0', 'traits.overview');
+        $resultResponse->assertJsonPath('big5_public_projection_v1.trait_bands.O', 'mid');
+
+        $reportResponse = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $reportResponse->assertOk();
+        $reportResponse->assertJsonPath('big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
+        $reportResponse->assertJsonPath('big5_public_projection_v1.ordered_section_keys.1', 'traits.why_this_profile');
+        $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
+        $reportResponse->assertJsonPath('report.sections.0.key', 'traits.overview');
+        $reportResponse->assertJsonPath('report.sections.4.key', 'growth.next_actions');
+
+        $reportEvent = DB::table('events')
+            ->where('event_code', 'report_view')
+            ->orderByDesc('created_at')
+            ->first();
+
+        $this->assertNotNull($reportEvent);
+        $meta = $this->decodeMeta($reportEvent->meta_json ?? null);
+        $this->assertSame(['traits.overview', 'traits.why_this_profile', 'relationships.interpersonal_style', 'career.work_style', 'growth.next_actions'], array_slice((array) ($meta['ordered_section_keys'] ?? []), 0, 5));
+        $this->assertArrayHasKey('trait_bands', $meta);
+        $this->assertArrayHasKey('scene_fingerprint', $meta);
+    }
+
+    private function seedAttempt(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', (string) Str::uuid()), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v1',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 120,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinutes(8),
+            'submitted_at' => now()->subMinutes(1),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+        ]);
+
+        return $attemptId;
+    }
+
+    private function seedResult(string $attemptId): void
+    {
+        /** @var BigFivePackLoader $loader */
+        $loader = app(BigFivePackLoader::class);
+        /** @var BigFiveScorerV3 $scorer */
+        $scorer = app(BigFiveScorerV3::class);
+
+        $questions = $loader->readCompiledJson('questions.compiled.json', 'v1');
+        $norms = $loader->readCompiledJson('norms.compiled.json', 'v1');
+        $policyCompiled = $loader->readCompiledJson('policy.compiled.json', 'v1');
+
+        $questionIndex = [];
+        foreach ((array) ($questions['question_index'] ?? []) as $qid => $row) {
+            if (is_array($row)) {
+                $questionIndex[(int) $qid] = $row;
+            }
+        }
+
+        $answersById = [];
+        for ($i = 1; $i <= 120; $i++) {
+            $answersById[$i] = 3;
+        }
+
+        $score = $scorer->score(
+            $answersById,
+            $questionIndex,
+            is_array($norms) ? $norms : [],
+            is_array($policyCompiled['policy'] ?? null) ? $policyCompiled['policy'] : [],
+            [
+                'locale' => 'zh-CN',
+                'country' => 'CN_MAINLAND',
+                'region' => 'CN_MAINLAND',
+                'gender' => 'ALL',
+                'age_band' => 'all',
+                'time_seconds_total' => 480.0,
+                'duration_ms' => 480000,
+            ]
+        );
+
+        DB::table('results')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v1',
+            'type_code' => 'BIG5',
+            'scores_json' => json_encode(['domains_mean' => $score['raw_scores']['domains_mean'] ?? []], JSON_UNESCAPED_UNICODE),
+            'scores_pct' => json_encode($score['scores_0_100']['domains_percentile'] ?? [], JSON_UNESCAPED_UNICODE),
+            'axis_states' => json_encode([], JSON_UNESCAPED_UNICODE),
+            'content_package_version' => 'v1',
+            'result_json' => json_encode([
+                'normed_json' => $score,
+                'breakdown_json' => ['score_result' => $score],
+                'axis_scores_json' => [
+                    'score_result' => $score,
+                    'scores_pct' => $score['scores_0_100']['domains_percentile'] ?? [],
+                ],
+            ], JSON_UNESCAPED_UNICODE),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => 1,
+            'computed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeMeta(mixed $raw): array
+    {
+        if (is_array($raw)) {
+            return $raw;
+        }
+        if (! is_string($raw) || trim($raw) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive;
+
+use App\Models\Result;
+use App\Services\BigFive\BigFivePublicProjectionService;
+use Tests\TestCase;
+
+final class BigFivePublicProjectionServiceTest extends TestCase
+{
+    public function test_it_builds_formal_big5_projection_fields_and_sections(): void
+    {
+        $result = new Result([
+            'result_json' => [
+                'normed_json' => [
+                    'engine_version' => 'big5_ipipneo120_v3.0.0',
+                    'raw_scores' => [
+                        'domains_mean' => ['O' => 4.2, 'C' => 3.8, 'E' => 3.2, 'A' => 3.9, 'N' => 2.3],
+                    ],
+                    'scores_0_100' => [
+                        'domains_percentile' => ['O' => 81, 'C' => 73, 'E' => 48, 'A' => 76, 'N' => 22],
+                    ],
+                    'facts' => [
+                        'domain_buckets' => ['O' => 'high', 'C' => 'high', 'E' => 'mid', 'A' => 'high', 'N' => 'low'],
+                        'top_strength_facets' => ['O5', 'A3', 'C4'],
+                        'top_growth_facets' => ['E3', 'E2', 'C5'],
+                    ],
+                    'tags' => ['big5:o_high', 'big5:c_high', 'profile:explorer'],
+                ],
+            ],
+        ]);
+
+        $projection = app(BigFivePublicProjectionService::class)->buildFromResult($result, 'zh-CN', 'full', false);
+
+        $this->assertSame('big5.public_projection.v1', $projection['schema_version']);
+        $this->assertSame(['O', 'C', 'E', 'A', 'N'], array_values(array_map(
+            static fn (array $trait): string => (string) ($trait['key'] ?? ''),
+            (array) ($projection['trait_vector'] ?? [])
+        )));
+        $this->assertSame('high', data_get($projection, 'trait_bands.O'));
+        $this->assertSame('low', data_get($projection, 'trait_bands.N'));
+        $this->assertSame('O', data_get($projection, 'dominant_traits.0.key'));
+        $this->assertContains('profile:explorer', (array) ($projection['variant_keys'] ?? []));
+        $this->assertSame('exploratory', data_get($projection, 'scene_fingerprint.novelty'));
+        $this->assertSame('traits.overview', data_get($projection, 'ordered_section_keys.0'));
+        $this->assertSame('career.work_style', data_get($projection, 'ordered_section_keys.3'));
+        $this->assertSame('growth.next_actions', data_get($projection, 'ordered_section_keys.4'));
+        $this->assertNotSame('', (string) data_get($projection, 'explainability_summary.headline', ''));
+        $this->assertSame('N', data_get($projection, 'action_plan_summary.focus_trait'));
+        $this->assertCount(5, (array) ($projection['sections'] ?? []));
+        $this->assertSame('paid', data_get($projection, 'sections.2.access_level'));
+    }
+
+    public function test_it_keeps_trait_vector_in_ocean_order_and_breaks_percentile_ties_stably(): void
+    {
+        $result = new Result([
+            'result_json' => [
+                'normed_json' => [
+                    'engine_version' => 'big5_ipipneo120_v3.0.0',
+                    'raw_scores' => [
+                        'domains_mean' => ['O' => 3.0, 'C' => 3.0, 'E' => 3.0, 'A' => 3.0, 'N' => 3.0],
+                    ],
+                    'scores_0_100' => [
+                        'domains_percentile' => ['O' => 70, 'C' => 70, 'E' => 55, 'A' => 70, 'N' => 55],
+                    ],
+                    'facts' => [
+                        'domain_buckets' => ['O' => 'high', 'C' => 'high', 'E' => 'mid', 'A' => 'high', 'N' => 'mid'],
+                        'top_strength_facets' => ['O2', 'C3', 'A4'],
+                        'top_growth_facets' => ['E2', 'N3', 'O1'],
+                    ],
+                    'tags' => ['profile:explorer'],
+                ],
+            ],
+        ]);
+
+        $projection = app(BigFivePublicProjectionService::class)->buildFromResult($result, 'en', 'free', true);
+
+        $this->assertSame(
+            ['O', 'C', 'E', 'A', 'N'],
+            array_values(array_map(
+                static fn (array $trait): string => (string) ($trait['key'] ?? ''),
+                (array) ($projection['trait_vector'] ?? [])
+            ))
+        );
+        $this->assertSame(['O', 'C', 'A'], array_values(array_map(
+            static fn (array $trait): string => (string) ($trait['key'] ?? ''),
+            (array) ($projection['dominant_traits'] ?? [])
+        )));
+        $this->assertSame('E', data_get($projection, 'action_plan_summary.focus_trait'));
+    }
+}


### PR DESCRIPTION
## Summary

This PR establishes the backend half of Big Five PR-9A: result engine foundation.

It turns Big Five from a mostly legacy report path into a formal result-engine authority with a replayable public projection.

## What changed

Backend:
- adds `big5.public_projection.v1`
- derives formal authority for:
  - `trait_vector`
  - `trait_bands`
  - `dominant_traits`
  - `variant_keys`
  - `scene_fingerprint`
  - `explainability_summary`
  - `action_plan_summary`
  - `ordered_section_keys`
- prepends first-wave Big Five engine sections into the report chain
- exposes `big5_public_projection_v1` on result and report read paths
- extends Big Five result/report telemetry meta with section ordering, trait bands, scene fingerprint, and variant keys

This PR also closes the replay stability gap discovered during review:
- `trait_vector` now preserves canonical `O/C/E/A/N` order
- ranked views are split out through `dominant_traits`
- percentile ties now resolve deterministically with `DOMAIN_ORDER`
- `action_plan_summary.focus_trait` is tie-stable as well

## Why this matters

This is the first real copy of the MBTI result-engine pattern onto a second assessment.

After this PR, Big Five has:
- a single backend authority
- a formal projection/report/read-path foundation
- replayable ordering behavior
- enough section/block structure to serve as the second template in the platform

## Validation

I ran:

- `php artisan test tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php tests/Feature/Content/BigFiveReportBlocksContractTest.php tests/Feature/Observability/BigFiveTelemetryTest.php`

All passed:
- 6 tests passed
- 258 assertions

## Scope note

This PR intentionally does not pull in task-external dirty files, especially:
- `backend/content_packs/BIG5_OCEAN/v1/compiled/*`
- `backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php`
- `backend/app/Console/Commands/PacksPublish.php`
- `backend/app/Console/Commands/PacksRollback.php`
- `backend/config/storage_rollout.php`

It is limited to Big Five result-engine foundation on the backend.
