### PR TITLE
[codex] enable v2 mirror quarantine restore purge lifecycle

### DIFF
--- a/backend/app/Services/Storage/ExactRootQuarantineService.php
+++ b/backend/app/Services/Storage/ExactRootQuarantineService.php
@@ -15,6 +15,7 @@ final class ExactRootQuarantineService
      */
     private const ALLOWED_SOURCE_KINDS = [
         'legacy.source_pack',
+        'v2.mirror',
     ];
 
     private const PLAN_SCHEMA = 'storage_quarantine_exact_roots_plan.v1';

--- a/backend/app/Services/Storage/QuarantinedRootPurgeService.php
+++ b/backend/app/Services/Storage/QuarantinedRootPurgeService.php
@@ -9,7 +9,13 @@ use Illuminate\Support\Facades\File;
 
 final class QuarantinedRootPurgeService
 {
-    private const ALLOWED_SOURCE_KIND = 'legacy.source_pack';
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_SOURCE_KINDS = [
+        'legacy.source_pack',
+        'v2.mirror',
+    ];
 
     private const PLAN_SCHEMA = 'storage_purge_quarantined_root_plan.v1';
 
@@ -264,7 +270,7 @@ final class QuarantinedRootPurgeService
         }
 
         $sourceKind = trim((string) ($sentinel['source_kind'] ?? ''));
