### PR TITLE
[codex] enable v2 primary quarantine restore purge lifecycle

### DIFF
--- a/backend/app/Services/Storage/ExactRootQuarantineService.php
+++ b/backend/app/Services/Storage/ExactRootQuarantineService.php
@@ -17,6 +17,7 @@ final class ExactRootQuarantineService
     private const ALLOWED_SOURCE_KINDS = [
         'legacy.source_pack',
         'v2.mirror',
+        'v2.primary',
     ];
 
     private const PLAN_SCHEMA = 'storage_quarantine_exact_roots_plan.v1';
@@ -371,7 +372,7 @@ final class ExactRootQuarantineService
             ];
         }
 
-        if ($sourceKind === 'v2.mirror' && $releaseId !== '') {
+        if (in_array($sourceKind, ['v2.mirror', 'v2.primary'], true) && $releaseId !== '') {
             $release = DB::table('content_pack_releases')->where('id', $releaseId)->first();
             if (! $release) {
                 return [
@@ -383,12 +384,17 @@ final class ExactRootQuarantineService
             }
 
             $runtimeTruth = $this->v2RuntimeTruth->inspectRelease($release, $disk);
-            if (! (bool) ($runtimeTruth['runtime_safe_if_mirror_removed'] ?? false)) {
+            $runtimeSafe = $sourceKind === 'v2.primary'
+                ? (bool) ($runtimeTruth['runtime_safe_if_primary_removed'] ?? false)
+                : (bool) ($runtimeTruth['runtime_safe_if_mirror_removed'] ?? false);
+            if (! $runtimeSafe) {
                 return [
                     'status' => 'blocked',
                     'entry' => $baseEntry + [
-                        'reason' => 'v2_runtime_not_safe_if_mirror_removed',
-                        'detail' => (string) ($runtimeTruth['reason'] ?? 'V2 mirror removal is not runtime safe.'),
+                        'reason' => $sourceKind === 'v2.primary'
+                            ? 'v2_runtime_not_safe_if_primary_removed'
+                            : 'v2_runtime_not_safe_if_mirror_removed',
+                        'detail' => (string) ($runtimeTruth['reason'] ?? sprintf('V2 %s removal is not runtime safe.', $sourceKind === 'v2.primary' ? 'primary' : 'mirror')),
                     ],
                 ];
             }

--- a/backend/app/Services/Storage/QuarantinedRootPurgeService.php
+++ b/backend/app/Services/Storage/QuarantinedRootPurgeService.php
@@ -16,6 +16,7 @@ final class QuarantinedRootPurgeService
     private const ALLOWED_SOURCE_KINDS = [
         'legacy.source_pack',
         'v2.mirror',
+        'v2.primary',
     ];
 
     private const PLAN_SCHEMA = 'storage_purge_quarantined_root_plan.v1';
@@ -316,17 +317,26 @@ final class QuarantinedRootPurgeService
 
         $releaseId = trim((string) ($manifest->content_pack_release_id ?? ''));
         $runtimeTruth = null;
-        if ($sourceKind === 'v2.mirror' && $releaseId !== '') {
+        if (in_array($sourceKind, ['v2.mirror', 'v2.primary'], true) && $releaseId !== '') {
             $release = \Illuminate\Support\Facades\DB::table('content_pack_releases')->where('id', $releaseId)->first();
             if (! $release) {
                 throw new \RuntimeException('linked release row is missing.');
             }
 
             $runtimeTruth = $this->v2RuntimeTruth->inspectRelease($release, $disk);
-            if (! (bool) ($runtimeTruth['runtime_safe_if_mirror_removed'] ?? false)) {
-                throw new \RuntimeException('v2 mirror removal is not runtime safe: '.(string) ($runtimeTruth['reason'] ?? 'runtime guard blocked'));
+            $runtimeSafe = $sourceKind === 'v2.primary'
+                ? (bool) ($runtimeTruth['runtime_safe_if_primary_removed'] ?? false)
+                : (bool) ($runtimeTruth['runtime_safe_if_mirror_removed'] ?? false);
+            if (! $runtimeSafe) {
+                throw new \RuntimeException(sprintf(
+                    'v2 %s removal is not runtime safe: %s',
+                    $sourceKind === 'v2.primary' ? 'primary' : 'mirror',
+                    (string) ($runtimeTruth['reason'] ?? 'runtime guard blocked')
+                ));
             }
-            $validation['v2_runtime_safe_if_mirror_removed'] = true;
+            $validation[$sourceKind === 'v2.primary'
+                ? 'v2_runtime_safe_if_primary_removed'
+                : 'v2_runtime_safe_if_mirror_removed'] = true;
         }
 
         $restorePlan = $this->restoreService->buildPlan($itemRoot);

--- a/backend/app/Services/Storage/QuarantinedRootRestoreService.php
+++ b/backend/app/Services/Storage/QuarantinedRootRestoreService.php
@@ -15,6 +15,8 @@ final class QuarantinedRootRestoreService
 
     private const V2_MIRROR_SOURCE_KIND = 'v2.mirror';
 
+    private const V2_PRIMARY_SOURCE_KIND = 'v2.primary';
+
     private const PLAN_SCHEMA = 'storage_restore_quarantined_root_plan.v1';
 
     private const RUN_SCHEMA = 'storage_restore_quarantined_root_run.v1';
@@ -242,7 +244,7 @@ final class QuarantinedRootRestoreService
         }
 
         $sourceKind = trim((string) ($sentinel['source_kind'] ?? ''));
-        if (! in_array($sourceKind, [self::LEGACY_SOURCE_KIND, self::V2_MIRROR_SOURCE_KIND], true)) {
+        if (! in_array($sourceKind, [self::LEGACY_SOURCE_KIND, self::V2_MIRROR_SOURCE_KIND, self::V2_PRIMARY_SOURCE_KIND], true)) {
             throw new \RuntimeException('restore source_kind is not allowed.');
         }
 
@@ -334,7 +336,7 @@ final class QuarantinedRootRestoreService
                 $validation['linked_release_runtime_source_matches_target'] = $resolvedSource === null
                     ? null
                     : true;
-            } else {
+            } elseif ($sourceKind === self::V2_MIRROR_SOURCE_KIND) {
                 if ($resolvedSource === null) {
                     throw new \RuntimeException('linked release currently does not resolve to a stable runtime root.');
                 }
@@ -342,6 +344,14 @@ final class QuarantinedRootRestoreService
                 $resolvedRuntimeRoot = $this->normalizeRoot((string) ($resolvedSource['root'] ?? ''));
                 if ($resolvedRuntimeRoot === $targetRoot) {
                     throw new \RuntimeException('linked release currently resolves to the mirror target.');
+                }
+                $validation['linked_release_runtime_source_preserved'] = true;
+            } else {
+                if ($resolvedSource !== null) {
+                    $resolvedRuntimeRoot = $this->normalizeRoot((string) ($resolvedSource['root'] ?? ''));
+                    if (! in_array($resolvedRuntimeRoot, $candidateRoots, true)) {
+                        throw new \RuntimeException('linked release currently resolves outside the V2 runtime root set.');
+                    }
                 }
                 $validation['linked_release_runtime_source_preserved'] = true;
             }
@@ -482,6 +492,7 @@ final class QuarantinedRootRestoreService
         string $releaseId
     ): void {
         $contentReleasesRoot = $this->normalizeRoot(storage_path('app/private/content_releases'));
+        $privatePacksV2Root = $this->normalizeRoot(storage_path('app/private/packs_v2'));
         $contentPacksV2Root = $this->normalizeRoot(storage_path('app/content_packs_v2'));
         $backupsRoot = $this->normalizeRoot(storage_path('app/private/content_releases/backups'));
         $defaultRoot = $this->normalizeRoot(rtrim((string) config('content_packs.root', ''), '/\\'));
@@ -510,6 +521,22 @@ final class QuarantinedRootRestoreService
             $contentReleasesPattern = '#^'.preg_quote($contentReleasesRoot, '#').'/[^/]+/source_pack$#';
             if (preg_match($contentReleasesPattern, $targetRoot) !== 1) {
                 throw new \RuntimeException('restore target must match legacy content_releases/{release_id}/source_pack shape.');
+            }
+        } elseif ($sourceKind === self::V2_PRIMARY_SOURCE_KIND) {
+            if (! $this->isUnderPrefix($targetRoot, $privatePacksV2Root)) {
+                throw new \RuntimeException('restore target is outside the V2 primary allowlist.');
+            }
+
+            if ($packId === '' || $packVersion === '' || $releaseId === '') {
+                throw new \RuntimeException('restore target is missing V2 primary identity context.');
+            }
+
+            $primaryPattern = '#^'.preg_quote($privatePacksV2Root, '#')
+                .'/'.preg_quote($packId, '#')
+                .'/'.preg_quote($packVersion, '#')
+                .'/'.preg_quote($releaseId, '#').'$#';
+            if (preg_match($primaryPattern, $targetRoot) !== 1) {
+                throw new \RuntimeException('restore target must match V2 primary private/packs_v2/{pack_id}/{pack_version}/{release_id} shape.');
             }
         } elseif ($sourceKind === self::V2_MIRROR_SOURCE_KIND) {
             if (! $this->isUnderPrefix($targetRoot, $contentPacksV2Root)) {

--- a/backend/tests/Feature/Storage/ExactRootQuarantineServiceTest.php
+++ b/backend/tests/Feature/Storage/ExactRootQuarantineServiceTest.php
@@ -254,6 +254,49 @@ final class ExactRootQuarantineServiceTest extends TestCase
         $this->assertSame($expectedMaterializedDir, $resolved);
     }
 
+    public function test_service_quarantines_v2_primary_when_runtime_safe_if_primary_removed(): void
+    {
+        $fixture = $this->seedV2PrimaryQuarantineFixture('v2_primary_quarantine_ok');
+        $service = app(ExactRootQuarantineService::class);
+
+        $plan = $service->buildPlan('s3');
+        $candidate = collect((array) ($plan['candidates'] ?? []))
+            ->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+
+        $this->assertIsArray($candidate);
+        $this->assertSame('v2.primary', (string) ($candidate['source_kind'] ?? ''));
+
+        $result = $service->executePlan($plan);
+        $quarantinedEntry = collect((array) ($result['quarantined'] ?? []))
+            ->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+
+        $this->assertIsArray($quarantinedEntry);
+        $this->assertDirectoryDoesNotExist($fixture['primary_root']);
+        $this->assertDirectoryExists($fixture['mirror_root']);
+        $this->assertSame($fixture['storage_path'], (string) DB::table('content_pack_releases')->where('id', $fixture['release_id'])->value('storage_path'));
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['mirror_root'].'/compiled', $resolved);
+    }
+
+    public function test_service_blocks_v2_primary_quarantine_when_runtime_unsafe_if_primary_removed(): void
+    {
+        $fixture = $this->seedV2PrimaryQuarantineFixture('v2_primary_quarantine_blocked', createMirror: false);
+        $service = app(ExactRootQuarantineService::class);
+
+        $plan = $service->buildPlan('s3');
+        $blockedEntry = collect((array) ($plan['blocked'] ?? []))
+            ->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+
+        $this->assertIsArray($blockedEntry);
+        $this->assertSame('v2_runtime_not_safe_if_primary_removed', (string) ($blockedEntry['reason'] ?? ''));
+        $this->assertSame('PACKS2_REMOTE_REHYDRATE_DISABLED', (string) ($blockedEntry['detail'] ?? ''));
+        $this->assertDirectoryExists($fixture['primary_root']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/packs_v2_materialized'));
+    }
+
     public function test_service_rejects_tampered_plan_source_path_without_moving_arbitrary_directory(): void
     {
         $releaseId = (string) Str::uuid();
@@ -461,6 +504,106 @@ final class ExactRootQuarantineServiceTest extends TestCase
             'source_kind' => 'v2.mirror',
             'source_disk' => 'local',
             'source_storage_path' => $mirrorRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'quarantine-test-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.quarantine.test',
+                    'url' => 'https://cos.quarantine.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        return [
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'manifest_hash' => $manifestHash,
+            'mirror_root' => $mirrorRoot,
+            'primary_root' => $primaryRoot,
+            'release_id' => $releaseId,
+            'storage_path' => $storagePath,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   exact_manifest_id:int,
+     *   manifest_hash:string,
+     *   mirror_root:string,
+     *   primary_root:string,
+     *   release_id:string,
+     *   storage_path:string
+     * }
+     */
+    private function seedV2PrimaryQuarantineFixture(string $suffix, bool $createMirror = true): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        if ($createMirror) {
+            $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        }
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.primary',
+            'source_disk' => 'local',
+            'source_storage_path' => $primaryRoot,
             'manifest_hash' => $manifestHash,
             'pack_id' => 'BIG5_OCEAN',
             'pack_version' => 'v1',

--- a/backend/tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php
+++ b/backend/tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php
@@ -182,6 +182,60 @@ final class QuarantinedRootPurgeServiceTest extends TestCase
         $this->assertSame(0, DB::table('content_pack_activations')->count());
     }
 
+    public function test_service_builds_plan_and_purges_valid_quarantined_v2_primary_when_runtime_safe_if_primary_removed(): void
+    {
+        $fixture = $this->quarantineV2PrimaryFixture('purge_v2_primary_valid');
+        $service = app(QuarantinedRootPurgeService::class);
+
+        $plan = $service->buildPlan($fixture['item_root'], 's3');
+
+        $this->assertSame('planned', (string) ($plan['status'] ?? ''));
+        $this->assertSame('v2.primary', (string) ($plan['source_kind'] ?? ''));
+        $this->assertSame($fixture['item_root'], (string) ($plan['item_root'] ?? ''));
+        $this->assertSame($fixture['exact_manifest_id'], (int) ($plan['exact_manifest_id'] ?? 0));
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolvedBefore = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['mirror_root'].'/compiled', $resolvedBefore);
+
+        $result = $service->executePlan($plan, $fixture['item_root']);
+
+        $this->assertSame('success', (string) ($result['status'] ?? ''));
+        $this->assertDirectoryDoesNotExist($fixture['item_root']);
+        $this->assertDirectoryExists($fixture['mirror_root']);
+        $this->assertFileExists((string) ($result['run_dir'] ?? '').'/run.json');
+        $this->assertFileExists((string) ($result['receipt_path'] ?? ''));
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+
+        $resolvedAfter = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['mirror_root'].'/compiled', $resolvedAfter);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+        $this->assertSame(0, DB::table('content_pack_activations')->count());
+    }
+
+    public function test_service_blocks_v2_primary_purge_when_runtime_unsafe_if_primary_removed(): void
+    {
+        $fixture = $this->quarantineV2PrimaryFixture('purge_v2_primary_blocked', createMirror: false);
+        $service = app(QuarantinedRootPurgeService::class);
+
+        $plan = $service->buildPlan($fixture['item_root'], 's3');
+
+        $this->assertSame('blocked', (string) ($plan['status'] ?? ''));
+        $this->assertSame(
+            'v2 primary removal is not runtime safe: PACKS2_REMOTE_REHYDRATE_DISABLED',
+            (string) ($plan['blocked_reason'] ?? '')
+        );
+        $this->assertDirectoryExists($fixture['item_root']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/packs_v2_materialized'));
+    }
+
     public function test_service_blocks_when_sentinel_or_exact_authority_or_remote_coverage_is_missing(): void
     {
         $fixture = $this->quarantineLegacySourcePackFixture('purge_blocked_sentinel');
@@ -467,6 +521,114 @@ final class QuarantinedRootPurgeServiceTest extends TestCase
             'item_root' => (string) ($quarantinedEntry['target_root'] ?? ''),
             'mirror_root' => $mirrorRoot,
             'primary_root' => $primaryRoot,
+            'release_id' => $releaseId,
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'manifest_hash' => $manifestHash,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   item_root:string,
+     *   primary_root:string,
+     *   mirror_root:string,
+     *   release_id:string,
+     *   exact_manifest_id:int,
+     *   manifest_hash:string
+     * }
+     */
+    private function quarantineV2PrimaryFixture(string $suffix, bool $createMirror = true): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.primary',
+            'source_disk' => 'local',
+            'source_storage_path' => $primaryRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'purge-service-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.purge-service.test',
+                    'url' => 'https://cos.purge-service.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $quarantinePlan = app(ExactRootQuarantineService::class)->buildPlan('s3');
+        $quarantineResult = app(ExactRootQuarantineService::class)->executePlan($quarantinePlan);
+        $quarantinedEntry = collect((array) ($quarantineResult['quarantined'] ?? []))
+            ->firstWhere('exact_manifest_id', (int) $manifest->getKey());
+        $this->assertIsArray($quarantinedEntry);
+
+        if (! $createMirror && is_dir($mirrorRoot)) {
+            File::deleteDirectory($mirrorRoot);
+        }
+
+        return [
+            'item_root' => (string) ($quarantinedEntry['target_root'] ?? ''),
+            'primary_root' => $primaryRoot,
+            'mirror_root' => $mirrorRoot,
             'release_id' => $releaseId,
             'exact_manifest_id' => (int) $manifest->getKey(),
             'manifest_hash' => $manifestHash,

--- a/backend/tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php
+++ b/backend/tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php
@@ -135,6 +135,39 @@ final class QuarantinedRootRestoreServiceTest extends TestCase
         $this->assertSame($fixture['primary_root'].'/compiled', $resolved);
     }
 
+    public function test_service_restores_valid_quarantined_v2_primary_back_to_original_primary_path(): void
+    {
+        $fixture = $this->quarantineV2PrimaryFixture('restore_v2_primary_success');
+        $service = app(QuarantinedRootRestoreService::class);
+
+        $plan = $service->buildPlan($fixture['item_root']);
+
+        $this->assertSame('planned', (string) ($plan['status'] ?? ''));
+        $this->assertSame('v2.primary', (string) ($plan['source_kind'] ?? ''));
+        $this->assertSame($fixture['primary_root'], (string) ($plan['target_root'] ?? ''));
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        $result = $service->executePlan($plan, $fixture['item_root']);
+
+        $this->assertSame('success', (string) ($result['status'] ?? ''));
+        $this->assertDirectoryExists($fixture['primary_root']);
+        $this->assertDirectoryDoesNotExist($fixture['item_root']);
+        $this->assertDirectoryExists($fixture['mirror_root']);
+        $this->assertFileDoesNotExist($fixture['primary_root'].'/.quarantine.json');
+        $this->assertRootMatchesExactAuthority($fixture['primary_root'], $fixture['files'], $fixture['manifest_hash']);
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['primary_root'].'/compiled', $resolved);
+    }
+
     public function test_service_blocks_when_target_exists_or_sentinel_is_invalid_or_source_kind_not_allowed(): void
     {
         $fixture = $this->quarantineLegacySourcePackFixture('restore_blocked_target_exists');
@@ -158,7 +191,7 @@ final class QuarantinedRootRestoreServiceTest extends TestCase
 
         $fixture = $this->quarantineLegacySourcePackFixture('restore_blocked_source_kind');
         $sentinel = json_decode((string) File::get($fixture['item_root'].'/.quarantine.json'), true);
-        $sentinel['source_kind'] = 'v2.primary';
+        $sentinel['source_kind'] = 'v2.primary.shadow';
         File::put($fixture['item_root'].'/.quarantine.json', json_encode($sentinel, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
 
         $sourceKindPlan = $service->buildPlan($fixture['item_root']);
@@ -246,6 +279,17 @@ final class QuarantinedRootRestoreServiceTest extends TestCase
         $this->assertSame(
             'restore target must match legacy content_releases/{release_id}/source_pack shape.',
             (string) ($invalidShapePlan['blocked_reason'] ?? '')
+        );
+
+        $invalidPrimaryFixture = $this->quarantineV2PrimaryFixture(
+            'restore_blocked_invalid_primary_shape',
+            storage_path('app/private/packs_v2/BIG5_OCEAN/v1/nested/'.Str::uuid())
+        );
+        $invalidPrimaryPlan = $service->buildPlan($invalidPrimaryFixture['item_root']);
+        $this->assertSame('blocked', (string) ($invalidPrimaryPlan['status'] ?? ''));
+        $this->assertSame(
+            'restore target must match V2 primary private/packs_v2/{pack_id}/{pack_version}/{release_id} shape.',
+            (string) ($invalidPrimaryPlan['blocked_reason'] ?? '')
         );
     }
 
@@ -464,6 +508,112 @@ final class QuarantinedRootRestoreServiceTest extends TestCase
             'item_root' => (string) ($quarantinedEntry['target_root'] ?? ''),
             'mirror_root' => $mirrorRoot,
             'primary_root' => $primaryRoot,
+            'release_id' => $releaseId,
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'manifest_hash' => $manifestHash,
+            'files' => $files,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   item_root:string,
+     *   primary_root:string,
+     *   mirror_root:string,
+     *   release_id:string,
+     *   exact_manifest_id:int,
+     *   manifest_hash:string,
+     *   files:array<string,string>
+     * }
+     */
+    private function quarantineV2PrimaryFixture(string $suffix, ?string $primaryRoot = null): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot ??= storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.primary',
+            'source_disk' => 'local',
+            'source_storage_path' => $primaryRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'restore-service-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.restore-service.test',
+                    'url' => 'https://cos.restore-service.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $quarantinePlan = app(ExactRootQuarantineService::class)->buildPlan('s3');
+        $quarantineResult = app(ExactRootQuarantineService::class)->executePlan($quarantinePlan);
+        $quarantinedEntry = collect((array) ($quarantineResult['quarantined'] ?? []))
+            ->firstWhere('exact_manifest_id', (int) $manifest->getKey());
+        $this->assertIsArray($quarantinedEntry);
+
+        return [
+            'item_root' => (string) ($quarantinedEntry['target_root'] ?? ''),
+            'primary_root' => $primaryRoot,
+            'mirror_root' => $mirrorRoot,
             'release_id' => $releaseId,
             'exact_manifest_id' => (int) $manifest->getKey(),
             'manifest_hash' => $manifestHash,

--- a/backend/tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php
+++ b/backend/tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php
@@ -232,6 +232,53 @@ final class StoragePurgeQuarantinedRootCommandTest extends TestCase
         $this->assertSame($fixture['primary_root'].'/compiled', $resolvedAfter);
     }
 
+    public function test_command_plans_and_executes_purge_for_quarantined_v2_primary_when_runtime_safe_if_primary_removed(): void
+    {
+        $fixture = $this->quarantineV2PrimaryFixture('command_purge_v2_primary_success');
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolvedBefore = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['mirror_root'].'/compiled', $resolvedBefore);
+
+        $this->assertSame(0, Artisan::call('storage:purge-quarantined-root', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--item-root' => $fixture['item_root'],
+        ]));
+
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('source_kind=v2.primary', $dryRunOutput);
+        $planPath = $this->extractOutputValue($dryRunOutput, 'plan');
+        $this->assertFileExists($planPath);
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        $this->assertSame(0, Artisan::call('storage:purge-quarantined-root', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=success', $executeOutput);
+        $runDir = $this->extractOutputValue($executeOutput, 'run_dir');
+        $receiptPath = $this->extractOutputValue($executeOutput, 'receipt');
+        $this->assertFileExists($runDir.'/run.json');
+        $this->assertFileExists($receiptPath);
+        $this->assertDirectoryDoesNotExist($fixture['item_root']);
+        $this->assertDirectoryExists($fixture['mirror_root']);
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+
+        $resolvedAfter = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['mirror_root'].'/compiled', $resolvedAfter);
+    }
+
     /**
      * @return array{item_root:string,release_id:string}
      */
@@ -439,6 +486,123 @@ final class StoragePurgeQuarantinedRootCommandTest extends TestCase
         $runDir = $this->extractOutputValue(Artisan::output(), 'run_dir');
         $itemRoot = collect((array) json_decode((string) File::get($runDir.'/run.json'), true)['quarantined'] ?? [])
             ->firstWhere('source_storage_path', $mirrorRoot)['target_root'] ?? '';
+        $this->assertNotSame('', $itemRoot);
+
+        return [
+            'item_root' => $itemRoot,
+            'release_id' => $releaseId,
+            'primary_root' => $primaryRoot,
+            'mirror_root' => $mirrorRoot,
+            'manifest_hash' => $manifestHash,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   item_root:string,
+     *   release_id:string,
+     *   primary_root:string,
+     *   mirror_root:string,
+     *   manifest_hash:string
+     * }
+     */
+    private function quarantineV2PrimaryFixture(string $suffix, bool $createMirror = true): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        if ($createMirror) {
+            $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        }
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.primary',
+            'source_disk' => 'local',
+            'source_storage_path' => $primaryRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'purge-command-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.purge-command.test',
+                    'url' => 'https://cos.purge-command.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $quarantinePlan = Artisan::call('storage:quarantine-exact-roots', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]);
+        $this->assertSame(0, $quarantinePlan);
+        $planPath = $this->extractOutputValue(Artisan::output(), 'plan');
+
+        $quarantineExecute = Artisan::call('storage:quarantine-exact-roots', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]);
+        $this->assertSame(0, $quarantineExecute);
+
+        $runDir = $this->extractOutputValue(Artisan::output(), 'run_dir');
+        $itemRoot = collect((array) json_decode((string) File::get($runDir.'/run.json'), true)['quarantined'] ?? [])
+            ->firstWhere('source_storage_path', $primaryRoot)['target_root'] ?? '';
         $this->assertNotSame('', $itemRoot);
 
         return [

--- a/backend/tests/Feature/Storage/StorageQuarantineExactRootsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageQuarantineExactRootsCommandTest.php
@@ -247,6 +247,48 @@ final class StorageQuarantineExactRootsCommandTest extends TestCase
             ->value('storage_path'));
     }
 
