### PR TITLE
[codex] add V2 runtime truth guard for storage lifecycle

### DIFF
--- a/backend/app/Services/Content/ContentPackV2RemoteRehydrateService.php
+++ b/backend/app/Services/Content/ContentPackV2RemoteRehydrateService.php
@@ -118,6 +118,47 @@ final class ContentPackV2RemoteRehydrateService
         }
     }
 
+    /**
+     * @return array{
+     *   available:bool,
+     *   exact_manifest_id:int,
+     *   exact_identity_hash:string,
+     *   source_kind:string,
+     *   manifest_hash:string,
+     *   reason:?string
+     * }
+     */
+    public function probeRemoteFallback(object $release, string $disk): array
+    {
+        $disk = trim($disk);
+        if ($disk === '') {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_DISK_REQUIRED');
+        }
+
+        $exactManifest = $this->resolveExactManifest($release);
+        $plan = $this->rehydrateService->buildPlan((int) $exactManifest->getKey(), null, $disk);
+        if ((int) data_get($plan, 'summary.missing_locations', 0) > 0) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_REMOTE_COVERAGE_INCOMPLETE');
+        }
+
+        /** @var Collection<int,array<string,mixed>> $files */
+        $files = collect(is_array($plan['files'] ?? null) ? $plan['files'] : [])
+            ->filter(static fn ($file): bool => is_array($file))
+            ->values();
+        if ($files->isEmpty()) {
+            throw new RuntimeException('PACKS2_REMOTE_REHYDRATE_PLAN_EMPTY');
+        }
+
+        return [
+            'available' => true,
+            'exact_manifest_id' => (int) $exactManifest->getKey(),
+            'exact_identity_hash' => (string) $exactManifest->exact_identity_hash,
+            'source_kind' => (string) $exactManifest->source_kind,
+            'manifest_hash' => strtolower(trim((string) $exactManifest->manifest_hash)),
+            'reason' => null,
+        ];
+    }
+
     private function resolveExactManifest(object $release): ContentReleaseExactManifest
     {
         $releaseId = trim((string) ($release->id ?? ''));

--- a/backend/app/Services/Content/ContentPackV2RuntimeTruthService.php
+++ b/backend/app/Services/Content/ContentPackV2RuntimeTruthService.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use App\Services\Storage\ReleaseStorageLocator;
+
+final class ContentPackV2RuntimeTruthService
+{
+    public function __construct(
+        private readonly ReleaseStorageLocator $releaseStorageLocator,
+        private readonly ContentPackV2RemoteRehydrateService $remoteRehydrate,
+    ) {}
+
+    /**
+     * @return array{
+     *   primary_available:bool,
+     *   mirror_available:bool,
+     *   remote_fallback_available:bool,
+     *   runtime_safe_if_primary_removed:bool,
+     *   runtime_safe_if_mirror_removed:bool,
+     *   reason:?string,
+     *   remote_fallback_enabled:bool,
+     *   remote_fallback_reason:?string,
+     *   primary_root:string,
+     *   mirror_root:string
+     * }
+     */
+    public function inspectRelease(object $release, string $disk): array
+    {
+        $storagePath = trim((string) ($release->storage_path ?? ''));
+        [$primaryRoot, $mirrorRoot] = $this->resolveV2Roots($storagePath);
+
+        $primaryAvailable = $primaryRoot !== '' && $this->releaseStorageLocator->compiledDirFromRoot($primaryRoot) !== null;
+        $mirrorAvailable = $mirrorRoot !== '' && $this->releaseStorageLocator->compiledDirFromRoot($mirrorRoot) !== null;
+
+        $remoteFallbackEnabled = (bool) config('storage_rollout.packs_v2_remote_rehydrate_enabled', false);
+        $remoteFallbackAvailable = false;
+        $remoteFallbackReason = null;
+
+        if ($remoteFallbackEnabled) {
+            try {
+                $probe = $this->remoteRehydrate->probeRemoteFallback($release, $disk);
+                $remoteFallbackAvailable = (bool) ($probe['available'] ?? false);
+                $remoteFallbackReason = $remoteFallbackAvailable
+                    ? null
+                    : trim((string) ($probe['reason'] ?? 'PACKS2_REMOTE_REHYDRATE_PROBE_FAILED'));
+            } catch (\Throwable $e) {
+                $remoteFallbackReason = $e->getMessage();
+            }
+        } else {
+            $remoteFallbackReason = 'PACKS2_REMOTE_REHYDRATE_DISABLED';
+        }
+
+        $runtimeSafeIfPrimaryRemoved = $mirrorAvailable || $remoteFallbackAvailable;
+        $runtimeSafeIfMirrorRemoved = $primaryAvailable || $remoteFallbackAvailable;
+
+        $reason = null;
+        if (! $runtimeSafeIfPrimaryRemoved || ! $runtimeSafeIfMirrorRemoved) {
+            $reason = $remoteFallbackReason;
+        }
+
+        return [
+            'primary_available' => $primaryAvailable,
+            'mirror_available' => $mirrorAvailable,
+            'remote_fallback_available' => $remoteFallbackAvailable,
+            'runtime_safe_if_primary_removed' => $runtimeSafeIfPrimaryRemoved,
+            'runtime_safe_if_mirror_removed' => $runtimeSafeIfMirrorRemoved,
+            'reason' => $reason,
+            'remote_fallback_enabled' => $remoteFallbackEnabled,
+            'remote_fallback_reason' => $remoteFallbackReason,
+            'primary_root' => $primaryRoot,
+            'mirror_root' => $mirrorRoot,
+        ];
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    private function resolveV2Roots(string $storagePath): array
+    {
+        $primaryRoot = '';
+        $mirrorRoot = '';
+
+        foreach ($this->releaseStorageLocator->candidateRootsFromStoragePath($storagePath) as $root) {
+            $normalized = $this->normalizeRoot($root);
+            if ($normalized === '') {
+                continue;
+            }
+
+            if ($primaryRoot === '' && str_contains($normalized, '/app/private/packs_v2/')) {
+                $primaryRoot = $normalized;
+
+                continue;
+            }
+
+            if ($mirrorRoot === '' && str_contains($normalized, '/app/content_packs_v2/')) {
+                $mirrorRoot = $normalized;
+            }
+        }
+
+        return [$primaryRoot, $mirrorRoot];
+    }
+
+    private function normalizeRoot(string $root): string
+    {
+        return str_replace('\\', '/', rtrim(trim($root), '/\\'));
+    }
+}

--- a/backend/app/Services/Storage/ExactRootQuarantineService.php
+++ b/backend/app/Services/Storage/ExactRootQuarantineService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Storage;
 
 use App\Models\ContentReleaseExactManifest;
+use App\Services\Content\ContentPackV2RuntimeTruthService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 
@@ -23,6 +24,7 @@ final class ExactRootQuarantineService
     public function __construct(
         private readonly ExactReleaseRehydrateService $rehydrateService,
         private readonly ReleaseStorageLocator $releaseStorageLocator,
+        private readonly ContentPackV2RuntimeTruthService $v2RuntimeTruth,
     ) {}
 
     /**
@@ -367,6 +369,29 @@ final class ExactRootQuarantineService
                     'missing_locations' => $missingLocations,
                 ],
             ];
+        }
+
+        if ($sourceKind === 'v2.mirror' && $releaseId !== '') {
+            $release = DB::table('content_pack_releases')->where('id', $releaseId)->first();
+            if (! $release) {
+                return [
+                    'status' => 'blocked',
+                    'entry' => $baseEntry + [
+                        'reason' => 'linked_release_missing',
+                    ],
+                ];
+            }
+
+            $runtimeTruth = $this->v2RuntimeTruth->inspectRelease($release, $disk);
+            if (! (bool) ($runtimeTruth['runtime_safe_if_mirror_removed'] ?? false)) {
+                return [
+                    'status' => 'blocked',
+                    'entry' => $baseEntry + [
+                        'reason' => 'v2_runtime_not_safe_if_mirror_removed',
+                        'detail' => (string) ($runtimeTruth['reason'] ?? 'V2 mirror removal is not runtime safe.'),
+                    ],
+                ];
+            }
         }
 
         return [

--- a/backend/app/Services/Storage/QuarantinedRootPurgeService.php
+++ b/backend/app/Services/Storage/QuarantinedRootPurgeService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Storage;
 
 use App\Models\ContentReleaseExactManifest;
+use App\Services\Content\ContentPackV2RuntimeTruthService;
 use Illuminate\Support\Facades\File;
 
 final class QuarantinedRootPurgeService
@@ -24,6 +25,7 @@ final class QuarantinedRootPurgeService
     public function __construct(
         private readonly QuarantinedRootRestoreService $restoreService,
         private readonly ExactReleaseRehydrateService $rehydrateService,
+        private readonly ContentPackV2RuntimeTruthService $v2RuntimeTruth,
     ) {}
 
     /**
@@ -312,11 +314,38 @@ final class QuarantinedRootPurgeService
         }
         $validation['exact_child_rows_exist'] = true;
 
+        $releaseId = trim((string) ($manifest->content_pack_release_id ?? ''));
+        $runtimeTruth = null;
+        if ($sourceKind === 'v2.mirror' && $releaseId !== '') {
+            $release = \Illuminate\Support\Facades\DB::table('content_pack_releases')->where('id', $releaseId)->first();
+            if (! $release) {
+                throw new \RuntimeException('linked release row is missing.');
+            }
+
+            $runtimeTruth = $this->v2RuntimeTruth->inspectRelease($release, $disk);
+            if (! (bool) ($runtimeTruth['runtime_safe_if_mirror_removed'] ?? false)) {
+                throw new \RuntimeException('v2 mirror removal is not runtime safe: '.(string) ($runtimeTruth['reason'] ?? 'runtime guard blocked'));
+            }
+            $validation['v2_runtime_safe_if_mirror_removed'] = true;
+        }
+
         $restorePlan = $this->restoreService->buildPlan($itemRoot);
         if (($restorePlan['status'] ?? '') !== 'planned') {
-            throw new \RuntimeException('restore dry-run is blocked: '.(string) ($restorePlan['blocked_reason'] ?? 'restore blocked.'));
+            $restoreBlockedReason = (string) ($restorePlan['blocked_reason'] ?? 'restore blocked.');
+            $canBypassRestoreStableRootCheck = $sourceKind === 'v2.mirror'
+                && is_array($runtimeTruth)
+                && (bool) ($runtimeTruth['runtime_safe_if_mirror_removed'] ?? false)
+                && $restoreBlockedReason === 'linked release currently does not resolve to a stable runtime root.';
+
+            if (! $canBypassRestoreStableRootCheck) {
+                throw new \RuntimeException('restore dry-run is blocked: '.$restoreBlockedReason);
+            }
+
+            $validation['restore_dry_run_plannable'] = false;
+            $validation['restore_dry_run_equivalent_via_runtime_truth'] = true;
+        } else {
+            $validation['restore_dry_run_plannable'] = true;
         }
-        $validation['restore_dry_run_plannable'] = true;
 
         $rehydratePlan = $this->rehydrateService->buildPlan($exactManifestId, null, $disk);
         $missingLocations = (int) data_get($rehydratePlan, 'summary.missing_locations', 0);

--- a/backend/tests/Feature/Storage/ExactRootQuarantineServiceTest.php
+++ b/backend/tests/Feature/Storage/ExactRootQuarantineServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Storage;
 
+use App\Services\Content\ContentPackV2Resolver;
 use App\Services\Storage\ExactReleaseFileSetCatalogService;
 use App\Services\Storage\ExactRootQuarantineService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -206,6 +207,51 @@ final class ExactRootQuarantineServiceTest extends TestCase
         $this->assertFileExists($fixture['primary_root'].'/compiled/payload.compiled.json');
         $this->assertFileExists((string) ($quarantinedEntry['target_root'] ?? '').'/.quarantine.json');
         $this->assertSame($fixture['storage_path'], (string) DB::table('content_pack_releases')->where('id', $fixture['release_id'])->value('storage_path'));
+    }
+
+    public function test_service_blocks_v2_mirror_quarantine_when_primary_is_missing_and_remote_fallback_is_unavailable(): void
+    {
+        $fixture = $this->seedV2MirrorQuarantineFixture('v2_mirror_primary_missing_blocked');
+        File::deleteDirectory($fixture['primary_root']);
+
+        $service = app(ExactRootQuarantineService::class);
+        $plan = $service->buildPlan('s3');
+
+        $blockedEntry = collect((array) ($plan['blocked'] ?? []))
+            ->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+
+        $this->assertIsArray($blockedEntry);
+        $this->assertSame('v2_runtime_not_safe_if_mirror_removed', (string) ($blockedEntry['reason'] ?? ''));
+        $this->assertSame('PACKS2_REMOTE_REHYDRATE_DISABLED', (string) ($blockedEntry['detail'] ?? ''));
+        $this->assertDirectoryExists($fixture['mirror_root']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/packs_v2_materialized'));
+    }
+
+    public function test_service_allows_v2_mirror_quarantine_when_primary_is_missing_and_remote_fallback_is_available(): void
+    {
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', true);
+
+        $fixture = $this->seedV2MirrorQuarantineFixture('v2_mirror_primary_missing_remote_ok');
+        File::deleteDirectory($fixture['primary_root']);
+
+        $service = app(ExactRootQuarantineService::class);
+        $plan = $service->buildPlan('s3');
+
+        $candidate = collect((array) ($plan['candidates'] ?? []))
+            ->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+        $this->assertIsArray($candidate);
+
+        $result = $service->executePlan($plan);
+        $quarantinedEntry = collect((array) ($result['quarantined'] ?? []))
+            ->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+        $this->assertIsArray($quarantinedEntry);
+        $this->assertDirectoryDoesNotExist($fixture['mirror_root']);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $expectedMaterializedDir = storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.hash('sha256', $fixture['storage_path']).'/'.$fixture['manifest_hash'].'/compiled');
+        $this->assertSame($expectedMaterializedDir, $resolved);
     }
 
     public function test_service_rejects_tampered_plan_source_path_without_moving_arbitrary_directory(): void

--- a/backend/tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php
+++ b/backend/tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php
@@ -137,6 +137,51 @@ final class QuarantinedRootPurgeServiceTest extends TestCase
         $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
     }
 
+    public function test_service_blocks_v2_mirror_purge_when_primary_is_missing_and_remote_fallback_is_unavailable(): void
+    {
+        $fixture = $this->quarantineV2MirrorFixture('purge_v2_mirror_primary_missing_blocked');
+        File::deleteDirectory($fixture['primary_root']);
+
+        $service = app(QuarantinedRootPurgeService::class);
+        $plan = $service->buildPlan($fixture['item_root'], 's3');
+
+        $this->assertSame('blocked', (string) ($plan['status'] ?? ''));
+        $this->assertSame(
+            'v2 mirror removal is not runtime safe: PACKS2_REMOTE_REHYDRATE_DISABLED',
+            (string) ($plan['blocked_reason'] ?? '')
+        );
+        $this->assertDirectoryExists($fixture['item_root']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/packs_v2_materialized'));
+    }
+
+    public function test_service_purges_v2_mirror_when_primary_is_missing_and_remote_fallback_is_available(): void
+    {
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', true);
+
+        $fixture = $this->quarantineV2MirrorFixture('purge_v2_mirror_primary_missing_remote_ok');
+        File::deleteDirectory($fixture['primary_root']);
+
+        $service = app(QuarantinedRootPurgeService::class);
+        $plan = $service->buildPlan($fixture['item_root'], 's3');
+
+        $this->assertSame('planned', (string) ($plan['status'] ?? ''));
+        $this->assertSame('v2.mirror', (string) ($plan['source_kind'] ?? ''));
+
+        $result = $service->executePlan($plan, $fixture['item_root']);
+        $this->assertSame('success', (string) ($result['status'] ?? ''));
+        $this->assertDirectoryDoesNotExist($fixture['item_root']);
+        $this->assertFileExists((string) ($result['run_dir'] ?? '').'/run.json');
+        $this->assertFileExists((string) ($result['receipt_path'] ?? ''));
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $expectedMaterializedDir = storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.hash('sha256', 'private/packs_v2/BIG5_OCEAN/v1/'.$fixture['release_id']).'/'.$fixture['manifest_hash'].'/compiled');
+        $this->assertSame($expectedMaterializedDir, $resolved);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+        $this->assertSame(0, DB::table('content_pack_activations')->count());
+    }
+
     public function test_service_blocks_when_sentinel_or_exact_authority_or_remote_coverage_is_missing(): void
     {
         $fixture = $this->quarantineLegacySourcePackFixture('purge_blocked_sentinel');

--- a/backend/tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php
+++ b/backend/tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Content;
+
+use App\Services\Content\ContentPackV2RuntimeTruthService;
+use App\Services\Storage\ExactReleaseFileSetCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ContentPackV2RuntimeTruthServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-packs2-runtime-truth-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath);
+        $this->app->useStoragePath($this->isolatedStoragePath);
+
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', false);
+        config()->set('storage_rollout.resolver_materialization_enabled', false);
+        config()->set('storage_rollout.blob_offload_disk', 's3');
+        config()->set('filesystems.disks.s3.bucket', 'packs2-runtime-truth-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.packs2-runtime-truth.test');
+        Storage::forgetDisk('s3');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_truth_reports_mirror_removal_safe_when_primary_is_present(): void
+    {
+        $fixture = $this->seedV2ReleaseFixture('truth_primary_present', createPrimary: true, createMirror: true);
+
+        /** @var ContentPackV2RuntimeTruthService $service */
+        $service = app(ContentPackV2RuntimeTruthService::class);
+        $truth = $service->inspectRelease($fixture['release'], 's3');
+
+        $this->assertTrue((bool) $truth['primary_available']);
+        $this->assertTrue((bool) $truth['mirror_available']);
+        $this->assertFalse((bool) $truth['remote_fallback_available']);
+        $this->assertTrue((bool) $truth['runtime_safe_if_primary_removed']);
+        $this->assertTrue((bool) $truth['runtime_safe_if_mirror_removed']);
+        $this->assertNull($truth['reason']);
+    }
+
+    public function test_truth_blocks_mirror_removal_when_primary_is_missing_and_remote_fallback_is_disabled(): void
+    {
+        $fixture = $this->seedV2ReleaseFixture('truth_primary_missing_disabled', createPrimary: false, createMirror: true);
+
+        /** @var ContentPackV2RuntimeTruthService $service */
+        $service = app(ContentPackV2RuntimeTruthService::class);
+        $truth = $service->inspectRelease($fixture['release'], 's3');
+
+        $this->assertFalse((bool) $truth['primary_available']);
+        $this->assertTrue((bool) $truth['mirror_available']);
+        $this->assertFalse((bool) $truth['remote_fallback_available']);
+        $this->assertTrue((bool) $truth['runtime_safe_if_primary_removed']);
+        $this->assertFalse((bool) $truth['runtime_safe_if_mirror_removed']);
+        $this->assertSame('PACKS2_REMOTE_REHYDRATE_DISABLED', (string) $truth['reason']);
+    }
+
+    public function test_truth_allows_mirror_removal_when_primary_is_missing_and_remote_fallback_is_available(): void
+    {
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', true);
+        $fixture = $this->seedV2ReleaseFixture('truth_primary_missing_remote_ok', createPrimary: false, createMirror: true);
+
+        /** @var ContentPackV2RuntimeTruthService $service */
+        $service = app(ContentPackV2RuntimeTruthService::class);
+        $truth = $service->inspectRelease($fixture['release'], 's3');
+
+        $this->assertFalse((bool) $truth['primary_available']);
+        $this->assertTrue((bool) $truth['mirror_available']);
+        $this->assertTrue((bool) $truth['remote_fallback_available']);
+        $this->assertTrue((bool) $truth['runtime_safe_if_primary_removed']);
+        $this->assertTrue((bool) $truth['runtime_safe_if_mirror_removed']);
+        $this->assertNull($truth['reason']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/packs_v2_materialized'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+        $this->assertSame($fixture['storage_path'], (string) DB::table('content_pack_releases')->where('id', $fixture['release_id'])->value('storage_path'));
+    }
+
+    public function test_truth_blocks_mirror_removal_when_exact_manifest_or_remote_coverage_is_missing(): void
+    {
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', true);
+
+        $missingExact = $this->seedV2ReleaseFixture('truth_missing_exact', createPrimary: false, createMirror: true, createExactManifest: false);
+        /** @var ContentPackV2RuntimeTruthService $service */
+        $service = app(ContentPackV2RuntimeTruthService::class);
+        $missingExactTruth = $service->inspectRelease($missingExact['release'], 's3');
+        $this->assertFalse((bool) $missingExactTruth['runtime_safe_if_mirror_removed']);
+        $this->assertSame('PACKS2_REMOTE_REHYDRATE_EXACT_MANIFEST_NOT_FOUND', (string) $missingExactTruth['reason']);
+
+        $missingCoverage = $this->seedV2ReleaseFixture('truth_missing_remote', createPrimary: false, createMirror: true, createRemoteCoverage: false);
+        $missingCoverageTruth = $service->inspectRelease($missingCoverage['release'], 's3');
+        $this->assertFalse((bool) $missingCoverageTruth['runtime_safe_if_mirror_removed']);
+        $this->assertSame('PACKS2_REMOTE_REHYDRATE_REMOTE_COVERAGE_INCOMPLETE', (string) $missingCoverageTruth['reason']);
+    }
+
+    /**
+     * @return array{
+     *   release_id:string,
+     *   release:object,
+     *   storage_path:string
+     * }
+     */
+    private function seedV2ReleaseFixture(
+        string $suffix,
+        bool $createPrimary,
+        bool $createMirror,
+        bool $createExactManifest = true,
+        bool $createRemoteCoverage = true,
+    ): array {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        ['manifest_hash' => $manifestHash, 'files' => $files] = $this->buildRemoteFiles($suffix);
+
+        if ($createPrimary) {
+            $this->writeCompiledTree($primaryRoot, $files);
+        }
+
+        if ($createMirror) {
+            $this->writeCompiledTree($mirrorRoot, $files);
+        }
+
+        $this->insertRelease($releaseId, $manifestHash, $storagePath);
+        if ($createExactManifest) {
+            $this->seedExactManifest($releaseId, 'v2.mirror', $mirrorRoot, $manifestHash, $files, $createRemoteCoverage);
+        }
+
+        /** @var object $release */
+        $release = DB::table('content_pack_releases')->where('id', $releaseId)->first();
+
+        return [
+            'release_id' => $releaseId,
+            'release' => $release,
+            'storage_path' => $storagePath,
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function writeCompiledTree(string $root, array $files): void
+    {
+        foreach ($files as $logicalPath => $payload) {
+            $absolutePath = $root.'/'.str_replace('/', DIRECTORY_SEPARATOR, $logicalPath);
+            File::ensureDirectoryExists(dirname($absolutePath));
+            File::put($absolutePath, $payload);
+        }
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function seedExactManifest(
+        string $releaseId,
+        string $sourceKind,
+        string $sourceRoot,
+        string $manifestHash,
+        array $files,
+        bool $createRemoteCoverage = true,
+    ): object {
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => $sourceKind,
+            'source_disk' => 'local',
+            'source_storage_path' => $sourceRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => $manifestHash,
+            'content_hash' => hash('sha256', 'content|'.$manifestHash),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$manifestHash,
+            'payload_json' => ['runtime_truth' => true],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            if (! $createRemoteCoverage) {
+                continue;
+            }
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->updateOrInsert(
+                [
+                    'disk' => 's3',
+                    'storage_path' => $remotePath,
+                ],
+                [
+                    'blob_hash' => $hash,
+                    'location_kind' => 'remote_copy',
+                    'size_bytes' => strlen($payload),
+                    'checksum' => 'sha256:'.$hash,
+                    'etag' => 'etag-'.substr($hash, 0, 8),
+                    'storage_class' => 'STANDARD_IA',
+                    'verified_at' => now(),
+                    'meta_json' => json_encode([
+                        'bucket' => 'packs2-runtime-truth-bucket',
+                        'region' => 'ap-guangzhou',
+                        'endpoint' => 'https://cos.packs2-runtime-truth.test',
+                        'url' => 'https://cos.packs2-runtime-truth.test/'.$remotePath,
+                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]
+            );
+        }
+
+        return $manifest;
+    }
+
+    /**
+     * @return array{manifest_hash:string,files:array<string,string>}
+     */
+    private function buildRemoteFiles(string $suffix): array
+    {
+        $manifestPayload = json_encode([
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($manifestPayload);
+
+        return [
+            'manifest_hash' => hash('sha256', $manifestPayload),
+            'files' => [
+                'compiled/manifest.json' => $manifestPayload,
+                'compiled/questions.compiled.json' => json_encode([
+                    'source' => $suffix,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'compiled/layout.compiled.json' => json_encode([
+                    'layout' => $suffix,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ],
+        ];
+    }
+
+    private function insertRelease(string $releaseId, string $manifestHash, string $storagePath): void
+    {
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => 'packs2_publish',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v1',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => 'test',
+            'created_by' => 'test',
+            'manifest_hash' => $manifestHash,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => null,
+            'norms_version' => null,
+            'git_sha' => null,
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $storagePath,
+            'source_commit' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared V2 runtime truth guard for lifecycle safety decisions
- expose a read-only remote fallback probe from the V2 remote rehydrate service
- harden v2.mirror quarantine/purge when primary is missing and remote fallback is unavailable

## Tests
- vendor/bin/phpunit tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php tests/Feature/Storage/ExactRootQuarantineServiceTest.php tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php
- php artisan migrate
- curl -i http://127.0.0.1:18081/api/healthz
- bash backend/scripts/ci_verify_mbti.sh
