### PR TITLE
[codex] Ship PR-9C career OS consolidation (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -18,6 +18,7 @@ use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiReadModelContractService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Mbti\MbtiUserStateOrchestrationService;
+use App\Services\Mbti\MbtiWorkingLifeConsolidationService;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
@@ -47,6 +48,7 @@ class AttemptReadController extends Controller
         private MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private MbtiUserStateOrchestrationService $mbtiUserStateOrchestrationService,
         private MbtiReadModelContractService $mbtiReadModelContractService,
+        private MbtiWorkingLifeConsolidationService $mbtiWorkingLifeConsolidationService,
         private MbtiAccessHubBuilder $mbtiAccessHubBuilder,
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
@@ -642,6 +644,10 @@ class AttemptReadController extends Controller
             'supporting_scales' => is_array($personalization['supporting_scales'] ?? null) ? $personalization['supporting_scales'] : [],
             'big5_influence_keys' => is_array($personalization['big5_influence_keys'] ?? null) ? $personalization['big5_influence_keys'] : [],
             'mbti_adjusted_focus_keys' => is_array($personalization['mbti_adjusted_focus_keys'] ?? null) ? $personalization['mbti_adjusted_focus_keys'] : [],
+            'working_life_v1' => is_array($personalization['working_life_v1'] ?? null) ? $personalization['working_life_v1'] : [],
+            'career_focus_key' => trim((string) ($personalization['career_focus_key'] ?? '')),
+            'career_journey_keys' => is_array($personalization['career_journey_keys'] ?? null) ? $personalization['career_journey_keys'] : [],
+            'career_action_priority_keys' => is_array($personalization['career_action_priority_keys'] ?? null) ? $personalization['career_action_priority_keys'] : [],
             'user_state' => is_array($personalization['user_state'] ?? null) ? $personalization['user_state'] : [],
             'orchestration' => is_array($personalization['orchestration'] ?? null) ? $personalization['orchestration'] : [],
             'continuity' => is_array($personalization['continuity'] ?? null) ? $personalization['continuity'] : [],
@@ -735,13 +741,15 @@ class AttemptReadController extends Controller
             $hasUnlock
         );
 
