### PR TITLE
[codex] add exact release rehydrate verify loop

### DIFF
--- a/backend/app/Console/Commands/StorageRehydrateExactRelease.php
+++ b/backend/app/Console/Commands/StorageRehydrateExactRelease.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\ExactReleaseRehydrateService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageRehydrateExactRelease extends Command
+{
+    protected $signature = 'storage:rehydrate-exact-release
+        {--dry-run : Build a rehydrate plan only}
+        {--execute : Execute rehydrate into a verify-only run directory}
+        {--exact-manifest-id= : Exact release manifest id}
+        {--release-id= : Content pack release id}
+        {--disk= : Remote disk, defaults to storage_rollout.blob_offload_disk}
+        {--target-root= : Optional safe base directory for rehydrate run output}';
+
+    protected $description = 'Rehydrate an exact content release root from verified remote blob locations into a new verify-only run directory.';
+
+    public function __construct(
+        private readonly ExactReleaseRehydrateService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $disk = trim((string) ($this->option('disk') ?? ''));
+        if ($disk === '') {
+            $disk = trim((string) config('storage_rollout.blob_offload_disk', 's3'));
+        }
+
+        try {
+            $exactManifestId = $this->parseExactManifestId();
+            $releaseId = trim((string) ($this->option('release-id') ?? ''));
+            if ($exactManifestId === null && $releaseId === '') {
+                throw new \RuntimeException('either --exact-manifest-id or --release-id is required.');
+            }
+
+            $this->ensureTargetDiskIsRemote($disk);
+            $targetRoot = $this->resolveTargetRoot(trim((string) ($this->option('target-root') ?? '')));
+            $this->ensureSafeTargetRoot($targetRoot);
+
+            $plan = $this->service->buildPlan($exactManifestId, $releaseId !== '' ? $releaseId : null, $disk, $targetRoot);
+            $planPath = $this->persistPlan($plan);
+
+            if ($dryRun) {
+                $this->emitDryRunOutput($planPath, $plan);
+                $this->recordAudit('planned', $disk, $planPath, $plan, [
+                    'rehydrated_files' => 0,
+                    'verified_files' => 0,
+                    'bytes' => 0,
+                    'run_dir' => null,
+                ], 'success');
+
+                return self::SUCCESS;
+            }
+
+            $this->ensureExecuteDiskConfigured($disk);
+            $result = $this->service->executePlan($plan);
+            $this->emitExecuteOutput($planPath, $plan, $result);
+            $this->recordAudit('executed', $disk, $planPath, $plan, $result, 'success');
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            if (isset($planPath) && isset($plan) && is_array($plan)) {
+                $this->recordAudit('failed', $disk, $planPath, $plan, [
+                    'rehydrated_files' => 0,
+                    'verified_files' => 0,
+                    'bytes' => 0,
+                    'run_dir' => null,
+                    'error' => $e->getMessage(),
+                ], 'failure');
+            }
+
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function parseExactManifestId(): ?int
+    {
+        $value = trim((string) ($this->option('exact-manifest-id') ?? ''));
+        if ($value === '') {
+            return null;
+        }
+
+        if (! ctype_digit($value)) {
+            throw new \RuntimeException('--exact-manifest-id must be a positive integer.');
+        }
+
+        return (int) $value;
+    }
+
+    private function ensureTargetDiskIsRemote(string $disk): void
+    {
+        $driver = trim((string) config('filesystems.disks.'.$disk.'.driver', ''));
+        if ($driver === '') {
+            throw new \RuntimeException('rehydrate disk is not configured: filesystems.disks.'.$disk.' is missing.');
+        }
+
+        if ($driver === 'local') {
+            throw new \RuntimeException('rehydrate target disk must be remote: local disks are not allowed.');
+        }
+    }
+
+    private function ensureExecuteDiskConfigured(string $disk): void
+    {
+        $driver = trim((string) config('filesystems.disks.'.$disk.'.driver', ''));
+        if ($driver !== 's3') {
+            return;
+        }
+
+        $bucket = trim((string) config('filesystems.disks.'.$disk.'.bucket', ''));
+        if ($bucket === '') {
+            throw new \RuntimeException('s3 rehydrate disk is not configured: filesystems.disks.'.$disk.'.bucket is empty.');
+        }
+    }
+
+    private function resolveTargetRoot(string $targetRootOption): string
+    {
+        if ($targetRootOption === '') {
+            return storage_path('app/private/rehydrate_runs');
+        }
+
+        if (str_starts_with($targetRootOption, DIRECTORY_SEPARATOR)) {
+            return $this->normalizePath($targetRootOption);
+        }
+
+        return $this->normalizePath(storage_path('app/private/'.ltrim($targetRootOption, '/\\')));
+    }
+
+    private function ensureSafeTargetRoot(string $targetRoot): void
+    {
+        $forbiddenRoots = [
+            storage_path('app/private/content_releases'),
+            storage_path('app/private/packs_v2'),
+            storage_path('app/content_packs_v2'),
+            storage_path('app/private/packs_v2_materialized'),
+            storage_path('app/private/blobs'),
+        ];
+
+        foreach ($forbiddenRoots as $forbiddenRoot) {
+            $forbiddenRoot = $this->normalizePath($forbiddenRoot);
+            if ($targetRoot === $forbiddenRoot || str_starts_with($targetRoot.'/', $forbiddenRoot.'/') || str_starts_with($forbiddenRoot.'/', $targetRoot.'/')) {
+                throw new \RuntimeException('unsafe target root for rehydrate runs: '.$targetRoot);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function persistPlan(array $plan): string
+    {
+        $planDir = storage_path('app/private/rehydrate_plans');
+        File::ensureDirectoryExists($planDir);
+
+        $planPath = $planDir.DIRECTORY_SEPARATOR.now()->format('Ymd_His').'_exact_release_rehydrate_'.substr(bin2hex(random_bytes(4)), 0, 8).'.json';
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode rehydrate plan json.');
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        return $planPath;
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function emitDryRunOutput(string $planPath, array $plan): void
+    {
+        $summary = is_array($plan['summary'] ?? null) ? $plan['summary'] : [];
+        $manifest = is_array($plan['exact_manifest'] ?? null) ? $plan['exact_manifest'] : [];
+
+        $this->line('status=planned');
+        $this->line('exact_manifest_id='.(int) ($manifest['id'] ?? 0));
+        $this->line('disk='.(string) ($plan['disk'] ?? ''));
+        $this->line('file_count='.(int) ($summary['file_count'] ?? 0));
+        $this->line('total_bytes='.(int) ($summary['total_bytes'] ?? 0));
+        $this->line('missing_locations='.(int) ($summary['missing_locations'] ?? 0));
+        $this->line('plan='.$planPath);
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @param  array<string,mixed>  $result
+     */
+    private function emitExecuteOutput(string $planPath, array $plan, array $result): void
+    {
+        $manifest = is_array($plan['exact_manifest'] ?? null) ? $plan['exact_manifest'] : [];
+
+        $this->line('status=executed');
+        $this->line('exact_manifest_id='.(int) ($manifest['id'] ?? 0));
+        $this->line('disk='.(string) ($plan['disk'] ?? ''));
+        $this->line('rehydrated_files='.(int) ($result['rehydrated_files'] ?? 0));
+        $this->line('verified_files='.(int) ($result['verified_files'] ?? 0));
+        $this->line('bytes='.(int) ($result['bytes'] ?? 0));
+        $this->line('run_dir='.(string) ($result['run_dir'] ?? ''));
+        $this->line('plan='.$planPath);
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @param  array<string,mixed>  $result
+     */
+    private function recordAudit(string $mode, string $disk, string $planPath, array $plan, array $result, string $resultLabel): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_rehydrate_exact_release',
+            'target_type' => 'storage',
+            'target_id' => (string) (($plan['exact_manifest']['id'] ?? 'exact_manifest')),
+            'meta_json' => json_encode([
+                'mode' => $mode,
+                'disk' => $disk,
+                'plan_path' => $planPath,
+                'plan' => $plan,
+                'result' => $result,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_rehydrate_exact_release',
+            'request_id' => null,
+            'reason' => 'exact_release_rehydrate_verify',
+            'result' => $resultLabel,
+            'created_at' => now(),
+        ]);
+    }
+
+    private function normalizePath(string $path): string
+    {
+        return str_replace('\\', '/', rtrim(trim($path), '/\\'));
+    }
+}

--- a/backend/app/Services/Storage/ExactReleaseRehydrateService.php
+++ b/backend/app/Services/Storage/ExactReleaseRehydrateService.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\ContentReleaseExactManifest;
+use App\Models\StorageBlobLocation;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
+final class ExactReleaseRehydrateService
+{
+    private const LOCATION_KIND_REMOTE_COPY = 'remote_copy';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildPlan(?int $exactManifestId, ?string $releaseId, string $disk, ?string $targetRoot = null): array
+    {
+        $manifest = $this->resolveExactManifest($exactManifestId, $releaseId);
+        $files = $manifest->files()
+            ->orderBy('logical_path')
+            ->get();
+
+        if ($files->isEmpty()) {
+            throw new \RuntimeException('exact manifest has no file rows to rehydrate.');
+        }
+
+        $targetRoot = $this->normalizeAbsolutePath($targetRoot ?: storage_path('app/private/rehydrate_runs'));
+        $totalBytes = 0;
+        $missingLocations = 0;
+        $plannedFiles = [];
+
+        foreach ($files as $file) {
+            $logicalPath = $this->normalizeRelativePath((string) $file->logical_path);
+            $sizeBytes = max(0, (int) $file->size_bytes);
+            $totalBytes += $sizeBytes;
+
+            $location = $this->resolveVerifiedLocation((string) $file->blob_hash, $disk);
+            if ($location === null) {
+                $missingLocations++;
+            }
+
+            $plannedFiles[] = [
+                'logical_path' => $logicalPath,
+                'blob_hash' => strtolower(trim((string) $file->blob_hash)),
+                'size_bytes' => $sizeBytes,
+                'checksum' => $file->checksum,
+                'content_type' => $file->content_type,
+                'encoding' => $file->encoding,
+                'remote_location' => $location === null ? null : [
+                    'id' => (int) $location->id,
+                    'disk' => (string) $location->disk,
+                    'storage_path' => (string) $location->storage_path,
+                    'verified_at' => optional($location->verified_at)->toAtomString(),
+                    'meta_json' => $location->meta_json,
+                ],
+            ];
+        }
+
+        return [
+            'schema' => (string) config('storage_rollout.rehydrate_plan_schema_version', 'storage_rehydrate_exact_release_plan.v1'),
+            'generated_at' => now()->toAtomString(),
+            'disk' => trim($disk),
+            'target_root' => $targetRoot,
+            'run_key' => hash('sha256', trim((string) $manifest->exact_identity_hash).'|'.trim($disk)),
+            'exact_manifest' => [
+                'id' => (int) $manifest->getKey(),
+                'content_pack_release_id' => $manifest->content_pack_release_id,
+                'exact_identity_hash' => (string) $manifest->exact_identity_hash,
+                'pack_id' => $manifest->pack_id,
+                'pack_version' => $manifest->pack_version,
+                'source_kind' => (string) $manifest->source_kind,
+                'source_disk' => (string) $manifest->source_disk,
+                'source_storage_path' => (string) $manifest->source_storage_path,
+                'manifest_hash' => (string) $manifest->manifest_hash,
+            ],
+            'summary' => [
+                'file_count' => $files->count(),
+                'total_bytes' => $totalBytes,
+                'missing_locations' => $missingLocations,
+            ],
+            'files' => $plannedFiles,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    public function executePlan(array $plan): array
+    {
+        $disk = trim((string) ($plan['disk'] ?? ''));
+        $targetRoot = $this->normalizeAbsolutePath((string) ($plan['target_root'] ?? ''));
+        $exactManifest = is_array($plan['exact_manifest'] ?? null) ? $plan['exact_manifest'] : [];
+        $files = collect(is_array($plan['files'] ?? null) ? $plan['files'] : [])
+            ->filter(static fn ($file): bool => is_array($file))
+            ->values();
+
+        if ($disk === '' || $targetRoot === '') {
+            throw new \RuntimeException('invalid rehydrate plan: disk and target_root are required.');
+        }
+
+        if ((int) (($plan['summary']['missing_locations'] ?? 0)) > 0) {
+            throw new \RuntimeException('cannot execute rehydrate plan with missing verified remote locations.');
+        }
+
+        if ($files->isEmpty()) {
+            throw new \RuntimeException('cannot execute rehydrate plan without file rows.');
+        }
+
+        $runBase = $targetRoot.DIRECTORY_SEPARATOR.now()->format('Ymd_His').'_'.substr(bin2hex(random_bytes(4)), 0, 8);
+        $stagingDir = $runBase.DIRECTORY_SEPARATOR.'staging';
+        $finalDir = $runBase.DIRECTORY_SEPARATOR.'final';
+        File::ensureDirectoryExists($stagingDir);
+
+        $rehydratedFiles = 0;
+        $verifiedFiles = 0;
+        $bytes = 0;
+
+        try {
+            foreach ($files as $file) {
+                /** @var array<string,mixed> $file */
+                $location = is_array($file['remote_location'] ?? null) ? $file['remote_location'] : null;
+                if ($location === null) {
+                    throw new \RuntimeException('missing verified remote location for '.$this->filePathLabel($file));
+                }
+
+                $remotePath = trim((string) ($location['storage_path'] ?? ''));
+                if ($remotePath === '') {
+                    throw new \RuntimeException('invalid remote location for '.$this->filePathLabel($file));
+                }
+
+                $remoteDisk = Storage::disk($disk);
+                if (! $remoteDisk->exists($remotePath)) {
+                    throw new \RuntimeException('remote object missing for '.$this->filePathLabel($file).': '.$remotePath);
+                }
+
+                $payload = $remoteDisk->get($remotePath);
+                if (! is_string($payload)) {
+                    throw new \RuntimeException('failed to read remote object for '.$this->filePathLabel($file));
+                }
+
+                $this->verifyPayload($payload, $file);
+
+                $destination = $stagingDir.DIRECTORY_SEPARATOR.$this->normalizeRelativePath((string) $file['logical_path']);
+                File::ensureDirectoryExists(dirname($destination));
+                File::put($destination, $payload);
+
+                $rehydratedFiles++;
+                $verifiedFiles++;
+                $bytes += strlen($payload);
+            }
+
+            $this->verifyTree($stagingDir, $files, trim((string) ($exactManifest['manifest_hash'] ?? '')));
+            if (! File::moveDirectory($stagingDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize rehydrated run directory.');
+            }
+
+            $manifest = [
+                'schema' => (string) config('storage_rollout.rehydrate_plan_schema_version', 'storage_rehydrate_exact_release_plan.v1'),
+                'built_at' => now()->toAtomString(),
+                'disk' => $disk,
+                'exact_manifest_id' => (int) ($exactManifest['id'] ?? 0),
+                'exact_identity_hash' => (string) ($exactManifest['exact_identity_hash'] ?? ''),
+                'file_count' => $rehydratedFiles,
+                'verified_files' => $verifiedFiles,
+                'bytes' => $bytes,
+            ];
+            $encoded = json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                throw new \RuntimeException('failed to encode rehydrate sentinel.');
+            }
+            File::put($finalDir.DIRECTORY_SEPARATOR.'.rehydrate.json', $encoded.PHP_EOL);
+
+            return [
+                'exact_manifest_id' => (int) ($exactManifest['id'] ?? 0),
+                'disk' => $disk,
+                'rehydrated_files' => $rehydratedFiles,
+                'verified_files' => $verifiedFiles,
+                'bytes' => $bytes,
+                'run_dir' => $finalDir,
+            ];
+        } catch (\Throwable $e) {
+            if (is_dir($runBase)) {
+                File::deleteDirectory($runBase);
+            }
+
+            throw $e;
+        }
+    }
+
+    private function resolveExactManifest(?int $exactManifestId, ?string $releaseId): ContentReleaseExactManifest
+    {
+        $releaseId = trim((string) $releaseId);
+
+        if ($exactManifestId !== null) {
+            $manifest = ContentReleaseExactManifest::query()
+                ->whereKey($exactManifestId)
+                ->first();
+
+            if ($manifest === null) {
+                throw new \RuntimeException('exact manifest not found: '.$exactManifestId);
+            }
+
+            if ($releaseId !== '' && trim((string) $manifest->content_pack_release_id) !== $releaseId) {
+                throw new \RuntimeException('exact manifest does not belong to release '.$releaseId.'.');
+            }
+
+            return $manifest;
+        }
+
+        if ($releaseId === '') {
+            throw new \RuntimeException('either exact manifest id or release id is required.');
+        }
+
+        $manifests = ContentReleaseExactManifest::query()
+            ->where('content_pack_release_id', $releaseId)
+            ->orderBy('id')
+            ->get();
+
+        if ($manifests->count() === 0) {
+            throw new \RuntimeException('no exact manifest found for release '.$releaseId.'.');
+        }
+
+        if ($manifests->count() > 1) {
+            throw new \RuntimeException('multiple exact manifests found for release '.$releaseId.'; pass --exact-manifest-id explicitly.');
+        }
+
+        /** @var ContentReleaseExactManifest $manifest */
+        $manifest = $manifests->first();
+
+        return $manifest;
+    }
+
+    private function resolveVerifiedLocation(string $blobHash, string $disk): ?StorageBlobLocation
+    {
+        return StorageBlobLocation::query()
+            ->where('blob_hash', strtolower(trim($blobHash)))
+            ->where('disk', trim($disk))
+            ->where('location_kind', self::LOCATION_KIND_REMOTE_COPY)
+            ->whereNotNull('verified_at')
+            ->orderByDesc('verified_at')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    /**
+     * @param  array<string,mixed>  $file
+     */
+    private function verifyPayload(string $payload, array $file): void
+    {
+        $expectedHash = strtolower(trim((string) ($file['blob_hash'] ?? '')));
+        if ($expectedHash === '' || hash('sha256', $payload) !== $expectedHash) {
+            throw new \RuntimeException('blob hash mismatch for '.$this->filePathLabel($file));
+        }
+
+        $expectedSize = max(0, (int) ($file['size_bytes'] ?? 0));
+        if (strlen($payload) !== $expectedSize) {
+            throw new \RuntimeException('size mismatch for '.$this->filePathLabel($file));
+        }
+
+        $checksum = trim((string) ($file['checksum'] ?? ''));
+        if ($checksum !== '' && str_starts_with($checksum, 'sha256:')) {
+            $expectedChecksum = strtolower(substr($checksum, strlen('sha256:')));
+            if ($expectedChecksum !== '' && hash('sha256', $payload) !== $expectedChecksum) {
+                throw new \RuntimeException('checksum mismatch for '.$this->filePathLabel($file));
+            }
+        }
+    }
+
+    /**
+     * @param  Collection<int,array<string,mixed>>  $files
+     */
+    private function verifyTree(string $stagingDir, Collection $files, string $manifestHash): void
+    {
+        $actualPaths = collect(File::allFiles($stagingDir))
+            ->map(fn (\SplFileInfo $file): string => str_replace('\\', '/', ltrim(substr($file->getPathname(), strlen($stagingDir)), '/\\')))
+            ->sort()
+            ->values()
+            ->all();
+
+        $expectedPaths = $files
+            ->map(fn (array $file): string => $this->normalizeRelativePath((string) $file['logical_path']))
+            ->sort()
+            ->values()
+            ->all();
+
+        if ($actualPaths !== $expectedPaths) {
+            throw new \RuntimeException('rehydrated logical_path set does not match exact authority.');
+        }
+
+        foreach ($files as $file) {
+            $path = $stagingDir.DIRECTORY_SEPARATOR.$this->normalizeRelativePath((string) $file['logical_path']);
+            if (! is_file($path)) {
+                throw new \RuntimeException('rehydrated file missing after write: '.$this->filePathLabel($file));
+            }
+
+            $payload = (string) File::get($path);
+            $this->verifyPayload($payload, $file);
+        }
+
+        if ($manifestHash !== '') {
+            $manifestPath = $stagingDir.DIRECTORY_SEPARATOR.'compiled'.DIRECTORY_SEPARATOR.'manifest.json';
+            if (! is_file($manifestPath)) {
+                throw new \RuntimeException('rehydrated manifest.json is missing.');
+            }
+
+            if (hash_file('sha256', $manifestPath) !== strtolower($manifestHash)) {
+                throw new \RuntimeException('rehydrated manifest hash does not match exact authority.');
+            }
+        }
+    }
+
+    private function normalizeRelativePath(string $path): string
+    {
+        $normalized = str_replace('\\', '/', trim($path));
+        if ($normalized === '') {
+            throw new \RuntimeException('logical_path cannot be empty.');
+        }
+
+        if (str_starts_with($normalized, '/') || preg_match('/^[A-Za-z]:[\/\\\\]/', $normalized) === 1) {
+            throw new \RuntimeException('logical_path must be relative to the rehydrate run directory.');
+        }
+
+        $segments = array_values(array_filter(explode('/', $normalized), static fn (string $segment): bool => $segment !== ''));
+        if ($segments === []) {
+            throw new \RuntimeException('logical_path cannot be empty.');
+        }
+
+        foreach ($segments as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new \RuntimeException('logical_path contains forbidden traversal segments: '.$path);
+            }
+        }
+
+        return implode('/', $segments);
+    }
+
+    private function normalizeAbsolutePath(string $path): string
+    {
+        return str_replace('\\', '/', rtrim(trim($path), '/\\'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $file
+     */
+    private function filePathLabel(array $file): string
+    {
+        return (string) ($file['logical_path'] ?? '[unknown logical_path]');
+    }
+}

--- a/backend/config/storage_rollout.php
+++ b/backend/config/storage_rollout.php
@@ -7,6 +7,7 @@ return [
     'exact_manifest_schema_version' => 'storage_exact_manifest.v1',
     'snapshot_schema_version' => 'storage_snapshot.v1',
     'blob_offload_plan_schema_version' => 'storage_blob_offload_plan.v1',
+    'rehydrate_plan_schema_version' => 'storage_rehydrate_exact_release_plan.v1',
     'blob_catalog_enabled' => false,
     'manifest_catalog_enabled' => false,
     'snapshot_catalog_enabled' => false,

--- a/backend/tests/Feature/Storage/ExactReleaseRehydrateServiceTest.php
+++ b/backend/tests/Feature/Storage/ExactReleaseRehydrateServiceTest.php
@@ -1,0 +1,323 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ExactReleaseFileSetCatalogService;
+use App\Services\Storage\ExactReleaseRehydrateService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ExactReleaseRehydrateServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-exact-rehydrate-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_rollout.blob_offload_disk', 's3');
+        config()->set('filesystems.disks.s3.bucket', 'rehydrate-test-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.rehydrate.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_builds_plan_and_rehydrates_from_verified_remote_locations(): void
+    {
+        $releaseId = (string) Str::uuid();
+        $fixture = $this->seedExactManifestFixture($releaseId, 'legacy.source_pack', 'service_success');
+
+        $service = app(ExactReleaseRehydrateService::class);
+        $targetRoot = storage_path('app/private/rehydrate_runs');
+        $plan = $service->buildPlan($fixture['exact_manifest_id'], null, 's3', $targetRoot);
+
+        $this->assertSame('storage_rehydrate_exact_release_plan.v1', (string) ($plan['schema'] ?? ''));
+        $this->assertSame($fixture['exact_manifest_id'], (int) ($plan['exact_manifest']['id'] ?? 0));
+        $this->assertSame(3, (int) ($plan['summary']['file_count'] ?? 0));
+        $this->assertSame(0, (int) ($plan['summary']['missing_locations'] ?? 0));
+        $this->assertSame(array_sum(array_map('strlen', $fixture['files'])), (int) ($plan['summary']['total_bytes'] ?? 0));
+
+        $result = $service->executePlan($plan);
+        $this->assertSame($fixture['exact_manifest_id'], (int) ($result['exact_manifest_id'] ?? 0));
+        $this->assertSame('s3', (string) ($result['disk'] ?? ''));
+        $this->assertSame(3, (int) ($result['rehydrated_files'] ?? 0));
+        $this->assertSame(3, (int) ($result['verified_files'] ?? 0));
+
+        $runDir = (string) ($result['run_dir'] ?? '');
+        $this->assertDirectoryExists($runDir);
+        $this->assertFileExists($runDir.'/.rehydrate.json');
+
+        foreach ($fixture['files'] as $logicalPath => $payload) {
+            $path = $runDir.'/'.$logicalPath;
+            $this->assertFileExists($path);
+            $this->assertSame(hash('sha256', $payload), hash_file('sha256', $path));
+            $this->assertSame(strlen($payload), filesize($path));
+        }
+
+        $sentinel = json_decode((string) file_get_contents($runDir.'/.rehydrate.json'), true);
+        $this->assertIsArray($sentinel);
+        $this->assertSame($fixture['exact_manifest_id'], (int) ($sentinel['exact_manifest_id'] ?? 0));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    public function test_service_reports_missing_verified_locations_and_execute_fails_without_writes(): void
+    {
+        $releaseId = (string) Str::uuid();
+        $fixture = $this->seedExactManifestFixture($releaseId, 'v2.mirror', 'service_missing_location', [
+            'compiled/payload.compiled.json',
+        ]);
+
+        $service = app(ExactReleaseRehydrateService::class);
+        $targetRoot = storage_path('app/private/rehydrate_runs');
+        $plan = $service->buildPlan($fixture['exact_manifest_id'], null, 's3', $targetRoot);
+
+        $this->assertSame(1, (int) ($plan['summary']['missing_locations'] ?? 0));
+
+        try {
+            $service->executePlan($plan);
+            $this->fail('expected executePlan to fail when a verified remote location is missing.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('missing verified remote locations', $e->getMessage());
+        }
+
+        $this->assertDirectoryDoesNotExist($targetRoot);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    public function test_service_ignores_non_remote_copy_locations_and_rejects_traversal_logical_paths(): void
+    {
+        $releaseId = (string) Str::uuid();
+        $fixture = $this->seedExactManifestFixture($releaseId, 'legacy.source_pack', 'service_non_remote_copy');
+
+        DB::table('storage_blob_locations')->insert([
+            'blob_hash' => $fixture['manifest_blob_hash'],
+            'disk' => 's3',
+            'storage_path' => 'rollout/blobs/bad/'.$fixture['manifest_blob_hash'].'.json',
+            'location_kind' => 'local_shadow',
+            'size_bytes' => strlen($fixture['files']['compiled/manifest.json']),
+            'checksum' => 'sha256:'.$fixture['manifest_blob_hash'],
+            'etag' => 'etag-non-remote-copy',
+            'storage_class' => 'STANDARD',
+            'verified_at' => now()->addSecond(),
+            'meta_json' => json_encode(['bucket' => 'shadow'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->addSecond(),
+            'updated_at' => now()->addSecond(),
+        ]);
+
+        $service = app(ExactReleaseRehydrateService::class);
+        $plan = $service->buildPlan($fixture['exact_manifest_id'], null, 's3', storage_path('app/private/rehydrate_runs'));
+        $manifestEntry = collect((array) ($plan['files'] ?? []))
+            ->firstWhere('logical_path', 'compiled/manifest.json');
+        $this->assertIsArray($manifestEntry);
+        $this->assertSame('remote_copy', (string) (($manifestEntry['remote_location']['meta_json']['source_kind'] ?? 'remote_copy') ?: 'remote_copy'));
+        $this->assertSame('rollout/blobs/'.substr($fixture['manifest_blob_hash'], 0, 2).'/'.$fixture['manifest_blob_hash'].'.json', (string) ($manifestEntry['remote_location']['storage_path'] ?? ''));
+
+        $badManifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'legacy.source_pack',
+            'source_disk' => 'local',
+            'source_storage_path' => storage_path('app/private/content_releases/service_bad_path/source_pack'),
+            'manifest_hash' => hash('sha256', '{"bad":"path"}'),
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'bad-path-compiled'),
+            'content_hash' => hash('sha256', 'bad-path-content'),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-bad-path',
+            'payload_json' => ['suffix' => 'bad_path'],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], [[
+            'logical_path' => '../content_releases/live/manifest.json',
+            'blob_hash' => $fixture['manifest_blob_hash'],
+            'size_bytes' => strlen($fixture['files']['compiled/manifest.json']),
+            'role' => 'manifest',
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'checksum' => 'sha256:'.$fixture['manifest_blob_hash'],
+        ]]);
+
+        try {
+            $service->buildPlan((int) $badManifest->getKey(), null, 's3', storage_path('app/private/rehydrate_runs'));
+            $this->fail('expected buildPlan to reject traversal logical_path entries.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('logical_path contains forbidden traversal segments', $e->getMessage());
+        }
+    }
+
+    /**
+     * @param  list<string>  $missingLocationPaths
+     * @return array{
+     *   exact_manifest_id:int,
+     *   files:array<string,string>,
+     *   manifest_blob_hash:string
+     * }
+     */
+    private function seedExactManifestFixture(string $releaseId, string $sourceKind, string $suffix, array $missingLocationPaths = []): array
+    {
+        $this->insertRelease($releaseId, 'BIG5_OCEAN', 'v1');
+
+        $files = [
+            'compiled/manifest.json' => $this->manifestBytes('BIG5_OCEAN', 'v1', $suffix),
+            'compiled/payload.compiled.json' => json_encode(['suffix' => $suffix, 'kind' => 'payload'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}',
+            'compiled/nested/cards.compiled.json' => json_encode(['suffix' => $suffix, 'kind' => 'cards'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}',
+        ];
+
+        $catalogService = app(ExactReleaseFileSetCatalogService::class);
+        $manifest = $catalogService->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => $sourceKind,
+            'source_disk' => 'local',
+            'source_storage_path' => storage_path('app/private/content_releases/'.$suffix.'/source_pack'),
+            'manifest_hash' => hash('sha256', $files['compiled/manifest.json']),
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $logicalPath => $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            if (in_array($logicalPath, $missingLocationPaths, true)) {
+                continue;
+            }
+
+            $remotePath = 'rollout/blobs/'.substr($hash, 0, 2).'/'.$hash.'.json';
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'rehydrate-test-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.rehydrate.test',
+                    'url' => 'https://cos.rehydrate.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        return [
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'files' => $files,
+            'manifest_blob_hash' => hash('sha256', $files['compiled/manifest.json']),
+        ];
+    }
+
+    private function insertRelease(string $releaseId, string $packId, string $packVersion): void
+    {
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'EXACT-REHYDRATE',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => $packId,
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => str_repeat('a', 64),
+            'compiled_hash' => str_repeat('b', 64),
+            'content_hash' => str_repeat('c', 64),
+            'norms_version' => '2026Q1',
+            'git_sha' => 'git-'.$packVersion,
+            'pack_version' => $packVersion,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => 'git-'.$packVersion,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function manifestBytes(string $packId, string $packVersion, string $suffix): string
+    {
+        $payload = json_encode([
+            'pack_id' => $packId,
+            'pack_version' => $packVersion,
+            'suffix' => $suffix,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return is_string($payload) ? $payload : '{}';
+    }
+}

--- a/backend/tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ExactReleaseFileSetCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageRehydrateExactReleaseCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-rehydrate-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_rollout.blob_offload_disk', 's3');
+        config()->set('filesystems.disks.s3.bucket', 'rehydrate-command-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.rehydrate-command.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_plans_and_executes_rehydrate_from_exact_manifest_id(): void
+    {
+        $releaseId = (string) Str::uuid();
+        $fixture = $this->seedExactManifestFixture($releaseId, 'legacy.source_pack', 'command_success');
+
+        $this->assertSame(0, Artisan::call('storage:rehydrate-exact-release', [
+            '--dry-run' => true,
+            '--exact-manifest-id' => (string) $fixture['exact_manifest_id'],
+            '--disk' => 's3',
+        ]));
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('exact_manifest_id='.$fixture['exact_manifest_id'], $dryRunOutput);
+        $this->assertStringContainsString('disk=s3', $dryRunOutput);
+        $this->assertStringContainsString('file_count=3', $dryRunOutput);
+        $this->assertStringContainsString('missing_locations=0', $dryRunOutput);
+
+        $planPath = $this->extractOutputValue($dryRunOutput, 'plan');
+        $this->assertFileExists($planPath);
+        $plan = json_decode((string) file_get_contents($planPath), true);
+        $this->assertIsArray($plan);
+        $this->assertSame('storage_rehydrate_exact_release_plan.v1', (string) ($plan['schema'] ?? ''));
+
+        $this->assertSame(0, Artisan::call('storage:rehydrate-exact-release', [
+            '--execute' => true,
+            '--exact-manifest-id' => (string) $fixture['exact_manifest_id'],
+            '--disk' => 's3',
+        ]));
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('exact_manifest_id='.$fixture['exact_manifest_id'], $executeOutput);
+        $this->assertStringContainsString('rehydrated_files=3', $executeOutput);
+        $this->assertStringContainsString('verified_files=3', $executeOutput);
+
+        $runDir = $this->extractOutputValue($executeOutput, 'run_dir');
+        $this->assertDirectoryExists($runDir);
+        $this->assertFileExists($runDir.'/.rehydrate.json');
+        $this->assertFileExists($runDir.'/compiled/manifest.json');
+        $this->assertFileExists($runDir.'/compiled/payload.compiled.json');
+        $this->assertFileExists($runDir.'/compiled/nested/cards.compiled.json');
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_rehydrate_exact_release')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($audit);
+        $auditMeta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($auditMeta);
+        $this->assertSame('executed', (string) ($auditMeta['mode'] ?? ''));
+        $this->assertSame($fixture['exact_manifest_id'], (int) ($auditMeta['plan']['exact_manifest']['id'] ?? 0));
+        $this->assertSame($runDir, (string) ($auditMeta['result']['run_dir'] ?? ''));
+    }
+
+    public function test_command_fails_fast_when_release_id_maps_to_multiple_exact_manifests(): void
+    {
+        $releaseId = (string) Str::uuid();
+        $this->seedExactManifestFixture($releaseId, 'legacy.source_pack', 'command_ambiguous_a');
+        $this->seedExactManifestFixture($releaseId, 'legacy.current_pack', 'command_ambiguous_b', false);
+
+        $this->assertSame(1, Artisan::call('storage:rehydrate-exact-release', [
+            '--dry-run' => true,
+            '--release-id' => $releaseId,
+            '--disk' => 's3',
+        ]));
+        $output = Artisan::output();
+        $this->assertStringContainsString('multiple exact manifests found for release', $output);
+
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/rehydrate_runs'));
+    }
+
+    public function test_command_can_execute_via_release_id_when_it_maps_to_one_exact_manifest(): void
+    {
+        $releaseId = (string) Str::uuid();
+        $fixture = $this->seedExactManifestFixture($releaseId, 'v2.mirror', 'command_release_id_success');
+
+        $this->assertSame(0, Artisan::call('storage:rehydrate-exact-release', [
+            '--execute' => true,
+            '--release-id' => $releaseId,
+            '--disk' => 's3',
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=executed', $output);
+        $this->assertStringContainsString('exact_manifest_id='.$fixture['exact_manifest_id'], $output);
+        $this->assertStringContainsString('rehydrated_files=3', $output);
+
+        $runDir = $this->extractOutputValue($output, 'run_dir');
+        $this->assertDirectoryExists($runDir);
+        $this->assertFileExists($runDir.'/.rehydrate.json');
+    }
+
+    public function test_command_rejects_dangerous_target_root(): void
+    {
+        $releaseId = (string) Str::uuid();
+        $fixture = $this->seedExactManifestFixture($releaseId, 'legacy.source_pack', 'command_bad_target');
+
+        $this->assertSame(1, Artisan::call('storage:rehydrate-exact-release', [
+            '--dry-run' => true,
+            '--exact-manifest-id' => (string) $fixture['exact_manifest_id'],
+            '--disk' => 's3',
+            '--target-root' => storage_path('app/private/content_releases'),
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('unsafe target root for rehydrate runs', $output);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/rehydrate_plans'));
+    }
+
+    /**
+     * @return array{exact_manifest_id:int}
+     */
+    private function seedExactManifestFixture(string $releaseId, string $sourceKind, string $suffix, bool $withLocations = true): array
+    {
+        if (! DB::table('content_pack_releases')->where('id', $releaseId)->exists()) {
+            $this->insertRelease($releaseId, 'BIG5_OCEAN', 'v1');
+        }
+
+        $files = [
+            'compiled/manifest.json' => $this->manifestBytes('BIG5_OCEAN', 'v1', $suffix),
+            'compiled/payload.compiled.json' => json_encode(['suffix' => $suffix, 'kind' => 'payload'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}',
+            'compiled/nested/cards.compiled.json' => json_encode(['suffix' => $suffix, 'kind' => 'cards'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}',
+        ];
+
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => $sourceKind,
+            'source_disk' => 'local',
+            'source_storage_path' => storage_path('app/private/content_releases/'.$suffix.'/source_pack'),
+            'manifest_hash' => hash('sha256', $files['compiled/manifest.json']),
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            if (! $withLocations) {
+                continue;
+            }
+
+            $remotePath = 'rollout/blobs/'.substr($hash, 0, 2).'/'.$hash.'.json';
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'rehydrate-command-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.rehydrate-command.test',
+                    'url' => 'https://cos.rehydrate-command.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        return ['exact_manifest_id' => (int) $manifest->getKey()];
+    }
+
+    private function insertRelease(string $releaseId, string $packId, string $packVersion): void
+    {
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'EXACT-REHYDRATE-CMD',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => $packId,
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => str_repeat('a', 64),
+            'compiled_hash' => str_repeat('b', 64),
+            'content_hash' => str_repeat('c', 64),
+            'norms_version' => '2026Q1',
+            'git_sha' => 'git-'.$packVersion,
+            'pack_version' => $packVersion,
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => 'git-'.$packVersion,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function extractOutputValue(string $output, string $key): string
+    {
+        foreach (preg_split('/\r\n|\r|\n/', trim($output)) ?: [] as $line) {
+            if (str_starts_with($line, $key.'=')) {
+                return substr($line, strlen($key) + 1);
+            }
+        }
+
+        $this->fail('unable to extract '.$key.' from output: '.$output);
+    }
+
+    private function manifestBytes(string $packId, string $packVersion, string $suffix): string
+    {
+        $payload = json_encode([
+            'pack_id' => $packId,
+            'pack_version' => $packVersion,
+            'suffix' => $suffix,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return is_string($payload) ? $payload : '{}';
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the low-risk PR-17 rehydrate / restore-verify loop for content release roots.

The scope stays intentionally narrow:

- add `storage:rehydrate-exact-release` with `--dry-run` and `--execute`
- add `ExactReleaseRehydrateService`
- build rehydrate plans from exact release authority only
- execute rehydrate from verified remote blob locations only
- rebuild into a brand-new verify/run directory
- verify file count, logical path set, blob hash, file size, and manifest hash
- keep runtime readers unchanged
- do not add remote-read cutover
- do not add delete
- do not add scheduler automation

## Root cause

After PR-16, the repository already had the two required truth layers:

- exact content release file-set authority in `content_release_exact_manifests` and `content_release_exact_manifest_files`
- verified remote blob copies in `storage_blob_locations`

What was still missing was the orchestration layer that joins those two truths into a deterministic rehydrate/restore-verify flow.

Without that layer, the system could prove exact file sets and could prove verified remote blob copies, but it still could not demonstrate the minimal restore loop:

1. select one exact release root
2. resolve every exact file row to a verified remote blob location
3. rebuild a clean compiled tree in a new verify directory
4. verify the rebuilt tree against exact authority
5. leave all runtime readers untouched

## What this PR adds

### 1. `storage:rehydrate-exact-release`

This PR adds:

- `php artisan storage:rehydrate-exact-release --dry-run`
- `php artisan storage:rehydrate-exact-release --execute`
- `--exact-manifest-id`
- `--release-id`
- `--disk`
- `--target-root`

Rules enforced by the command:

- exactly one of `--dry-run` or `--execute` is required
- at least one of `--exact-manifest-id` or `--release-id` is required
- if `--release-id` resolves to multiple exact manifests, the command fails fast instead of guessing
- target disk must be remote
- execute must also pass the existing remote disk configuration guard
- target root must not point to runtime-sensitive directories

The command writes:

- plan JSON to `storage/app/private/rehydrate_plans`
- audit rows with action `storage_rehydrate_exact_release`

### 2. `ExactReleaseRehydrateService`

This PR adds `ExactReleaseRehydrateService`.

It does two things:

#### Build plan

The plan is built only from exact authority:

- parent: `content_release_exact_manifests`
- children: `content_release_exact_manifest_files`

It does **not** use additive scaffold tables as exact truth.

For each exact file row, the plan resolves one bytes source only from:

- `storage_blob_locations`
- same target disk
- `verified_at IS NOT NULL`
- `location_kind = remote_copy`

Dry-run reports:

- `status=planned`
- `exact_manifest_id`
- `disk`
- `file_count`
- `total_bytes`
- `missing_locations`
- `plan`

#### Execute rehydrate

Execute is intentionally strict:

- it fails fast if any exact file row has no verified remote location
- it does not fall back to local physical source files
- it writes into a new run directory under `storage/app/private/rehydrate_runs/{timestamp}_{rand}`
- it stages first, verifies, and only then finalizes the run directory
- it writes `.rehydrate.json` into the final run directory

### 3. File-level verify

The rebuilt tree is verified against exact authority by checking:

- exact file count
- exact logical path set
- per-file SHA-256 equals exact `blob_hash`
- per-file size equals exact `size_bytes`
- `compiled/manifest.json` SHA-256 equals the exact manifest hash

Success is only reported after the whole tree verifies.

### 4. Review hardening included before PR creation

This branch also closes the follow-up review findings on the first PR-17 implementation:

- `logical_path` is now validated so traversal or absolute paths are rejected before any write happens
- rehydrate source selection is now explicitly restricted to `location_kind = remote_copy`
- focused tests now cover:
  - `--release-id` single-manifest success path
  - dangerous `--target-root` rejection
  - traversal-path rejection
  - non-`remote_copy` verified locations being ignored

## Safety boundaries preserved

This PR does **not** change:

- runtime content read contracts
- ArtifactStore canonical-first / legacy-fallback reader order
- legacy publish / rollback runtime success paths
- ContentPackV2 publish / resolver / materialization runtime behavior
- Blob offload semantics
- Blob GC semantics
- StoragePrune semantics
- BigFiveOps route / stdout / audit contracts

This PR does **not** add:

- remote-read cutover
- local delete
- GC execute
- scheduler automation

## Files changed

- `backend/app/Console/Commands/StorageRehydrateExactRelease.php`
- `backend/app/Services/Storage/ExactReleaseRehydrateService.php`
- `backend/config/storage_rollout.php`
- `backend/tests/Feature/Storage/ExactReleaseRehydrateServiceTest.php`
- `backend/tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php`

## Validation

These checks were run on the PR-17 diff:

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php -l app/Console/Commands/StorageRehydrateExactRelease.php
php -l app/Services/Storage/ExactReleaseRehydrateService.php
php -l tests/Feature/Storage/ExactReleaseRehydrateServiceTest.php
php -l tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php
php -l config/storage_rollout.php

./vendor/bin/pint \
  app/Console/Commands/StorageRehydrateExactRelease.php \
  app/Services/Storage/ExactReleaseRehydrateService.php \
  tests/Feature/Storage/ExactReleaseRehydrateServiceTest.php \
  tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php \
  config/storage_rollout.php

php artisan migrate

vendor/bin/phpunit tests/Feature/Storage/ExactReleaseRehydrateServiceTest.php
vendor/bin/phpunit tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php

vendor/bin/phpunit \
  tests/Feature/Storage/StorageBackfillExactReleaseFileSetsCommandTest.php \
  tests/Feature/Storage/ExactReleaseFileSetCatalogServiceTest.php \
  tests/Feature/Storage/StorageBlobOffloadCommandTest.php \
  tests/Feature/Content/Packs2MetadataDualWriteTest.php \
  tests/Feature/Content/LegacyContentPackBridgeMetadataTest.php \
  tests/Feature/Storage/ExactReleaseRehydrateServiceTest.php \
  tests/Feature/Storage/StorageRehydrateExactReleaseCommandTest.php

php artisan storage:rehydrate-exact-release --dry-run --exact-manifest-id=1 --disk=s3
php artisan storage:rehydrate-exact-release --execute --exact-manifest-id=1 --disk=s3

php artisan route:list > /tmp/pr17_route_list.txt
php artisan serve --host=127.0.0.1 --port=18081
curl -i http://127.0.0.1:18081/api/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
```

Observed results:

- focused rehydrate tests: passed
- requested regression suite: passed
- `php artisan migrate`: `Nothing to migrate.`
- live dry-run: passed and wrote a rehydrate plan
- live execute: failed fast on the expected S3 bucket config guard when `filesystems.disks.s3.bucket` is empty
- fake S3 execute path: covered by focused tests and passed
- `curl -i /api/healthz`: `HTTP/1.1 200 OK`
- `bash backend/scripts/ci_verify_mbti.sh`: passed with exit code `0`

## Notes

This PR stages only the PR-17 rehydrate files. It intentionally does not include unrelated local workspace modifications already present on the checkout.
