### PR TITLE
[codex] add V2 resolver remote rehydrate fallback

### DIFF
--- a/backend/app/Services/Content/ContentPackV2RemoteRehydrateService.php
+++ b/backend/app/Services/Content/ContentPackV2RemoteRehydrateService.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use App\Models\ContentReleaseExactManifest;
+use App\Services\Storage\ExactReleaseRehydrateService;
+use App\Services\Storage\ReleaseStorageLocator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use RuntimeException;
+
+final class ContentPackV2RemoteRehydrateService
+{
+    private const ALLOWED_SOURCE_KINDS = [
+        'v2.primary',
+        'v2.mirror',
+    ];
+
+    public function __construct(
+        private readonly ContentPackV2Materializer $materializer,
+        private readonly ExactReleaseRehydrateService $rehydrateService,
+        private readonly ReleaseStorageLocator $releaseStorageLocator,
+    ) {}
+
+    public function materializeFromRemote(object $release, string $disk): string
+    {
+        $disk = trim($disk);
+        if ($disk === '') {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_DISK_REQUIRED');
+        }
+
+        $exactManifest = $this->resolveExactManifest($release);
+        $plan = $this->rehydrateService->buildPlan((int) $exactManifest->getKey(), null, $disk);
+        if ((int) data_get($plan, 'summary.missing_locations', 0) > 0) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_REMOTE_COVERAGE_INCOMPLETE');
+        }
+
+        $targetCompiledDir = $this->materializer->targetCompiledDir($release);
+        $targetRoot = dirname($targetCompiledDir);
+        $sentinelPath = $targetRoot.'/.materialization.json';
+
+        if ($this->isFresh($release, $targetCompiledDir, $sentinelPath)) {
+            return $targetCompiledDir;
+        }
+
+        /** @var Collection<int,array<string,mixed>> $files */
+        $files = collect(is_array($plan['files'] ?? null) ? $plan['files'] : [])
+            ->filter(static fn ($file): bool => is_array($file))
+            ->values();
+        if ($files->isEmpty()) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_PLAN_EMPTY');
+        }
+
+        $stagingRoot = $targetRoot.'-remote-staging-'.substr(bin2hex(random_bytes(4)), 0, 8);
+        File::deleteDirectory($stagingRoot);
+        File::ensureDirectoryExists($stagingRoot);
+
+        try {
+            foreach ($files as $file) {
+                $location = is_array($file['remote_location'] ?? null) ? $file['remote_location'] : null;
+                if ($location === null) {
+                    throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_MISSING_REMOTE_LOCATION');
+                }
+
+                $remotePath = trim((string) ($location['storage_path'] ?? ''));
+                if ($remotePath === '') {
+                    throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_INVALID_REMOTE_PATH');
+                }
+
+                $remoteDisk = Storage::disk($disk);
+                if (! $remoteDisk->exists($remotePath)) {
+                    throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_REMOTE_OBJECT_MISSING');
+                }
+
+                $payload = $remoteDisk->get($remotePath);
+                if (! is_string($payload)) {
+                    throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_REMOTE_READ_FAILED');
+                }
+
+                $this->verifyPayload($payload, $file);
+
+                $destination = $stagingRoot.DIRECTORY_SEPARATOR.$this->normalizeRelativePath((string) ($file['logical_path'] ?? ''));
+                File::ensureDirectoryExists(dirname($destination));
+                File::put($destination, $payload);
+            }
+
+            $this->verifyTree(
+                $stagingRoot,
+                $files,
+                strtolower(trim((string) data_get($plan, 'exact_manifest.manifest_hash', '')))
+            );
+
+            $this->writeSentinel($stagingRoot.'/.materialization.json', $release, $exactManifest);
+
+            if (File::isDirectory($targetRoot)) {
+                File::deleteDirectory($targetRoot);
+            }
+
+            File::ensureDirectoryExists(dirname($targetRoot));
+            if (! File::moveDirectory($stagingRoot, $targetRoot)) {
+                throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_FINALIZE_FAILED');
+            }
+
+            if (! is_file($targetCompiledDir.'/manifest.json')) {
+                throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_MANIFEST_MISSING');
+            }
+
+            return $targetCompiledDir;
+        } catch (\Throwable $e) {
+            if (File::isDirectory($stagingRoot)) {
+                File::deleteDirectory($stagingRoot);
+            }
+
+            throw $e;
+        }
+    }
+
+    private function resolveExactManifest(object $release): ContentReleaseExactManifest
+    {
+        $releaseId = trim((string) ($release->id ?? ''));
+        if ($releaseId === '') {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_RELEASE_ID_REQUIRED');
+        }
+
+        $manifestHash = strtolower(trim((string) ($release->manifest_hash ?? '')));
+        $storagePath = trim((string) ($release->storage_path ?? ''));
+        if ($storagePath === '') {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_STORAGE_PATH_REQUIRED');
+        }
+
+        $query = ContentReleaseExactManifest::query()
+            ->where('content_pack_release_id', $releaseId)
+            ->whereIn('source_kind', self::ALLOWED_SOURCE_KINDS)
+            ->orderBy('id');
+        if ($manifestHash !== '') {
+            $query->where('manifest_hash', $manifestHash);
+        }
+
+        $manifests = $query->get();
+        if ($manifests->isEmpty()) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_EXACT_MANIFEST_NOT_FOUND');
+        }
+
+        $candidateRoots = $this->releaseStorageLocator->candidateRootsFromStoragePath($storagePath);
+        foreach ($candidateRoots as $candidateRoot) {
+            $matches = $manifests->filter(
+                fn (ContentReleaseExactManifest $manifest): bool => $this->normalizeRoot((string) $manifest->source_storage_path) === $this->normalizeRoot($candidateRoot)
+            )->values();
+
+            if ($matches->count() === 1) {
+                /** @var ContentReleaseExactManifest $selected */
+                $selected = $matches->first();
+
+                return $selected;
+            }
+
+            if ($matches->count() > 1) {
+                throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_EXACT_MANIFEST_AMBIGUOUS');
+            }
+        }
+
+        if ($manifests->count() === 1) {
+            /** @var ContentReleaseExactManifest $selected */
+            $selected = $manifests->first();
+
+            return $selected;
+        }
+
+        throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_EXACT_MANIFEST_AMBIGUOUS');
+    }
+
+    private function isFresh(object $release, string $targetCompiledDir, string $sentinelPath): bool
+    {
+        if (! is_file($targetCompiledDir.'/manifest.json') || ! is_file($sentinelPath)) {
+            return false;
+        }
+
+        $decoded = json_decode((string) File::get($sentinelPath), true);
+        if (! is_array($decoded)) {
+            return false;
+        }
+
+        return (string) ($decoded['storage_path'] ?? '') === $this->storagePath($release)
+            && (string) ($decoded['manifest_hash'] ?? '') === $this->manifestHash($release);
+    }
+
+    private function writeSentinel(string $sentinelPath, object $release, ContentReleaseExactManifest $manifest): void
+    {
+        $encoded = json_encode([
+            'release_id' => trim((string) ($release->id ?? '')),
+            'storage_path' => $this->storagePath($release),
+            'manifest_hash' => $this->manifestHash($release),
+            'source_compiled_dir' => 'remote_rehydrate://exact_manifest/'.(int) $manifest->getKey(),
+            'materialized_at' => now()->toIso8601String(),
+            'remote_fallback' => true,
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'exact_identity_hash' => (string) $manifest->exact_identity_hash,
+            'source_kind' => (string) $manifest->source_kind,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_SENTINEL_ENCODE_FAILED');
+        }
+
+        File::put($sentinelPath, $encoded.PHP_EOL);
+    }
+
+    /**
+     * @param  array<string,mixed>  $file
+     */
+    private function verifyPayload(string $payload, array $file): void
+    {
+        $expectedHash = strtolower(trim((string) ($file['blob_hash'] ?? '')));
+        if ($expectedHash === '' || hash('sha256', $payload) !== $expectedHash) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_BLOB_HASH_MISMATCH');
+        }
+
+        $expectedSize = max(0, (int) ($file['size_bytes'] ?? 0));
+        if (strlen($payload) !== $expectedSize) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_SIZE_MISMATCH');
+        }
+
+        $checksum = trim((string) ($file['checksum'] ?? ''));
+        if ($checksum !== '' && str_starts_with($checksum, 'sha256:')) {
+            $expectedChecksum = strtolower(substr($checksum, strlen('sha256:')));
+            if ($expectedChecksum !== '' && hash('sha256', $payload) !== $expectedChecksum) {
+                throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_CHECKSUM_MISMATCH');
+            }
+        }
+    }
+
+    /**
+     * @param  Collection<int,array<string,mixed>>  $files
+     */
+    private function verifyTree(string $root, Collection $files, string $manifestHash): void
+    {
+        $actualPaths = collect(File::allFiles($root))
+            ->map(fn (\SplFileInfo $file): string => str_replace('\\', '/', ltrim(substr($file->getPathname(), strlen($root)), '/\\')))
+            ->sort()
+            ->values()
+            ->all();
+
+        $expectedPaths = $files
+            ->map(fn (array $file): string => $this->normalizeRelativePath((string) ($file['logical_path'] ?? '')))
+            ->sort()
+            ->values()
+            ->all();
+
+        if ($actualPaths !== $expectedPaths) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_LOGICAL_PATH_MISMATCH');
+        }
+
+        foreach ($files as $file) {
+            $path = $root.DIRECTORY_SEPARATOR.$this->normalizeRelativePath((string) ($file['logical_path'] ?? ''));
+            if (! is_file($path)) {
+                throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_FILE_MISSING');
+            }
+
+            $payload = (string) File::get($path);
+            $this->verifyPayload($payload, $file);
+        }
+
+        if ($manifestHash !== '') {
+            $manifestPath = $root.DIRECTORY_SEPARATOR.'compiled'.DIRECTORY_SEPARATOR.'manifest.json';
+            if (! is_file($manifestPath)) {
+                throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_MANIFEST_PATH_MISSING');
+            }
+
+            if (hash_file('sha256', $manifestPath) !== $manifestHash) {
+                throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_MANIFEST_HASH_MISMATCH');
+            }
+        }
+    }
+
+    private function normalizeRelativePath(string $path): string
+    {
+        $normalized = str_replace('\\', '/', trim($path));
+        if ($normalized === '') {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_LOGICAL_PATH_EMPTY');
+        }
+
+        if (str_starts_with($normalized, '/') || preg_match('/^[A-Za-z]:[\/\\\\]/', $normalized) === 1) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_LOGICAL_PATH_ABSOLUTE');
+        }
+
+        $segments = array_values(array_filter(explode('/', $normalized), static fn (string $segment): bool => $segment !== ''));
+        if ($segments === []) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_LOGICAL_PATH_EMPTY');
+        }
+
+        foreach ($segments as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_LOGICAL_PATH_TRAVERSAL');
+            }
+        }
+
+        return implode('/', $segments);
+    }
+
+    private function manifestHash(object $release): string
+    {
+        return strtolower(trim((string) ($release->manifest_hash ?? '')));
+    }
+
+    private function storagePath(object $release): string
+    {
+        return trim((string) ($release->storage_path ?? ''));
+    }
+
+    private function normalizeRoot(string $root): string
+    {
+        return str_replace('\\', '/', rtrim(trim($root), '/\\'));
+    }
+}