-        return app(\App\Services\Mbti\MbtiBigFiveSynthesisService::class)->attach($effective, [
+        $effective = app(\App\Services\Mbti\MbtiBigFiveSynthesisService::class)->attach($effective, [
             'org_id' => (int) ($attempt->org_id ?? 0),
             'user_id' => $attempt->user_id ?? null,
             'anon_id' => $attempt->anon_id ?? null,
             'attempt_id' => (string) ($attempt->id ?? ''),
             'locale' => (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')),
         ]);
+
+        return $this->mbtiWorkingLifeConsolidationService->attach($effective);
     }
 
     /**

--- a/backend/app/Services/Mbti/MbtiBigFiveSynthesisService.php
+++ b/backend/app/Services/Mbti/MbtiBigFiveSynthesisService.php
@@ -18,6 +18,7 @@ final class MbtiBigFiveSynthesisService
     private const TARGET_SECTION_KEYS = [
         'growth.stability_confidence',
         'growth.next_actions',
+        'career.next_step',
     ];
 
     public function __construct(
@@ -115,11 +116,13 @@ final class MbtiBigFiveSynthesisService
 
         $stabilityEnhancement = $this->buildStabilityEnhancement($neuroticismBand, $locale);
         $actionEnhancement = $this->buildNextActionEnhancement($conscientiousnessBand, $locale);
+        $careerNextStepEnhancement = $this->buildCareerNextStepEnhancement($conscientiousnessBand, $locale);
         $dominantTraits = is_array($big5Projection['dominant_traits'] ?? null) ? $big5Projection['dominant_traits'] : [];
 
         $synthesisKeys = array_values(array_filter([
             (string) ($stabilityEnhancement['synthesis_key'] ?? ''),
             (string) ($actionEnhancement['synthesis_key'] ?? ''),
+            (string) ($careerNextStepEnhancement['synthesis_key'] ?? ''),
         ]));
 
         return [
@@ -139,6 +142,7 @@ final class MbtiBigFiveSynthesisService
             'section_enhancements' => [
                 'growth.stability_confidence' => $stabilityEnhancement,
                 'growth.next_actions' => $actionEnhancement,
+                'career.next_step' => $careerNextStepEnhancement,
             ],
         ];
     }
@@ -264,6 +268,45 @@ final class MbtiBigFiveSynthesisService
 
         return [
             'section_key' => 'growth.next_actions',
+            'supporting_scale' => 'BIG5_OCEAN',
+            'synthesis_key' => $synthesisKey,
+            'title' => $headline,
+            'body' => $body,
+            'influence_keys' => [sprintf('big5.band.c.%s', $band)],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildCareerNextStepEnhancement(string $band, string $locale): array
+    {
+        [$headline, $body, $synthesisKey] = match ($band) {
+            'high' => [
+                $locale === 'zh-CN' ? 'Big Five 补充：职业下一步适合被做成明确里程碑' : 'Big Five add-on: the next career step works best as a milestone',
+                $locale === 'zh-CN'
+                    ? 'Big Five 显示你的尽责性更高，所以职业下一步最适合被写成带时间边界的里程碑：先定一个可交付成果，再把协作对象、截止时间和验证标准一起钉住。'
+                    : 'Your Big Five result points to higher conscientiousness, so the next career step works best when turned into a milestone with a deadline, owner, and proof point.',
+                'big5.career_next_step.high.commit_to_milestone',
+            ],
+            'low' => [
+                $locale === 'zh-CN' ? 'Big Five 补充：职业下一步更适合先降低动作摩擦' : 'Big Five add-on: the next career step benefits from lower friction',
+                $locale === 'zh-CN'
+                    ? 'Big Five 显示你的尽责性更低，所以职业下一步不要设计成又大又抽象的跃迁。更有效的做法是先把动作缩成一次对话、一次投递、一次作品更新或一次环境试探。'
+                    : 'Your Big Five result points to lower conscientiousness, so the next career step should avoid large abstract leaps. A single conversation, application, portfolio update, or environment test will work better.',
+                'big5.career_next_step.low.reduce_activation_friction',
+            ],
+            default => [
+                $locale === 'zh-CN' ? 'Big Five 补充：职业下一步适合轻量而连续地推进' : 'Big Five add-on: the next career step favors steady cadence',
+                $locale === 'zh-CN'
+                    ? 'Big Five 显示你的尽责性位于中段，所以职业下一步最适合保持轻量但连续：每周固定推进一次，比偶尔冲刺更容易积累可见进展。'
+                    : 'Your Big Five result sits in the middle range for conscientiousness, so the next career step works best as a light but repeatable weekly move.',
+                'big5.career_next_step.mid.keep_light_cadence',
+            ],
+        };
+
+        return [
+            'section_key' => 'career.next_step',
             'supporting_scale' => 'BIG5_OCEAN',
             'synthesis_key' => $synthesisKey,
             'title' => $headline,

--- a/backend/app/Services/Mbti/MbtiReadModelContractService.php
+++ b/backend/app/Services/Mbti/MbtiReadModelContractService.php
@@ -28,6 +28,10 @@ final class MbtiReadModelContractService
         'supporting_scales',
         'big5_influence_keys',
         'mbti_adjusted_focus_keys',
+        'working_life_v1',
+        'career_focus_key',
+        'career_journey_keys',
+        'career_action_priority_keys',
     ];
 
     /**
@@ -92,6 +96,9 @@ final class MbtiReadModelContractService
         'cross_assessment_v1.supporting_scales',
         'cross_assessment_v1.big5_influence_keys',
         'cross_assessment_v1.mbti_adjusted_focus_keys',
+        'working_life_v1.career_focus_key',
+        'working_life_v1.career_journey_keys',
+        'working_life_v1.career_action_priority_keys',
     ];
 
     /**

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -568,6 +568,7 @@ final class MbtiResultPersonalizationService
         private readonly ContentPacksIndex $packsIndex,
         private readonly MbtiUserStateOrchestrationService $userStateOrchestrationService,
         private readonly MbtiBigFiveSynthesisService $bigFiveSynthesisService,
+        private readonly MbtiWorkingLifeConsolidationService $workingLifeConsolidationService,
         private readonly MbtiPrivacyConsentContractService $privacyConsentContractService,
         private readonly MbtiReadModelContractService $readModelContractService,
     ) {
@@ -657,7 +658,7 @@ final class MbtiResultPersonalizationService
         }
 
         $personalization = $this->userStateOrchestrationService->withBaseline([
-                'schema_version' => 'mbti.personalization.phase8c.v1',
+                'schema_version' => 'mbti.personalization.phase9c.v1',
                 'locale' => $locale,
                 'type_code' => $typeCode,
                 'identity' => $identity,
@@ -702,6 +703,7 @@ final class MbtiResultPersonalizationService
             'attempt_id' => $context['attempt_id'] ?? null,
             'locale' => $locale,
         ]);
+        $personalization = $this->workingLifeConsolidationService->attach($personalization);
 
         $personalization = $this->privacyConsentContractService->attachContract($personalization, [
             'region' => trim((string) ($context['region'] ?? config('regions.default_region', 'CN_MAINLAND'))),

--- a/backend/app/Services/Mbti/MbtiWorkingLifeConsolidationService.php
+++ b/backend/app/Services/Mbti/MbtiWorkingLifeConsolidationService.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti;
+
+final class MbtiWorkingLifeConsolidationService
+{
+    private const VERSION = 'mbti.working_life.v1';
+
+    /**
+     * @var list<string>
+     */
+    private const DEFAULT_JOURNEY_KEYS = [
+        'career.next_step',
+        'career.work_experiments',
+        'career.work_environment',
+        'career.collaboration_fit',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @return array<string, mixed>
+     */
+    public function attach(array $personalization): array
+    {
+        if ($personalization === []) {
+            return [];
+        }
+
+        $authority = $this->buildAuthority($personalization);
+        if ($authority === []) {
+            return $personalization;
+        }
+
+        $personalization['working_life_v1'] = $authority;
+        $personalization['career_focus_key'] = $authority['career_focus_key'];
+        $personalization['career_journey_keys'] = $authority['career_journey_keys'];
+        $personalization['career_action_priority_keys'] = $authority['career_action_priority_keys'];
+
+        return $personalization;
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @return array<string, mixed>
+     */
+    public function buildAuthority(array $personalization): array
+    {
+        $careerFocusKey = $this->resolveCareerFocusKey($personalization);
+        $careerJourneyKeys = $this->resolveCareerJourneyKeys($careerFocusKey);
+        $careerActionPriorityKeys = $this->resolveCareerActionPriorityKeys($careerFocusKey, $personalization);
+        $careerReadingKeys = $this->resolveCareerReadingKeys($personalization);
+        $supportingScales = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            is_array($personalization['supporting_scales'] ?? null) ? $personalization['supporting_scales'] : []
+        )));
+        $big5InfluenceKeys = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            is_array($personalization['big5_influence_keys'] ?? null) ? $personalization['big5_influence_keys'] : []
+        )));
+
+        return [
+            'version' => self::VERSION,
+            'career_focus_key' => $careerFocusKey,
+            'career_journey_keys' => $careerJourneyKeys,
+            'role_fit_keys' => $this->normalizeStringList($personalization['role_fit_keys'] ?? []),
+            'collaboration_fit_keys' => $this->normalizeStringList($personalization['collaboration_fit_keys'] ?? []),
+            'work_env_preference_keys' => $this->normalizeStringList($personalization['work_env_preference_keys'] ?? []),
+            'career_next_step_keys' => $this->normalizeStringList($personalization['career_next_step_keys'] ?? []),
+            'career_action_priority_keys' => $careerActionPriorityKeys,
+            'career_reading_keys' => $careerReadingKeys,
+            'supporting_scales' => $supportingScales,
+            'big5_influence_keys' => $big5InfluenceKeys,
+            'synthesis_keys' => $this->resolveCareerSynthesisKeys($personalization),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     */
+    private function resolveCareerFocusKey(array $personalization): string
+    {
+        $primaryFocusKey = trim((string) data_get($personalization, 'orchestration.primary_focus_key', ''));
+        if (str_starts_with($primaryFocusKey, 'career.')) {
+            return $primaryFocusKey;
+        }
+
+        if (is_array(data_get($personalization, 'cross_assessment_v1.section_enhancements.career.next_step'))) {
+            return 'career.next_step';
+        }
+
+        foreach ((array) data_get($personalization, 'orchestration.secondary_focus_keys', []) as $secondaryFocusKey) {
+            $secondaryFocusKey = trim((string) $secondaryFocusKey);
+            if (str_starts_with($secondaryFocusKey, 'career.')) {
+                return $secondaryFocusKey;
+            }
+        }
+
+        $currentIntentCluster = trim((string) data_get($personalization, 'user_state.current_intent_cluster', ''));
+        if ($currentIntentCluster === 'career_move') {
+            return data_get($personalization, 'user_state.has_unlock') === true
+                ? 'career.work_experiments'
+                : 'career.next_step';
+        }
+
+        return 'career.next_step';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveCareerJourneyKeys(string $careerFocusKey): array
+    {
+        $journeyKeys = match ($careerFocusKey) {
+            'career.work_experiments' => [
+                'career.work_experiments',
+                'career.next_step',
+                'career.work_environment',
+                'career.collaboration_fit',
+            ],
+            'career.collaboration_fit' => [
+                'career.collaboration_fit',
+                'career.work_environment',
+                'career.next_step',
+                'career.work_experiments',
+            ],
+            'career.work_environment' => [
+                'career.work_environment',
+                'career.collaboration_fit',
+                'career.next_step',
+                'career.work_experiments',
+            ],
+            default => self::DEFAULT_JOURNEY_KEYS,
+        };
+
+        return array_values(array_unique(array_filter($journeyKeys)));
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @return list<string>
+     */
+    private function resolveCareerActionPriorityKeys(string $careerFocusKey, array $personalization): array
+    {
+        $keys = [$careerFocusKey];
+        foreach (['career.next_step', 'career.work_experiments', 'career_bridge'] as $candidate) {
+            if (! in_array($candidate, $keys, true)) {
+                $keys[] = $candidate;
+            }
+        }
+
+        $ctaPriorityKeys = $this->normalizeStringList(data_get($personalization, 'orchestration.cta_priority_keys', []));
+        if (in_array('workspace_lite', $ctaPriorityKeys, true) && ! in_array('workspace_lite', $keys, true)) {
+            $keys[] = 'workspace_lite';
+        }
+
+        return $keys;
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @return list<string>
+     */
+    private function resolveCareerReadingKeys(array $personalization): array
+    {
+        $orderedRecommendationKeys = $this->normalizeStringList($personalization['ordered_recommendation_keys'] ?? []);
+        $candidates = is_array($personalization['recommended_read_candidates'] ?? null)
+            ? $personalization['recommended_read_candidates']
+            : [];
+
+        $candidateByKey = [];
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $key = trim((string) ($candidate['key'] ?? ''));
+            if ($key === '') {
+                continue;
+            }
+
+            $candidateByKey[$key] = $candidate;
+        }
+
+        $careerReadingKeys = [];
+        foreach ($orderedRecommendationKeys as $key) {
+            $candidate = $candidateByKey[$key] ?? null;
+            $tags = is_array($candidate['tags'] ?? null) ? $candidate['tags'] : [];
+            $normalizedTags = array_map(static fn (mixed $tag): string => strtolower(trim((string) $tag)), $tags);
+
+            $isCareerCandidate = str_contains($key, 'career')
+                || str_contains($key, 'work')
+                || count(array_intersect($normalizedTags, ['career', 'work', 'growth', 'action'])) > 0;
+
+            if ($isCareerCandidate) {
+                $careerReadingKeys[] = $key;
+            }
+        }
+
+        if ($careerReadingKeys === []) {
+            $careerReadingKeys = array_slice($orderedRecommendationKeys, 0, 2);
+        }
+
+        return array_values(array_unique(array_filter($careerReadingKeys)));
+    }
+
+    /**
+     * @param  array<string, mixed>  $personalization
+     * @return list<string>
+     */
+    private function resolveCareerSynthesisKeys(array $personalization): array
+    {
+        $sectionEnhancements = is_array(data_get($personalization, 'cross_assessment_v1.section_enhancements'))
+            ? data_get($personalization, 'cross_assessment_v1.section_enhancements')
+            : [];
+
+        $synthesisKeys = [];
+        foreach (['career.next_step', 'career.work_environment', 'career.collaboration_fit'] as $sectionKey) {
+            $synthesisKey = trim((string) data_get($sectionEnhancements, $sectionKey.'.synthesis_key', ''));
+            if ($synthesisKey !== '') {
+                $synthesisKeys[] = $synthesisKey;
+            }
+        }
+
+        foreach ($this->normalizeStringList($personalization['synthesis_keys'] ?? []) as $synthesisKey) {
+            if (str_contains($synthesisKey, 'career_') || str_contains($synthesisKey, '.career_')) {
+                $synthesisKeys[] = $synthesisKey;
+            }
+        }
+
+        return array_values(array_unique($synthesisKeys));
+    }
+
+    /**
+     * @param  mixed  $value
+     * @return list<string>
+     */
+    private function normalizeStringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $item): string => trim((string) $item),
+            $value
+        ))));
+    }
+}