-        if ($sourceKind !== self::ALLOWED_SOURCE_KIND) {
+        if (! in_array($sourceKind, self::ALLOWED_SOURCE_KINDS, true)) {
             throw new \RuntimeException('purge source_kind is not allowed.');
         }
 

--- a/backend/app/Services/Storage/QuarantinedRootRestoreService.php
+++ b/backend/app/Services/Storage/QuarantinedRootRestoreService.php
@@ -11,7 +11,9 @@ use Illuminate\Support\Facades\File;
 
 final class QuarantinedRootRestoreService
 {
-    private const ALLOWED_SOURCE_KIND = 'legacy.source_pack';
+    private const LEGACY_SOURCE_KIND = 'legacy.source_pack';
+
+    private const V2_MIRROR_SOURCE_KIND = 'v2.mirror';
 
     private const PLAN_SCHEMA = 'storage_restore_quarantined_root_plan.v1';
 
@@ -240,7 +242,7 @@ final class QuarantinedRootRestoreService
         }
 
         $sourceKind = trim((string) ($sentinel['source_kind'] ?? ''));
-        if ($sourceKind !== self::ALLOWED_SOURCE_KIND) {
+        if (! in_array($sourceKind, [self::LEGACY_SOURCE_KIND, self::V2_MIRROR_SOURCE_KIND], true)) {
             throw new \RuntimeException('restore source_kind is not allowed.');
         }
 
@@ -290,17 +292,23 @@ final class QuarantinedRootRestoreService
         $this->verifyRootMatchesExactAuthority($itemRoot, $files, $manifestHash, true);
         $validation['quarantined_root_exact_verified'] = true;
 
+        $releaseId = trim((string) ($manifest->content_pack_release_id ?? ''));
         $targetRoot = $sourceStoragePath;
         if (file_exists($targetRoot)) {
             throw new \RuntimeException('restore target already exists.');
         }
         $validation['target_path_absent'] = true;
 
-        $this->assertTargetAllowed($targetRoot);
+        $this->assertTargetAllowed(
+            $sourceKind,
+            $targetRoot,
+            strtoupper(trim((string) ($manifest->pack_id ?? ''))),
+            trim((string) ($manifest->pack_version ?? '')),
+            $releaseId
+        );
         $validation['target_path_allowlisted'] = true;
         $validation['target_path_not_in_danger_set'] = true;
 
-        $releaseId = trim((string) ($manifest->content_pack_release_id ?? ''));
         if ($releaseId !== '') {
             $release = DB::table('content_pack_releases')->where('id', $releaseId)->first();
             if (! $release) {
@@ -316,15 +324,27 @@ final class QuarantinedRootRestoreService
             $validation['linked_release_declares_target'] = true;
 
             $resolvedSource = $this->releaseStorageLocator->resolveReleaseSource($release);
-            if ($resolvedSource !== null) {
-                $resolvedRuntimeRoot = $this->normalizeRoot((string) ($resolvedSource['root'] ?? ''));
-                if ($resolvedRuntimeRoot !== $targetRoot) {
-                    throw new \RuntimeException('linked release currently resolves to a different runtime root.');
+            if ($sourceKind === self::LEGACY_SOURCE_KIND) {
+                if ($resolvedSource !== null) {
+                    $resolvedRuntimeRoot = $this->normalizeRoot((string) ($resolvedSource['root'] ?? ''));
+                    if ($resolvedRuntimeRoot !== $targetRoot) {
+                        throw new \RuntimeException('linked release currently resolves to a different runtime root.');
+                    }
                 }
+                $validation['linked_release_runtime_source_matches_target'] = $resolvedSource === null
+                    ? null
+                    : true;
+            } else {
+                if ($resolvedSource === null) {
+                    throw new \RuntimeException('linked release currently does not resolve to a stable runtime root.');
+                }
+
+                $resolvedRuntimeRoot = $this->normalizeRoot((string) ($resolvedSource['root'] ?? ''));
+                if ($resolvedRuntimeRoot === $targetRoot) {
+                    throw new \RuntimeException('linked release currently resolves to the mirror target.');
+                }
+                $validation['linked_release_runtime_source_preserved'] = true;
             }
-            $validation['linked_release_runtime_source_matches_target'] = $resolvedSource === null
-                ? null
-                : true;
 
             if (in_array($releaseId, $this->activeReleaseIds(), true)) {
                 throw new \RuntimeException('linked release is active; restore is blocked.');
@@ -454,9 +474,15 @@ final class QuarantinedRootRestoreService
         }
     }
 
-    private function assertTargetAllowed(string $targetRoot): void
-    {
+    private function assertTargetAllowed(
+        string $sourceKind,
+        string $targetRoot,
+        string $packId,
+        string $packVersion,
+        string $releaseId
+    ): void {
         $contentReleasesRoot = $this->normalizeRoot(storage_path('app/private/content_releases'));
+        $contentPacksV2Root = $this->normalizeRoot(storage_path('app/content_packs_v2'));
         $backupsRoot = $this->normalizeRoot(storage_path('app/private/content_releases/backups'));
         $defaultRoot = $this->normalizeRoot(rtrim((string) config('content_packs.root', ''), '/\\'));
         if ($defaultRoot !== '' && basename($defaultRoot) !== 'default') {
@@ -476,13 +502,31 @@ final class QuarantinedRootRestoreService
             $this->restoreRootBase(),
         ];
 
-        if (! $this->isUnderPrefix($targetRoot, $contentReleasesRoot)) {
-            throw new \RuntimeException('restore target is outside the legacy source_pack allowlist.');
-        }
+        if ($sourceKind === self::LEGACY_SOURCE_KIND) {
+            if (! $this->isUnderPrefix($targetRoot, $contentReleasesRoot)) {
+                throw new \RuntimeException('restore target is outside the legacy source_pack allowlist.');
+            }
 
-        $contentReleasesPattern = '#^'.preg_quote($contentReleasesRoot, '#').'/[^/]+/source_pack$#';
-        if (preg_match($contentReleasesPattern, $targetRoot) !== 1) {
-            throw new \RuntimeException('restore target must match legacy content_releases/{release_id}/source_pack shape.');
+            $contentReleasesPattern = '#^'.preg_quote($contentReleasesRoot, '#').'/[^/]+/source_pack$#';
+            if (preg_match($contentReleasesPattern, $targetRoot) !== 1) {
+                throw new \RuntimeException('restore target must match legacy content_releases/{release_id}/source_pack shape.');
+            }
+        } elseif ($sourceKind === self::V2_MIRROR_SOURCE_KIND) {
+            if (! $this->isUnderPrefix($targetRoot, $contentPacksV2Root)) {
+                throw new \RuntimeException('restore target is outside the V2 mirror allowlist.');
+            }
+
+            if ($packId === '' || $packVersion === '' || $releaseId === '') {
+                throw new \RuntimeException('restore target is missing V2 mirror identity context.');
+            }
+
+            $mirrorPattern = '#^'.preg_quote($contentPacksV2Root, '#')
+                .'/'.preg_quote($packId, '#')
+                .'/'.preg_quote($packVersion, '#')
+                .'/'.preg_quote($releaseId, '#').'$#';
+            if (preg_match($mirrorPattern, $targetRoot) !== 1) {
+                throw new \RuntimeException('restore target must match V2 mirror content_packs_v2/{pack_id}/{pack_version}/{release_id} shape.');
+            }
         }
 
         $dangerRoots = array_filter(array_merge([$backupsRoot, $defaultRoot], $artifactRoots, $materializedRoots, $quarantineRoots));

--- a/backend/tests/Feature/Storage/ExactRootQuarantineServiceTest.php
+++ b/backend/tests/Feature/Storage/ExactRootQuarantineServiceTest.php
@@ -76,7 +76,6 @@ final class ExactRootQuarantineServiceTest extends TestCase
 
         $sourcePackRoot = storage_path('app/private/content_releases/'.Str::uuid().'/source_pack');
         $v2PrimaryRoot = storage_path('app/private/packs_v2/SDS_20/v1/'.Str::uuid());
-        $v2MirrorRoot = storage_path('app/content_packs_v2/EQ_60/v1/'.Str::uuid());
         $previousPackRoot = storage_path('app/private/content_releases/backups/'.Str::uuid().'/previous_pack');
         $currentPackRoot = storage_path('app/private/content_releases/backups/'.Str::uuid().'/current_pack');
         $liveAliasRoot = $this->isolatedPacksRoot.'/default/CN_MAINLAND/zh-CN/BIG5-LIVE';
@@ -86,7 +85,6 @@ final class ExactRootQuarantineServiceTest extends TestCase
 
         $sourcePack = $this->seedExactRootFixture($sourcePackReleaseId, 'legacy.source_pack', $sourcePackRoot, 'source_pack_ok', 'BIG5_OCEAN', 'v1');
         $this->seedExactRootFixture((string) Str::uuid(), 'v2.primary', $v2PrimaryRoot, 'v2_primary_blocked', 'SDS_20', 'v1');
-        $this->seedExactRootFixture((string) Str::uuid(), 'v2.mirror', $v2MirrorRoot, 'v2_mirror_blocked', 'EQ_60', 'v1');
         $this->seedExactRootFixture((string) Str::uuid(), 'legacy.previous_pack', $previousPackRoot, 'blocked_previous', 'BIG5_OCEAN', 'v1');
         $this->seedExactRootFixture((string) Str::uuid(), 'legacy.current_pack', $currentPackRoot, 'blocked_current', 'BIG5_OCEAN', 'v1');
         $this->seedExactRootFixture((string) Str::uuid(), 'live_alias', $liveAliasRoot, 'blocked_live_alias', 'BIG5_OCEAN', 'v1');
@@ -135,7 +133,6 @@ final class ExactRootQuarantineServiceTest extends TestCase
         $this->assertFileExists($runDir.'/run.json');
         $this->assertDirectoryDoesNotExist($sourcePackRoot);
         $this->assertDirectoryExists($v2PrimaryRoot);
-        $this->assertDirectoryExists($v2MirrorRoot);
         $this->assertDirectoryExists($previousPackRoot);
         $this->assertDirectoryExists($currentPackRoot);
         $this->assertDirectoryExists($liveAliasRoot);
@@ -184,6 +181,31 @@ final class ExactRootQuarantineServiceTest extends TestCase
         $this->assertSame(1, (int) ($result['failed_root_count'] ?? 0));
         $this->assertDirectoryExists($sourceRoot);
         $this->assertFileExists((string) ($result['run_dir'] ?? '').'/run.json');
+    }
+
+    public function test_service_quarantines_v2_mirror_without_affecting_primary_runtime_resolution(): void
+    {
+        $fixture = $this->seedV2MirrorQuarantineFixture('v2_mirror_quarantine_ok');
+        $service = app(ExactRootQuarantineService::class);
+
+        $plan = $service->buildPlan('s3');
+        $candidates = collect((array) ($plan['candidates'] ?? []));
+        $mirrorCandidate = $candidates->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+
+        $this->assertIsArray($mirrorCandidate);
+        $this->assertSame('v2.mirror', (string) ($mirrorCandidate['source_kind'] ?? ''));
+
+        $result = $service->executePlan($plan);
+
+        $quarantinedEntry = collect((array) ($result['quarantined'] ?? []))
+            ->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+        $this->assertIsArray($quarantinedEntry);
+        $this->assertDirectoryDoesNotExist($fixture['mirror_root']);
+        $this->assertDirectoryExists($fixture['primary_root']);
+        $this->assertFileExists($fixture['primary_root'].'/compiled/manifest.json');
+        $this->assertFileExists($fixture['primary_root'].'/compiled/payload.compiled.json');
+        $this->assertFileExists((string) ($quarantinedEntry['target_root'] ?? '').'/.quarantine.json');
+        $this->assertSame($fixture['storage_path'], (string) DB::table('content_pack_releases')->where('id', $fixture['release_id'])->value('storage_path'));
     }
 
     public function test_service_rejects_tampered_plan_source_path_without_moving_arbitrary_directory(): void
@@ -358,6 +380,156 @@ final class ExactRootQuarantineServiceTest extends TestCase
                 'git_sha' => null,
                 'pack_version' => $packVersion,
                 'manifest_json' => null,
+                'storage_path' => $storagePath,
+                'source_commit' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+    }
+
+    /**
+     * @return array{
+     *   exact_manifest_id:int,
+     *   manifest_hash:string,
+     *   mirror_root:string,
+     *   primary_root:string,
+     *   release_id:string,
+     *   storage_path:string
+     * }
+     */
+    private function seedV2MirrorQuarantineFixture(string $suffix): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.mirror',
+            'source_disk' => 'local',
+            'source_storage_path' => $mirrorRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'quarantine-test-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.quarantine.test',
+                    'url' => 'https://cos.quarantine.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        return [
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'manifest_hash' => $manifestHash,
+            'mirror_root' => $mirrorRoot,
+            'primary_root' => $primaryRoot,
+            'release_id' => $releaseId,
+            'storage_path' => $storagePath,
+        ];
+    }
+
+    private function insertV2Release(string $releaseId, string $packId, string $packVersion, string $storagePath, string $manifestHash): void
+    {
+        $versionId = 'version-'.$releaseId;
+
+        DB::table('content_pack_versions')->updateOrInsert(
+            ['id' => $versionId],
+            [
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'pack_id' => $packId,
+                'content_package_version' => $packVersion,
+                'dir_version_alias' => $packVersion,
+                'source_type' => 'publish',
+                'source_ref' => 'test',
+                'sha256' => hash('sha256', $storagePath),
+                'manifest_json' => '{}',
+                'extracted_rel_path' => ltrim(str_replace('\\', '/', $storagePath), '/'),
+                'created_by' => 'test',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        DB::table('content_pack_releases')->updateOrInsert(
+            ['id' => $releaseId],
+            [
+                'action' => 'packs2_publish',
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'dir_alias' => $packVersion,
+                'from_version_id' => null,
+                'to_version_id' => $versionId,
+                'from_pack_id' => null,
+                'to_pack_id' => $packId,
+                'status' => 'success',
+                'message' => 'test',
+                'created_by' => 'test',
+                'manifest_hash' => $manifestHash,
+                'compiled_hash' => $manifestHash,
+                'content_hash' => hash('sha256', 'content|'.$releaseId),
+                'norms_version' => '2026Q1',
+                'git_sha' => null,
+                'pack_version' => $packVersion,
+                'manifest_json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
                 'storage_path' => $storagePath,
                 'source_commit' => null,
                 'created_at' => now(),

--- a/backend/tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php
+++ b/backend/tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Storage;
 
+use App\Services\Content\ContentPackV2Resolver;
 use App\Services\Storage\ExactReleaseFileSetCatalogService;
 use App\Services\Storage\ExactRootQuarantineService;
 use App\Services\Storage\QuarantinedRootPurgeService;
@@ -96,6 +97,43 @@ final class QuarantinedRootPurgeServiceTest extends TestCase
             ->where('id', $fixture['release_id'])
             ->value('storage_path'));
         $this->assertSame(0, DB::table('content_pack_activations')->count());
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    public function test_service_builds_plan_and_purges_valid_quarantined_v2_mirror_without_affecting_primary_runtime_resolution(): void
+    {
+        $fixture = $this->quarantineV2MirrorFixture('purge_v2_mirror_valid');
+        $service = app(QuarantinedRootPurgeService::class);
+
+        $plan = $service->buildPlan($fixture['item_root'], 's3');
+
+        $this->assertSame('planned', (string) ($plan['status'] ?? ''));
+        $this->assertSame('v2.mirror', (string) ($plan['source_kind'] ?? ''));
+        $this->assertSame($fixture['item_root'], (string) ($plan['item_root'] ?? ''));
+        $this->assertSame($fixture['exact_manifest_id'], (int) ($plan['exact_manifest_id'] ?? 0));
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolvedBefore = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['primary_root'].'/compiled', $resolvedBefore);
+
+        $result = $service->executePlan($plan, $fixture['item_root']);
+
+        $this->assertSame('success', (string) ($result['status'] ?? ''));
+        $this->assertDirectoryDoesNotExist($fixture['item_root']);
+        $this->assertDirectoryExists($fixture['primary_root']);
+        $this->assertFileExists((string) ($result['run_dir'] ?? '').'/run.json');
+        $this->assertFileExists((string) ($result['receipt_path'] ?? ''));
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+
+        $resolvedAfter = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['primary_root'].'/compiled', $resolvedAfter);
         $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
     }
 
@@ -287,6 +325,110 @@ final class QuarantinedRootPurgeServiceTest extends TestCase
     }
 
     /**
+     * @return array{
+     *   item_root:string,
+     *   mirror_root:string,
+     *   primary_root:string,
+     *   release_id:string,
+     *   exact_manifest_id:int,
+     *   manifest_hash:string
+     * }
+     */
+    private function quarantineV2MirrorFixture(string $suffix): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.mirror',
+            'source_disk' => 'local',
+            'source_storage_path' => $mirrorRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'purge-service-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.purge-service.test',
+                    'url' => 'https://cos.purge-service.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $quarantinePlan = app(ExactRootQuarantineService::class)->buildPlan('s3');
+        $quarantineResult = app(ExactRootQuarantineService::class)->executePlan($quarantinePlan);
+        $quarantinedEntry = collect((array) ($quarantineResult['quarantined'] ?? []))
+            ->firstWhere('exact_manifest_id', (int) $manifest->getKey());
+        $this->assertIsArray($quarantinedEntry);
+
+        return [
+            'item_root' => (string) ($quarantinedEntry['target_root'] ?? ''),
+            'mirror_root' => $mirrorRoot,
+            'primary_root' => $primaryRoot,
+            'release_id' => $releaseId,
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'manifest_hash' => $manifestHash,
+        ];
+    }
+
+    /**
      * @return array<string,string>
      */
     private function createCompiledTree(string $root, string $packId, string $packVersion, string $suffix): array
@@ -364,5 +506,57 @@ final class QuarantinedRootPurgeServiceTest extends TestCase
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+    }
+
+    private function insertV2Release(string $releaseId, string $packId, string $packVersion, string $storagePath, string $manifestHash): void
+    {
+        $versionId = 'version-'.$releaseId;
+
+        DB::table('content_pack_versions')->updateOrInsert(
+            ['id' => $versionId],
+            [
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'pack_id' => $packId,
+                'content_package_version' => $packVersion,
+                'dir_version_alias' => $packVersion,
+                'source_type' => 'publish',
+                'source_ref' => 'test',
+                'sha256' => hash('sha256', $storagePath),
+                'manifest_json' => '{}',
+                'extracted_rel_path' => ltrim(str_replace('\\', '/', $storagePath), '/'),
+                'created_by' => 'test',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        DB::table('content_pack_releases')->updateOrInsert(
+            ['id' => $releaseId],
+            [
+                'action' => 'packs2_publish',
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'dir_alias' => $packVersion,
+                'from_version_id' => null,
+                'to_version_id' => $versionId,
+                'from_pack_id' => null,
+                'to_pack_id' => $packId,
+                'status' => 'success',
+                'message' => null,
+                'created_by' => 'test',
+                'manifest_hash' => $manifestHash,
+                'compiled_hash' => $manifestHash,
+                'content_hash' => hash('sha256', 'content|'.$releaseId),
+                'norms_version' => '2026Q1',
+                'git_sha' => 'git-test',
+                'pack_version' => $packVersion,
+                'manifest_json' => '{}',
+                'storage_path' => $storagePath,
+                'source_commit' => 'git-test',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
     }
 }

--- a/backend/tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php
+++ b/backend/tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Storage;
 
+use App\Services\Content\ContentPackV2Resolver;
 use App\Services\Storage\ExactReleaseFileSetCatalogService;
 use App\Services\Storage\ExactRootQuarantineService;
 use App\Services\Storage\QuarantinedRootRestoreService;
@@ -99,6 +100,39 @@ final class QuarantinedRootRestoreServiceTest extends TestCase
             ->value('storage_path'));
         $this->assertSame(0, DB::table('content_pack_activations')->count());
         $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    public function test_service_restores_valid_quarantined_v2_mirror_back_to_original_mirror_path(): void
+    {
+        $fixture = $this->quarantineV2MirrorFixture('restore_v2_mirror_success');
+        $service = app(QuarantinedRootRestoreService::class);
+
+        $plan = $service->buildPlan($fixture['item_root']);
+
+        $this->assertSame('planned', (string) ($plan['status'] ?? ''));
+        $this->assertSame('v2.mirror', (string) ($plan['source_kind'] ?? ''));
+        $this->assertSame($fixture['mirror_root'], (string) ($plan['target_root'] ?? ''));
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        $result = $service->executePlan($plan, $fixture['item_root']);
+
+        $this->assertSame('success', (string) ($result['status'] ?? ''));
+        $this->assertDirectoryExists($fixture['mirror_root']);
+        $this->assertDirectoryDoesNotExist($fixture['item_root']);
+        $this->assertDirectoryExists($fixture['primary_root']);
+        $this->assertFileDoesNotExist($fixture['mirror_root'].'/.quarantine.json');
+        $this->assertRootMatchesExactAuthority($fixture['mirror_root'], $fixture['files'], $fixture['manifest_hash']);
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['primary_root'].'/compiled', $resolved);
     }
 
     public function test_service_blocks_when_target_exists_or_sentinel_is_invalid_or_source_kind_not_allowed(): void
@@ -332,6 +366,112 @@ final class QuarantinedRootRestoreServiceTest extends TestCase
     }
 
     /**
+     * @return array{
+     *   item_root:string,
+     *   mirror_root:string,
+     *   primary_root:string,
+     *   release_id:string,
+     *   exact_manifest_id:int,
+     *   manifest_hash:string,
+     *   files:array<string,string>
+     * }
+     */
+    private function quarantineV2MirrorFixture(string $suffix, ?string $mirrorRoot = null): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot ??= storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.mirror',
+            'source_disk' => 'local',
+            'source_storage_path' => $mirrorRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'restore-service-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.restore-service.test',
+                    'url' => 'https://cos.restore-service.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $quarantinePlan = app(ExactRootQuarantineService::class)->buildPlan('s3');
+        $quarantineResult = app(ExactRootQuarantineService::class)->executePlan($quarantinePlan);
+        $quarantinedEntry = collect((array) ($quarantineResult['quarantined'] ?? []))
+            ->firstWhere('exact_manifest_id', (int) $manifest->getKey());
+        $this->assertIsArray($quarantinedEntry);
+
+        return [
+            'item_root' => (string) ($quarantinedEntry['target_root'] ?? ''),
+            'mirror_root' => $mirrorRoot,
+            'primary_root' => $primaryRoot,
+            'release_id' => $releaseId,
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'manifest_hash' => $manifestHash,
+            'files' => $files,
+        ];
+    }
+
+    /**
      * @return array<string,string>
      */
     private function createCompiledTree(string $root, string $packId, string $packVersion, string $suffix): array
@@ -395,6 +535,37 @@ final class QuarantinedRootRestoreServiceTest extends TestCase
         );
 
         return $versionId;
+    }
+
+    private function insertV2Release(string $releaseId, string $packId, string $packVersion, string $storagePath, string $manifestHash): void
+    {
+        DB::table('content_pack_releases')->updateOrInsert(
+            ['id' => $releaseId],
+            [
+                'action' => 'packs2_publish',
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'dir_alias' => $packVersion,
+                'from_version_id' => null,
+                'to_version_id' => null,
+                'from_pack_id' => null,
+                'to_pack_id' => $packId,
+                'status' => 'success',
+                'message' => null,
+                'created_by' => 'test',
+                'manifest_hash' => $manifestHash,
+                'compiled_hash' => $manifestHash,
+                'content_hash' => null,
+                'norms_version' => null,
+                'git_sha' => 'test-sha',
+                'pack_version' => $packVersion,
+                'manifest_json' => null,
+                'storage_path' => $storagePath,
+                'source_commit' => 'test-sha',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
     }
 
     /**

--- a/backend/tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php
+++ b/backend/tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Storage;
 
 use App\Console\Commands\StoragePurgeQuarantinedRoot;
 use App\Console\Commands\StorageQuarantineExactRoots;
+use App\Services\Content\ContentPackV2Resolver;
 use App\Services\Storage\ExactReleaseFileSetCatalogService;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -184,6 +185,53 @@ final class StoragePurgeQuarantinedRootCommandTest extends TestCase
         $this->assertStringContainsString('purge plan item_root does not match requested item root.', Artisan::output());
     }
 
+    public function test_command_plans_and_executes_purge_for_quarantined_v2_mirror_without_affecting_primary_runtime_resolution(): void
+    {
+        $fixture = $this->quarantineV2MirrorFixture('command_purge_v2_mirror_success');
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolvedBefore = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['primary_root'].'/compiled', $resolvedBefore);
+
+        $this->assertSame(0, Artisan::call('storage:purge-quarantined-root', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--item-root' => $fixture['item_root'],
+        ]));
+
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('source_kind=v2.mirror', $dryRunOutput);
+        $planPath = $this->extractOutputValue($dryRunOutput, 'plan');
+        $this->assertFileExists($planPath);
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        $this->assertSame(0, Artisan::call('storage:purge-quarantined-root', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=success', $executeOutput);
+        $runDir = $this->extractOutputValue($executeOutput, 'run_dir');
+        $receiptPath = $this->extractOutputValue($executeOutput, 'receipt');
+        $this->assertFileExists($runDir.'/run.json');
+        $this->assertFileExists($receiptPath);
+        $this->assertDirectoryDoesNotExist($fixture['item_root']);
+        $this->assertDirectoryExists($fixture['primary_root']);
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+
+        $resolvedAfter = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['primary_root'].'/compiled', $resolvedAfter);
+    }
+
     /**
      * @return array{item_root:string,release_id:string}
      */
@@ -288,6 +336,121 @@ final class StoragePurgeQuarantinedRootCommandTest extends TestCase
     }
 
     /**
+     * @return array{
+     *   item_root:string,
+     *   release_id:string,
+     *   primary_root:string,
+     *   mirror_root:string,
+     *   manifest_hash:string
+     * }
+     */
+    private function quarantineV2MirrorFixture(string $suffix): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.mirror',
+            'source_disk' => 'local',
+            'source_storage_path' => $mirrorRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'purge-command-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.purge-command.test',
+                    'url' => 'https://cos.purge-command.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $quarantinePlan = Artisan::call('storage:quarantine-exact-roots', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]);
+        $this->assertSame(0, $quarantinePlan);
+        $planPath = $this->extractOutputValue(Artisan::output(), 'plan');
+
+        $quarantineExecute = Artisan::call('storage:quarantine-exact-roots', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]);
+        $this->assertSame(0, $quarantineExecute);
+
+        $runDir = $this->extractOutputValue(Artisan::output(), 'run_dir');
+        $itemRoot = collect((array) json_decode((string) File::get($runDir.'/run.json'), true)['quarantined'] ?? [])
+            ->firstWhere('source_storage_path', $mirrorRoot)['target_root'] ?? '';
+        $this->assertNotSame('', $itemRoot);
+
+        return [
+            'item_root' => $itemRoot,
+            'release_id' => $releaseId,
+            'primary_root' => $primaryRoot,
+            'mirror_root' => $mirrorRoot,
+            'manifest_hash' => $manifestHash,
+        ];
+    }
+
+    /**
      * @return array<string,string>
      */
     private function createCompiledTree(string $root, string $packId, string $packVersion, string $suffix): array