--- a/backend/app/Services/Content/ContentPackV2Resolver.php
+++ b/backend/app/Services/Content/ContentPackV2Resolver.php
@@ -12,6 +12,7 @@ final class ContentPackV2Resolver
 {
     public function __construct(
         private readonly ContentPackV2Materializer $materializer,
+        private readonly ContentPackV2RemoteRehydrateService $remoteRehydrate,
     ) {}
 
     public function resolveActiveCompiledPath(string $packId, string $packVersion): ?string
@@ -111,7 +112,32 @@ final class ContentPackV2Resolver
             }
         }
 
-        return null;
+        if (! $this->shouldRemoteRehydrate()) {
+            return null;
+        }
+
+        try {
+            return $this->remoteRehydrate->materializeFromRemote($release, $this->remoteRehydrateDisk());
+        } catch (Throwable $e) {
+            Log::warning('PACKS2_RESOLVER_REMOTE_REHYDRATE_FAILED', [
+                'release_id' => trim((string) ($release->id ?? '')),
+                'manifest_hash' => strtolower(trim((string) ($release->manifest_hash ?? ''))),
+                'storage_path' => $storagePath,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    private function shouldRemoteRehydrate(): bool
+    {
+        return (bool) config('storage_rollout.packs_v2_remote_rehydrate_enabled', false);
+    }
+
+    private function remoteRehydrateDisk(): string
+    {
+        return trim((string) config('storage_rollout.blob_offload_disk', 's3'));
     }
 
     private function shouldMaterialize(): bool

--- a/backend/config/storage_rollout.php
+++ b/backend/config/storage_rollout.php
@@ -23,6 +23,7 @@ return [
     'artifact_dual_write_enabled' => false,
     'content_pack_v2_dual_write_enabled' => false,
     'resolver_materialization_enabled' => false,
+    'packs_v2_remote_rehydrate_enabled' => false,
     'blob_offload_disk' => env('STORAGE_BLOB_OFFLOAD_DISK', 's3'),
     'blob_offload_prefix' => env('STORAGE_BLOB_OFFLOAD_PREFIX', 'rollout/blobs'),
     'blob_offload_storage_class' => env('STORAGE_BLOB_OFFLOAD_STORAGE_CLASS'),

--- a/backend/tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php
+++ b/backend/tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Content;
+
+use App\Services\Content\ContentPackV2Resolver;
+use App\Services\Storage\ExactReleaseFileSetCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ContentPackV2ResolverRemoteRehydrateFallbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-packs2-remote-rehydrate-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath);
+        $this->app->useStoragePath($this->isolatedStoragePath);
+
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', true);
+        config()->set('storage_rollout.resolver_materialization_enabled', false);
+        config()->set('storage_rollout.blob_offload_disk', 's3');
+        config()->set('filesystems.disks.s3.bucket', 'packs2-remote-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.packs2-remote.test');
+        Storage::forgetDisk('s3');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_remote_fallback_materializes_active_release_when_primary_and_mirror_are_missing(): void
+    {
+        $fixture = $this->seedV2RemoteFixture('remote_active_primary', 'v2.primary');
+        $expectedMaterializedDir = $this->expectedMaterializedDir($fixture['storage_path'], $fixture['manifest_hash']);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1');
+
+        $this->assertSame($expectedMaterializedDir, $resolved);
+        $this->assertFileExists($expectedMaterializedDir.'/manifest.json');
+        $this->assertSame('{"source":"remote_active_primary"}', (string) File::get($expectedMaterializedDir.'/questions.compiled.json'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/'.$fixture['storage_path']));
+        $this->assertDirectoryDoesNotExist(storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$fixture['release_id']));
+
+        $sentinel = json_decode((string) File::get(dirname($expectedMaterializedDir).'/.materialization.json'), true);
+        $this->assertIsArray($sentinel);
+        $this->assertTrue((bool) ($sentinel['remote_fallback'] ?? false));
+        $this->assertSame('v2.primary', (string) ($sentinel['source_kind'] ?? ''));
+        $this->assertSame((int) $fixture['exact_manifest_id'], (int) ($sentinel['exact_manifest_id'] ?? 0));
+        $this->assertSame((string) $fixture['exact_identity_hash'], (string) ($sentinel['exact_identity_hash'] ?? ''));
+        $this->assertSame($fixture['storage_path'], (string) ($sentinel['storage_path'] ?? ''));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+        $this->assertSame($fixture['storage_path'], (string) DB::table('content_pack_releases')->where('id', $fixture['release_id'])->value('storage_path'));
+    }
+
+    public function test_remote_fallback_materializes_historical_release_and_reuses_same_cache_bucket(): void
+    {
+        $sharedStoragePath = 'private/packs_v2/BIG5_OCEAN/v1/shared-history-tree';
+        $olderReleaseId = (string) Str::uuid();
+        $latestReleaseId = (string) Str::uuid();
+        ['manifest_hash' => $manifestHash, 'files' => $files] = $this->buildRemoteFiles('remote_history_mirror');
+
+        $this->insertRelease($olderReleaseId, $manifestHash, $sharedStoragePath, createdAt: now()->subMinute());
+        $this->insertRelease($latestReleaseId, $manifestHash, $sharedStoragePath, action: 'packs2_rollback', createdAt: now());
+        $this->seedExactManifest($latestReleaseId, 'v2.mirror', storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$latestReleaseId), $manifestHash, $files);
+
+        $expectedMaterializedDir = $this->expectedMaterializedDir($sharedStoragePath, $manifestHash);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $firstResolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $manifestHash);
+        $this->assertSame($expectedMaterializedDir, $firstResolved);
+        $this->assertSame('{"source":"remote_history_mirror"}', (string) File::get($expectedMaterializedDir.'/questions.compiled.json'));
+
+        $targetRoot = dirname($expectedMaterializedDir);
+        File::put($targetRoot.'/marker.txt', 'keep-me');
+
+        $secondResolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $manifestHash);
+        $this->assertSame($expectedMaterializedDir, $secondResolved);
+        $this->assertFileExists($targetRoot.'/marker.txt');
+
+        $sentinel = json_decode((string) File::get($targetRoot.'/.materialization.json'), true);
+        $this->assertIsArray($sentinel);
+        $this->assertSame('v2.mirror', (string) ($sentinel['source_kind'] ?? ''));
+        $this->assertSame($latestReleaseId, (string) ($sentinel['release_id'] ?? ''));
+    }
+
+    public function test_remote_fallback_returns_null_when_verified_remote_coverage_is_missing(): void
+    {
+        $fixture = $this->seedV2RemoteFixture('remote_missing_coverage', 'v2.primary', createRemoteCoverage: false);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1');
+
+        $this->assertNull($resolved);
+        $this->assertDirectoryDoesNotExist(dirname($this->expectedMaterializedDir($fixture['storage_path'], $fixture['manifest_hash'])));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    public function test_remote_fallback_returns_null_when_exact_manifest_is_missing_or_ambiguous(): void
+    {
+        $missingFixture = $this->seedV2RemoteFixture('remote_missing_manifest', 'v2.primary', createExactManifest: false);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $this->assertNull($resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1'));
+
+        $ambiguousReleaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.Str::uuid();
+        ['manifest_hash' => $manifestHash, 'files' => $files] = $this->buildRemoteFiles('remote_ambiguous');
+
+        $this->insertRelease($ambiguousReleaseId, $manifestHash, $storagePath, createdAt: now()->addSecond());
+        $this->seedExactManifest($ambiguousReleaseId, 'v2.primary', storage_path('app/private/packs_v2/BIG5_OCEAN/v1/'.Str::uuid()), $manifestHash, $files);
+        $this->seedExactManifest($ambiguousReleaseId, 'v2.mirror', storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.Str::uuid()), $manifestHash, $files);
+
+        $this->assertNull($resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $manifestHash));
+        $this->assertDirectoryDoesNotExist(dirname($this->expectedMaterializedDir($storagePath, $manifestHash)));
+        $this->assertDirectoryDoesNotExist(dirname($this->expectedMaterializedDir($missingFixture['storage_path'], $missingFixture['manifest_hash'])));
+    }
+
+    /**
+     * @return array{
+     *   release_id:string,
+     *   exact_manifest_id:int|null,
+     *   exact_identity_hash:string|null,
+     *   storage_path:string,
+     *   manifest_hash:string
+     * }
+     */
+    private function seedV2RemoteFixture(
+        string $suffix,
+        string $sourceKind,
+        bool $createExactManifest = true,
+        bool $createRemoteCoverage = true,
+    ): array {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        ['manifest_hash' => $manifestHash, 'files' => $files] = $this->buildRemoteFiles($suffix);
+
+        $this->insertRelease($releaseId, $manifestHash, $storagePath);
+        $this->activateRelease($releaseId);
+
+        $manifest = null;
+        if ($createExactManifest) {
+            $sourceRoot = $sourceKind === 'v2.primary'
+                ? storage_path('app/'.$storagePath)
+                : storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+            $manifest = $this->seedExactManifest($releaseId, $sourceKind, $sourceRoot, $manifestHash, $files, $createRemoteCoverage);
+        }
+
+        return [
+            'release_id' => $releaseId,
+            'exact_manifest_id' => $manifest?->getKey(),
+            'exact_identity_hash' => $manifest?->exact_identity_hash,
+            'storage_path' => $storagePath,
+            'manifest_hash' => $manifestHash,
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function seedExactManifest(
+        string $releaseId,
+        string $sourceKind,
+        string $sourceRoot,
+        string $manifestHash,
+        array $files,
+        bool $createRemoteCoverage = true,
+    ): object {
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => $sourceKind,
+            'source_disk' => 'local',
+            'source_storage_path' => $sourceRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => $manifestHash,
+            'content_hash' => hash('sha256', 'content|'.$manifestHash),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$manifestHash,
+            'payload_json' => ['remote_fallback' => true],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            if (! $createRemoteCoverage) {
+                continue;
+            }
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->updateOrInsert(
+                [
+                    'disk' => 's3',
+                    'storage_path' => $remotePath,
+                ],
+                [
+                    'blob_hash' => $hash,
+                    'location_kind' => 'remote_copy',
+                    'size_bytes' => strlen($payload),
+                    'checksum' => 'sha256:'.$hash,
+                    'etag' => 'etag-'.substr($hash, 0, 8),
+                    'storage_class' => 'STANDARD_IA',
+                    'verified_at' => now(),
+                    'meta_json' => json_encode([
+                        'bucket' => 'packs2-remote-bucket',
+                        'region' => 'ap-guangzhou',
+                        'endpoint' => 'https://cos.packs2-remote.test',
+                        'url' => 'https://cos.packs2-remote.test/'.$remotePath,
+                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]
+            );
+        }
+
+        return $manifest;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    /**
+     * @return array{manifest_hash:string,files:array<string,string>}
+     */
+    private function buildRemoteFiles(string $suffix): array
+    {
+        $manifestPayload = json_encode([
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($manifestPayload);
+
+        return [
+            'manifest_hash' => hash('sha256', $manifestPayload),
+            'files' => [
+                'compiled/manifest.json' => $manifestPayload,
+                'compiled/questions.compiled.json' => json_encode([
+                    'source' => $suffix,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'compiled/layout.compiled.json' => json_encode([
+                    'layout' => $suffix,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ],
+        ];
+    }
+
+    private function insertRelease(
+        string $releaseId,
+        string $manifestHash,
+        string $storagePath,
+        string $action = 'packs2_publish',
+        mixed $createdAt = null,
+    ): void {
+        $createdAt ??= now();
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => $action,
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v1',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => 'test',
+            'created_by' => 'test',
+            'manifest_hash' => $manifestHash,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => null,
+            'norms_version' => null,
+            'git_sha' => null,
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $storagePath,
+            'source_commit' => null,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ]);
+    }
+
+    private function activateRelease(string $releaseId): void
+    {
+        DB::table('content_pack_activations')->updateOrInsert(
+            [
+                'pack_id' => 'BIG5_OCEAN',
+                'pack_version' => 'v1',
+            ],
+            [
+                'release_id' => $releaseId,
+                'activated_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+    }
+
+    private function expectedMaterializedDir(string $storagePath, string $manifestHash): string
+    {
+        return storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.hash('sha256', $storagePath).'/'.$manifestHash.'/compiled');
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a local-miss-only remote rehydrate fallback for the V2 content resolver.

The scope stays intentionally narrow:

- add a gated remote fallback branch in `ContentPackV2Resolver`
- add `ContentPackV2RemoteRehydrateService`
- rebuild only from exact authority + verified `remote_copy` locations
- write rebuilt output only into the existing `packs_v2_materialized/**` cache contract
- keep local primary / mirror hits unchanged
- keep resolver return type unchanged: local compiled dir only
- do not add direct remote-read
- do not change publish / quarantine / restore / purge / offload / gc contracts

## Root cause

`ContentPackV2Resolver` still had a hard local dependency on V2 primary / mirror roots.

That blocked any future quarantine / purge of historical V2 roots, because once both local roots were missing, the resolver had no runtime-safe way to recover a local compiled tree even though the repo already had:

- exact release file-set authority
- verified remote blob copies
- exact rehydrate verify semantics

## What this PR adds

### 1. Resolver seam remote fallback

`ContentPackV2Resolver::resolveCompiledPathFromRelease()` now keeps the existing priority order:

1. local primary
2. local mirror
3. remote fallback into local materialized cache
4. warning + `null`

Remote fallback is gated behind:

- `storage_rollout.packs_v2_remote_rehydrate_enabled`

When the flag is disabled, behavior stays unchanged.

### 2. `ContentPackV2RemoteRehydrateService`

The new helper/service is responsible only for remote rebuild into the existing materialized cache target.

It:

- resolves a unique exact manifest for the release
- only accepts `source_kind` in:
  - `v2.primary`
  - `v2.mirror`
- requires exact child rows to be non-empty
- requires every exact child blob to have a verified `remote_copy` location on the requested disk
- rebuilds the tree from remote bytes into the existing materialized target root
- verifies file count, logical paths, blob hashes, sizes, and `compiled/manifest.json` hash
- writes materialization sentinel metadata that records remote fallback provenance

### 3. Cache contract preserved

The materialized cache key is still the existing contract:

- `storage_path + manifest_hash`

Target layout remains:

- `storage/app/private/packs_v2_materialized/{pack_id}/{pack_version}/{sha256(storage_path)}/{manifest_hash}/compiled`

This means:

- no new runtime cache bucket shape
- no `exact_identity_hash` cache-key split
- historical rows with the same `storage_path + manifest_hash` still reuse the same target

## Safety boundaries preserved

This PR does **not** change:

- local primary hit behavior
- local mirror hit behavior
- `resolveCompiledPathByManifestHash()` return contract
- loaders' fallback behavior
- `ContentPackPublisher` publish / rollback semantics
- `ArtifactStore` reader order
- `ReleaseStorageLocator` V2 primary / mirror truth
- any route, middleware, migration, or scheduler wiring
- any quarantine / restore / purge / offload / gc command contract

This PR does **not** add:

- direct remote-read
- remote-read cutover
- delete semantics
- scheduler automation

## Validation

```bash
cd /private/tmp/fap-api-pr21-v2-remote-rehydrate-fallback/backend

php artisan route:list > /tmp/pr21_route_list.txt
php artisan migrate

vendor/bin/phpunit \
  tests/Feature/Content/Packs2MetadataDualWriteTest.php \
  tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php \
  tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php \
  tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php

php artisan serve --host=127.0.0.1 --port=18081
curl -i http://127.0.0.1:18081/api/healthz

cd /private/tmp/fap-api-pr21-v2-remote-rehydrate-fallback
bash backend/scripts/ci_verify_mbti.sh
```

Observed results:

- focused resolver/materialization/remote fallback suite: passed
- requested regression subset: passed
- `php artisan migrate`: `Nothing to migrate.`
- `curl -i /api/healthz`: `HTTP/1.1 200 OK`
- `bash backend/scripts/ci_verify_mbti.sh`: passed with exit code `0`