--- a/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+++ b/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
@@ -96,7 +96,7 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
 
         $this->assertTrue((bool) ($payload['ok'] ?? false));
         $this->assertSame(
-            'mbti.personalization.phase8c.v1',
+            'mbti.personalization.phase9c.v1',
             data_get($payload, 'report._meta.personalization.schema_version')
         );
         $this->assertSame(
@@ -104,7 +104,7 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             data_get($payload, 'report._meta.personalization.engine_version')
         );
         $this->assertSame(
-            'phase8c.v1',
+            'phase9c.v1',
             data_get($payload, 'report._meta.personalization.dynamic_sections_version')
         );
         $this->assertIsArray(data_get($payload, 'report._meta.personalization.ordered_recommendation_keys'));
@@ -127,6 +127,10 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
         );
         $this->assertContains(
             'user_state',
+            data_get($payload, 'report._meta.personalization.read_contract_v1.overlay_patch.personalization_fields', [])
+        );
+        $this->assertContains(
+            'working_life_v1',
             data_get($payload, 'report._meta.personalization.read_contract_v1.overlay_patch.personalization_fields', [])
         );
         $this->assertSame(
@@ -209,6 +213,18 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
         $this->assertContains(
             'career_next_step.theme.clarify_decision_criteria',
             data_get($payload, 'report._meta.personalization.career_next_step_keys', [])
+        );
+        $this->assertSame(
+            'mbti.working_life.v1',
+            data_get($payload, 'report._meta.personalization.working_life_v1.version')
+        );
+        $this->assertSame(
+            'career.next_step',
+            data_get($payload, 'report._meta.personalization.working_life_v1.career_focus_key')
+        );
+        $this->assertContains(
+            'career_bridge',
+            data_get($payload, 'report._meta.personalization.working_life_v1.career_action_priority_keys', [])
         );
         $this->assertNotSame(
             '',
@@ -369,11 +385,11 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             ->first(static fn (array $section): bool => (string) ($section['key'] ?? '') === 'relationships.try_this_week');
 
         $this->assertSame(
-            'mbti.personalization.phase8c.v1',
+            'mbti.personalization.phase9c.v1',
             data_get($projection, '_meta.personalization.schema_version')
         );
         $this->assertSame(
-            'phase8c.v1',
+            'phase9c.v1',
             data_get($projection, '_meta.personalization.dynamic_sections_version')
         );
         $this->assertSame(

--- a/backend/tests/Feature/V0_3/MbtiBigFiveCrossAssessmentSynthesisTest.php
+++ b/backend/tests/Feature/V0_3/MbtiBigFiveCrossAssessmentSynthesisTest.php
@@ -43,11 +43,17 @@ class MbtiBigFiveCrossAssessmentSynthesisTest extends TestCase
         $nextActionsEnhancement = is_array($crossAssessment['section_enhancements']['growth.next_actions'] ?? null)
             ? $crossAssessment['section_enhancements']['growth.next_actions']
             : [];
+        $careerNextStepEnhancement = is_array($crossAssessment['section_enhancements']['career.next_step'] ?? null)
+            ? $crossAssessment['section_enhancements']['career.next_step']
+            : [];
         $stabilitySection = is_array($personalizationSections['growth.stability_confidence'] ?? null)
             ? $personalizationSections['growth.stability_confidence']
             : [];
         $nextActionsSection = is_array($personalizationSections['growth.next_actions'] ?? null)
             ? $personalizationSections['growth.next_actions']
+            : [];
+        $careerNextStepSection = is_array($personalizationSections['career.next_step'] ?? null)
+            ? $personalizationSections['career.next_step']
             : [];
 
         $this->assertSame('mbti_big5.cross_assessment.v1', data_get($payload, 'mbti_cross_assessment_v1.version'));
@@ -55,6 +61,7 @@ class MbtiBigFiveCrossAssessmentSynthesisTest extends TestCase
             [
                 'big5.neuroticism.high.buffer_reactivity',
                 'big5.conscientiousness.low.use_external_scaffolding',
+                'big5.career_next_step.low.reduce_activation_friction',
             ],
             data_get($payload, 'mbti_cross_assessment_v1.synthesis_keys')
         );
@@ -63,7 +70,7 @@ class MbtiBigFiveCrossAssessmentSynthesisTest extends TestCase
             data_get($payload, 'mbti_cross_assessment_v1.supporting_scales')
         );
         $this->assertSame(
-            ['growth.stability_confidence', 'growth.next_actions'],
+            ['growth.stability_confidence', 'growth.next_actions', 'career.next_step'],
             data_get($payload, 'mbti_cross_assessment_v1.mbti_adjusted_focus_keys')
         );
         $this->assertSame(
@@ -86,6 +93,14 @@ class MbtiBigFiveCrossAssessmentSynthesisTest extends TestCase
             '外部提醒',
             (string) ($nextActionsEnhancement['body'] ?? '')
         );
+        $this->assertSame(
+            'big5.career_next_step.low.reduce_activation_friction',
+            $careerNextStepEnhancement['synthesis_key'] ?? null
+        );
+        $this->assertStringContainsString(
+            '职业下一步',
+            (string) ($careerNextStepEnhancement['title'] ?? '')
+        );
         $this->assertStringContainsString(
             ':synth.big5_neuroticism_high_buffer_reactivity',
             (string) ($stabilitySection['variant_key'] ?? '')
@@ -93,6 +108,10 @@ class MbtiBigFiveCrossAssessmentSynthesisTest extends TestCase
         $this->assertStringContainsString(
             ':synth.big5_conscientiousness_low_use_external_scaffolding',
             (string) ($nextActionsSection['variant_key'] ?? '')
+        );
+        $this->assertStringContainsString(
+            ':synth.big5_career_next_step_low_reduce_activation_friction',
+            (string) ($careerNextStepSection['variant_key'] ?? '')
         );
 
         $event = DB::table('events')

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -43,8 +43,8 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertSame('INTJ-A', (string) ($meta['type_code'] ?? ''));
             $this->assertSame('A', (string) ($meta['identity'] ?? ''));
             $this->assertSame('report_phase4a_contract', (string) ($meta['engine_version'] ?? ''));
-            $this->assertSame('mbti.personalization.phase8c.v1', (string) ($meta['schema_version'] ?? ''));
-            $this->assertSame('phase8c.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
+            $this->assertSame('mbti.personalization.phase9c.v1', (string) ($meta['schema_version'] ?? ''));
+            $this->assertSame('phase9c.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
             $this->assertIsArray($meta['axis_bands'] ?? null);
             $this->assertSame('boundary', (string) (($meta['axis_bands']['EI'] ?? '')));
             $this->assertSame('boundary', (string) (($meta['axis_bands']['AT'] ?? '')));
@@ -84,6 +84,10 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertIsArray($meta['collaboration_fit_keys'] ?? null);
             $this->assertIsArray($meta['work_env_preference_keys'] ?? null);
             $this->assertIsArray($meta['career_next_step_keys'] ?? null);
+            $this->assertIsArray($meta['working_life_v1'] ?? null);
+            $this->assertIsString((string) ($meta['career_focus_key'] ?? ''));
+            $this->assertIsArray($meta['career_journey_keys'] ?? null);
+            $this->assertIsArray($meta['career_action_priority_keys'] ?? null);
             $this->assertNotSame('', trim((string) ($meta['action_plan_summary'] ?? '')));
             $this->assertIsArray($meta['weekly_action_keys'] ?? null);
             $this->assertIsArray($meta['relationship_action_keys'] ?? null);
@@ -118,6 +122,7 @@ class MbtiResultTelemetryContractTest extends TestCase
         $this->assertSame($eventMeta['report_view']['relationship_action_keys'] ?? null, $eventMeta['result_view']['relationship_action_keys'] ?? null);
         $this->assertSame($eventMeta['report_view']['work_experiment_keys'] ?? null, $eventMeta['result_view']['work_experiment_keys'] ?? null);
         $this->assertSame($eventMeta['report_view']['watchout_keys'] ?? null, $eventMeta['result_view']['watchout_keys'] ?? null);
+        $this->assertSame($eventMeta['report_view']['working_life_v1'] ?? null, $eventMeta['result_view']['working_life_v1'] ?? null);
         $this->assertSame($eventMeta['report_view']['privacy_contract_version'] ?? null, $eventMeta['result_view']['privacy_contract_version'] ?? null);
         $this->assertSame($eventMeta['report_view']['consent_scope'] ?? null, $eventMeta['result_view']['consent_scope'] ?? null);
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.is_first_view'));
@@ -153,6 +158,12 @@ class MbtiResultTelemetryContractTest extends TestCase
             ['unlock_full_report', 'share_result', 'career_bridge'],
             data_get($eventMeta, 'report_view.orchestration.cta_priority_keys')
         );
+        $this->assertSame('career.work_experiments', data_get($eventMeta, 'result_view.working_life_v1.career_focus_key'));
+        $this->assertSame(
+            ['career.work_experiments', 'career.next_step', 'career.work_environment', 'career.collaboration_fit'],
+            data_get($eventMeta, 'result_view.working_life_v1.career_journey_keys')
+        );
+        $this->assertContains('career_bridge', data_get($eventMeta, 'result_view.working_life_v1.career_action_priority_keys', []));
         $this->assertIsArray(data_get($eventMeta, 'result_view.ordered_recommendation_keys', []));
         $this->assertIsArray(data_get($eventMeta, 'result_view.recommendation_priority_keys', []));
         $this->assertSame('weekly_action.theme.protect_energy_lane', data_get($eventMeta, 'result_view.action_focus_key'));

--- a/backend/tests/Unit/Services/Mbti/MbtiBigFiveSynthesisServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiBigFiveSynthesisServiceTest.php
@@ -37,16 +37,18 @@ final class MbtiBigFiveSynthesisServiceTest extends TestCase
             [
                 'big5.neuroticism.high.buffer_reactivity',
                 'big5.conscientiousness.low.use_external_scaffolding',
+                'big5.career_next_step.low.reduce_activation_friction',
             ],
             $authority['synthesis_keys']
         );
         $this->assertSame(
-            ['growth.stability_confidence', 'growth.next_actions'],
+            ['growth.stability_confidence', 'growth.next_actions', 'career.next_step'],
             $authority['mbti_adjusted_focus_keys']
         );
         $this->assertSame(['N', 'A', 'O'], $authority['supporting_traits']);
         $stability = $authority['section_enhancements']['growth.stability_confidence'] ?? [];
         $nextActions = $authority['section_enhancements']['growth.next_actions'] ?? [];
+        $careerNextStep = $authority['section_enhancements']['career.next_step'] ?? [];
         $this->assertSame(
             'big5.neuroticism.high.buffer_reactivity',
             $stability['synthesis_key'] ?? null
@@ -62,6 +64,14 @@ final class MbtiBigFiveSynthesisServiceTest extends TestCase
         $this->assertStringContainsString(
             '外部提醒',
             (string) ($nextActions['body'] ?? '')
+        );
+        $this->assertSame(
+            'big5.career_next_step.low.reduce_activation_friction',
+            $careerNextStep['synthesis_key'] ?? null
+        );
+        $this->assertStringContainsString(
+            '职业下一步',
+            (string) ($careerNextStep['title'] ?? '')
         );
     }
 }

--- a/backend/tests/Unit/Services/Mbti/MbtiPrivacyConsentContractServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiPrivacyConsentContractServiceTest.php
@@ -189,7 +189,7 @@ final class MbtiPrivacyConsentContractServiceTest extends TestCase
             ],
             'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
             'engine_version' => 'report_phase4a_contract',