@@ -365,6 +528,56 @@ final class StoragePurgeQuarantinedRootCommandTest extends TestCase
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+    }
+
+    private function insertV2Release(string $releaseId, string $packId, string $packVersion, string $storagePath, string $manifestHash): void
+    {
+        DB::table('content_pack_versions')->updateOrInsert(
+            ['id' => 'version-'.$releaseId],
+            [
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'pack_id' => $packId,
+                'content_package_version' => $packVersion,
+                'dir_version_alias' => $packVersion,
+                'source_type' => 'publish',
+                'source_ref' => 'test',
+                'sha256' => hash('sha256', $storagePath),
+                'manifest_json' => '{}',
+                'extracted_rel_path' => ltrim(str_replace('\\', '/', $storagePath), '/'),
+                'created_by' => 'test',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        DB::table('content_pack_releases')->updateOrInsert(
+            ['id' => $releaseId],
+            [
+                'action' => 'packs2_publish',
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'dir_alias' => $packVersion,
+                'from_version_id' => null,
+                'to_version_id' => 'version-'.$releaseId,
+                'from_pack_id' => null,
+                'to_pack_id' => $packId,
+                'status' => 'success',
+                'message' => null,
+                'created_by' => 'test',
+                'manifest_hash' => $manifestHash,
+                'compiled_hash' => $manifestHash,
+                'content_hash' => hash('sha256', 'content|'.$releaseId),
+                'norms_version' => '2026Q1',
+                'git_sha' => 'git-test',
+                'pack_version' => $packVersion,
+                'manifest_json' => '{}',
+                'storage_path' => $storagePath,
+                'source_commit' => 'git-test',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
     }
 
     private function extractOutputValue(string $output, string $key): string

--- a/backend/tests/Feature/Storage/StorageQuarantineExactRootsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageQuarantineExactRootsCommandTest.php
@@ -203,6 +203,50 @@ final class StorageQuarantineExactRootsCommandTest extends TestCase
         $this->assertDirectoryExists($arbitraryRoot);
     }
 
+    public function test_command_can_quarantine_v2_mirror_without_touching_primary_runtime_resolution(): void
+    {
+        $fixture = $this->seedV2MirrorExactRootFixture('command_v2_mirror_quarantine');
+
+        $this->assertSame(0, Artisan::call('storage:quarantine-exact-roots', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $planPath = $this->extractOutputValue($dryRunOutput, 'plan');
+        $this->assertFileExists($planPath);
+
+        $plan = json_decode((string) File::get($planPath), true);
+        $this->assertIsArray($plan);
+        $mirrorCandidate = collect((array) ($plan['candidates'] ?? []))
+            ->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+        $this->assertIsArray($mirrorCandidate);
+        $this->assertSame('v2.mirror', (string) ($mirrorCandidate['source_kind'] ?? ''));
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        $this->assertSame(0, Artisan::call('storage:quarantine-exact-roots', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $runDir = $this->extractOutputValue($executeOutput, 'run_dir');
+        $this->assertFileExists($runDir.'/run.json');
+        $this->assertDirectoryDoesNotExist($fixture['mirror_root']);
+        $this->assertDirectoryExists($fixture['primary_root']);
+        $this->assertFileExists($fixture['primary_root'].'/compiled/manifest.json');
+        $this->assertFileExists($fixture['primary_root'].'/compiled/payload.compiled.json');
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+    }
+
     /**
      * @return array{manifest_blob_hash:string}
      */
@@ -343,6 +387,157 @@ final class StorageQuarantineExactRootsCommandTest extends TestCase
                 'git_sha' => null,
                 'pack_version' => $packVersion,
                 'manifest_json' => null,
+                'storage_path' => $storagePath,
+                'source_commit' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+    }
+
+    /**
+     * @return array{
+     *   exact_manifest_id:int,
+     *   release_id:string,
+     *   mirror_root:string,
+     *   primary_root:string,
+     *   manifest_hash:string
+     * }
+     */
+    private function seedV2MirrorExactRootFixture(string $suffix): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.mirror',
+            'source_disk' => 'local',
+            'source_storage_path' => $mirrorRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'quarantine-command-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.quarantine-command.test',
+                    'url' => 'https://cos.quarantine-command.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        return [
+            'exact_manifest_id' => (int) DB::table('content_release_exact_manifests')
+                ->where('content_pack_release_id', $releaseId)
+                ->where('source_kind', 'v2.mirror')
+                ->value('id'),
+            'release_id' => $releaseId,
+            'mirror_root' => $mirrorRoot,
+            'primary_root' => $primaryRoot,
+            'manifest_hash' => $manifestHash,
+        ];
+    }
+
+    private function insertV2Release(string $releaseId, string $packId, string $packVersion, string $storagePath, string $manifestHash): void
+    {
+        $versionId = 'version-'.$releaseId;
+
+        DB::table('content_pack_versions')->updateOrInsert(
+            ['id' => $versionId],
+            [
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'pack_id' => $packId,
+                'content_package_version' => $packVersion,
+                'dir_version_alias' => $packVersion,
+                'source_type' => 'publish',
+                'source_ref' => 'test',
+                'sha256' => hash('sha256', $storagePath),
+                'manifest_json' => '{}',
+                'extracted_rel_path' => ltrim(str_replace('\\', '/', $storagePath), '/'),
+                'created_by' => 'test',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        DB::table('content_pack_releases')->updateOrInsert(
+            ['id' => $releaseId],
+            [
+                'action' => 'packs2_publish',
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'dir_alias' => $packVersion,
+                'from_version_id' => null,
+                'to_version_id' => $versionId,
+                'from_pack_id' => null,
+                'to_pack_id' => $packId,
+                'status' => 'success',
+                'message' => 'test',
+                'created_by' => 'test',
+                'manifest_hash' => $manifestHash,
+                'compiled_hash' => $manifestHash,
+                'content_hash' => hash('sha256', 'content|'.$releaseId),
+                'norms_version' => '2026Q1',
+                'git_sha' => null,
+                'pack_version' => $packVersion,
+                'manifest_json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
                 'storage_path' => $storagePath,
                 'source_commit' => null,
                 'created_at' => now(),

--- a/backend/tests/Feature/Storage/StorageRestoreQuarantinedRootCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageRestoreQuarantinedRootCommandTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Storage;
 
 use App\Console\Commands\StorageQuarantineExactRoots;
 use App\Console\Commands\StorageRestoreQuarantinedRoot;
+use App\Services\Content\ContentPackV2Resolver;
 use App\Services\Storage\ExactReleaseFileSetCatalogService;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -175,6 +176,48 @@ final class StorageRestoreQuarantinedRootCommandTest extends TestCase
         $this->assertDirectoryDoesNotExist($fixture['source_root']);
     }
 
+    public function test_command_plans_and_executes_restore_for_quarantined_v2_mirror(): void
+    {
+        $fixture = $this->quarantineV2MirrorFixture('command_restore_v2_mirror_success');
+
+        $this->assertSame(0, Artisan::call('storage:restore-quarantined-root', [
+            '--dry-run' => true,
+            '--item-root' => $fixture['item_root'],
+        ]));
+
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('source_kind=v2.mirror', $dryRunOutput);
+        $planPath = $this->extractOutputValue($dryRunOutput, 'plan');
+        $this->assertFileExists($planPath);
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        $this->assertSame(0, Artisan::call('storage:restore-quarantined-root', [
+            '--execute' => true,
+            '--plan' => $planPath,
+        ]));
+
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=success', $executeOutput);
+        $runDir = $this->extractOutputValue($executeOutput, 'run_dir');
+        $this->assertFileExists($runDir.'/run.json');
+        $this->assertDirectoryExists($fixture['mirror_root']);
+        $this->assertDirectoryDoesNotExist($fixture['item_root']);
+        $this->assertDirectoryExists($fixture['primary_root']);
+        $this->assertFileDoesNotExist($fixture['mirror_root'].'/.quarantine.json');
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['primary_root'].'/compiled', $resolved);
+    }
+
     /**
      * @return array{item_root:string,source_root:string,release_id:string}
      */
@@ -275,6 +318,119 @@ final class StorageRestoreQuarantinedRootCommandTest extends TestCase
     }
 
     /**
+     * @return array{
+     *   item_root:string,
+     *   mirror_root:string,
+     *   primary_root:string,
+     *   release_id:string,
+     *   manifest_hash:string
+     * }
+     */
+    private function quarantineV2MirrorFixture(string $suffix): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.mirror',
+            'source_disk' => 'local',
+            'source_storage_path' => $mirrorRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'restore-command-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.restore-command.test',
+                    'url' => 'https://cos.restore-command.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $this->assertSame(0, Artisan::call('storage:quarantine-exact-roots', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+        $planPath = $this->extractOutputValue(Artisan::output(), 'plan');
+        $this->assertSame(0, Artisan::call('storage:quarantine-exact-roots', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $runDir = $this->extractOutputValue(Artisan::output(), 'run_dir');
+        $quarantinedEntry = collect((array) json_decode((string) File::get($runDir.'/run.json'), true)['quarantined'] ?? [])
+            ->firstWhere('source_storage_path', $mirrorRoot);
+        $itemRoot = (string) ($quarantinedEntry['target_root'] ?? '');
+        $this->assertNotSame('', $itemRoot);
+
+        return [
+            'item_root' => $itemRoot,
+            'mirror_root' => $mirrorRoot,
+            'primary_root' => $primaryRoot,
+            'release_id' => $releaseId,
+            'manifest_hash' => $manifestHash,
+        ];
+    }
+
+    /**
      * @return array<string,string>
      */
     private function createCompiledTree(string $root, string $packId, string $packVersion, string $suffix): array
@@ -328,6 +484,39 @@ final class StorageRestoreQuarantinedRootCommandTest extends TestCase
                 'git_sha' => 'test-sha',
                 'pack_version' => $packVersion,
                 'manifest_json' => null,
+                'storage_path' => $storagePath,
+                'source_commit' => 'test-sha',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+    }
+
+    private function insertV2Release(string $releaseId, string $packId, string $packVersion, string $storagePath, string $manifestHash): void
+    {
+        $versionId = (string) Str::uuid();
+
+        DB::table('content_pack_releases')->updateOrInsert(
+            ['id' => $releaseId],
+            [
+                'action' => 'packs2_publish',
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'dir_alias' => $packVersion,
+                'from_version_id' => null,
+                'to_version_id' => $versionId,
+                'from_pack_id' => null,
+                'to_pack_id' => $packId,
+                'status' => 'success',
+                'message' => null,
+                'created_by' => 'test',
+                'manifest_hash' => $manifestHash,
+                'compiled_hash' => $manifestHash,
+                'content_hash' => hash('sha256', 'content|'.$releaseId),
+                'norms_version' => '2026Q1',
+                'git_sha' => 'test-sha',
+                'pack_version' => $packVersion,
+                'manifest_json' => '{}',
                 'storage_path' => $storagePath,
                 'source_commit' => 'test-sha',
                 'created_at' => now(),


### PR DESCRIPTION
## Summary
- enable `v2.mirror` exact roots in the existing quarantine / restore / purge sibling services
- keep `v2.primary` blocked
- preserve current runtime resolver, materializer, loader, activation, and `content_pack_releases.storage_path` contracts
- add focused storage tests covering the `v2.mirror` lifecycle and keep V2 resolver regression suites green

## Scope
This PR only extends the storage lifecycle allowlist from `legacy.source_pack` to `v2.mirror` where safe.

It does not:
- enable `v2.primary`
- change resolver/materializer behavior
- change runtime read order
- change quarantine/restore/purge output contracts
- change routes, middleware, migrations, scheduler, or storage reader contracts

## Validation
- `php artisan route:list`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/Storage/ExactRootQuarantineServiceTest.php tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php tests/Feature/Storage/StorageQuarantineExactRootsCommandTest.php tests/Feature/Storage/StorageRestoreQuarantinedRootCommandTest.php tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
