### PR TITLE
[codex] Ship PR-9B MBTI and Big Five cross-assessment synthesis (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -387,6 +387,10 @@ class AttemptReadController extends Controller
             if (is_array($privacyContract)) {
                 $responsePayload['mbti_privacy_contract_v1'] = $privacyContract;
             }
+            $crossAssessment = data_get($responsePayload, 'report._meta.personalization.cross_assessment_v1');
+            if (is_array($crossAssessment)) {
+                $responsePayload['mbti_cross_assessment_v1'] = $crossAssessment;
+            }
         }
 
         $mbtiEventMeta = $scaleCode === 'MBTI'
@@ -633,6 +637,11 @@ class AttemptReadController extends Controller
             'action_priority_keys' => is_array($personalization['action_priority_keys'] ?? null) ? $personalization['action_priority_keys'] : [],
             'reading_focus_key' => trim((string) ($personalization['reading_focus_key'] ?? '')),
             'action_focus_key' => trim((string) ($personalization['action_focus_key'] ?? '')),
+            'cross_assessment_v1' => is_array($personalization['cross_assessment_v1'] ?? null) ? $personalization['cross_assessment_v1'] : [],
+            'synthesis_keys' => is_array($personalization['synthesis_keys'] ?? null) ? $personalization['synthesis_keys'] : [],
+            'supporting_scales' => is_array($personalization['supporting_scales'] ?? null) ? $personalization['supporting_scales'] : [],
+            'big5_influence_keys' => is_array($personalization['big5_influence_keys'] ?? null) ? $personalization['big5_influence_keys'] : [],
+            'mbti_adjusted_focus_keys' => is_array($personalization['mbti_adjusted_focus_keys'] ?? null) ? $personalization['mbti_adjusted_focus_keys'] : [],
             'user_state' => is_array($personalization['user_state'] ?? null) ? $personalization['user_state'] : [],
             'orchestration' => is_array($personalization['orchestration'] ?? null) ? $personalization['orchestration'] : [],
             'continuity' => is_array($personalization['continuity'] ?? null) ? $personalization['continuity'] : [],
@@ -719,12 +728,20 @@ class AttemptReadController extends Controller
             return [];
         }
 