-            'dynamic_sections_version' => 'phase8c.v1',
+            'dynamic_sections_version' => 'phase9c.v1',
         ];
     }
 }

--- a/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
@@ -14,7 +14,7 @@ final class MbtiReadModelContractServiceTest extends TestCase
         $service = app(MbtiReadModelContractService::class);
 
         $contract = $service->buildContract([
-            'schema_version' => 'mbti.personalization.phase8c.v1',
+            'schema_version' => 'mbti.personalization.phase9c.v1',
             'identity' => 'A',
             'privacy_contract_v1' => ['version' => 'mbti.privacy_contract.v1'],
             'variant_keys' => ['overview' => 'overview:clear'],
@@ -24,18 +24,22 @@ final class MbtiReadModelContractServiceTest extends TestCase
             'continuity' => ['carryover_focus_key' => 'growth.next_actions'],
             'ordered_recommendation_keys' => ['read-action'],
             'reading_focus_key' => 'read-action',
+            'working_life_v1' => ['career_focus_key' => 'career.next_step'],
+            'career_focus_key' => 'career.next_step',
         ]);
 
         $this->assertSame('mbti.read_contract.v1', $contract['version']);
         $this->assertContains('identity', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('privacy_contract_v1', $contract['canonical_read_model']['personalization_fields']);
-        $this->assertContains('variant_keys', $contract['canonical_read_model']['personalization_fields']);
+        $this->assertNotContains('variant_keys', $contract['canonical_read_model']['personalization_fields']);
         $this->assertNotContains('user_state', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('mbti_privacy_contract_v1', $contract['cacheable_fields']);
         $this->assertSame(
             [
                 'user_state',
                 'orchestration',
+                'sections',
+                'variant_keys',
                 'ordered_recommendation_keys',
                 'ordered_action_keys',
                 'recommendation_priority_keys',
@@ -43,6 +47,15 @@ final class MbtiReadModelContractServiceTest extends TestCase
                 'reading_focus_key',
                 'action_focus_key',
                 'continuity',
+                'cross_assessment_v1',
+                'synthesis_keys',
+                'supporting_scales',
+                'big5_influence_keys',
+                'mbti_adjusted_focus_keys',
+                'working_life_v1',
+                'career_focus_key',
+                'career_journey_keys',
+                'career_action_priority_keys',
             ],
             $contract['overlay_patch']['personalization_fields']
         );
@@ -51,6 +64,7 @@ final class MbtiReadModelContractServiceTest extends TestCase
         $this->assertContains('mbti_public_projection_v1._meta.personalization.continuity', $contract['non_cacheable_fields']);
         $this->assertContains('user_state', $contract['telemetry_parity_fields']);
         $this->assertContains('continuity.carryover_focus_key', $contract['telemetry_parity_fields']);
+        $this->assertContains('working_life_v1.career_focus_key', $contract['telemetry_parity_fields']);
     }
 
     public function test_apply_overlay_patch_preserves_canonical_fields_and_replaces_only_overlay_fields(): void
@@ -64,6 +78,7 @@ final class MbtiReadModelContractServiceTest extends TestCase
             'orchestration' => ['primary_focus_key' => 'growth.next_actions'],
             'continuity' => ['carryover_focus_key' => 'growth.next_actions'],
             'ordered_recommendation_keys' => ['read-action'],
+            'working_life_v1' => ['career_focus_key' => 'career.next_step'],
         ];
 
         $effective = [
@@ -73,6 +88,7 @@ final class MbtiReadModelContractServiceTest extends TestCase
             'orchestration' => ['primary_focus_key' => 'traits.close_call_axes'],
             'continuity' => ['carryover_focus_key' => 'traits.close_call_axes'],
             'ordered_recommendation_keys' => ['read-explain'],
+            'working_life_v1' => ['career_focus_key' => 'career.work_experiments'],
         ];
 
         $merged = $service->applyOverlayPatch($canonical, $effective);