+    public function test_command_can_quarantine_v2_primary_when_runtime_safe_if_primary_removed(): void
+    {
+        $fixture = $this->seedV2PrimaryExactRootFixture('command_v2_primary_quarantine');
+
+        $this->assertSame(0, Artisan::call('storage:quarantine-exact-roots', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $planPath = $this->extractOutputValue($dryRunOutput, 'plan');
+        $this->assertFileExists($planPath);
+
+        $plan = json_decode((string) File::get($planPath), true);
+        $this->assertIsArray($plan);
+        $primaryCandidate = collect((array) ($plan['candidates'] ?? []))
+            ->firstWhere('exact_manifest_id', $fixture['exact_manifest_id']);
+        $this->assertIsArray($primaryCandidate);
+        $this->assertSame('v2.primary', (string) ($primaryCandidate['source_kind'] ?? ''));
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        $this->assertSame(0, Artisan::call('storage:quarantine-exact-roots', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $runDir = $this->extractOutputValue($executeOutput, 'run_dir');
+        $this->assertFileExists($runDir.'/run.json');
+        $this->assertDirectoryDoesNotExist($fixture['primary_root']);
+        $this->assertDirectoryExists($fixture['mirror_root']);
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+    }
+
     /**
      * @return array{manifest_blob_hash:string}
      */
@@ -330,6 +372,100 @@ final class StorageQuarantineExactRootsCommandTest extends TestCase
 
         return [
             'manifest_blob_hash' => hash('sha256', $files['compiled/manifest.json']),
+        ];
+    }
+
+    /**
+     * @return array{
+     *   exact_manifest_id:int,
+     *   release_id:string,
+     *   primary_root:string,
+     *   mirror_root:string
+     * }
+     */
+    private function seedV2PrimaryExactRootFixture(string $suffix): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.primary',
+            'source_disk' => 'local',
+            'source_storage_path' => $primaryRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'quarantine-command-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.quarantine-command.test',
+                    'url' => 'https://cos.quarantine-command.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        return [
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'release_id' => $releaseId,
+            'primary_root' => $primaryRoot,
+            'mirror_root' => $mirrorRoot,
         ];
     }
 

--- a/backend/tests/Feature/Storage/StorageRestoreQuarantinedRootCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageRestoreQuarantinedRootCommandTest.php
@@ -218,6 +218,48 @@ final class StorageRestoreQuarantinedRootCommandTest extends TestCase
         $this->assertSame($fixture['primary_root'].'/compiled', $resolved);
     }
 
