### PR TITLE
[codex] Ship PR-9E locale and cultural calibration layer (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -253,6 +253,12 @@ class AttemptReadController extends Controller
             if ($controlledNarrative !== []) {
                 $responsePayload['controlled_narrative_v1'] = $controlledNarrative;
             }
+            $culturalCalibration = is_array($big5Projection['cultural_calibration_v1'] ?? null)
+                ? $big5Projection['cultural_calibration_v1']
+                : [];
+            if ($culturalCalibration !== []) {
+                $responsePayload['cultural_calibration_v1'] = $culturalCalibration;
+            }
         }
 
         return response()->json($responsePayload);
@@ -380,6 +386,12 @@ class AttemptReadController extends Controller
             if ($controlledNarrative !== []) {
                 $responsePayload['controlled_narrative_v1'] = $controlledNarrative;
             }
+            $culturalCalibration = is_array($projection['cultural_calibration_v1'] ?? null)
+                ? $projection['cultural_calibration_v1']
+                : [];
+            if ($culturalCalibration !== []) {
+                $responsePayload['cultural_calibration_v1'] = $culturalCalibration;
+            }
         }
 
         $effectiveMbtiPersonalization = $scaleCode === 'MBTI'
@@ -408,6 +420,10 @@ class AttemptReadController extends Controller
             $controlledNarrative = data_get($responsePayload, 'report._meta.personalization.controlled_narrative_v1');
             if (is_array($controlledNarrative)) {
                 $responsePayload['controlled_narrative_v1'] = $controlledNarrative;
+            }
+            $culturalCalibration = data_get($responsePayload, 'report._meta.personalization.cultural_calibration_v1');
+            if (is_array($culturalCalibration)) {
+                $responsePayload['cultural_calibration_v1'] = $culturalCalibration;
             }
             $crossAssessment = data_get($responsePayload, 'report._meta.personalization.cross_assessment_v1');
             if (is_array($crossAssessment)) {
@@ -598,6 +614,7 @@ class AttemptReadController extends Controller
         $variantKeys = is_array($projection['variant_keys'] ?? null) ? $projection['variant_keys'] : [];
         $orderedSectionKeys = is_array($projection['ordered_section_keys'] ?? null) ? $projection['ordered_section_keys'] : [];
         $controlledNarrative = is_array($projection['controlled_narrative_v1'] ?? null) ? $projection['controlled_narrative_v1'] : [];
+        $culturalCalibration = is_array($projection['cultural_calibration_v1'] ?? null) ? $projection['cultural_calibration_v1'] : [];
 
         $meta = [
             'trait_bands' => $traitBands,
@@ -617,6 +634,18 @@ class AttemptReadController extends Controller
             $meta['narrative_model_version'] = trim((string) ($controlledNarrative['model_version'] ?? ''));
             $meta['narrative_prompt_version'] = trim((string) ($controlledNarrative['prompt_version'] ?? ''));
             $meta['narrative_fingerprint'] = trim((string) ($controlledNarrative['narrative_fingerprint'] ?? ''));
+        }
+        if ($culturalCalibration !== []) {
+            $meta['locale_context'] = trim((string) ($culturalCalibration['locale_context'] ?? ''));
+            $meta['cultural_context'] = trim((string) ($culturalCalibration['cultural_context'] ?? ''));
+            $meta['calibrated_section_keys'] = array_values(array_filter(array_map(
+                'strval',
+                is_array($culturalCalibration['calibrated_section_keys'] ?? null) ? $culturalCalibration['calibrated_section_keys'] : []
+            )));
+            $meta['calibration_fingerprint'] = trim((string) ($culturalCalibration['calibration_fingerprint'] ?? ''));
+            $meta['calibration_contract_version'] = trim((string) ($culturalCalibration['calibration_contract_version'] ?? ''));
+            $meta['calibration_policy_version'] = trim((string) ($culturalCalibration['calibration_policy_version'] ?? ''));
+            $meta['calibration_source'] = trim((string) ($culturalCalibration['calibration_source'] ?? ''));
         }
 
         return array_filter($meta, static function (mixed $value): bool {
@@ -683,6 +712,7 @@ class AttemptReadController extends Controller
             'user_state' => is_array($personalization['user_state'] ?? null) ? $personalization['user_state'] : [],
             'orchestration' => is_array($personalization['orchestration'] ?? null) ? $personalization['orchestration'] : [],
             'continuity' => is_array($personalization['continuity'] ?? null) ? $personalization['continuity'] : [],
+            'cultural_calibration_v1' => is_array($personalization['cultural_calibration_v1'] ?? null) ? $personalization['cultural_calibration_v1'] : [],
             'engine_version' => trim((string) ($personalization['engine_version'] ?? '')),
         ];
 
@@ -710,6 +740,22 @@ class AttemptReadController extends Controller
             : [];
         if ($privacyContract !== []) {
             $meta = array_merge($meta, $this->mbtiPrivacyConsentContractService->buildTelemetryConsentMeta($privacyContract));
+        }
+
+        $culturalCalibration = is_array($personalization['cultural_calibration_v1'] ?? null)
+            ? $personalization['cultural_calibration_v1']
+            : [];
+        if ($culturalCalibration !== []) {
+            $meta['locale_context'] = trim((string) ($culturalCalibration['locale_context'] ?? ''));
+            $meta['cultural_context'] = trim((string) ($culturalCalibration['cultural_context'] ?? ''));
+            $meta['calibrated_section_keys'] = array_values(array_filter(array_map(
+                'strval',
+                is_array($culturalCalibration['calibrated_section_keys'] ?? null) ? $culturalCalibration['calibrated_section_keys'] : []
+            )));
+            $meta['calibration_fingerprint'] = trim((string) ($culturalCalibration['calibration_fingerprint'] ?? ''));
+            $meta['calibration_contract_version'] = trim((string) ($culturalCalibration['calibration_contract_version'] ?? ''));
+            $meta['calibration_policy_version'] = trim((string) ($culturalCalibration['calibration_policy_version'] ?? ''));
+            $meta['calibration_source'] = trim((string) ($culturalCalibration['calibration_source'] ?? ''));
         }
 
         return array_filter($meta, static function (mixed $value): bool {

--- a/backend/app/Services/BigFive/BigFivePublicProjectionService.php
+++ b/backend/app/Services/BigFive/BigFivePublicProjectionService.php
@@ -7,6 +7,7 @@ namespace App\Services\BigFive;
 use App\Models\Result;
 use App\Services\AI\ControlledGenerationRuntime;
 use App\Services\AI\ControlledNarrativeLayerService;
+use App\Services\Content\CulturalCalibrationLayerService;
 
 final class BigFivePublicProjectionService
 {
@@ -15,6 +16,7 @@ final class BigFivePublicProjectionService
     public function __construct(
         private readonly ControlledGenerationRuntime $controlledGenerationRuntime,
         private readonly ControlledNarrativeLayerService $controlledNarrativeLayerService,
+        private readonly CulturalCalibrationLayerService $culturalCalibrationLayerService,
     ) {
     }
 
@@ -174,6 +176,10 @@ final class BigFivePublicProjectionService
         );
         $projection['_meta']['narrative_runtime_contract_v1'] = $runtimeContract;
         $projection['controlled_narrative_v1'] = $this->controlledNarrativeLayerService->buildFromRuntimeContract($runtimeContract);
+        $projection['cultural_calibration_v1'] = $this->culturalCalibrationLayerService->buildForBigFive(
+            $projection,
+            ['locale' => $locale]
+        );
 
         return $projection;
     }

--- a/backend/app/Services/Content/CulturalCalibrationLayerService.php
+++ b/backend/app/Services/Content/CulturalCalibrationLayerService.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+final class CulturalCalibrationLayerService
+{
+    public const VERSION = 'cultural_calibration.v1';
+
+    /**
+     * @var list<string>
+     */
+    private const TRUTH_GUARD_FIELDS = [
+        'type_code',
+        'identity',
+        'variant_keys',
+        'scene_fingerprint',
+        'working_life_v1',
+        'cross_assessment_v1',
+        'user_state',
+        'orchestration',
+        'continuity',
+        'trait_vector',
+        'trait_bands',
+        'dominant_traits',
+        'action_plan_summary',
+    ];
+
+    public function __construct(
+        private readonly ContentPacksIndex $packsIndex,
+        private readonly MbtiContentGovernanceService $mbtiGovernanceService,
+    ) {
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function buildForMbti(array $authority, array $context = []): array
+    {
+        $localeContext = $this->normalizeLocaleContext((string) ($context['locale'] ?? ''));
+        $region = $this->resolveRegion((string) ($context['region'] ?? ''), $localeContext);
+        $governanceDoc = $this->loadMbtiGovernanceDocument($context);
+
+        $culturalContext = trim((string) ($governanceDoc['cultural_context'] ?? ''));
+        if ($culturalContext === '') {
+            $culturalContext = sprintf('%s.%s', $region, $localeContext);
+        }
+
+        $payload = $this->mbtiPayloadForLocale($localeContext, $authority);
+        $policyVersion = trim((string) ($governanceDoc['version'] ?? ''));
+        if ($policyVersion === '') {
+            $policyVersion = $governanceDoc !== []
+                ? 'governance.v1'
+                : 'runtime.locale_policy.v1';
+        }
+
+        return $this->buildContract(
+            scaleCode: 'MBTI',
+            localeContext: $localeContext,
+            culturalContext: $culturalContext,
+            calibrationSource: $governanceDoc !== [] ? 'content_governance' : 'runtime_policy',
+            calibrationPolicyVersion: $policyVersion,
+            payload: $payload,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $projection
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function buildForBigFive(array $projection, array $context = []): array
+    {
+        $localeContext = $this->normalizeLocaleContext((string) ($context['locale'] ?? ''));
+        $region = $this->resolveRegion((string) ($context['region'] ?? ''), $localeContext);
+        $payload = $this->bigFivePayloadForLocale($localeContext, $projection);
+
+        return $this->buildContract(
+            scaleCode: 'BIG5_OCEAN',
+            localeContext: $localeContext,
+            culturalContext: sprintf('%s.%s', $region, $localeContext),
+            calibrationSource: 'runtime_policy',
+            calibrationPolicyVersion: 'runtime.locale_policy.v1',
+            payload: $payload,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function buildContract(
+        string $scaleCode,
+        string $localeContext,
+        string $culturalContext,
+        string $calibrationSource,
+        string $calibrationPolicyVersion,
+        array $payload,
+    ): array {
+        $narrativeOverrides = is_array($payload['narrative_overrides'] ?? null)
+            ? $payload['narrative_overrides']
+            : [];
+        $sectionOverrides = is_array($payload['section_overrides'] ?? null)
+            ? $payload['section_overrides']
+            : [];
+        $workingLifeSummary = trim((string) ($payload['working_life_summary'] ?? ''));
+        $calibratedSectionKeys = array_values(array_unique(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            [
+                ...(is_array($payload['calibrated_section_keys'] ?? null) ? $payload['calibrated_section_keys'] : []),
+                ...array_keys($sectionOverrides),
+            ]
+        ))));
+
+        $fingerprint = hash('sha256', json_encode([
+            'version' => self::VERSION,
+            'scale_code' => $scaleCode,
+            'locale_context' => $localeContext,
+            'cultural_context' => $culturalContext,
+            'calibration_source' => $calibrationSource,
+            'calibration_policy_version' => $calibrationPolicyVersion,
+            'calibrated_section_keys' => $calibratedSectionKeys,
+            'narrative_overrides' => $narrativeOverrides,
+            'working_life_summary' => $workingLifeSummary,
+            'section_overrides' => $sectionOverrides,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}');
+
+        return [
+            'version' => self::VERSION,
+            'calibration_contract_version' => self::VERSION,
+            'locale_context' => $localeContext,
+            'cultural_context' => $culturalContext,
+            'calibrated_section_keys' => $calibratedSectionKeys,
+            'calibration_fingerprint' => $fingerprint,
+            'calibration_policy_version' => $calibrationPolicyVersion,
+            'calibration_source' => $calibrationSource,
+            'enabled' => $calibratedSectionKeys !== []
+                || trim((string) ($narrativeOverrides['intro'] ?? '')) !== ''
+                || trim((string) ($narrativeOverrides['summary'] ?? '')) !== ''
+                || $workingLifeSummary !== '',
+            'narrative_overrides' => [
+                'intro' => trim((string) ($narrativeOverrides['intro'] ?? '')),
+                'summary' => trim((string) ($narrativeOverrides['summary'] ?? '')),
+            ],
+            'working_life_summary' => $workingLifeSummary,
+            'section_overrides' => $this->normalizeSectionOverrides($sectionOverrides),
+            'truth_guard_fields' => self::TRUTH_GUARD_FIELDS,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function loadMbtiGovernanceDocument(array $context): array
+    {
+        $packId = trim((string) ($context['pack_id'] ?? ''));
+        $dirVersion = trim((string) ($context['dir_version'] ?? ''));
+        if ($packId === '' || $dirVersion === '') {
+            return [];
+        }
+
+        $resolved = $this->packsIndex->find($packId, $dirVersion);
+        if (! ($resolved['ok'] ?? false)) {
+            return [];
+        }
+
+        $item = is_array($resolved['item'] ?? null) ? $resolved['item'] : [];
+        $baseDir = trim((string) ($item['base_dir'] ?? ''));
+        if ($baseDir === '') {
+            $manifestPath = trim((string) ($item['manifest_path'] ?? ''));
+            if ($manifestPath !== '') {
+                $baseDir = dirname(base_path($manifestPath));
+            }
+        }
+        if ($baseDir === '') {
+            return [];
+        }
+
+        $doc = $this->mbtiGovernanceService->loadDocument($baseDir);
+
+        return is_array($doc) ? $doc : [];
+    }
+
+    private function normalizeLocaleContext(string $locale): string
+    {
+        $normalized = trim($locale);
+        if ($normalized === '') {
+            return 'zh-CN';
+        }
+
+        if (str_starts_with(strtolower($normalized), 'zh')) {
+            return 'zh-CN';
+        }
+
+        if (strtolower($normalized) === 'en') {
+            return 'en-US';
+        }
+
+        return $normalized;
+    }
+
+    private function resolveRegion(string $region, string $localeContext): string
+    {
+        $region = trim($region);
+        if ($region !== '') {
+            return $region;
+        }
+
+        return str_starts_with(strtolower($localeContext), 'zh')
+            ? 'CN_MAINLAND'
+            : 'US';
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return array<string, mixed>
+     */
+    private function mbtiPayloadForLocale(string $localeContext, array $authority): array
+    {
+        $isZh = str_starts_with(strtolower($localeContext), 'zh');
+        $workingLifeFocus = trim((string) data_get($authority, 'working_life_v1.career_focus_key', ''));
+        $actionFocus = trim((string) ($authority['action_focus_key'] ?? ''));
+        $focusLabel = $workingLifeFocus !== '' ? $workingLifeFocus : $actionFocus;
+
+        if ($isZh) {
+            return [
+                'calibrated_section_keys' => [
+                    'result.intro',
+                    'result.summary',
+                    'growth.next_actions',
+                    'career.next_step',
+                    'relationships.communication_style',
+                ],
+                'narrative_overrides' => [
+                    'intro' => '文化校准：在中文语境里，更适合先铺场景与关系，再给结论。',
+                    'summary' => $focusLabel !== ''
+                        ? "这层校准不会改写你的类型与焦点，但会把 {$focusLabel} 的表达调成更强调分寸、关系和低摩擦推进的语境。"
+                        : '这层校准不会改写你的类型与焦点，只会把建议表达得更贴近中文工作与关系语境。',
+                ],
+                'working_life_summary' => '在当前语境里，职业推进更适合先做低风险试探、保留协作余地，再逐步公开偏好、边界和下一步。',
+                'section_overrides' => [
+                    'growth.next_actions' => [
+                        'section_key' => 'growth.next_actions',
+                        'title' => '语境校准：先用低摩擦动作启动',
+                        'body' => '把下一步压缩成一个不伤关系、可低成本试跑的动作，再通过外部反馈决定是否继续放大。',
+                    ],
+                    'career.next_step' => [
+                        'section_key' => 'career.next_step',
+                        'title' => '语境校准：先用试探性动作推进职业变化',
+                        'body' => '把职业动作先缩成一次沟通、一次试探或一次环境观察，先验证空间，再决定是否公开升级意图。',
+                    ],
+                    'relationships.communication_style' => [
+                        'section_key' => 'relationships.communication_style',
+                        'title' => '语境校准：先铺语境，再给结论',
+                        'body' => '沟通里先交代情境、感受和合作目标，再落到结论与边界，通常更容易让对方接住你的真实意图。',
+                    ],
+                ],
+            ];
+        }
+
+        return [
+            'calibrated_section_keys' => [
+                'result.intro',
+                'result.summary',
+                'growth.next_actions',
+                'career.next_step',
+                'relationships.communication_style',
+            ],
+            'narrative_overrides' => [
+                'intro' => 'Cultural calibration: lead with the point, then name the trade-off.',
+                'summary' => $focusLabel !== ''
+                    ? "This layer keeps {$focusLabel} and every canonical result field intact, while framing it for a more explicit English-speaking context."
+                    : 'This layer keeps the canonical result intact while making advice more explicit, boundary-aware, and action-forward in an English-speaking context.',
+            ],
+            'working_life_summary' => 'In this locale, the working-life chain is framed around explicit priorities, visible trade-offs, and next steps that can be named early.',
+            'section_overrides' => [
+                'growth.next_actions' => [
+                    'section_key' => 'growth.next_actions',
+                    'title' => 'Locale calibration: make the next step explicit',
+                    'body' => 'Name one concrete action, one owner, and one trigger. The goal is not softer momentum; it is visible momentum with low ambiguity.',
+                ],
+                'career.next_step' => [
+                    'section_key' => 'career.next_step',
+                    'title' => 'Locale calibration: state the next career move clearly',
+                    'body' => 'Frame the next move as a visible experiment with a clear ask, a time box, and a named trade-off instead of a vague intention.',
+                ],
+                'relationships.communication_style' => [
+                    'section_key' => 'relationships.communication_style',
+                    'title' => 'Locale calibration: name the point and the boundary',
+                    'body' => 'In communication, say the main point earlier, then name the boundary or decision rule so others do not have to infer your actual position.',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $projection
+     * @return array<string, mixed>
+     */
+    private function bigFivePayloadForLocale(string $localeContext, array $projection): array
+    {
+        $isZh = str_starts_with(strtolower($localeContext), 'zh');
+        $dominantTrait = trim((string) data_get($projection, 'dominant_traits.0.label', data_get($projection, 'dominant_traits.0.key', '')));
+
+        if ($isZh) {
+            return [
+                'calibrated_section_keys' => [
+                    'result.summary',
+                    'traits.overview',
+                ],
+                'narrative_overrides' => [
+                    'intro' => '语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。',
+                    'summary' => $dominantTrait !== ''
+                        ? "在中文工作语境里，更适合把 {$dominantTrait} 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                        : '在中文工作语境里，更适合把特质读成协作与环境偏好的线索，而不是固定标签。',
+                ],
+                'section_overrides' => [
+                    'traits.overview' => [
+                        'section_key' => 'traits.overview',
+                        'title' => '语境校准：先讲协作含义，再讲特质名称',
+                        'body' => '在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。',
+                    ],
+                ],
+            ];
+        }
+
+        return [
+            'calibrated_section_keys' => [
+                'result.summary',
+                'traits.overview',
+            ],
+            'narrative_overrides' => [
+                'intro' => 'Locale calibration: use the profile as a planning aid, not an identity box.',
+                'summary' => $dominantTrait !== ''
+                    ? "In an English-speaking context, {$dominantTrait} should be framed as a planning signal for work style and environment fit, not as a fixed label."
+                    : 'In an English-speaking context, trait signals should be framed as planning inputs for work style and environment fit, not as identity labels.',
+            ],
+            'section_overrides' => [
+                'traits.overview' => [
+                    'section_key' => 'traits.overview',
+                    'title' => 'Locale calibration: turn traits into operating signals',
+                    'body' => 'Frame the profile in terms of decision speed, collaboration style, and environment fit so the user can act on it immediately.',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $sectionOverrides
+     * @return array<string, array<string, string>>
+     */
+    private function normalizeSectionOverrides(array $sectionOverrides): array
+    {
+        $normalized = [];
+
+        foreach ($sectionOverrides as $sectionKey => $override) {
+            if (! is_array($override)) {
+                continue;
+            }
+
+            $resolvedSectionKey = trim((string) ($override['section_key'] ?? $sectionKey));
+            if ($resolvedSectionKey === '') {
+                continue;
+            }
+
+            $normalized[$resolvedSectionKey] = [
+                'section_key' => $resolvedSectionKey,
+                'title' => trim((string) ($override['title'] ?? '')),
+                'body' => trim((string) ($override['body'] ?? '')),
+            ];
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Services/Mbti/MbtiReadModelContractService.php
+++ b/backend/app/Services/Mbti/MbtiReadModelContractService.php
@@ -53,6 +53,7 @@ final class MbtiReadModelContractService
         'mbti_public_projection_v1.sections',
         'controlled_narrative_v1',
         'narrative_runtime_contract_v1',
+        'cultural_calibration_v1',
     ];
 
     /**
@@ -77,6 +78,7 @@ final class MbtiReadModelContractService
         'mbti_read_contract_v1',
         'controlled_narrative_v1',
         'narrative_runtime_contract_v1',
+        'cultural_calibration_v1',
     ];
 
     /**
@@ -108,6 +110,11 @@ final class MbtiReadModelContractService
         'narrative_runtime_contract_v1.model_version',
         'narrative_runtime_contract_v1.prompt_version',
         'narrative_runtime_contract_v1.narrative_fingerprint',
+        'cultural_calibration_v1.locale_context',
+        'cultural_calibration_v1.cultural_context',
+        'cultural_calibration_v1.calibrated_section_keys',
+        'cultural_calibration_v1.calibration_fingerprint',
+        'cultural_calibration_v1.calibration_contract_version',
     ];
 
     /**

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -7,6 +7,7 @@ namespace App\Services\Mbti;
 use App\Services\AI\ControlledGenerationRuntime;
 use App\Services\AI\ControlledNarrativeLayerService;
 use App\Services\Content\ContentPacksIndex;
+use App\Services\Content\CulturalCalibrationLayerService;
 
 final class MbtiResultPersonalizationService
 {
@@ -574,6 +575,7 @@ final class MbtiResultPersonalizationService
         private readonly MbtiPrivacyConsentContractService $privacyConsentContractService,
         private readonly ControlledGenerationRuntime $controlledGenerationRuntime,
         private readonly ControlledNarrativeLayerService $controlledNarrativeLayerService,
+        private readonly CulturalCalibrationLayerService $culturalCalibrationLayerService,
         private readonly MbtiReadModelContractService $readModelContractService,
     ) {
     }
@@ -662,7 +664,7 @@ final class MbtiResultPersonalizationService
         }
 
         $personalization = $this->userStateOrchestrationService->withBaseline([
-                'schema_version' => 'mbti.personalization.phase9c.v1',
+                'schema_version' => 'mbti.personalization.phase9e.v1',
                 'locale' => $locale,
                 'type_code' => $typeCode,
                 'identity' => $identity,
@@ -723,7 +725,7 @@ final class MbtiResultPersonalizationService
                 'type_code' => $typeCode,
                 'identity' => $identity,
                 'engine_version' => trim((string) ($context['engine_version'] ?? data_get($reportPayload, 'versions.engine', ''))),
-                'schema_version' => 'mbti.personalization.phase9c.v1',
+                'schema_version' => 'mbti.personalization.phase9e.v1',
                 'dynamic_sections_version' => trim((string) ($dynamicDoc['version'] ?? '')),
                 'user_id' => $context['user_id'] ?? null,
                 'anon_id' => $context['anon_id'] ?? null,
@@ -734,6 +736,15 @@ final class MbtiResultPersonalizationService
             is_array($personalization['narrative_runtime_contract_v1'] ?? null)
                 ? $personalization['narrative_runtime_contract_v1']
                 : []
+        );
+        $personalization['cultural_calibration_v1'] = $this->culturalCalibrationLayerService->buildForMbti(
+            $personalization,
+            [
+                'locale' => $locale,
+                'region' => trim((string) ($context['region'] ?? config('regions.default_region', 'CN_MAINLAND'))),
+                'pack_id' => trim((string) ($context['pack_id'] ?? data_get($reportPayload, 'versions.content_pack_id', ''))),
+                'dir_version' => trim((string) ($context['dir_version'] ?? data_get($reportPayload, 'versions.dir_version', ''))),
+            ]
         );
 
         return $this->readModelContractService->attachContract($personalization);

--- a/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+++ b/backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
@@ -96,7 +96,7 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
 
         $this->assertTrue((bool) ($payload['ok'] ?? false));
         $this->assertSame(
-            'mbti.personalization.phase9c.v1',
+            'mbti.personalization.phase9e.v1',
             data_get($payload, 'report._meta.personalization.schema_version')
         );
         $this->assertSame(
@@ -128,6 +128,14 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
         $this->assertSame(
             'controlled_narrative.v1',
             data_get($payload, 'report._meta.personalization.controlled_narrative_v1.version')
+        );
+        $this->assertSame(
+            'cultural_calibration.v1',
+            data_get($payload, 'report._meta.personalization.cultural_calibration_v1.version')
+        );
+        $this->assertSame(
+            'CN_MAINLAND.zh-CN',
+            data_get($payload, 'report._meta.personalization.cultural_calibration_v1.cultural_context')
         );
         $this->assertSame(
             'off',
@@ -401,7 +409,7 @@ final class MbtiPhase2AssemblerIntegrationTest extends TestCase
             ->first(static fn (array $section): bool => (string) ($section['key'] ?? '') === 'relationships.try_this_week');
 
         $this->assertSame(
-            'mbti.personalization.phase9c.v1',
+            'mbti.personalization.phase9e.v1',
             data_get($projection, '_meta.personalization.schema_version')
         );
         $this->assertSame(

--- a/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
@@ -45,6 +45,8 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         $resultResponse->assertJsonPath('big5_public_projection_v1.trait_bands.O', 'mid');
         $resultResponse->assertJsonPath('big5_public_projection_v1.controlled_narrative_v1.version', 'controlled_narrative.v1');
         $resultResponse->assertJsonPath('big5_public_projection_v1.controlled_narrative_v1.runtime_mode', 'mock');
+        $resultResponse->assertJsonPath('big5_public_projection_v1.cultural_calibration_v1.version', 'cultural_calibration.v1');
+        $resultResponse->assertJsonPath('big5_public_projection_v1.cultural_calibration_v1.cultural_context', 'CN_MAINLAND.zh-CN');
 
         $reportResponse = $this->withHeaders([
             'Authorization' => 'Bearer '.$token,
@@ -56,6 +58,7 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         $reportResponse->assertJsonPath('big5_public_projection_v1.ordered_section_keys.1', 'traits.why_this_profile');
         $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
         $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.controlled_narrative_v1.version', 'controlled_narrative.v1');
+        $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.cultural_calibration_v1.version', 'cultural_calibration.v1');
         $reportResponse->assertJsonPath('report.sections.0.key', 'traits.overview');
         $reportResponse->assertJsonPath('report.sections.4.key', 'growth.next_actions');
 
@@ -71,6 +74,10 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         $this->assertArrayHasKey('scene_fingerprint', $meta);
         $this->assertSame('controlled_narrative.v1', (string) ($meta['narrative_contract_version'] ?? ''));
         $this->assertSame('mock', (string) ($meta['narrative_runtime_mode'] ?? ''));
+        $this->assertSame('zh-CN', (string) ($meta['locale_context'] ?? ''));
+        $this->assertSame('CN_MAINLAND.zh-CN', (string) ($meta['cultural_context'] ?? ''));
+        $this->assertSame('cultural_calibration.v1', (string) ($meta['calibration_contract_version'] ?? ''));
+        $this->assertContains('traits.overview', $meta['calibrated_section_keys'] ?? []);
     }
 
     private function seedAttempt(string $anonId): string

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -43,7 +43,7 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertSame('INTJ-A', (string) ($meta['type_code'] ?? ''));
             $this->assertSame('A', (string) ($meta['identity'] ?? ''));
             $this->assertSame('report_phase4a_contract', (string) ($meta['engine_version'] ?? ''));
-            $this->assertSame('mbti.personalization.phase9c.v1', (string) ($meta['schema_version'] ?? ''));
+            $this->assertSame('mbti.personalization.phase9e.v1', (string) ($meta['schema_version'] ?? ''));
             $this->assertSame('phase9c.v1', (string) ($meta['dynamic_sections_version'] ?? ''));
             $this->assertSame('controlled_narrative.v1', (string) ($meta['narrative_contract_version'] ?? ''));
             $this->assertSame('narrative_runtime_contract.v1', (string) ($meta['narrative_runtime_contract_version'] ?? ''));
@@ -110,6 +110,13 @@ class MbtiResultTelemetryContractTest extends TestCase
             $this->assertIsArray($meta['continuity'] ?? null);
             $this->assertSame('mbti.privacy_contract.v1', (string) ($meta['privacy_contract_version'] ?? ''));
             $this->assertIsArray($meta['consent_scope'] ?? null);
+            $this->assertSame('zh-CN', (string) ($meta['locale_context'] ?? ''));
+            $this->assertSame('CN_MAINLAND.zh-CN', (string) ($meta['cultural_context'] ?? ''));
+            $this->assertSame('cultural_calibration.v1', (string) ($meta['calibration_contract_version'] ?? ''));
+            $this->assertSame('governance.v1', (string) ($meta['calibration_policy_version'] ?? ''));
+            $this->assertSame('content_governance', (string) ($meta['calibration_source'] ?? ''));
+            $this->assertContains('growth.next_actions', $meta['calibrated_section_keys'] ?? []);
+            $this->assertNotSame('', trim((string) ($meta['calibration_fingerprint'] ?? '')));
             $this->assertContains('role_fit.role.NT', $meta['role_fit_keys'] ?? []);
         }
 
@@ -134,6 +141,10 @@ class MbtiResultTelemetryContractTest extends TestCase
         $this->assertSame($eventMeta['report_view']['narrative_contract_version'] ?? null, $eventMeta['result_view']['narrative_contract_version'] ?? null);
         $this->assertSame($eventMeta['report_view']['narrative_runtime_contract_version'] ?? null, $eventMeta['result_view']['narrative_runtime_contract_version'] ?? null);
         $this->assertSame($eventMeta['report_view']['narrative_fingerprint'] ?? null, $eventMeta['result_view']['narrative_fingerprint'] ?? null);
+        $this->assertSame($eventMeta['report_view']['locale_context'] ?? null, $eventMeta['result_view']['locale_context'] ?? null);
+        $this->assertSame($eventMeta['report_view']['cultural_context'] ?? null, $eventMeta['result_view']['cultural_context'] ?? null);
+        $this->assertSame($eventMeta['report_view']['calibrated_section_keys'] ?? null, $eventMeta['result_view']['calibrated_section_keys'] ?? null);
+        $this->assertSame($eventMeta['report_view']['calibration_fingerprint'] ?? null, $eventMeta['result_view']['calibration_fingerprint'] ?? null);
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.is_first_view'));
         $this->assertSame(false, data_get($eventMeta, 'result_view.user_state.is_revisit'));
         $this->assertSame(true, data_get($eventMeta, 'result_view.user_state.has_share'));

--- a/backend/tests/Unit/Services/Content/CulturalCalibrationLayerServiceTest.php
+++ b/backend/tests/Unit/Services/Content/CulturalCalibrationLayerServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Content;
+
+use App\Services\Content\CulturalCalibrationLayerService;
+use Tests\TestCase;
+
+final class CulturalCalibrationLayerServiceTest extends TestCase
+{
+    public function test_it_builds_mbti_calibration_from_content_governance_when_pack_context_is_available(): void
+    {
+        $service = app(CulturalCalibrationLayerService::class);
+
+        $calibration = $service->buildForMbti([
+            'action_focus_key' => 'growth.next_actions',
+            'working_life_v1' => [
+                'career_focus_key' => 'career.next_step',
+            ],
+        ], [
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+        ]);
+
+        $this->assertSame('cultural_calibration.v1', $calibration['version']);
+        $this->assertSame('zh-CN', $calibration['locale_context']);
+        $this->assertSame('CN_MAINLAND.zh-CN', $calibration['cultural_context']);
+        $this->assertSame('governance.v1', $calibration['calibration_policy_version']);
+        $this->assertSame('content_governance', $calibration['calibration_source']);
+        $this->assertContains('career.next_step', $calibration['calibrated_section_keys']);
+        $this->assertContains('relationships.communication_style', $calibration['calibrated_section_keys']);
+        $this->assertNotSame('', trim((string) ($calibration['narrative_overrides']['intro'] ?? '')));
+        $this->assertNotSame('', trim((string) ($calibration['working_life_summary'] ?? '')));
+        $this->assertNotSame('', trim((string) ($calibration['calibration_fingerprint'] ?? '')));
+    }
+
+    public function test_it_builds_runtime_policy_calibration_for_english_mbti_and_big_five(): void
+    {
+        $service = app(CulturalCalibrationLayerService::class);
+
+        $mbtiCalibration = $service->buildForMbti([
+            'action_focus_key' => 'growth.next_actions',
+            'working_life_v1' => [
+                'career_focus_key' => 'career.next_step',
+            ],
+        ], [
+            'locale' => 'en-US',
+            'region' => 'US',
+        ]);
+
+        $bigFiveCalibration = $service->buildForBigFive([
+            'variant_keys' => ['profile:explorer'],
+        ], [
+            'locale' => 'en-US',
+            'region' => 'US',
+        ]);
+
+        $this->assertSame('en-US', $mbtiCalibration['locale_context']);
+        $this->assertSame('US.en-US', $mbtiCalibration['cultural_context']);
+        $this->assertSame('runtime_policy', $mbtiCalibration['calibration_source']);
+        $this->assertSame('runtime.locale_policy.v1', $mbtiCalibration['calibration_policy_version']);
+        $this->assertContains('growth.next_actions', $mbtiCalibration['calibrated_section_keys']);
+
+        $this->assertSame('en-US', $bigFiveCalibration['locale_context']);
+        $this->assertSame('US.en-US', $bigFiveCalibration['cultural_context']);
+        $this->assertSame('runtime_policy', $bigFiveCalibration['calibration_source']);
+        $this->assertContains('traits.overview', $bigFiveCalibration['calibrated_section_keys']);
+        $this->assertNotSame('', trim((string) ($bigFiveCalibration['narrative_overrides']['summary'] ?? '')));
+    }
+}

--- a/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php
@@ -14,11 +14,19 @@ final class MbtiReadModelContractServiceTest extends TestCase
         $service = app(MbtiReadModelContractService::class);
 
         $contract = $service->buildContract([
-            'schema_version' => 'mbti.personalization.phase9c.v1',
+            'schema_version' => 'mbti.personalization.phase9e.v1',
             'identity' => 'A',
             'privacy_contract_v1' => ['version' => 'mbti.privacy_contract.v1'],
             'controlled_narrative_v1' => ['version' => 'controlled_narrative.v1', 'runtime_mode' => 'off'],
             'narrative_runtime_contract_v1' => ['version' => 'narrative_runtime_contract.v1', 'runtime_mode' => 'off'],
+            'cultural_calibration_v1' => [
+                'version' => 'cultural_calibration.v1',
+                'locale_context' => 'zh-CN',
+                'cultural_context' => 'CN_MAINLAND.zh-CN',
+                'calibrated_section_keys' => ['growth.next_actions'],
+                'calibration_fingerprint' => 'fixture-calibration',
+                'calibration_contract_version' => 'cultural_calibration.v1',
+            ],
             'variant_keys' => ['overview' => 'overview:clear'],
             'scene_fingerprint' => ['work' => ['style_key' => 'work.primary.EI.E.clear']],
             'user_state' => ['is_first_view' => true],
@@ -35,11 +43,13 @@ final class MbtiReadModelContractServiceTest extends TestCase
         $this->assertContains('privacy_contract_v1', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('controlled_narrative_v1', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('narrative_runtime_contract_v1', $contract['canonical_read_model']['personalization_fields']);
+        $this->assertContains('cultural_calibration_v1', $contract['canonical_read_model']['personalization_fields']);
         $this->assertNotContains('variant_keys', $contract['canonical_read_model']['personalization_fields']);
         $this->assertNotContains('user_state', $contract['canonical_read_model']['personalization_fields']);
         $this->assertContains('mbti_privacy_contract_v1', $contract['cacheable_fields']);
         $this->assertContains('controlled_narrative_v1', $contract['cacheable_fields']);
         $this->assertContains('narrative_runtime_contract_v1', $contract['cacheable_fields']);
+        $this->assertContains('cultural_calibration_v1', $contract['cacheable_fields']);
         $this->assertSame(
             [
                 'user_state',
@@ -72,6 +82,8 @@ final class MbtiReadModelContractServiceTest extends TestCase
         $this->assertContains('continuity.carryover_focus_key', $contract['telemetry_parity_fields']);
         $this->assertContains('working_life_v1.career_focus_key', $contract['telemetry_parity_fields']);
         $this->assertContains('narrative_runtime_contract_v1.runtime_mode', $contract['telemetry_parity_fields']);
+        $this->assertContains('cultural_calibration_v1.locale_context', $contract['telemetry_parity_fields']);
+        $this->assertContains('cultural_calibration_v1.calibration_fingerprint', $contract['telemetry_parity_fields']);
     }
 
     public function test_apply_overlay_patch_preserves_canonical_fields_and_replaces_only_overlay_fields(): void

--- a/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
@@ -86,7 +86,7 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
 
         $this->assertSame('ENFP-T', $clear['type_code']);
         $this->assertSame('T', $clear['identity']);
-        $this->assertSame('mbti.personalization.phase9c.v1', $clear['schema_version']);
+        $this->assertSame('mbti.personalization.phase9e.v1', $clear['schema_version']);
         $this->assertSame('clear', data_get($clear, 'axis_bands.EI'));
         $this->assertSame('strong', data_get($strong, 'axis_bands.EI'));
         $this->assertSame(false, data_get($clear, 'boundary_flags.EI'));
@@ -102,6 +102,14 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
         $this->assertSame('controlled_narrative.v1', data_get($clear, 'controlled_narrative_v1.narrative_contract_version'));
         $this->assertSame('off', data_get($clear, 'controlled_narrative_v1.runtime_mode'));
         $this->assertSame('', data_get($clear, 'controlled_narrative_v1.narrative_intro'));
+        $this->assertSame('cultural_calibration.v1', data_get($clear, 'cultural_calibration_v1.version'));
+        $this->assertSame('zh-CN', data_get($clear, 'cultural_calibration_v1.locale_context'));
+        $this->assertSame('CN_MAINLAND.zh-CN', data_get($clear, 'cultural_calibration_v1.cultural_context'));
+        $this->assertSame('governance.v1', data_get($clear, 'cultural_calibration_v1.calibration_policy_version'));
+        $this->assertSame('content_governance', data_get($clear, 'cultural_calibration_v1.calibration_source'));
+        $this->assertContains('growth.next_actions', data_get($clear, 'cultural_calibration_v1.calibrated_section_keys', []));
+        $this->assertContains('career.next_step', data_get($clear, 'cultural_calibration_v1.calibrated_section_keys', []));
+        $this->assertNotSame('', trim((string) data_get($clear, 'cultural_calibration_v1.calibration_fingerprint')));
         $this->assertContains('working_life_v1', data_get($clear, 'narrative_runtime_contract_v1.truth_guard_fields', []));
         $this->assertSame('mbti.privacy_contract.v1', data_get($clear, 'privacy_contract_v1.version'));
         $this->assertSame(true, data_get($clear, 'privacy_contract_v1.consent_scope.subject_export'));
@@ -795,6 +803,8 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
         $this->assertSame('mock', data_get($personalization, 'narrative_runtime_contract_v1.runtime_mode'));
         $this->assertNotSame('', trim((string) data_get($personalization, 'controlled_narrative_v1.narrative_intro')));
         $this->assertNotSame('', trim((string) data_get($personalization, 'controlled_narrative_v1.narrative_summary')));
+        $this->assertSame('cultural_calibration.v1', data_get($personalization, 'cultural_calibration_v1.version'));
+        $this->assertSame('zh-CN', data_get($personalization, 'cultural_calibration_v1.locale_context'));
         $this->assertSame('INTJ-A', (string) ($personalization['type_code'] ?? ''));
         $this->assertSame('A', (string) ($personalization['identity'] ?? ''));
     }


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-9E: locale and cultural calibration layer.

It adds an authority-safe calibration layer so the same MBTI / Big Five truth can be expressed differently across locale and cultural context without changing canonical scoring or derived truth.

## What changed

Backend:
- adds `cultural_calibration_v1`
- derives:
  - `locale_context`
  - `cultural_context`
  - `calibrated_section_keys`
  - `calibration_fingerprint`
  - `calibration_contract_version`
  - `calibration_policy_version`
  - `calibration_source`
- integrates MBTI calibration with content governance
- exposes calibration through personalization, projection, read-path, and telemetry

## Why this matters

The platform is no longer only translated literally.
It now has a governed calibration layer that can adapt explanation tone, action framing, working-life framing, and communication guidance across locales while preserving the same underlying authority.

## Validation

I ran:

- `php artisan test tests/Unit/Services/Content/CulturalCalibrationLayerServiceTest.php tests/Unit/Services/Mbti/MbtiReadModelContractServiceTest.php tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php tests/Feature/V0_3/MbtiResultTelemetryContractTest.php tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php`

All passed:
- 15 tests passed
- 602 assertions

## Scope note

This PR does not:
- change canonical MBTI or Big Five truth
- introduce migrations or new dependencies
- move locale logic into the frontend
- expand into a global CMS or translation platform