@@ -83,6 +99,7 @@ final class MbtiReadModelContractServiceTest extends TestCase
         $this->assertSame(['primary_focus_key' => 'traits.close_call_axes'], $merged['orchestration']);
         $this->assertSame(['carryover_focus_key' => 'traits.close_call_axes'], $merged['continuity']);
         $this->assertSame(['read-explain'], $merged['ordered_recommendation_keys']);
+        $this->assertSame(['career_focus_key' => 'career.work_experiments'], $merged['working_life_v1']);
         $this->assertSame('mbti.read_contract.v1', data_get($merged, 'read_contract_v1.version'));
     }
 }

--- a/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
@@ -86,14 +86,14 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
 
         $this->assertSame('ENFP-T', $clear['type_code']);
         $this->assertSame('T', $clear['identity']);
-        $this->assertSame('mbti.personalization.phase8c.v1', $clear['schema_version']);
+        $this->assertSame('mbti.personalization.phase9c.v1', $clear['schema_version']);
         $this->assertSame('clear', data_get($clear, 'axis_bands.EI'));
         $this->assertSame('strong', data_get($strong, 'axis_bands.EI'));
         $this->assertSame(false, data_get($clear, 'boundary_flags.EI'));
         $this->assertSame(false, data_get($strong, 'boundary_flags.EI'));
         $this->assertSame('MBTI.cn-mainland.zh-CN.v0.3', $clear['pack_id']);
         $this->assertSame('report_phase4a_contract', $clear['engine_version']);