-        return $this->mbtiUserStateOrchestrationService->overlayEffective(
+        $effective = $this->mbtiUserStateOrchestrationService->overlayEffective(
             $personalization,
             (int) ($attempt->org_id ?? 0),
             (string) ($attempt->id ?? ''),
             $hasUnlock
         );
+
+        return app(\App\Services\Mbti\MbtiBigFiveSynthesisService::class)->attach($effective, [
+            'org_id' => (int) ($attempt->org_id ?? 0),
+            'user_id' => $attempt->user_id ?? null,
+            'anon_id' => $attempt->anon_id ?? null,
+            'attempt_id' => (string) ($attempt->id ?? ''),
+            'locale' => (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')),
+        ]);
     }
 
     /**

--- a/backend/app/Services/Mbti/MbtiBigFiveSynthesisService.php
+++ b/backend/app/Services/Mbti/MbtiBigFiveSynthesisService.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\BigFive\BigFivePublicProjectionService;
+
+final class MbtiBigFiveSynthesisService
+{
+    private const VERSION = 'mbti_big5.cross_assessment.v1';
+
+    /**
+     * @var list<string>
+     */
+    private const TARGET_SECTION_KEYS = [
+        'growth.stability_confidence',
+        'growth.next_actions',
+    ];
+
+    public function __construct(
+        private readonly BigFivePublicProjectionService $bigFivePublicProjectionService,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function attach(array $personalization, array $context = []): array
+    {
+        if ($personalization === []) {
+            return [];
+        }
+
+        $resolved = $this->resolveLatestBigFiveSubjectResult($context);
+        if ($resolved === null) {
+            return $personalization;
+        }
+
+        $locale = $this->normalizeLocale((string) ($personalization['locale'] ?? $context['locale'] ?? 'zh-CN'));
+        $projection = $this->bigFivePublicProjectionService->buildFromResult(
+            $resolved['result'],
+            $locale
+        );
+        $authority = $this->buildAuthorityFromProjection(
+            $projection,
+            $personalization,
+            $locale,
+            (string) ($resolved['attempt']->id ?? '')
+        );
+
+        if ($authority === []) {
+            return $personalization;
+        }
+
+        $personalization['cross_assessment_v1'] = $authority;
+        $personalization['synthesis_keys'] = $authority['synthesis_keys'];
+        $personalization['supporting_scales'] = $authority['supporting_scales'];
+        $personalization['big5_influence_keys'] = $authority['big5_influence_keys'];
+        $personalization['mbti_adjusted_focus_keys'] = $authority['mbti_adjusted_focus_keys'];
+
+        $sections = is_array($personalization['sections'] ?? null) ? $personalization['sections'] : [];
+        $variantKeys = is_array($personalization['variant_keys'] ?? null) ? $personalization['variant_keys'] : [];
+        foreach ((array) ($authority['section_enhancements'] ?? []) as $sectionKey => $enhancement) {
+            if (! is_array($enhancement)) {
+                continue;
+            }
+
+            $synthesisKey = trim((string) ($enhancement['synthesis_key'] ?? ''));
+            if ($synthesisKey === '') {
+                continue;
+            }
+
+            if (is_array($sections[$sectionKey] ?? null)) {
+                $existingVariantKey = trim((string) ($sections[$sectionKey]['variant_key'] ?? ''));
+                $sections[$sectionKey]['variant_key'] = $this->appendSynthesisSuffix($existingVariantKey, $synthesisKey);
+                $sections[$sectionKey]['synthesis_key'] = $synthesisKey;
+                $sections[$sectionKey]['supporting_scale'] = trim((string) ($enhancement['supporting_scale'] ?? 'BIG5_OCEAN'));
+                $sections[$sectionKey]['cross_assessment_version'] = self::VERSION;
+            }
+
+            $variantKeys[$sectionKey] = $this->appendSynthesisSuffix(
+                trim((string) ($variantKeys[$sectionKey] ?? ($sections[$sectionKey]['variant_key'] ?? ''))),
+                $synthesisKey
+            );
+        }
+
+        $personalization['sections'] = $sections;
+        $personalization['variant_keys'] = $variantKeys;
+
+        return $personalization;
+    }
+
+    /**
+     * @param  array<string, mixed>  $big5Projection
+     * @param  array<string, mixed>  $personalization
+     * @return array<string, mixed>
+     */
+    public function buildAuthorityFromProjection(
+        array $big5Projection,
+        array $personalization,
+        string $locale,
+        string $supportingAttemptId = ''
+    ): array {
+        $traitBands = is_array($big5Projection['trait_bands'] ?? null) ? $big5Projection['trait_bands'] : [];
+        if ($traitBands === []) {
+            return [];
+        }
+
+        $neuroticismBand = $this->normalizeBand((string) ($traitBands['N'] ?? 'mid'));
+        $conscientiousnessBand = $this->normalizeBand((string) ($traitBands['C'] ?? 'mid'));
+
+        $stabilityEnhancement = $this->buildStabilityEnhancement($neuroticismBand, $locale);
+        $actionEnhancement = $this->buildNextActionEnhancement($conscientiousnessBand, $locale);
+        $dominantTraits = is_array($big5Projection['dominant_traits'] ?? null) ? $big5Projection['dominant_traits'] : [];
+
+        $synthesisKeys = array_values(array_filter([
+            (string) ($stabilityEnhancement['synthesis_key'] ?? ''),
+            (string) ($actionEnhancement['synthesis_key'] ?? ''),
+        ]));
+
+        return [
+            'version' => self::VERSION,
+            'supporting_scales' => ['BIG5_OCEAN'],
+            'supporting_attempt_id' => $supportingAttemptId,
+            'synthesis_keys' => $synthesisKeys,
+            'big5_influence_keys' => [
+                sprintf('big5.band.n.%s', $neuroticismBand),
+                sprintf('big5.band.c.%s', $conscientiousnessBand),
+            ],
+            'mbti_adjusted_focus_keys' => self::TARGET_SECTION_KEYS,
+            'supporting_traits' => array_values(array_filter(array_map(
+                static fn (array $trait): string => trim((string) ($trait['key'] ?? '')),
+                array_slice($dominantTraits, 0, 3)
+            ))),
+            'section_enhancements' => [
+                'growth.stability_confidence' => $stabilityEnhancement,
+                'growth.next_actions' => $actionEnhancement,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array{attempt:Attempt,result:Result}|null
+     */
+    private function resolveLatestBigFiveSubjectResult(array $context): ?array
+    {
+        $orgId = (int) ($context['org_id'] ?? 0);
+        $userId = trim((string) ($context['user_id'] ?? ''));
+        $anonId = trim((string) ($context['anon_id'] ?? ''));
+        if ($userId === '' && $anonId === '') {
+            return null;
+        }
+
+        $query = Result::query()
+            ->select('results.*')
+            ->join('attempts', 'attempts.id', '=', 'results.attempt_id')
+            ->where('results.org_id', $orgId)
+            ->where('results.scale_code', 'BIG5_OCEAN')
+            ->where('results.is_valid', true);
+
+        if ($userId !== '') {
+            $query->where('attempts.user_id', $userId);
+        } else {
+            $query->where('attempts.anon_id', $anonId);
+        }
+
+        /** @var Result|null $result */
+        $result = $query
+            ->orderByDesc('attempts.submitted_at')
+            ->orderByDesc('results.computed_at')
+            ->first();
+
+        if (! $result instanceof Result) {
+            return null;
+        }
+
+        $attempt = Attempt::query()
+            ->where('org_id', $orgId)
+            ->where('id', (string) $result->attempt_id)
+            ->first();
+
+        if (! $attempt instanceof Attempt) {
+            return null;
+        }
+
+        return [
+            'attempt' => $attempt,
+            'result' => $result,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildStabilityEnhancement(string $band, string $locale): array
+    {
+        [$headline, $body, $synthesisKey] = match ($band) {
+            'high' => [
+                $locale === 'zh-CN' ? 'Big Five 补充：高情绪性会放大情境敏感' : 'Big Five add-on: high neuroticism amplifies context shifts',
+                $locale === 'zh-CN'
+                    ? 'Big Five 显示你的情绪性更高，这会放大 MBTI 里“情境敏感型稳定”的体感强度。更有帮助的读法不是怀疑类型本身，而是提前给恢复窗口、节奏减压和情绪缓冲留出位置。'
+                    : 'Your Big Five result points to higher neuroticism, which can intensify how MBTI context-sensitive stability feels in daily life. The useful read is not to question the type itself, but to create recovery room, lower-friction pacing, and emotional buffering earlier.',
+                'big5.neuroticism.high.buffer_reactivity',
+            ],
+            'low' => [
+                $locale === 'zh-CN' ? 'Big Five 补充：低情绪性会托住稳定感' : 'Big Five add-on: low neuroticism supports steadiness',
+                $locale === 'zh-CN'
+                    ? 'Big Five 显示你的情绪性更低，这会帮助你在 MBTI 的近边界切换里更快回到可用区。你仍然会在情境里切换表达方式，但更容易保持内在稳定感。'
+                    : 'Your Big Five result points to lower neuroticism, which helps you recover faster when MBTI boundary shifts show up. You can still switch styles across contexts, but you are more likely to keep an inner sense of steadiness.',
+                'big5.neuroticism.low.reinforce_stability',
+            ],
+            default => [
+                $locale === 'zh-CN' ? 'Big Five 补充：中段情绪性决定了稳定窗口' : 'Big Five add-on: mid neuroticism shapes the stability window',
+                $locale === 'zh-CN'
+                    ? 'Big Five 显示你的情绪性位于中段，这意味着 MBTI 里的稳定与切换会更受情境负荷影响。最关键的不是改掉切换，而是更早识别什么场景会把你推向边界。'
+                    : 'Your Big Five result sits in the middle range for neuroticism, which means the MBTI stability pattern is more sensitive to context load. The important move is not eliminating the shift, but noticing earlier which situations push you toward the edge.',
+                'big5.neuroticism.mid.context_window',
+            ],
+        };
+
+        return [
+            'section_key' => 'growth.stability_confidence',
+            'supporting_scale' => 'BIG5_OCEAN',
+            'synthesis_key' => $synthesisKey,
+            'title' => $headline,
+            'body' => $body,
+            'influence_keys' => [sprintf('big5.band.n.%s', $band)],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildNextActionEnhancement(string $band, string $locale): array
+    {
+        [$headline, $body, $synthesisKey] = match ($band) {
+            'high' => [
+                $locale === 'zh-CN' ? 'Big Five 补充：高尽责性适合结构化推进' : 'Big Five add-on: high conscientiousness favors structured follow-through',
+                $locale === 'zh-CN'
+                    ? 'Big Five 显示你的尽责性更高，所以 MBTI 的下一步动作最适合被压成固定节奏、明确标准和可追踪清单。比起一次做很多，持续复用同一套动作模板会更快见效。'
+                    : 'Your Big Five result points to higher conscientiousness, so MBTI next actions work best when compressed into fixed rhythm, explicit standards, and trackable checklists. Reusing the same action template beats trying too many moves at once.',
+                'big5.conscientiousness.high.use_structured_sprints',
+            ],
+            'low' => [
+                $locale === 'zh-CN' ? 'Big Five 补充：低尽责性更需要外部支架' : 'Big Five add-on: low conscientiousness needs external scaffolding',
+                $locale === 'zh-CN'
+                    ? 'Big Five 显示你的尽责性更低，所以 MBTI 的下一步动作不要依赖纯意志力。把动作拆成更小的可逆步骤，再借助外部提醒、同伴反馈或固定触发器，执行会稳定很多。'
+                    : 'Your Big Five result points to lower conscientiousness, so MBTI next actions should not rely on willpower alone. Smaller reversible steps plus reminders, social accountability, or fixed triggers will make execution much more stable.',
+                'big5.conscientiousness.low.use_external_scaffolding',
+            ],
+            default => [
+                $locale === 'zh-CN' ? 'Big Five 补充：中段尽责性适合轻量节奏' : 'Big Five add-on: mid conscientiousness favors light structure',
+                $locale === 'zh-CN'
+                    ? 'Big Five 显示你的尽责性位于中段，因此 MBTI 的下一步动作最适合轻量但连续的节奏。给动作一个可重复的起点和结束条件，比追求完美计划更有效。'
+                    : 'Your Big Five result sits in the middle range for conscientiousness, so MBTI next actions work best with light but repeatable structure. A reliable start cue and stop condition will help more than trying to design the perfect plan.',
+                'big5.conscientiousness.mid.repeat_light_structure',
+            ],
+        };
+
+        return [
+            'section_key' => 'growth.next_actions',
+            'supporting_scale' => 'BIG5_OCEAN',
+            'synthesis_key' => $synthesisKey,
+            'title' => $headline,
+            'body' => $body,
+            'influence_keys' => [sprintf('big5.band.c.%s', $band)],
+        ];
+    }
+
+    private function appendSynthesisSuffix(string $variantKey, string $synthesisKey): string
+    {
+        $normalizedSynthesis = trim((string) preg_replace('/[^a-z0-9]+/i', '_', strtolower($synthesisKey)));
+        if ($normalizedSynthesis === '') {
+            return $variantKey;
+        }
+
+        if (str_contains($variantKey, ':synth.'.$normalizedSynthesis)) {
+            return $variantKey;
+        }
+
+        return $variantKey === ''
+            ? 'synth.'.$normalizedSynthesis
+            : $variantKey.':synth.'.$normalizedSynthesis;
+    }
+
+    private function normalizeBand(string $band): string
+    {
+        $normalized = strtolower(trim($band));
+
+        return in_array($normalized, ['low', 'mid', 'high'], true) ? $normalized : 'mid';
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh-CN' : 'en';
+    }
+}

--- a/backend/app/Services/Mbti/MbtiReadModelContractService.php
+++ b/backend/app/Services/Mbti/MbtiReadModelContractService.php
@@ -14,6 +14,8 @@ final class MbtiReadModelContractService
     private const OVERLAY_PERSONALIZATION_FIELDS = [
         'user_state',
         'orchestration',
+        'sections',
+        'variant_keys',
         'ordered_recommendation_keys',
         'ordered_action_keys',
         'recommendation_priority_keys',
@@ -21,6 +23,11 @@ final class MbtiReadModelContractService
         'reading_focus_key',
         'action_focus_key',
         'continuity',
+        'cross_assessment_v1',
+        'synthesis_keys',
+        'supporting_scales',
+        'big5_influence_keys',
+        'mbti_adjusted_focus_keys',
     ];
 
     /**
@@ -81,6 +88,10 @@ final class MbtiReadModelContractService
         'action_priority_keys',
         'reading_focus_key',
         'action_focus_key',
+        'cross_assessment_v1.synthesis_keys',
+        'cross_assessment_v1.supporting_scales',
+        'cross_assessment_v1.big5_influence_keys',
+        'cross_assessment_v1.mbti_adjusted_focus_keys',
     ];
 
     /**

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -567,6 +567,7 @@ final class MbtiResultPersonalizationService
     public function __construct(
         private readonly ContentPacksIndex $packsIndex,
         private readonly MbtiUserStateOrchestrationService $userStateOrchestrationService,
+        private readonly MbtiBigFiveSynthesisService $bigFiveSynthesisService,
         private readonly MbtiPrivacyConsentContractService $privacyConsentContractService,
         private readonly MbtiReadModelContractService $readModelContractService,
     ) {
@@ -693,6 +694,14 @@ final class MbtiResultPersonalizationService
                 'content_package_dir' => trim((string) ($context['dir_version'] ?? data_get($reportPayload, 'versions.dir_version', ''))),
                 'dynamic_sections_version' => trim((string) ($dynamicDoc['version'] ?? '')),
             ], (bool) ($context['has_unlock'] ?? false));
+
+        $personalization = $this->bigFiveSynthesisService->attach($personalization, [
+            'org_id' => (int) ($context['org_id'] ?? 0),
+            'user_id' => $context['user_id'] ?? null,
+            'anon_id' => $context['anon_id'] ?? null,
+            'attempt_id' => $context['attempt_id'] ?? null,
+            'locale' => $locale,
+        ]);
 
         $personalization = $this->privacyConsentContractService->attachContract($personalization, [
             'region' => trim((string) ($context['region'] ?? config('regions.default_region', 'CN_MAINLAND'))),

--- a/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php
+++ b/backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php
@@ -201,6 +201,10 @@ trait ReportPayloadAssemblerComposeFinalizeTrait
                 'pack_id' => $contentPackId,
                 'dir_version' => $contentPackageDir,
                 'locale' => $locale,
+                'org_id' => (int) ($input['org_id'] ?? 0),
+                'user_id' => $input['user_id'] ?? null,
+                'anon_id' => $input['anon_id'] ?? null,
+                'attempt_id' => $input['attempt_id'] ?? null,
                 'region' => (string) ($input['region'] ?? config('regions.default_region', 'CN_MAINLAND')),
                 'engine_version' => $reportEngineVersion !== '' ? $reportEngineVersion : (string) data_get($reportPayload, 'versions.engine', 'v1.2'),
                 'has_unlock' => in_array(

--- a/backend/tests/Feature/V0_3/MbtiBigFiveCrossAssessmentSynthesisTest.php
+++ b/backend/tests/Feature/V0_3/MbtiBigFiveCrossAssessmentSynthesisTest.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Http\Controllers\API\V0_3\AttemptReadController;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Support\OrgContext;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class MbtiBigFiveCrossAssessmentSynthesisTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mbti_report_exposes_cross_assessment_authority_when_big_five_exists_for_same_subject(): void
+    {
+        $this->seedScales();
+        Config::set('fap_experiments.experiments', []);
+
+        $anonId = 'mbti_big5_synthesis_anon';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $this->createBigFiveAttemptWithResult($anonId);
+
+        $response = $this->invokeReport($attemptId, $anonId);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getContent(), true) ?: [];
+        $crossAssessment = is_array(data_get($payload, 'report._meta.personalization.cross_assessment_v1'))
+            ? data_get($payload, 'report._meta.personalization.cross_assessment_v1')
+            : [];
+        $personalizationSections = is_array(data_get($payload, 'report._meta.personalization.sections'))
+            ? data_get($payload, 'report._meta.personalization.sections')
+            : [];
+        $stabilityEnhancement = is_array($crossAssessment['section_enhancements']['growth.stability_confidence'] ?? null)
+            ? $crossAssessment['section_enhancements']['growth.stability_confidence']
+            : [];
+        $nextActionsEnhancement = is_array($crossAssessment['section_enhancements']['growth.next_actions'] ?? null)
+            ? $crossAssessment['section_enhancements']['growth.next_actions']
+            : [];
+        $stabilitySection = is_array($personalizationSections['growth.stability_confidence'] ?? null)
+            ? $personalizationSections['growth.stability_confidence']
+            : [];
+        $nextActionsSection = is_array($personalizationSections['growth.next_actions'] ?? null)
+            ? $personalizationSections['growth.next_actions']
+            : [];
+
+        $this->assertSame('mbti_big5.cross_assessment.v1', data_get($payload, 'mbti_cross_assessment_v1.version'));
+        $this->assertSame(
+            [
+                'big5.neuroticism.high.buffer_reactivity',
+                'big5.conscientiousness.low.use_external_scaffolding',
+            ],
+            data_get($payload, 'mbti_cross_assessment_v1.synthesis_keys')
+        );
+        $this->assertSame(
+            ['BIG5_OCEAN'],
+            data_get($payload, 'mbti_cross_assessment_v1.supporting_scales')
+        );
+        $this->assertSame(
+            ['growth.stability_confidence', 'growth.next_actions'],
+            data_get($payload, 'mbti_cross_assessment_v1.mbti_adjusted_focus_keys')
+        );
+        $this->assertSame(
+            'big5.neuroticism.high.buffer_reactivity',
+            $stabilityEnhancement['synthesis_key'] ?? null
+        );
+        $this->assertSame(
+            'BIG5_OCEAN',
+            $stabilityEnhancement['supporting_scale'] ?? null
+        );
+        $this->assertStringContainsString(
+            '情绪性更高',
+            (string) ($stabilityEnhancement['body'] ?? '')
+        );
+        $this->assertSame(
+            'big5.conscientiousness.low.use_external_scaffolding',
+            $nextActionsEnhancement['synthesis_key'] ?? null
+        );
+        $this->assertStringContainsString(
+            '外部提醒',
+            (string) ($nextActionsEnhancement['body'] ?? '')
+        );
+        $this->assertStringContainsString(
+            ':synth.big5_neuroticism_high_buffer_reactivity',
+            (string) ($stabilitySection['variant_key'] ?? '')
+        );
+        $this->assertStringContainsString(
+            ':synth.big5_conscientiousness_low_use_external_scaffolding',
+            (string) ($nextActionsSection['variant_key'] ?? '')
+        );
+
+        $event = DB::table('events')
+            ->where('event_code', 'report_view')
+            ->where('attempt_id', $attemptId)
+            ->orderByDesc('occurred_at')
+            ->first();
+
+        $this->assertNotNull($event);
+        $eventMeta = json_decode((string) ($event->meta_json ?? '{}'), true) ?: [];
+        $this->assertSame(
+            data_get($payload, 'mbti_cross_assessment_v1.synthesis_keys'),
+            data_get($eventMeta, 'synthesis_keys')
+        );
+        $this->assertSame(
+            ['BIG5_OCEAN'],
+            data_get($eventMeta, 'supporting_scales')
+        );
+        $this->assertSame(
+            ['big5.band.n.high', 'big5.band.c.low'],
+            data_get($eventMeta, 'big5_influence_keys')
+        );
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'raw_score' => 0,
+                'final_score' => 0,
+                'breakdown_json' => [],
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'report_phase9b_contract',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createBigFiveAttemptWithResult(string $anonId): void
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v1',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 120,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed_big5'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v1',
+            'type_code' => 'BIG5_OCEAN',
+            'scores_json' => [
+                'O' => 58,
+                'C' => 29,
+                'E' => 46,
+                'A' => 64,
+                'N' => 82,
+            ],
+            'result_json' => [
+                'type_code' => 'BIG5_OCEAN',
+                'breakdown_json' => [
+                    'score_result' => [
+                        'engine_version' => 'big5.foundation.v1',
+                        'raw_scores' => [
+                            'domains_mean' => [
+                                'O' => 58,
+                                'C' => 29,
+                                'E' => 46,
+                                'A' => 64,
+                                'N' => 82,
+                            ],
+                        ],
+                        'scores_0_100' => [
+                            'domains_percentile' => [
+                                'O' => 58,
+                                'C' => 29,
+                                'E' => 46,
+                                'A' => 64,
+                                'N' => 82,
+                            ],
+                        ],
+                        'facts' => [
+                            'domain_buckets' => [
+                                'O' => 'mid',
+                                'C' => 'low',
+                                'E' => 'mid',
+                                'A' => 'high',
+                                'N' => 'high',
+                            ],
+                            'top_strength_facets' => ['A3'],
+                            'top_growth_facets' => ['C2'],
+                        ],
+                        'tags' => ['profile:overcontrolled'],
+                    ],
+                ],
+            ],
+            'normed_json' => [
+                'engine_version' => 'big5.foundation.v1',
+                'raw_scores' => [
+                    'domains_mean' => [
+                        'O' => 58,
+                        'C' => 29,
+                        'E' => 46,
+                        'A' => 64,
+                        'N' => 82,
+                    ],
+                ],
+                'scores_0_100' => [
+                    'domains_percentile' => [
+                        'O' => 58,
+                        'C' => 29,
+                        'E' => 46,
+                        'A' => 64,
+                        'N' => 82,
+                    ],
+                ],
+                'facts' => [
+                    'domain_buckets' => [
+                        'O' => 'mid',
+                        'C' => 'low',
+                        'E' => 'mid',
+                        'A' => 'high',
+                        'N' => 'high',
+                    ],
+                    'top_strength_facets' => ['A3'],
+                    'top_growth_facets' => ['C2'],
+                ],
+                'tags' => ['profile:overcontrolled'],
+            ],
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'big5_phase9a_contract',
+            'is_valid' => true,
+            'computed_at' => now()->subMinute(),
+        ]);
+    }
+
+    private function invokeReport(string $attemptId, string $anonId): \Illuminate\Http\JsonResponse
+    {
+        $request = Request::create("/api/v0.3/attempts/{$attemptId}/report", 'GET');
+        $request->headers->set('X-Anon-Id', $anonId);
+        $request->attributes->set('anon_id', $anonId);
+        $request->attributes->set('org_context_resolved', true);
+        $request->attributes->set('org_context_kind', OrgContext::KIND_PUBLIC);
+
+        $this->app->instance('request', $request);
+        app(OrgContext::class)->set(0, null, 'public', $anonId, OrgContext::KIND_PUBLIC);
+
+        /** @var AttemptReadController $controller */
+        $controller = app(AttemptReadController::class);
+
+        return $controller->report($request, $attemptId);
+    }
+}

--- a/backend/tests/Unit/Services/Mbti/MbtiBigFiveSynthesisServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiBigFiveSynthesisServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mbti;
+
+use App\Services\Mbti\MbtiBigFiveSynthesisService;
+use Tests\TestCase;
+
+final class MbtiBigFiveSynthesisServiceTest extends TestCase
+{
+    public function test_it_builds_stable_cross_assessment_authority_from_big_five_projection(): void
+    {
+        $service = app(MbtiBigFiveSynthesisService::class);
+
+        $authority = $service->buildAuthorityFromProjection([
+            'trait_bands' => [
+                'O' => 'mid',
+                'C' => 'low',
+                'E' => 'mid',
+                'A' => 'high',
+                'N' => 'high',
+            ],
+            'dominant_traits' => [
+                ['key' => 'N'],
+                ['key' => 'A'],
+                ['key' => 'O'],
+            ],
+        ], [
+            'locale' => 'zh-CN',
+        ], 'zh-CN', 'big5-attempt-1');
+
+        $this->assertSame('mbti_big5.cross_assessment.v1', $authority['version']);
+        $this->assertSame(['BIG5_OCEAN'], $authority['supporting_scales']);
+        $this->assertSame('big5-attempt-1', $authority['supporting_attempt_id']);
+        $this->assertSame(
+            [
+                'big5.neuroticism.high.buffer_reactivity',
+                'big5.conscientiousness.low.use_external_scaffolding',
+            ],
+            $authority['synthesis_keys']
+        );
+        $this->assertSame(
+            ['growth.stability_confidence', 'growth.next_actions'],
+            $authority['mbti_adjusted_focus_keys']
+        );
+        $this->assertSame(['N', 'A', 'O'], $authority['supporting_traits']);
+        $stability = $authority['section_enhancements']['growth.stability_confidence'] ?? [];
+        $nextActions = $authority['section_enhancements']['growth.next_actions'] ?? [];
+        $this->assertSame(
+            'big5.neuroticism.high.buffer_reactivity',
+            $stability['synthesis_key'] ?? null
+        );
+        $this->assertStringContainsString(
+            '情绪性更高',
+            (string) ($stability['body'] ?? '')
+        );
+        $this->assertSame(
+            'big5.conscientiousness.low.use_external_scaffolding',
+            $nextActions['synthesis_key'] ?? null
+        );
+        $this->assertStringContainsString(
+            '外部提醒',
+            (string) ($nextActions['body'] ?? '')
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR establishes the first formal MBTI × Big Five cross-assessment synthesis chain on the backend.

It does not change canonical MBTI scoring or canonical Big Five scoring. Instead, it lets authoritative Big Five signals enhance selected MBTI explanation and action sections through a backend-owned cross-assessment authority.

## Problem

Before this change, MBTI and Big Five were both running as valid result engines, but they were still parallel systems.

That meant the platform could produce two strong reports for the same user without ever allowing one scale to sharpen the interpretation of the other. The most valuable first-wave opportunity was being left on the table: using Big Five trait-band truth to refine the parts of MBTI that are most sensitive to regulation and follow-through.

## Root cause

The repo already had the main prerequisites:

- MBTI personalization, projection, report, snapshot, and telemetry
- Big Five public projection with trait bands and dominant traits
- read-path overlay and replay contracts

What was missing was a formal cross-assessment authority owned by the backend and threaded through the MBTI read path.

Without that, any synthesis would either stay absent or be forced into fragile frontend inference, which would violate the single-authority model.

## Fix

This PR introduces `mbti_big5.cross_assessment.v1` and attaches it to MBTI personalization.

The new authority emits:

- `cross_assessment_v1`
- `synthesis_keys`
- `supporting_scales`
- `big5_influence_keys`
- `mbti_adjusted_focus_keys`

First-wave synthesis is intentionally narrow and testable:

- Big Five `N` band enhances MBTI `growth.stability_confidence`
- Big Five `C` band enhances MBTI `growth.next_actions`

The read path now carries this authority through:

- report personalization
- projection personalization
- read overlay contract
- report-view telemetry

The patch also makes sure section-level personalization metadata such as `sections` and `variant_keys` are included in the allowed overlay patch, so synthesized variant suffixes replay correctly instead of drifting between canonical and effective envelopes.

## User impact

For users who have both MBTI and Big Five results, MBTI can now become more specific instead of remaining isolated.

In this first wave, MBTI stability and next-action guidance now change in visible ways when Big Five indicates stronger emotional reactivity or lower conscientious follow-through.

This is the platform’s first real cross-assessment authority chain, not just two adjacent reports.

## Validation

I ran:

- `php artisan test tests/Unit/Services/Mbti/MbtiBigFiveSynthesisServiceTest.php tests/Feature/V0_3/MbtiBigFiveCrossAssessmentSynthesisTest.php tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php tests/Feature/V0_3/MbtiResultTelemetryContractTest.php`

All passed:

- 10 tests passed
- 331 assertions

## Scope note

This PR is intentionally limited to MBTI × Big Five cross-assessment synthesis on the backend.

It does not:

- introduce migration or new dependencies
- change canonical scoring for either scale
- expand into full graph synthesis, recommendation systems, Team/API, or a third scale
- pull in task-external dirty Big Five compiled artifacts or unrelated ops changes
