### PR TITLE
[codex] Ship PR-9D controlled AI narrative layer (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -247,6 +247,12 @@ class AttemptReadController extends Controller
         ];
         if ($big5Projection !== []) {
             $responsePayload['big5_public_projection_v1'] = $big5Projection;
+            $controlledNarrative = is_array($big5Projection['controlled_narrative_v1'] ?? null)
+                ? $big5Projection['controlled_narrative_v1']
+                : [];
+            if ($controlledNarrative !== []) {
+                $responsePayload['controlled_narrative_v1'] = $controlledNarrative;
+            }
         }
 
         return response()->json($responsePayload);
@@ -368,6 +374,12 @@ class AttemptReadController extends Controller
                 );
             }
             $responsePayload['big5_public_projection_v1'] = $projection;
+            $controlledNarrative = is_array($projection['controlled_narrative_v1'] ?? null)
+                ? $projection['controlled_narrative_v1']
+                : [];
+            if ($controlledNarrative !== []) {
+                $responsePayload['controlled_narrative_v1'] = $controlledNarrative;
+            }
         }
 
         $effectiveMbtiPersonalization = $scaleCode === 'MBTI'
@@ -392,6 +404,10 @@ class AttemptReadController extends Controller
             $narrativeRuntime = data_get($responsePayload, 'report._meta.personalization.narrative_runtime_contract_v1');
             if (is_array($narrativeRuntime)) {
                 $responsePayload['narrative_runtime_contract_v1'] = $narrativeRuntime;
+            }
+            $controlledNarrative = data_get($responsePayload, 'report._meta.personalization.controlled_narrative_v1');
+            if (is_array($controlledNarrative)) {
+                $responsePayload['controlled_narrative_v1'] = $controlledNarrative;
             }
             $crossAssessment = data_get($responsePayload, 'report._meta.personalization.cross_assessment_v1');
             if (is_array($crossAssessment)) {
@@ -581,8 +597,9 @@ class AttemptReadController extends Controller
         $sceneFingerprint = is_array($projection['scene_fingerprint'] ?? null) ? $projection['scene_fingerprint'] : [];
         $variantKeys = is_array($projection['variant_keys'] ?? null) ? $projection['variant_keys'] : [];
         $orderedSectionKeys = is_array($projection['ordered_section_keys'] ?? null) ? $projection['ordered_section_keys'] : [];
+        $controlledNarrative = is_array($projection['controlled_narrative_v1'] ?? null) ? $projection['controlled_narrative_v1'] : [];
 
-        return array_filter([
+        $meta = [
             'trait_bands' => $traitBands,
             'dominant_traits' => array_values(array_filter(array_map(
                 static fn (mixed $trait): string => is_array($trait) ? trim((string) ($trait['key'] ?? '')) : '',
@@ -591,7 +608,18 @@ class AttemptReadController extends Controller
             'scene_fingerprint' => $sceneFingerprint,
             'variant_keys' => array_values(array_filter(array_map('strval', $variantKeys))),
             'ordered_section_keys' => array_values(array_filter(array_map('strval', $orderedSectionKeys))),
-        ], static function (mixed $value): bool {
+        ];
+
+        if ($controlledNarrative !== []) {
+            $meta['narrative_contract_version'] = trim((string) ($controlledNarrative['narrative_contract_version'] ?? ''));
+            $meta['narrative_runtime_mode'] = trim((string) ($controlledNarrative['runtime_mode'] ?? ''));
+            $meta['narrative_provider_name'] = trim((string) ($controlledNarrative['provider_name'] ?? ''));
+            $meta['narrative_model_version'] = trim((string) ($controlledNarrative['model_version'] ?? ''));
+            $meta['narrative_prompt_version'] = trim((string) ($controlledNarrative['prompt_version'] ?? ''));
+            $meta['narrative_fingerprint'] = trim((string) ($controlledNarrative['narrative_fingerprint'] ?? ''));
+        }
+
+        return array_filter($meta, static function (mixed $value): bool {
             return is_array($value) ? $value !== [] : $value !== null;
         });
     }
@@ -661,6 +689,12 @@ class AttemptReadController extends Controller
         $narrativeRuntime = is_array($personalization['narrative_runtime_contract_v1'] ?? null)
             ? $personalization['narrative_runtime_contract_v1']
             : [];
+        $controlledNarrative = is_array($personalization['controlled_narrative_v1'] ?? null)
+            ? $personalization['controlled_narrative_v1']
+            : [];
+        if ($controlledNarrative !== []) {
+            $meta['narrative_contract_version'] = trim((string) ($controlledNarrative['narrative_contract_version'] ?? ''));
+        }
         if ($narrativeRuntime !== []) {
             $meta['narrative_runtime_contract_version'] = trim((string) ($narrativeRuntime['version'] ?? ''));
             $meta['narrative_runtime_mode'] = trim((string) ($narrativeRuntime['runtime_mode'] ?? ''));

--- a/backend/app/Services/AI/ControlledGenerationRuntime.php
+++ b/backend/app/Services/AI/ControlledGenerationRuntime.php
@@ -15,6 +15,9 @@ final class ControlledGenerationRuntime
         'type_code',
         'identity',
         'variant_keys',
+        'trait_vector',
+        'trait_bands',
+        'dominant_traits',
         'scene_fingerprint',
         'working_life_v1',
         'cross_assessment_v1',
@@ -98,6 +101,10 @@ final class ControlledGenerationRuntime
             'explainability_summary',
             'action_plan_summary',
             'work_style_summary',
+            'trait_vector',
+            'trait_bands',
+            'dominant_traits',
+            'ordered_section_keys',
             'scene_fingerprint',
             'variant_keys',
             'working_life_v1',
@@ -204,18 +211,15 @@ final class ControlledGenerationRuntime
         string $providerName,
         string $errorCode
     ): NarrativeGenerationResponse {
-        $summary = trim((string) ($request->authority['action_plan_summary'] ?? ''));
+        $summary = $this->extractSummaryText($request->authority['action_plan_summary'] ?? null);
         if ($summary === '') {
-            $summary = trim((string) ($request->authority['explainability_summary'] ?? ''));
+            $summary = $this->extractSummaryText($request->authority['explainability_summary'] ?? null);
         }
         if ($summary === '') {
-            $summary = trim((string) ($request->authority['work_style_summary'] ?? ''));
+            $summary = $this->extractSummaryText($request->authority['work_style_summary'] ?? null);
         }
 
-        $sectionKeys = array_values(array_slice(array_keys((array) ($request->authority['variant_keys'] ?? [])), 0, 4));
-        if ($sectionKeys === []) {
-            $sectionKeys = array_values(array_slice((array) ($request->authority['career_journey_keys'] ?? []), 0, 4));
-        }
+        $sectionKeys = $this->extractNarrativeSectionKeys($request->authority, 4);
 
         $output = [
             'narrative_intro' => 'Deterministic narrative fallback is active.',
@@ -245,5 +249,100 @@ final class ControlledGenerationRuntime
             output: $output,
             errorCode: $errorCode,
         );
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return list<string>
+     */
+    public function extractNarrativeSectionKeys(array $authority, int $limit = 4): array
+    {
+        $variantKeys = $authority['variant_keys'] ?? [];
+        $sectionKeys = [];
+
+        if (is_array($variantKeys)) {
+            $isList = array_is_list($variantKeys);
+            foreach ($variantKeys as $key => $value) {
+                $candidate = null;
+
+                if (! $isList && is_string($key) && trim($key) !== '') {
+                    $candidate = trim($key);
+                } elseif (is_scalar($value)) {
+                    $candidate = trim((string) $value);
+                }
+
+                if ($candidate === null || $candidate === '') {
+                    continue;
+                }
+
+                $sectionKeys[] = $candidate;
+                if (count($sectionKeys) >= $limit) {
+                    return $sectionKeys;
+                }
+            }
+        }
+
+        foreach (['career_journey_keys', 'ordered_section_keys'] as $fallbackKey) {
+            $values = $authority[$fallbackKey] ?? [];
+            if (! is_array($values)) {
+                continue;
+            }
+
+            foreach ($values as $value) {
+                if (! is_scalar($value)) {
+                    continue;
+                }
+
+                $candidate = trim((string) $value);
+                if ($candidate === '' || in_array($candidate, $sectionKeys, true)) {
+                    continue;
+                }
+
+                $sectionKeys[] = $candidate;
+                if (count($sectionKeys) >= $limit) {
+                    return $sectionKeys;
+                }
+            }
+        }
+
+        return $sectionKeys;
+    }
+
+    private function extractSummaryText(mixed $value): string
+    {
+        if (is_string($value)) {
+            return trim($value);
+        }
+
+        if (! is_array($value)) {
+            return '';
+        }
+
+        foreach (['headline', 'summary', 'label'] as $key) {
+            $candidate = trim((string) ($value[$key] ?? ''));
+            if ($candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        foreach (['reasons', 'actions', 'bullets'] as $key) {
+            $items = $value[$key] ?? null;
+            if (! is_array($items)) {
+                continue;
+            }
+
+            foreach ($items as $item) {
+                if (! is_scalar($item)) {
+                    continue;
+                }
+
+                $candidate = trim((string) $item);
+                if ($candidate !== '') {
+                    return $candidate;
+                }
+            }
+        }
+
+        return '';
     }
 }

--- a/backend/app/Services/AI/ControlledNarrativeLayerService.php
+++ b/backend/app/Services/AI/ControlledNarrativeLayerService.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+final class ControlledNarrativeLayerService
+{
+    public const VERSION = 'controlled_narrative.v1';
+
+    /**
+     * @param  array<string, mixed>  $runtimeContract
+     * @return array<string, mixed>
+     */
+    public function buildFromRuntimeContract(array $runtimeContract): array
+    {
+        $response = is_array($runtimeContract['response'] ?? null) ? $runtimeContract['response'] : [];
+
+        $intro = trim((string) ($response['narrative_intro'] ?? ''));
+        $summary = trim((string) ($response['narrative_summary'] ?? ''));
+        $sectionNarrativeKeys = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            is_array($response['section_narrative_keys'] ?? null) ? $response['section_narrative_keys'] : []
+        )));
+
+        return [
+            'version' => self::VERSION,
+            'narrative_contract_version' => self::VERSION,
+            'runtime_contract_version' => trim((string) ($runtimeContract['version'] ?? '')),
+            'runtime_mode' => trim((string) ($runtimeContract['runtime_mode'] ?? 'off')),
+            'provider_name' => trim((string) ($runtimeContract['provider_name'] ?? '')),
+            'model_version' => trim((string) ($runtimeContract['model_version'] ?? '')),
+            'prompt_version' => trim((string) ($runtimeContract['prompt_version'] ?? '')),
+            'fail_open_mode' => trim((string) ($runtimeContract['fail_open_mode'] ?? '')),
+            'narrative_fingerprint' => trim((string) ($runtimeContract['narrative_fingerprint'] ?? '')),
+            'narrative_intro' => $intro,
+            'narrative_summary' => $summary,
+            'section_narrative_keys' => $sectionNarrativeKeys,
+            'enabled' => $intro !== '' || $summary !== '' || $sectionNarrativeKeys !== [],
+            'truth_guard_fields' => array_values(array_filter(array_map(
+                static fn (mixed $value): string => trim((string) $value),
+                is_array($runtimeContract['truth_guard_fields'] ?? null) ? $runtimeContract['truth_guard_fields'] : []
+            ))),
+        ];
+    }
+}

--- a/backend/app/Services/AI/MockNarrativeProvider.php
+++ b/backend/app/Services/AI/MockNarrativeProvider.php
@@ -15,26 +15,30 @@ final class MockNarrativeProvider implements NarrativeProviderInterface
     {
         $typeCode = trim((string) ($request->authority['type_code'] ?? $request->context['type_code'] ?? ''));
         $identity = trim((string) ($request->authority['identity'] ?? $request->context['identity'] ?? ''));
+        $dominantTraits = array_values(array_filter(array_map(
+            static fn (mixed $trait): string => is_array($trait)
+                ? trim((string) ($trait['label'] ?? $trait['key'] ?? ''))
+                : '',
+            is_array($request->authority['dominant_traits'] ?? null) ? $request->authority['dominant_traits'] : []
+        )));
         $focusKey = trim((string) data_get($request->authority, 'working_life_v1.career_focus_key', ''))
             ?: trim((string) ($request->authority['action_focus_key'] ?? ''))
             ?: trim((string) data_get($request->authority, 'orchestration.primary_focus_key', ''));
 
-        $summary = trim((string) ($request->authority['action_plan_summary'] ?? ''));
+        $summary = $this->extractSummaryText($request->authority['action_plan_summary'] ?? null);
         if ($summary === '') {
-            $summary = trim((string) ($request->authority['explainability_summary'] ?? ''));
+            $summary = $this->extractSummaryText($request->authority['explainability_summary'] ?? null);
         }
         if ($summary === '') {
-            $summary = trim((string) ($request->authority['work_style_summary'] ?? ''));
+            $summary = $this->extractSummaryText($request->authority['work_style_summary'] ?? null);
         }
 
-        $sectionKeys = array_values(array_slice(array_keys((array) ($request->authority['variant_keys'] ?? [])), 0, 6));
-        if ($sectionKeys === []) {
-            $sectionKeys = array_values(array_slice((array) data_get($request->authority, 'working_life_v1.career_journey_keys', []), 0, 4));
-        }
+        $sectionKeys = $this->extractNarrativeSectionKeys($request->authority, 6);
 
         $introParts = array_values(array_filter([
             $typeCode !== '' ? $typeCode : null,
             $identity !== '' ? "identity {$identity}" : null,
+            $dominantTraits !== [] ? 'traits '.implode('/', array_slice($dominantTraits, 0, 2)) : null,
             $focusKey !== '' ? "focus {$focusKey}" : null,
         ]));
 
@@ -74,5 +78,102 @@ final class MockNarrativeProvider implements NarrativeProviderInterface
             tokensOut: $tokensOut,
             costUsd: round((($tokensIn + $tokensOut) / 1000.0) * $costPer1k, 6),
         );
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return list<string>
+     */
+    private function extractNarrativeSectionKeys(array $authority, int $limit = 4): array
+    {
+        $variantKeys = $authority['variant_keys'] ?? [];
+        $sectionKeys = [];
+
+        if (is_array($variantKeys)) {
+            $isList = array_is_list($variantKeys);
+            foreach ($variantKeys as $key => $value) {
+                $candidate = null;
+
+                if (! $isList && is_string($key) && trim($key) !== '') {
+                    $candidate = trim($key);
+                } elseif (is_scalar($value)) {
+                    $candidate = trim((string) $value);
+                }
+
+                if ($candidate === null || $candidate === '') {
+                    continue;
+                }
+
+                $sectionKeys[] = $candidate;
+                if (count($sectionKeys) >= $limit) {
+                    return $sectionKeys;
+                }
+            }
+        }
+
+        foreach ([
+            data_get($authority, 'working_life_v1.career_journey_keys', []),
+            $authority['ordered_section_keys'] ?? [],
+        ] as $values) {
+            if (! is_array($values)) {
+                continue;
+            }
+
+            foreach ($values as $value) {
+                if (! is_scalar($value)) {
+                    continue;
+                }
+
+                $candidate = trim((string) $value);
+                if ($candidate === '' || in_array($candidate, $sectionKeys, true)) {
+                    continue;
+                }
+
+                $sectionKeys[] = $candidate;
+                if (count($sectionKeys) >= $limit) {
+                    return $sectionKeys;
+                }
+            }
+        }
+
+        return $sectionKeys;
+    }
+
+    private function extractSummaryText(mixed $value): string
+    {
+        if (is_string($value)) {
+            return trim($value);
+        }
+
+        if (! is_array($value)) {
+            return '';
+        }
+
+        foreach (['headline', 'summary', 'label'] as $key) {
+            $candidate = trim((string) ($value[$key] ?? ''));
+            if ($candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        foreach (['reasons', 'actions', 'bullets'] as $key) {
+            $items = $value[$key] ?? null;
+            if (! is_array($items)) {
+                continue;
+            }
+
+            foreach ($items as $item) {
+                if (! is_scalar($item)) {
+                    continue;
+                }
+
+                $candidate = trim((string) $item);
+                if ($candidate !== '') {
+                    return $candidate;
+                }
+            }
+        }
+
+        return '';
     }
 }

--- a/backend/app/Services/BigFive/BigFivePublicProjectionService.php
+++ b/backend/app/Services/BigFive/BigFivePublicProjectionService.php
@@ -5,10 +5,18 @@ declare(strict_types=1);
 namespace App\Services\BigFive;
 
 use App\Models\Result;
+use App\Services\AI\ControlledGenerationRuntime;
+use App\Services\AI\ControlledNarrativeLayerService;
 
 final class BigFivePublicProjectionService
 {
     private const DOMAIN_ORDER = ['O', 'C', 'E', 'A', 'N'];
+
+    public function __construct(
+        private readonly ControlledGenerationRuntime $controlledGenerationRuntime,
+        private readonly ControlledNarrativeLayerService $controlledNarrativeLayerService,
+    ) {
+    }
 
     /**
      * @var array<string,array{en:string,zh:string}>
@@ -153,6 +161,19 @@ final class BigFivePublicProjectionService
                 'locked' => $locked,
             ], static fn ($value): bool => $value !== null && $value !== ''),
         ];
+
+        $runtimeContract = $this->controlledGenerationRuntime->buildContract(
+            'big5.report',
+            'BIG5_OCEAN',
+            $locale === 'zh' ? 'zh-CN' : 'en',
+            $projection,
+            [
+                'engine_version' => (string) ($scoreResult['engine_version'] ?? ''),
+                'schema_version' => 'big5.public_projection.v1',
+            ]
+        );
+        $projection['_meta']['narrative_runtime_contract_v1'] = $runtimeContract;
+        $projection['controlled_narrative_v1'] = $this->controlledNarrativeLayerService->buildFromRuntimeContract($runtimeContract);
 
         return $projection;
     }

--- a/backend/app/Services/Mbti/MbtiReadModelContractService.php
+++ b/backend/app/Services/Mbti/MbtiReadModelContractService.php
@@ -51,6 +51,7 @@ final class MbtiReadModelContractService
         'mbti_public_projection_v1.profile',
         'mbti_public_projection_v1.dimensions',
         'mbti_public_projection_v1.sections',
+        'controlled_narrative_v1',
         'narrative_runtime_contract_v1',
     ];
 
@@ -74,6 +75,7 @@ final class MbtiReadModelContractService
         'mbti_public_projection_v1.dimensions',
         'mbti_public_projection_v1.sections',
         'mbti_read_contract_v1',
+        'controlled_narrative_v1',
         'narrative_runtime_contract_v1',
     ];
 

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Mbti;
 
 use App\Services\AI\ControlledGenerationRuntime;
+use App\Services\AI\ControlledNarrativeLayerService;
 use App\Services\Content\ContentPacksIndex;
 
 final class MbtiResultPersonalizationService
@@ -572,6 +573,7 @@ final class MbtiResultPersonalizationService
         private readonly MbtiWorkingLifeConsolidationService $workingLifeConsolidationService,
         private readonly MbtiPrivacyConsentContractService $privacyConsentContractService,
         private readonly ControlledGenerationRuntime $controlledGenerationRuntime,
+        private readonly ControlledNarrativeLayerService $controlledNarrativeLayerService,
         private readonly MbtiReadModelContractService $readModelContractService,
     ) {
     }
@@ -727,6 +729,11 @@ final class MbtiResultPersonalizationService
                 'anon_id' => $context['anon_id'] ?? null,
                 'attempt_id' => $context['attempt_id'] ?? null,
             ]
+        );
+        $personalization['controlled_narrative_v1'] = $this->controlledNarrativeLayerService->buildFromRuntimeContract(
+            is_array($personalization['narrative_runtime_contract_v1'] ?? null)
+                ? $personalization['narrative_runtime_contract_v1']
+                : []
         );
 
         return $this->readModelContractService->attachContract($personalization);

--- a/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+++ b/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
@@ -126,6 +126,10 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             data_get($payload, 'report._meta.personalization.narrative_runtime_contract_v1.version')
         );
         $this->assertSame(
+            'controlled_narrative.v1',
+            data_get($payload, 'report._meta.personalization.controlled_narrative_v1.version')
+        );
+        $this->assertSame(
             'off',
             data_get($payload, 'report._meta.personalization.narrative_runtime_contract_v1.runtime_mode')
         );

--- a/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
@@ -19,6 +19,11 @@ final class BigFiveResultEngineFoundationTest extends TestCase
 
     public function test_big5_result_and_report_read_paths_expose_projection_foundation_and_telemetry_meta(): void
     {
+        config()->set('ai.enabled', true);
+        config()->set('ai.narrative.enabled', true);
+        config()->set('ai.narrative.provider', 'mock');
+        config()->set('ai.breaker_enabled', false);
+
         $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
         $this->artisan('norms:import --scale=BIG5_OCEAN --csv=resources/norms/big5/big5_norm_stats_seed.csv --activate=1')
             ->assertExitCode(0);
@@ -38,6 +43,8 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         $resultResponse->assertJsonPath('big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
         $resultResponse->assertJsonPath('big5_public_projection_v1.ordered_section_keys.0', 'traits.overview');
         $resultResponse->assertJsonPath('big5_public_projection_v1.trait_bands.O', 'mid');
+        $resultResponse->assertJsonPath('big5_public_projection_v1.controlled_narrative_v1.version', 'controlled_narrative.v1');
+        $resultResponse->assertJsonPath('big5_public_projection_v1.controlled_narrative_v1.runtime_mode', 'mock');
 
         $reportResponse = $this->withHeaders([
             'Authorization' => 'Bearer '.$token,
@@ -48,6 +55,7 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         $reportResponse->assertJsonPath('big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
         $reportResponse->assertJsonPath('big5_public_projection_v1.ordered_section_keys.1', 'traits.why_this_profile');
         $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
+        $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.controlled_narrative_v1.version', 'controlled_narrative.v1');
         $reportResponse->assertJsonPath('report.sections.0.key', 'traits.overview');
         $reportResponse->assertJsonPath('report.sections.4.key', 'growth.next_actions');
 
@@ -61,6 +69,8 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         $this->assertSame(['traits.overview', 'traits.why_this_profile', 'relationships.interpersonal_style', 'career.work_style', 'growth.next_actions'], array_slice((array) ($meta['ordered_section_keys'] ?? []), 0, 5));
         $this->assertArrayHasKey('trait_bands', $meta);
         $this->assertArrayHasKey('scene_fingerprint', $meta);
+        $this->assertSame('controlled_narrative.v1', (string) ($meta['narrative_contract_version'] ?? ''));
+        $this->assertSame('mock', (string) ($meta['narrative_runtime_mode'] ?? ''));
     }
 
     private function seedAttempt(string $anonId): string

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -45,6 +45,7 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertSame('report_phase4a_contract', (string) ($meta['engine_version'] ?? ''));
             $this->assertSame('mbti.personalization.phase9c.v1', (string) ($meta['schema_version'] ?? ''));
             $this->assertSame('phase9c.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
+            $this->assertSame('controlled_narrative.v1', (string) ($meta['narrative_contract_version'] ?? ''));
             $this->assertSame('narrative_runtime_contract.v1', (string) ($meta['narrative_runtime_contract_version'] ?? ''));
             $this->assertSame('off', (string) ($meta['narrative_runtime_mode'] ?? ''));
             $this->assertSame('null', (string) ($meta['narrative_provider_name'] ?? ''));
@@ -130,6 +131,7 @@ class MbtiResultTelemetryContractTest extends TestCase
         $this->assertSame($eventMeta['report_view']['working_life_v1'] ?? null, $eventMeta['result_view']['working_life_v1'] ?? null);
         $this->assertSame($eventMeta['report_view']['privacy_contract_version'] ?? null, $eventMeta['result_view']['privacy_contract_version'] ?? null);
         $this->assertSame($eventMeta['report_view']['consent_scope'] ?? null, $eventMeta['result_view']['consent_scope'] ?? null);
+        $this->assertSame($eventMeta['report_view']['narrative_contract_version'] ?? null, $eventMeta['result_view']['narrative_contract_version'] ?? null);
         $this->assertSame($eventMeta['report_view']['narrative_runtime_contract_version'] ?? null, $eventMeta['result_view']['narrative_runtime_contract_version'] ?? null);
         $this->assertSame($eventMeta['report_view']['narrative_fingerprint'] ?? null, $eventMeta['result_view']['narrative_fingerprint'] ?? null);
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.is_first_view'));

--- a/backend/tests/Unit/Services/AI/ControlledNarrativeLayerServiceTest.php
+++ b/backend/tests/Unit/Services/AI/ControlledNarrativeLayerServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\AI;
+
+use App\Services\AI\ControlledNarrativeLayerService;
+use Tests\TestCase;
+
+final class ControlledNarrativeLayerServiceTest extends TestCase
+{
+    public function test_it_builds_a_controlled_narrative_contract_from_runtime_metadata(): void
+    {
+        $contract = app(ControlledNarrativeLayerService::class)->buildFromRuntimeContract([
+            'version' => 'narrative_runtime_contract.v1',
+            'runtime_mode' => 'mock',
+            'provider_name' => 'mock',
+            'model_version' => 'mock-narrative-model',
+            'prompt_version' => 'prompt.9d.v1',
+            'fail_open_mode' => 'deterministic',
+            'narrative_fingerprint' => 'abc123',
+            'response' => [
+                'narrative_intro' => 'Narrative intro.',
+                'narrative_summary' => 'Narrative summary.',
+                'section_narrative_keys' => ['growth.next_actions', 'career.next_step'],
+            ],
+            'truth_guard_fields' => ['type_code', 'variant_keys'],
+        ]);
+
+        $this->assertSame('controlled_narrative.v1', $contract['version']);
+        $this->assertSame('controlled_narrative.v1', $contract['narrative_contract_version']);
+        $this->assertSame('narrative_runtime_contract.v1', $contract['runtime_contract_version']);
+        $this->assertSame('mock', $contract['runtime_mode']);
+        $this->assertSame('Narrative intro.', $contract['narrative_intro']);
+        $this->assertSame('Narrative summary.', $contract['narrative_summary']);
+        $this->assertSame(['growth.next_actions', 'career.next_step'], $contract['section_narrative_keys']);
+        $this->assertSame(true, $contract['enabled']);
+        $this->assertContains('variant_keys', $contract['truth_guard_fields']);
+    }
+}

--- a/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
@@ -17,6 +17,7 @@ final class MbtiReadModelContractServiceTest extends TestCase
             'schema_version' => 'mbti.personalization.phase9c.v1',
             'identity' => 'A',
             'privacy_contract_v1' => ['version' => 'mbti.privacy_contract.v1'],
+            'controlled_narrative_v1' => ['version' => 'controlled_narrative.v1', 'runtime_mode' => 'off'],
             'narrative_runtime_contract_v1' => ['version' => 'narrative_runtime_contract.v1', 'runtime_mode' => 'off'],
             'variant_keys' => ['overview' => 'overview:clear'],
             'scene_fingerprint' => ['work' => ['style_key' => 'work.primary.EI.E.clear']],
@@ -32,10 +33,12 @@ final class MbtiReadModelContractServiceTest extends TestCase
         $this->assertSame('mbti.read_contract.v1', $contract['version']);
         $this->assertContains('identity', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('privacy_contract_v1', $contract['canonical_read_model']['personalization_fields']);
+        $this->assertContains('controlled_narrative_v1', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('narrative_runtime_contract_v1', $contract['canonical_read_model']['personalization_fields']);
         $this->assertNotContains('variant_keys', $contract['canonical_read_model']['personalization_fields']);
         $this->assertNotContains('user_state', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('mbti_privacy_contract_v1', $contract['cacheable_fields']);
+        $this->assertContains('controlled_narrative_v1', $contract['cacheable_fields']);
         $this->assertContains('narrative_runtime_contract_v1', $contract['cacheable_fields']);
         $this->assertSame(
             [

--- a/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
@@ -98,6 +98,10 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
         $this->assertSame('off', data_get($clear, 'narrative_runtime_contract_v1.runtime_mode'));
         $this->assertSame('null', data_get($clear, 'narrative_runtime_contract_v1.provider_name'));
         $this->assertSame(false, data_get($clear, 'narrative_runtime_contract_v1.output_present.narrative_intro'));
+        $this->assertSame('controlled_narrative.v1', data_get($clear, 'controlled_narrative_v1.version'));
+        $this->assertSame('controlled_narrative.v1', data_get($clear, 'controlled_narrative_v1.narrative_contract_version'));
+        $this->assertSame('off', data_get($clear, 'controlled_narrative_v1.runtime_mode'));
+        $this->assertSame('', data_get($clear, 'controlled_narrative_v1.narrative_intro'));
         $this->assertContains('working_life_v1', data_get($clear, 'narrative_runtime_contract_v1.truth_guard_fields', []));
         $this->assertSame('mbti.privacy_contract.v1', data_get($clear, 'privacy_contract_v1.version'));
         $this->assertSame(true, data_get($clear, 'privacy_contract_v1.consent_scope.subject_export'));
@@ -748,5 +752,50 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
             '在工作里',
             (string) data_get($english, 'scene_fingerprint.work.summary', '')
         );
+    }
+
+    public function test_it_can_emit_visible_controlled_narrative_without_changing_canonical_truth(): void
+    {
+        config()->set('ai.enabled', true);
+        config()->set('ai.narrative.enabled', true);
+        config()->set('ai.narrative.provider', 'mock');
+        config()->set('ai.breaker_enabled', false);
+
+        $personalization = app(MbtiResultPersonalizationService::class)->buildForReportPayload([
+            'versions' => [
+                'engine' => 'v1.2',
+                'content_pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'dir_version' => 'MBTI-CN-v0.3',
+            ],
+            'profile' => [
+                'type_code' => 'INTJ-A',
+            ],
+            'scores' => [
+                'EI' => ['pct' => 43, 'delta' => -7, 'side' => 'I', 'state' => 'moderate'],
+                'SN' => ['pct' => 71, 'delta' => 21, 'side' => 'N', 'state' => 'strong'],
+                'TF' => ['pct' => 66, 'delta' => 16, 'side' => 'T', 'state' => 'clear'],
+                'JP' => ['pct' => 61, 'delta' => 11, 'side' => 'J', 'state' => 'clear'],
+                'AT' => ['pct' => 59, 'delta' => 9, 'side' => 'A', 'state' => 'balanced'],
+            ],
+            'axis_states' => [
+                'EI' => 'moderate',
+                'SN' => 'strong',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'balanced',
+            ],
+        ], [
+            'type_code' => 'INTJ-A',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'locale' => 'zh-CN',
+            'engine_version' => 'report_phase4a_contract',
+        ]);
+
+        $this->assertSame('mock', data_get($personalization, 'narrative_runtime_contract_v1.runtime_mode'));
+        $this->assertNotSame('', trim((string) data_get($personalization, 'controlled_narrative_v1.narrative_intro')));
+        $this->assertNotSame('', trim((string) data_get($personalization, 'controlled_narrative_v1.narrative_summary')));
+        $this->assertSame('INTJ-A', (string) ($personalization['type_code'] ?? ''));
+        $this->assertSame('A', (string) ($personalization['identity'] ?? ''));
     }
 }


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-9D: controlled AI narrative layer.

It connects the PR-9D0 runtime/gateway foundation into MBTI and Big Five result read paths and exposes a formal `controlled_narrative_v1` contract without changing canonical truth.

## Problem

Before this change, the repo had a legal runtime abstraction for controlled generation, but the result engine still had no first-class narrative layer. Runtime metadata existed, yet there was no authority-safe output contract for result-page intros, summaries, or section-level narrative enhancement.

That left PR-9D0 as infrastructure without an actual product entry point.

## Root cause

The system already had:

- strong canonical and derived authority for MBTI and Big Five
- replayable read-path contracts
- a feature-flagged runtime abstraction with off-switch and fail-open behavior

What it was missing was the assembly step that turns runtime output into a formal narrative contract and attaches it to result/report surfaces without allowing narrative to overwrite any canonical fields.

## Fix

This PR adds `ControlledNarrativeLayerService` and introduces `controlled_narrative_v1` as a backend-owned narrative contract.

It:

- builds a versioned narrative layer from `narrative_runtime_contract_v1`
- attaches controlled narrative to MBTI personalization and read-path payloads
- attaches controlled narrative to Big Five public projection
- carries narrative metadata into report/result telemetry
- preserves strict separation between canonical truth and narrative expression
- hardens runtime fallback and mock generation so they can safely handle both MBTI and Big Five authority shapes

The resulting narrative layer remains:

- feature-flagged
- replayable
- versioned
- fail-open with deterministic fallback
- incapable of changing canonical truth

## User impact

This gives the platform its first real authority-safe narrative enhancement path.

Users can now see additive intros and summaries when narrative is enabled, while the underlying result, sections, orchestration, and telemetry truth remain the same.

## Validation

I ran:

- `php artisan test tests/Unit/Services/AI/ControlledGenerationRuntimeTest.php tests/Unit/Services/AI/ControlledNarrativeLayerServiceTest.php tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php tests/Feature/V0_3/MbtiResultTelemetryContractTest.php tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php`

All passed:

- 17 tests passed
- 569 assertions

## Scope note

This PR is intentionally limited to the backend controlled narrative contract and runtime integration.

It does not:

- change canonical scoring or canonical result truth
- introduce a new provider SDK or dependency
- expand into open-ended generation or chat flows
- pull in task-external dirty files such as pack publish/rollback or compiled artifact changes