+    public function test_command_plans_and_executes_restore_for_quarantined_v2_primary(): void
+    {
+        $fixture = $this->quarantineV2PrimaryFixture('command_restore_v2_primary_success');
+
+        $this->assertSame(0, Artisan::call('storage:restore-quarantined-root', [
+            '--dry-run' => true,
+            '--item-root' => $fixture['item_root'],
+        ]));
+
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('source_kind=v2.primary', $dryRunOutput);
+        $planPath = $this->extractOutputValue($dryRunOutput, 'plan');
+        $this->assertFileExists($planPath);
+
+        $releaseStoragePathBefore = DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path');
+
+        $this->assertSame(0, Artisan::call('storage:restore-quarantined-root', [
+            '--execute' => true,
+            '--plan' => $planPath,
+        ]));
+
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=success', $executeOutput);
+        $runDir = $this->extractOutputValue($executeOutput, 'run_dir');
+        $this->assertFileExists($runDir.'/run.json');
+        $this->assertDirectoryExists($fixture['primary_root']);
+        $this->assertDirectoryDoesNotExist($fixture['item_root']);
+        $this->assertDirectoryExists($fixture['mirror_root']);
+        $this->assertFileDoesNotExist($fixture['primary_root'].'/.quarantine.json');
+        $this->assertSame($releaseStoragePathBefore, DB::table('content_pack_releases')
+            ->where('id', $fixture['release_id'])
+            ->value('storage_path'));
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $fixture['manifest_hash']);
+        $this->assertSame($fixture['primary_root'].'/compiled', $resolved);
+    }
+
     /**
      * @return array{item_root:string,source_root:string,release_id:string}
      */
