### PR TITLE
[codex] Ship PR-9D0 AI runtime abstraction and controlled generation gateway (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -389,6 +389,10 @@ class AttemptReadController extends Controller
             if (is_array($privacyContract)) {
                 $responsePayload['mbti_privacy_contract_v1'] = $privacyContract;
             }
+            $narrativeRuntime = data_get($responsePayload, 'report._meta.personalization.narrative_runtime_contract_v1');
+            if (is_array($narrativeRuntime)) {
+                $responsePayload['narrative_runtime_contract_v1'] = $narrativeRuntime;
+            }
             $crossAssessment = data_get($responsePayload, 'report._meta.personalization.cross_assessment_v1');
             if (is_array($crossAssessment)) {
                 $responsePayload['mbti_cross_assessment_v1'] = $crossAssessment;
@@ -653,6 +657,19 @@ class AttemptReadController extends Controller
             'continuity' => is_array($personalization['continuity'] ?? null) ? $personalization['continuity'] : [],
             'engine_version' => trim((string) ($personalization['engine_version'] ?? '')),
         ];
+
+        $narrativeRuntime = is_array($personalization['narrative_runtime_contract_v1'] ?? null)
+            ? $personalization['narrative_runtime_contract_v1']
+            : [];
+        if ($narrativeRuntime !== []) {
+            $meta['narrative_runtime_contract_version'] = trim((string) ($narrativeRuntime['version'] ?? ''));
+            $meta['narrative_runtime_mode'] = trim((string) ($narrativeRuntime['runtime_mode'] ?? ''));
+            $meta['narrative_provider_name'] = trim((string) ($narrativeRuntime['provider_name'] ?? ''));
+            $meta['narrative_model_version'] = trim((string) ($narrativeRuntime['model_version'] ?? ''));
+            $meta['narrative_prompt_version'] = trim((string) ($narrativeRuntime['prompt_version'] ?? ''));
+            $meta['narrative_fingerprint'] = trim((string) ($narrativeRuntime['narrative_fingerprint'] ?? ''));
+            $meta['narrative_fail_open_mode'] = trim((string) ($narrativeRuntime['fail_open_mode'] ?? ''));
+        }
 
         $privacyContract = is_array($personalization['privacy_contract_v1'] ?? null)
             ? $personalization['privacy_contract_v1']

--- a/backend/app/Services/AI/ControlledGenerationRuntime.php
+++ b/backend/app/Services/AI/ControlledGenerationRuntime.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+final class ControlledGenerationRuntime
+{
+    public const CONTRACT_VERSION = 'narrative_runtime_contract.v1';
+
+    /**
+     * @var list<string>
+     */
+    private const TRUTH_GUARD_FIELDS = [
+        'type_code',
+        'identity',
+        'variant_keys',
+        'scene_fingerprint',
+        'working_life_v1',
+        'cross_assessment_v1',
+        'user_state',
+        'orchestration',
+        'continuity',
+        'career_focus_key',
+        'career_journey_keys',
+        'career_action_priority_keys',
+    ];
+
+    public function __construct(
+        private readonly BudgetLedger $budgetLedger,
+        private readonly NullNarrativeProvider $nullProvider,
+        private readonly MockNarrativeProvider $mockProvider,
+    ) {
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function buildContract(
+        string $surface,
+        string $scaleCode,
+        string $locale,
+        array $authority,
+        array $context = [],
+    ): array {
+        $request = new NarrativeGenerationRequest(
+            surface: trim($surface),
+            scaleCode: strtoupper(trim($scaleCode)),
+            locale: trim($locale) !== '' ? trim($locale) : 'zh-CN',
+            authority: $this->normalizeAuthority($authority),
+            context: $context,
+        );
+
+        if (! $this->isEnabled()) {
+            return $this->nullProvider->generate($request)->toContractArray(
+                self::CONTRACT_VERSION,
+                $request,
+                self::TRUTH_GUARD_FIELDS,
+            );
+        }
+
+        $providerName = $this->configuredProviderName();
+        $provider = $this->resolveProvider($providerName);
+        if (! $provider instanceof NarrativeProviderInterface) {
+            return $this->fallbackResponse($request, $providerName, 'AI_PROVIDER_UNAVAILABLE')
+                ->toContractArray(self::CONTRACT_VERSION, $request, self::TRUTH_GUARD_FIELDS);
+        }
+
+        try {
+            $this->guardBudget($request, $providerName);
+            $response = $provider->generate($request);
+            $this->incrementBudget($request, $response);
+        } catch (BudgetLedgerException $e) {
+            $response = $this->fallbackResponse($request, $providerName, $e->errorCode());
+        } catch (\Throwable $e) {
+            $response = $this->fallbackResponse($request, $providerName, 'AI_RUNTIME_FAILED');
+        }
+
+        return $response->toContractArray(self::CONTRACT_VERSION, $request, self::TRUTH_GUARD_FIELDS);
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return array<string, mixed>
+     */
+    private function normalizeAuthority(array $authority): array
+    {
+        $normalized = [];
+
+        foreach ([
+            'type_code',
+            'identity',
+            'engine_version',
+            'schema_version',
+            'dynamic_sections_version',
+            'explainability_summary',
+            'action_plan_summary',
+            'work_style_summary',
+            'scene_fingerprint',
+            'variant_keys',
+            'working_life_v1',
+            'cross_assessment_v1',
+            'user_state',
+            'orchestration',
+            'continuity',
+            'career_focus_key',
+            'career_journey_keys',
+            'career_action_priority_keys',
+            'reading_focus_key',
+            'action_focus_key',
+        ] as $key) {
+            if (! array_key_exists($key, $authority)) {
+                continue;
+            }
+
+            $value = $authority[$key];
+            if (is_string($value)) {
+                $value = trim($value);
+                if ($value === '') {
+                    continue;
+                }
+            } elseif (is_array($value) && $value === []) {
+                continue;
+            }
+
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
+    }
+
+    private function isEnabled(): bool
+    {
+        return (bool) config('ai.enabled', true)
+            && (bool) config('ai.narrative.enabled', false);
+    }
+
+    private function configuredProviderName(): string
+    {
+        $provider = trim((string) config('ai.narrative.provider', config('ai.provider', 'mock')));
+
+        return $provider !== '' ? strtolower($provider) : 'mock';
+    }
+
+    private function resolveProvider(string $providerName): ?NarrativeProviderInterface
+    {
+        return match ($providerName) {
+            'null', 'off' => $this->nullProvider,
+            'mock' => $this->mockProvider,
+            default => null,
+        };
+    }
+
+    private function guardBudget(NarrativeGenerationRequest $request, string $providerName): void
+    {
+        if (!(bool) config('ai.breaker_enabled', true)) {
+            return;
+        }
+
+        $tokens = $this->estimateTokens($request);
+        $costUsd = $this->estimateCostUsd($tokens);
+        $model = trim((string) config('ai.narrative.model', config('ai.model', 'mock-model')));
+        $subject = $request->budgetSubject();
+
+        $this->budgetLedger->checkAndThrow($providerName, $model, $subject, $tokens, $costUsd, 'day');
+        $this->budgetLedger->checkAndThrow($providerName, $model, $subject, $tokens, $costUsd, 'month');
+    }
+
+    private function incrementBudget(NarrativeGenerationRequest $request, NarrativeGenerationResponse $response): void
+    {
+        if (!(bool) config('ai.breaker_enabled', true)) {
+            return;
+        }
+
+        $model = trim((string) config('ai.narrative.model', config('ai.model', 'mock-model')));
+        $this->budgetLedger->incrementTokens(
+            $response->providerName,
+            $model,
+            $request->budgetSubject(),
+            $response->tokensIn,
+            $response->tokensOut,
+            $response->costUsd,
+        );
+    }
+
+    private function estimateTokens(NarrativeGenerationRequest $request): int
+    {
+        $encoded = json_encode($request->toArray(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}';
+
+        return max(1, (int) ceil(strlen($encoded) / 4));
+    }
+
+    private function estimateCostUsd(int $tokens): float
+    {
+        $rate = (float) config('ai.cost_per_1k_tokens_usd', 0.0);
+
+        return $rate > 0 ? round(($tokens / 1000.0) * $rate, 6) : 0.0;
+    }
+
+    private function fallbackResponse(
+        NarrativeGenerationRequest $request,
+        string $providerName,
+        string $errorCode
+    ): NarrativeGenerationResponse {
+        $summary = trim((string) ($request->authority['action_plan_summary'] ?? ''));
+        if ($summary === '') {
+            $summary = trim((string) ($request->authority['explainability_summary'] ?? ''));
+        }
+        if ($summary === '') {
+            $summary = trim((string) ($request->authority['work_style_summary'] ?? ''));
+        }
+
+        $sectionKeys = array_values(array_slice(array_keys((array) ($request->authority['variant_keys'] ?? [])), 0, 4));
+        if ($sectionKeys === []) {
+            $sectionKeys = array_values(array_slice((array) ($request->authority['career_journey_keys'] ?? []), 0, 4));
+        }
+
+        $output = [
+            'narrative_intro' => 'Deterministic narrative fallback is active.',
+            'narrative_summary' => $summary !== '' ? $summary : 'Structured authority remains available while the narrative runtime is degraded.',
+            'section_narrative_keys' => $sectionKeys,
+        ];
+
+        $fingerprint = hash('sha256', json_encode([
+            'contract_version' => self::CONTRACT_VERSION,
+            'runtime_mode' => 'fallback',
+            'provider' => $providerName,
+            'surface' => $request->surface,
+            'scale_code' => $request->scaleCode,
+            'locale' => $request->locale,
+            'authority' => $request->fingerprintPayload(),
+            'output' => $output,
+            'error_code' => $errorCode,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}');
+
+        return new NarrativeGenerationResponse(
+            runtimeMode: 'fallback',
+            providerName: $providerName,
+            modelVersion: trim((string) config('ai.narrative.model', config('ai.model', 'mock-model'))),
+            promptVersion: trim((string) config('ai.narrative.prompt_version', config('ai.prompt_version', 'v1.0.0'))),
+            failOpenMode: trim((string) config('ai.narrative.fail_open_mode', 'deterministic')),
+            narrativeFingerprint: $fingerprint,
+            output: $output,
+            errorCode: $errorCode,
+        );
+    }
+}

--- a/backend/app/Services/AI/MockNarrativeProvider.php
+++ b/backend/app/Services/AI/MockNarrativeProvider.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+final class MockNarrativeProvider implements NarrativeProviderInterface
+{
+    public function name(): string
+    {
+        return 'mock';
+    }
+
+    public function generate(NarrativeGenerationRequest $request): NarrativeGenerationResponse
+    {
+        $typeCode = trim((string) ($request->authority['type_code'] ?? $request->context['type_code'] ?? ''));
+        $identity = trim((string) ($request->authority['identity'] ?? $request->context['identity'] ?? ''));
+        $focusKey = trim((string) data_get($request->authority, 'working_life_v1.career_focus_key', ''))
+            ?: trim((string) ($request->authority['action_focus_key'] ?? ''))
+            ?: trim((string) data_get($request->authority, 'orchestration.primary_focus_key', ''));
+
+        $summary = trim((string) ($request->authority['action_plan_summary'] ?? ''));
+        if ($summary === '') {
+            $summary = trim((string) ($request->authority['explainability_summary'] ?? ''));
+        }
+        if ($summary === '') {
+            $summary = trim((string) ($request->authority['work_style_summary'] ?? ''));
+        }
+
+        $sectionKeys = array_values(array_slice(array_keys((array) ($request->authority['variant_keys'] ?? [])), 0, 6));
+        if ($sectionKeys === []) {
+            $sectionKeys = array_values(array_slice((array) data_get($request->authority, 'working_life_v1.career_journey_keys', []), 0, 4));
+        }
+
+        $introParts = array_values(array_filter([
+            $typeCode !== '' ? $typeCode : null,
+            $identity !== '' ? "identity {$identity}" : null,
+            $focusKey !== '' ? "focus {$focusKey}" : null,
+        ]));
+
+        $intro = $introParts !== []
+            ? 'Controlled narrative runtime ready for '.implode(' / ', $introParts).'.'
+            : 'Controlled narrative runtime ready from structured authority.';
+
+        $output = [
+            'narrative_intro' => $intro,
+            'narrative_summary' => $summary !== '' ? $summary : 'Structured authority is available for controlled narrative assembly.',
+            'section_narrative_keys' => $sectionKeys,
+        ];
+
+        $payload = [
+            'provider' => $this->name(),
+            'surface' => $request->surface,
+            'scale_code' => $request->scaleCode,
+            'locale' => $request->locale,
+            'authority' => $request->fingerprintPayload(),
+            'output' => $output,
+        ];
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}';
+        $tokensIn = max(1, (int) ceil(strlen($encoded) / 4));
+        $tokensOut = max(1, (int) ceil(strlen(json_encode($output, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}') / 4));
+        $costPer1k = (float) config('ai.cost_per_1k_tokens_usd', 0.0);
+
+        return new NarrativeGenerationResponse(
+            runtimeMode: 'mock',
+            providerName: $this->name(),
+            modelVersion: trim((string) config('ai.narrative.model', config('ai.model', 'mock-model'))),
+            promptVersion: trim((string) config('ai.narrative.prompt_version', config('ai.prompt_version', 'v1.0.0'))),
+            failOpenMode: trim((string) config('ai.narrative.fail_open_mode', 'deterministic')),
+            narrativeFingerprint: hash('sha256', $encoded),
+            output: $output,
+            errorCode: null,
+            tokensIn: $tokensIn,
+            tokensOut: $tokensOut,
+            costUsd: round((($tokensIn + $tokensOut) / 1000.0) * $costPer1k, 6),
+        );
+    }
+}

--- a/backend/app/Services/AI/NarrativeGenerationRequest.php
+++ b/backend/app/Services/AI/NarrativeGenerationRequest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+final class NarrativeGenerationRequest
+{
+    /**
+     * @param  array<string, mixed>  $authority
+     * @param  array<string, mixed>  $context
+     */
+    public function __construct(
+        public readonly string $surface,
+        public readonly string $scaleCode,
+        public readonly string $locale,
+        public readonly array $authority,
+        public readonly array $context = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'surface' => $this->surface,
+            'scale_code' => $this->scaleCode,
+            'locale' => $this->locale,
+            'authority' => $this->authority,
+            'context' => $this->safeContext(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function fingerprintPayload(): array
+    {
+        return [
+            'surface' => $this->surface,
+            'scale_code' => $this->scaleCode,
+            'locale' => $this->locale,
+            'authority' => $this->authority,
+            'context' => $this->safeContext(),
+        ];
+    }
+
+    public function budgetSubject(): string
+    {
+        $userId = trim((string) ($this->context['user_id'] ?? ''));
+        if ($userId !== '') {
+            return sprintf('narrative:%s:%s:user:%s', strtolower($this->scaleCode), $this->surface, $userId);
+        }
+
+        $anonId = trim((string) ($this->context['anon_id'] ?? ''));
+        if ($anonId !== '') {
+            return sprintf('narrative:%s:%s:anon:%s', strtolower($this->scaleCode), $this->surface, $anonId);
+        }
+
+        $attemptId = trim((string) ($this->context['attempt_id'] ?? ''));
+        if ($attemptId !== '') {
+            return sprintf('narrative:%s:%s:attempt:%s', strtolower($this->scaleCode), $this->surface, $attemptId);
+        }
+
+        return sprintf('narrative:%s:%s:unknown', strtolower($this->scaleCode), $this->surface);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function safeContext(): array
+    {
+        $safe = [];
+
+        foreach (['type_code', 'identity', 'engine_version', 'schema_version', 'dynamic_sections_version'] as $key) {
+            $value = $this->context[$key] ?? null;
+            $normalized = trim((string) $value);
+            if ($normalized !== '') {
+                $safe[$key] = $normalized;
+            }
+        }
+
+        return $safe;
+    }
+}

--- a/backend/app/Services/AI/NarrativeGenerationResponse.php
+++ b/backend/app/Services/AI/NarrativeGenerationResponse.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+final class NarrativeGenerationResponse
+{
+    /**
+     * @param  array<string, mixed>  $output
+     */
+    public function __construct(
+        public readonly string $runtimeMode,
+        public readonly string $providerName,
+        public readonly string $modelVersion,
+        public readonly string $promptVersion,
+        public readonly string $failOpenMode,
+        public readonly string $narrativeFingerprint,
+        public readonly array $output,
+        public readonly ?string $errorCode = null,
+        public readonly int $tokensIn = 0,
+        public readonly int $tokensOut = 0,
+        public readonly float $costUsd = 0.0,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toContractArray(string $contractVersion, NarrativeGenerationRequest $request, array $truthGuardFields): array
+    {
+        return [
+            'version' => $contractVersion,
+            'runtime_mode' => $this->runtimeMode,
+            'provider_name' => $this->providerName,
+            'model_version' => $this->modelVersion,
+            'prompt_version' => $this->promptVersion,
+            'fail_open_mode' => $this->failOpenMode,
+            'narrative_fingerprint' => $this->narrativeFingerprint,
+            'request' => [
+                'surface' => $request->surface,
+                'scale_code' => $request->scaleCode,
+                'locale' => $request->locale,
+                'authority_keys' => array_values(array_keys($request->authority)),
+            ],
+            'response' => [
+                'narrative_intro' => trim((string) ($this->output['narrative_intro'] ?? '')),
+                'narrative_summary' => trim((string) ($this->output['narrative_summary'] ?? '')),
+                'section_narrative_keys' => array_values((array) ($this->output['section_narrative_keys'] ?? [])),
+            ],
+            'output_present' => [
+                'narrative_intro' => trim((string) ($this->output['narrative_intro'] ?? '')) !== '',
+                'narrative_summary' => trim((string) ($this->output['narrative_summary'] ?? '')) !== '',
+                'section_narrative_keys' => ((array) ($this->output['section_narrative_keys'] ?? [])) !== [],
+            ],
+            'truth_guard_fields' => $truthGuardFields,
+            'error_code' => $this->errorCode,
+            'tokens_in' => $this->tokensIn,
+            'tokens_out' => $this->tokensOut,
+            'cost_usd' => round($this->costUsd, 6),
+        ];
+    }
+}

--- a/backend/app/Services/AI/NarrativeProviderInterface.php
+++ b/backend/app/Services/AI/NarrativeProviderInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+interface NarrativeProviderInterface
+{
+    public function name(): string;
+
+    public function generate(NarrativeGenerationRequest $request): NarrativeGenerationResponse;
+}

--- a/backend/app/Services/AI/NullNarrativeProvider.php
+++ b/backend/app/Services/AI/NullNarrativeProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+final class NullNarrativeProvider implements NarrativeProviderInterface
+{
+    public function name(): string
+    {
+        return 'null';
+    }
+
+    public function generate(NarrativeGenerationRequest $request): NarrativeGenerationResponse
+    {
+        return new NarrativeGenerationResponse(
+            runtimeMode: 'off',
+            providerName: $this->name(),
+            modelVersion: trim((string) config('ai.narrative.model', config('ai.model', 'mock-model'))),
+            promptVersion: trim((string) config('ai.narrative.prompt_version', config('ai.prompt_version', 'v1.0.0'))),
+            failOpenMode: 'off',
+            narrativeFingerprint: hash('sha256', json_encode([
+                'provider' => $this->name(),
+                'surface' => $request->surface,
+                'scale_code' => $request->scaleCode,
+                'locale' => $request->locale,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}'),
+            output: [
+                'narrative_intro' => '',
+                'narrative_summary' => '',
+                'section_narrative_keys' => [],
+            ],
+        );
+    }
+}

--- a/backend/app/Services/Mbti/MbtiReadModelContractService.php
+++ b/backend/app/Services/Mbti/MbtiReadModelContractService.php
@@ -51,6 +51,7 @@ final class MbtiReadModelContractService
         'mbti_public_projection_v1.profile',
         'mbti_public_projection_v1.dimensions',
         'mbti_public_projection_v1.sections',
+        'narrative_runtime_contract_v1',
     ];
 
     /**
@@ -73,6 +74,7 @@ final class MbtiReadModelContractService
         'mbti_public_projection_v1.dimensions',
         'mbti_public_projection_v1.sections',
         'mbti_read_contract_v1',
+        'narrative_runtime_contract_v1',
     ];
 
     /**
@@ -99,6 +101,11 @@ final class MbtiReadModelContractService
         'working_life_v1.career_focus_key',
         'working_life_v1.career_journey_keys',
         'working_life_v1.career_action_priority_keys',
+        'narrative_runtime_contract_v1.runtime_mode',
+        'narrative_runtime_contract_v1.provider_name',
+        'narrative_runtime_contract_v1.model_version',
+        'narrative_runtime_contract_v1.prompt_version',
+        'narrative_runtime_contract_v1.narrative_fingerprint',
     ];
 
     /**

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Mbti;
 
+use App\Services\AI\ControlledGenerationRuntime;
 use App\Services\Content\ContentPacksIndex;
 
 final class MbtiResultPersonalizationService
@@ -570,6 +571,7 @@ final class MbtiResultPersonalizationService
         private readonly MbtiBigFiveSynthesisService $bigFiveSynthesisService,
         private readonly MbtiWorkingLifeConsolidationService $workingLifeConsolidationService,
         private readonly MbtiPrivacyConsentContractService $privacyConsentContractService,
+        private readonly ControlledGenerationRuntime $controlledGenerationRuntime,
         private readonly MbtiReadModelContractService $readModelContractService,
     ) {
     }
@@ -709,6 +711,23 @@ final class MbtiResultPersonalizationService
             'region' => trim((string) ($context['region'] ?? config('regions.default_region', 'CN_MAINLAND'))),
             'locale' => $locale,
         ]);
+
+        $personalization['narrative_runtime_contract_v1'] = $this->controlledGenerationRuntime->buildContract(
+            'mbti.report',
+            'MBTI',
+            $locale,
+            $personalization,
+            [
+                'type_code' => $typeCode,
+                'identity' => $identity,
+                'engine_version' => trim((string) ($context['engine_version'] ?? data_get($reportPayload, 'versions.engine', ''))),
+                'schema_version' => 'mbti.personalization.phase9c.v1',
+                'dynamic_sections_version' => trim((string) ($dynamicDoc['version'] ?? '')),
+                'user_id' => $context['user_id'] ?? null,
+                'anon_id' => $context['anon_id'] ?? null,
+                'attempt_id' => $context['attempt_id'] ?? null,
+            ]
+        );
 
         return $this->readModelContractService->attachContract($personalization);
     }

--- a/backend/config/ai.php
+++ b/backend/config/ai.php
@@ -26,4 +26,12 @@ return [
     'queue_name' => env('AI_INSIGHTS_QUEUE', 'insights'),
     'cost_per_1k_tokens_usd' => (float) env('AI_COST_PER_1K_TOKENS_USD', 0.002),
     'dev_allow_anon_header' => env('AI_DEV_ALLOW_ANON_HEADER', false),
+
+    'narrative' => [
+        'enabled' => env('AI_NARRATIVE_ENABLED', false),
+        'provider' => env('AI_NARRATIVE_PROVIDER', env('AI_PROVIDER', 'mock')),
+        'model' => env('AI_NARRATIVE_MODEL', env('AI_MODEL', 'mock-model')),
+        'prompt_version' => env('AI_NARRATIVE_PROMPT_VERSION', env('AI_PROMPT_VERSION', 'v1.0.0')),
+        'fail_open_mode' => env('AI_NARRATIVE_FAIL_OPEN_MODE', 'deterministic'),
+    ],
 ];

--- a/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+++ b/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
@@ -122,6 +122,18 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             data_get($payload, 'report._meta.personalization.privacy_contract_v1.version')
         );
         $this->assertSame(
+            'narrative_runtime_contract.v1',
+            data_get($payload, 'report._meta.personalization.narrative_runtime_contract_v1.version')
+        );
+        $this->assertSame(
+            'off',
+            data_get($payload, 'report._meta.personalization.narrative_runtime_contract_v1.runtime_mode')
+        );
+        $this->assertSame(
+            'null',
+            data_get($payload, 'report._meta.personalization.narrative_runtime_contract_v1.provider_name')
+        );
+        $this->assertSame(
             true,
             data_get($payload, 'report._meta.personalization.privacy_contract_v1.consent_scope.subject_export')
         );

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -45,6 +45,11 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertSame('report_phase4a_contract', (string) ($meta['engine_version'] ?? ''));
             $this->assertSame('mbti.personalization.phase9c.v1', (string) ($meta['schema_version'] ?? ''));
             $this->assertSame('phase9c.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
+            $this->assertSame('narrative_runtime_contract.v1', (string) ($meta['narrative_runtime_contract_version'] ?? ''));
+            $this->assertSame('off', (string) ($meta['narrative_runtime_mode'] ?? ''));
+            $this->assertSame('null', (string) ($meta['narrative_provider_name'] ?? ''));
+            $this->assertSame('off', (string) ($meta['narrative_fail_open_mode'] ?? ''));
+            $this->assertNotSame('', trim((string) ($meta['narrative_fingerprint'] ?? '')));
             $this->assertIsArray($meta['axis_bands'] ?? null);
             $this->assertSame('boundary', (string) (($meta['axis_bands']['EI'] ?? '')));
             $this->assertSame('boundary', (string) (($meta['axis_bands']['AT'] ?? '')));
@@ -125,6 +130,8 @@ class MbtiResultTelemetryContractTest extends TestCase
         $this->assertSame($eventMeta['report_view']['working_life_v1'] ?? null, $eventMeta['result_view']['working_life_v1'] ?? null);
         $this->assertSame($eventMeta['report_view']['privacy_contract_version'] ?? null, $eventMeta['result_view']['privacy_contract_version'] ?? null);
         $this->assertSame($eventMeta['report_view']['consent_scope'] ?? null, $eventMeta['result_view']['consent_scope'] ?? null);
+        $this->assertSame($eventMeta['report_view']['narrative_runtime_contract_version'] ?? null, $eventMeta['result_view']['narrative_runtime_contract_version'] ?? null);
+        $this->assertSame($eventMeta['report_view']['narrative_fingerprint'] ?? null, $eventMeta['result_view']['narrative_fingerprint'] ?? null);
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.is_first_view'));
         $this->assertSame(false, data_get($eventMeta, 'result_view.user_state.is_revisit'));
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.has_share'));

--- a/backend/tests/Unit/Services/AI/ControlledGenerationRuntimeTest.php
+++ b/backend/tests/Unit/Services/AI/ControlledGenerationRuntimeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\AI;
+
+use App\Services\AI\ControlledGenerationRuntime;
+use Tests\TestCase;
+
+final class ControlledGenerationRuntimeTest extends TestCase
+{
+    public function test_runtime_off_returns_null_provider_contract_without_touching_truth(): void
+    {
+        config()->set('ai.enabled', true);
+        config()->set('ai.narrative.enabled', false);
+        config()->set('ai.breaker_enabled', false);
+
+        $contract = app(ControlledGenerationRuntime::class)->buildContract(
+            'mbti.report',
+            'MBTI',
+            'zh-CN',
+            [
+                'type_code' => 'INTJ-A',
+                'identity' => 'A',
+                'variant_keys' => ['overview' => 'overview:clear'],
+            ],
+        );
+
+        $this->assertSame('narrative_runtime_contract.v1', $contract['version']);
+        $this->assertSame('off', $contract['runtime_mode']);
+        $this->assertSame('null', $contract['provider_name']);
+        $this->assertSame('', $contract['response']['narrative_intro']);
+        $this->assertSame('', $contract['response']['narrative_summary']);
+        $this->assertContains('variant_keys', $contract['truth_guard_fields']);
+    }
+
+    public function test_runtime_mock_provider_returns_versioned_contract_and_stable_fingerprint(): void
+    {
+        config()->set('ai.enabled', true);
+        config()->set('ai.narrative.enabled', true);
+        config()->set('ai.narrative.provider', 'mock');
+        config()->set('ai.narrative.model', 'mock-narrative-model');
+        config()->set('ai.narrative.prompt_version', 'prompt.9d0.v1');
+        config()->set('ai.breaker_enabled', false);
+
+        $runtime = app(ControlledGenerationRuntime::class);
+        $authority = [
+            'type_code' => 'INTJ-A',
+            'identity' => 'A',
+            'explainability_summary' => 'Structured explainability is available.',
+            'action_plan_summary' => 'Use one repeatable next step.',
+            'variant_keys' => [
+                'overview' => 'overview:clear',
+                'growth.next_actions' => 'growth.next_actions:repeatable',
+            ],
+            'working_life_v1' => ['career_focus_key' => 'career.next_step'],
+        ];
+
+        $first = $runtime->buildContract('mbti.report', 'MBTI', 'zh-CN', $authority);
+        $second = $runtime->buildContract('mbti.report', 'MBTI', 'zh-CN', $authority);
+
+        $this->assertSame('mock', $first['runtime_mode']);
+        $this->assertSame('mock', $first['provider_name']);
+        $this->assertSame('mock-narrative-model', $first['model_version']);
+        $this->assertSame('prompt.9d0.v1', $first['prompt_version']);
+        $this->assertNotSame('', trim((string) $first['response']['narrative_intro']));
+        $this->assertNotSame('', trim((string) $first['response']['narrative_summary']));
+        $this->assertNotEmpty($first['response']['section_narrative_keys']);
+        $this->assertSame($first['narrative_fingerprint'], $second['narrative_fingerprint']);
+    }
+
+    public function test_runtime_fails_open_to_deterministic_fallback_when_provider_is_unavailable(): void
+    {
+        config()->set('ai.enabled', true);
+        config()->set('ai.narrative.enabled', true);
+        config()->set('ai.narrative.provider', 'openai');
+        config()->set('ai.breaker_enabled', false);
+        config()->set('ai.narrative.fail_open_mode', 'deterministic');
+
+        $contract = app(ControlledGenerationRuntime::class)->buildContract(
+            'mbti.report',
+            'MBTI',
+            'zh-CN',
+            [
+                'type_code' => 'INTJ-A',
+                'action_plan_summary' => 'Canonical action summary stays intact.',
+                'variant_keys' => ['growth.next_actions' => 'growth.next_actions:repeatable'],
+            ],
+        );
+
+        $this->assertSame('fallback', $contract['runtime_mode']);
+        $this->assertSame('openai', $contract['provider_name']);
+        $this->assertSame('deterministic', $contract['fail_open_mode']);
+        $this->assertSame('AI_PROVIDER_UNAVAILABLE', $contract['error_code']);
+        $this->assertSame('Canonical action summary stays intact.', $contract['response']['narrative_summary']);
+    }
+}

--- a/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
@@ -17,6 +17,7 @@ final class MbtiReadModelContractServiceTest extends TestCase
             'schema_version' => 'mbti.personalization.phase9c.v1',
             'identity' => 'A',
             'privacy_contract_v1' => ['version' => 'mbti.privacy_contract.v1'],
+            'narrative_runtime_contract_v1' => ['version' => 'narrative_runtime_contract.v1', 'runtime_mode' => 'off'],
             'variant_keys' => ['overview' => 'overview:clear'],
             'scene_fingerprint' => ['work' => ['style_key' => 'work.primary.EI.E.clear']],
             'user_state' => ['is_first_view' => true],
@@ -31,9 +32,11 @@ final class MbtiReadModelContractServiceTest extends TestCase
         $this->assertSame('mbti.read_contract.v1', $contract['version']);
         $this->assertContains('identity', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('privacy_contract_v1', $contract['canonical_read_model']['personalization_fields']);
+        $this->assertContains('narrative_runtime_contract_v1', $contract['canonical_read_model']['personalization_fields']);
         $this->assertNotContains('variant_keys', $contract['canonical_read_model']['personalization_fields']);
         $this->assertNotContains('user_state', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('mbti_privacy_contract_v1', $contract['cacheable_fields']);
+        $this->assertContains('narrative_runtime_contract_v1', $contract['cacheable_fields']);
         $this->assertSame(
             [
                 'user_state',
@@ -65,6 +68,7 @@ final class MbtiReadModelContractServiceTest extends TestCase
         $this->assertContains('user_state', $contract['telemetry_parity_fields']);
         $this->assertContains('continuity.carryover_focus_key', $contract['telemetry_parity_fields']);
         $this->assertContains('working_life_v1.career_focus_key', $contract['telemetry_parity_fields']);
+        $this->assertContains('narrative_runtime_contract_v1.runtime_mode', $contract['telemetry_parity_fields']);
     }
 
     public function test_apply_overlay_patch_preserves_canonical_fields_and_replaces_only_overlay_fields(): void

--- a/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
@@ -94,6 +94,11 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
         $this->assertSame('MBTI.cn-mainland.zh-CN.v0.3', $clear['pack_id']);
         $this->assertSame('report_phase4a_contract', $clear['engine_version']);
         $this->assertSame('phase9c.v1', $clear['dynamic_sections_version']);
+        $this->assertSame('narrative_runtime_contract.v1', data_get($clear, 'narrative_runtime_contract_v1.version'));
+        $this->assertSame('off', data_get($clear, 'narrative_runtime_contract_v1.runtime_mode'));
+        $this->assertSame('null', data_get($clear, 'narrative_runtime_contract_v1.provider_name'));
+        $this->assertSame(false, data_get($clear, 'narrative_runtime_contract_v1.output_present.narrative_intro'));
+        $this->assertContains('working_life_v1', data_get($clear, 'narrative_runtime_contract_v1.truth_guard_fields', []));
         $this->assertSame('mbti.privacy_contract.v1', data_get($clear, 'privacy_contract_v1.version'));
         $this->assertSame(true, data_get($clear, 'privacy_contract_v1.consent_scope.subject_export'));
         $this->assertContains(


### PR DESCRIPTION
## Summary

This PR establishes PR-9D0: AI runtime abstraction and controlled generation gateway.

It does not enable result-page narrative yet. Instead, it adds the backend-owned runtime/provider contract that later narrative work can safely consume.

## What changed

Backend:
- adds 
- adds 
- adds  and 
- adds request/response models for controlled generation
- introduces 
- wires runtime metadata into MBTI personalization, report/read metadata, and telemetry

The runtime is:
- feature-flagged
- versioned
- replayable
- fail-open with deterministic fallback
- authority-safe

## Why this matters

PR-9D was previously blocked because the repo had AI budget/mock/queue primitives, but not a result-page-safe runtime abstraction.

This PR closes that gap and provides the legal entry point for later controlled narrative enhancement without touching canonical truth.

## Validation

I ran:

- 

All passed:
- 14 tests passed
- 524 assertions

## Scope note

This PR does not:
- enable narrative UI
- change canonical MBTI or Big Five truth
- add a new AI provider SDK
- introduce migration or new dependencies