-        $this->assertSame('phase8c.v1', $clear['dynamic_sections_version']);
+        $this->assertSame('phase9c.v1', $clear['dynamic_sections_version']);
         $this->assertSame('mbti.privacy_contract.v1', data_get($clear, 'privacy_contract_v1.version'));
         $this->assertSame(true, data_get($clear, 'privacy_contract_v1.consent_scope.subject_export'));
         $this->assertContains(
@@ -202,6 +202,18 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
         $this->assertContains('work_env.preference.high_collaboration', data_get($clear, 'work_env_preference_keys'));
         $this->assertContains('work_env.boundary.JP', data_get($clear, 'work_env_preference_keys'));
         $this->assertContains('career_next_step.theme.clarify_decision_criteria', data_get($clear, 'career_next_step_keys'));
+        $this->assertSame('mbti.working_life.v1', data_get($clear, 'working_life_v1.version'));
+        $this->assertSame('career.next_step', data_get($clear, 'working_life_v1.career_focus_key'));
+        $this->assertSame(
+            ['career.next_step', 'career.work_experiments', 'career.work_environment', 'career.collaboration_fit'],
+            data_get($clear, 'working_life_v1.career_journey_keys')
+        );
+        $this->assertContains('career_bridge', data_get($clear, 'working_life_v1.career_action_priority_keys', []));
+        $this->assertSame('career.next_step', data_get($clear, 'career_focus_key'));
+        $this->assertSame(
+            ['career.next_step', 'career.work_experiments', 'career.work_environment', 'career.collaboration_fit'],
+            data_get($clear, 'career_journey_keys')
+        );
         $this->assertStringContainsString('一周内能重复', (string) ($clear['action_plan_summary'] ?? ''));
         $this->assertContains('weekly_action.theme.name_decision_rule', data_get($clear, 'weekly_action_keys'));
         $this->assertContains('relationship_action.theme.name_decision_rule', data_get($clear, 'relationship_action_keys'));

--- a/backend/tests/Unit/Services/Mbti/MbtiWorkingLifeConsolidationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiWorkingLifeConsolidationServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mbti;
+
+use App\Services\Mbti\MbtiWorkingLifeConsolidationService;
+use Tests\TestCase;
+
+final class MbtiWorkingLifeConsolidationServiceTest extends TestCase
+{
+    public function test_it_builds_working_life_authority_from_existing_career_and_cross_assessment_signals(): void
+    {
+        $service = app(MbtiWorkingLifeConsolidationService::class);
+
+        $authority = $service->buildAuthority([
+            'role_fit_keys' => ['role_fit.role.NF'],
+            'collaboration_fit_keys' => ['collaboration_fit.primary.EI.E.clear'],
+            'work_env_preference_keys' => ['work_env.preference.high_collaboration'],
+            'career_next_step_keys' => ['career_next_step.theme.clarify_decision_criteria'],
+            'ordered_recommendation_keys' => ['read-career', 'read-action', 'read-explain'],
+            'recommended_read_candidates' => [
+                ['key' => 'read-career', 'tags' => ['career', 'work']],
+                ['key' => 'read-action', 'tags' => ['action', 'growth']],
+                ['key' => 'read-explain', 'tags' => ['mbti']],
+            ],
+            'orchestration' => [
+                'primary_focus_key' => 'career.work_experiments',
+                'secondary_focus_keys' => ['career.next_step'],
+                'cta_priority_keys' => ['career_bridge', 'workspace_lite', 'share_result'],
+            ],
+            'user_state' => [
+                'has_unlock' => true,
+                'current_intent_cluster' => 'career_move',
+            ],
+            'supporting_scales' => ['BIG5_OCEAN'],
+            'big5_influence_keys' => ['big5.band.c.low'],
+            'synthesis_keys' => ['big5.career_next_step.low.reduce_activation_friction'],
+            'cross_assessment_v1' => [
+                'section_enhancements' => [
+                    'career.next_step' => [
+                        'synthesis_key' => 'big5.career_next_step.low.reduce_activation_friction',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('mbti.working_life.v1', $authority['version']);
+        $this->assertSame('career.work_experiments', $authority['career_focus_key']);
+        $this->assertSame(
+            ['career.work_experiments', 'career.next_step', 'career.work_environment', 'career.collaboration_fit'],
+            $authority['career_journey_keys']
+        );
+        $this->assertSame(
+            ['career.work_experiments', 'career.next_step', 'career_bridge', 'workspace_lite'],
+            $authority['career_action_priority_keys']
+        );
+        $this->assertSame(['read-career', 'read-action'], $authority['career_reading_keys']);
+        $this->assertSame(['BIG5_OCEAN'], $authority['supporting_scales']);
+        $this->assertSame(
+            ['big5.career_next_step.low.reduce_activation_friction'],
+            $authority['synthesis_keys']
+        );
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
@@ -1,6 +1,6 @@
 {
     "schema": "fap.mbti.dynamic_sections.v1",
-    "version": "phase8c.v1",
+    "version": "phase9c.v1",
   "labels": {
     "block_kinds": {
       "type_skeleton": "类型骨架",


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-9C: career OS consolidation.

It turns the existing MBTI career bridge, action planning, recommendation ordering, and first-wave Big Five synthesis into a single backend-owned `working_life_v1` authority.

## What changed

Backend:
- adds `working_life_v1`
- derives:
  - `career_focus_key`
  - `career_journey_keys`
  - `career_action_priority_keys`
  - `career_reading_keys`
- extends MBTI × Big Five synthesis into `career.next_step`
- carries working-life authority through personalization, read overlay, report, and telemetry
- bumps MBTI personalization/version metadata from `phase8c.v1` to `phase9c.v1`

This PR also closes the replay-contract drift discovered during review:
- `schema_version` now reflects the new working-life authority shape
- `dynamic_sections_version` now advances to `phase9c.v1`
- backend read-contract expectations stay aligned with the new overlay boundary

## Why this matters

Career and working-life are no longer just a loose cluster of sections.

The MBTI result stack now has a clearer working-life chain for:
- current focus
- journey order
- action priority
- reading priority
- Big Five-informed career next-step guidance

That makes the career layer replayable, telemetry-visible, and usable as an actual result-page operating chain.

## Validation

I ran:

- `php artisan test tests/Unit/Services/Mbti/MbtiWorkingLifeConsolidationServiceTest.php tests/Unit/Services/Mbti/MbtiBigFiveSynthesisServiceTest.php tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php tests/Unit/Services/Mbti/MbtiPrivacyConsentContractServiceTest.php tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php tests/Feature/V0_3/MbtiBigFiveCrossAssessmentSynthesisTest.php tests/Feature/V0_3/MbtiResultTelemetryContractTest.php`

All passed:
- 19 tests passed
- 564 assertions

## Scope note

This PR is intentionally limited to career OS consolidation inside the MBTI result experience.

It does not:
- introduce a job database
- create a standalone career recommendation system
- add migrations or new dependencies
- change MBTI or Big Five canonical scoring
- pull in task-external dirty files such as `backend/content_packs/BIG5_OCEAN/v1/compiled/*`, `backend/app/Console/Commands/PacksPublish.php`, or `backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php`