@@ -425,6 +467,119 @@ final class StorageRestoreQuarantinedRootCommandTest extends TestCase
             'item_root' => $itemRoot,
             'mirror_root' => $mirrorRoot,
             'primary_root' => $primaryRoot,
+            'release_id' => $releaseId,
+            'manifest_hash' => $manifestHash,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   item_root:string,
+     *   primary_root:string,
+     *   mirror_root:string,
+     *   release_id:string,
+     *   manifest_hash:string
+     * }
+     */
+    private function quarantineV2PrimaryFixture(string $suffix): array
+    {
+        $releaseId = (string) Str::uuid();
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $primaryRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+        $files = $this->createCompiledTree($primaryRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $this->createCompiledTree($mirrorRoot, 'BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $files['compiled/manifest.json']);
+        $this->insertV2Release($releaseId, 'BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+
+        app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'v2.primary',
+            'source_disk' => 'local',
+            'source_storage_path' => $primaryRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->insert([
+                'blob_hash' => $hash,
+                'disk' => 's3',
+                'storage_path' => $remotePath,
+                'location_kind' => 'remote_copy',
+                'size_bytes' => strlen($payload),
+                'checksum' => 'sha256:'.$hash,
+                'etag' => 'etag-'.$suffix.'-'.substr($hash, 0, 8),
+                'storage_class' => 'STANDARD_IA',
+                'verified_at' => now(),
+                'meta_json' => json_encode([
+                    'bucket' => 'restore-command-bucket',
+                    'region' => 'ap-guangzhou',
+                    'endpoint' => 'https://cos.restore-command.test',
+                    'url' => 'https://cos.restore-command.test/'.$remotePath,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $this->assertSame(0, Artisan::call('storage:quarantine-exact-roots', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+        $planPath = $this->extractOutputValue(Artisan::output(), 'plan');
+        $this->assertSame(0, Artisan::call('storage:quarantine-exact-roots', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $runDir = $this->extractOutputValue(Artisan::output(), 'run_dir');
+        $quarantinedEntry = collect((array) json_decode((string) File::get($runDir.'/run.json'), true)['quarantined'] ?? [])
+            ->firstWhere('source_storage_path', $primaryRoot);
+        $itemRoot = (string) ($quarantinedEntry['target_root'] ?? '');
+        $this->assertNotSame('', $itemRoot);
+
+        return [
+            'item_root' => $itemRoot,
+            'primary_root' => $primaryRoot,
+            'mirror_root' => $mirrorRoot,
             'release_id' => $releaseId,
             'manifest_hash' => $manifestHash,
         ];


### PR DESCRIPTION
## Summary
- enable v2.primary root quarantine, restore, and purge lifecycle
- gate v2.primary quarantine/purge on shared runtime truth safety from PR-23A
- keep resolver/materializer/runtime reader contracts unchanged while extending focused command/service coverage

## Tests
- `vendor/bin/phpunit tests/Feature/Storage/ExactRootQuarantineServiceTest.php tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php tests/Feature/Storage/StorageQuarantineExactRootsCommandTest.php tests/Feature/Storage/StorageRestoreQuarantinedRootCommandTest.php tests/Feature/Storage/StoragePurgeQuarantinedRootCommandTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php`
- `php artisan migrate`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
