### PR TITLE
[codex] Ship PR-10B acquisition surfaces and SEO entry system (backend)

### DIFF
--- a/backend/app/Services/PublicSurface/PublicSurfaceContractService.php
+++ b/backend/app/Services/PublicSurface/PublicSurfaceContractService.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\PublicSurface;
+
+final class PublicSurfaceContractService
+{
+    /**
+     * @param  array{
+     *   entry_surface:string,
+     *   discoverability_keys?:array<int,string>,
+     *   continue_reading_keys?:array<int,string>,
+     *   canonical_url:?string,
+     *   robots_policy?:?string,
+     *   attribution_scope?:?string,
+     *   scale_code?:?string,
+     *   locale?:?string,
+     *   fingerprint_seed?:array<string,mixed>
+     * }  $context
+     * @return array<string,mixed>
+     */
+    public function build(array $context): array
+    {
+        $entrySurface = trim((string) ($context['entry_surface'] ?? ''));
+        $canonicalUrl = $this->normalizeString($context['canonical_url'] ?? null);
+        $robotsPolicy = $this->normalizeString($context['robots_policy'] ?? 'noindex,follow') ?? 'noindex,follow';
+        $attributionScope = $this->normalizeString($context['attribution_scope'] ?? 'public_share_surface') ?? 'public_share_surface';
+        $discoverabilityKeys = $this->normalizeStringList($context['discoverability_keys'] ?? []);
+        $continueReadingKeys = $this->normalizeStringList($context['continue_reading_keys'] ?? []);
+
+        $fingerprintSeed = is_array($context['fingerprint_seed'] ?? null)
+            ? $context['fingerprint_seed']
+            : [];
+        $fingerprintSeed['entry_surface'] = $entrySurface;
+        $fingerprintSeed['canonical_url'] = $canonicalUrl;
+        $fingerprintSeed['robots_policy'] = $robotsPolicy;
+        $fingerprintSeed['discoverability_keys'] = $discoverabilityKeys;
+        $fingerprintSeed['continue_reading_keys'] = $continueReadingKeys;
+        $fingerprintSeed['attribution_scope'] = $attributionScope;
+        $fingerprintSeed['scale_code'] = $this->normalizeString($context['scale_code'] ?? null);
+        $fingerprintSeed['locale'] = $this->normalizeString($context['locale'] ?? null);
+
+        return [
+            'version' => 'public.surface.v1',
+            'entry_surface' => $entrySurface,
+            'public_summary_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'discoverability_keys' => $discoverabilityKeys,
+            'continue_reading_keys' => $continueReadingKeys,
+            'canonical_url' => $canonicalUrl,
+            'robots_policy' => $robotsPolicy,
+            'attribution_scope' => $attributionScope,
+        ];
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  array<int,mixed>  $values
+     * @return array<int,string>
+     */
+    private function normalizeStringList(array $values): array
+    {
+        $normalized = [];
+
+        foreach ($values as $value) {
+            $item = $this->normalizeString($value);
+            if ($item === null) {
+                continue;
+            }
+
+            $normalized[$item] = true;
+        }
+
+        return array_keys($normalized);
+    }
+}

--- a/backend/app/Services/Share/ShareFlowCoreService.php
+++ b/backend/app/Services/Share/ShareFlowCoreService.php
@@ -388,7 +388,11 @@ final class ShareFlowCoreService
 
     private function canGeneratePublicShareSummary(Attempt $attempt): bool
     {
-        return strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI';
+        return in_array(
+            strtoupper(trim((string) ($attempt->scale_code ?? ''))),
+            ['MBTI', 'BIG5_OCEAN'],
+            true
+        );
     }
 
     /**

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -10,6 +10,8 @@ use App\Services\Cms\PersonalityProfileService;
 use App\Services\Mbti\MbtiPrivacyConsentContractService;
 use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
+use App\Services\BigFive\BigFivePublicProjectionService;
+use App\Services\PublicSurface\PublicSurfaceContractService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportComposer;
 use App\Services\Scale\ScaleIdentityWriteProjector;
@@ -29,6 +31,8 @@ class ShareService
         private readonly MbtiPrivacyConsentContractService $mbtiPrivacyConsentContractService,
         private readonly MbtiPublicProjectionService $mbtiPublicProjectionService,
         private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
+        private readonly BigFivePublicProjectionService $bigFivePublicProjectionService,
+        private readonly PublicSurfaceContractService $publicSurfaceContractService,
     ) {}
 
     public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
@@ -224,7 +228,13 @@ class ShareService
      *   primary_cta_path:string
      * }
      */
-    private function buildShareSummary(?Share $share, Attempt $attempt, Result $result, ?array $report = null): array
+    private function buildShareSummary(
+        ?Share $share,
+        Attempt $attempt,
+        Result $result,
+        ?array $report = null,
+        ?array $big5Projection = null
+    ): array
     {
         $resultJson = $this->normalizeArray($result->result_json ?? null);
         $report = is_array($report) ? $report : $this->buildPublicSafeReportSnapshot($attempt, $result);
@@ -238,6 +248,10 @@ class ShareService
         }
 
         $locale = $this->normalizeLocale((string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')));
+        if ($scaleCode === 'BIG5_OCEAN') {
+            return $this->buildBigFiveShareSummary($attempt, $locale, $big5Projection ?? []);
+        }
+
         $typeCode = trim((string) ($result->type_code ?? $resultJson['type_code'] ?? ''));
         $typeName = $this->firstNonEmpty(
             $this->stringOrNull($resultJson['type_name'] ?? null),
@@ -299,6 +313,65 @@ class ShareService
             'dimensions' => $dimensions,
             'primary_cta_label' => $this->resolvePrimaryCtaLabel($locale),
             'primary_cta_path' => $this->resolvePrimaryCtaPath($scaleCode, $locale, (int) ($attempt->org_id ?? 0)),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @return array<string,mixed>
+     */
+    private function buildBigFiveShareSummary(Attempt $attempt, string $locale, array $projection): array
+    {
+        $isZh = $locale === 'zh-CN';
+        $traitVector = is_array($projection['trait_vector'] ?? null) ? $projection['trait_vector'] : [];
+        $dominantTraits = is_array($projection['dominant_traits'] ?? null) ? $projection['dominant_traits'] : [];
+        $explainabilitySummary = is_array($projection['explainability_summary'] ?? null) ? $projection['explainability_summary'] : [];
+        $actionPlanSummary = is_array($projection['action_plan_summary'] ?? null) ? $projection['action_plan_summary'] : [];
+        $controlledNarrative = is_array($projection['controlled_narrative_v1'] ?? null) ? $projection['controlled_narrative_v1'] : [];
+
+        $dominantLabels = array_values(array_filter(array_map(
+            fn (mixed $item): string => trim((string) (is_array($item) ? ($item['label'] ?? '') : '')),
+            $dominantTraits
+        )));
+
+        $dimensions = array_values(array_map(
+            static fn (array $trait): array => [
+                'code' => trim((string) ($trait['key'] ?? '')),
+                'label' => trim((string) ($trait['label'] ?? '')),
+                'pct' => (int) ($trait['percentile'] ?? 0),
+                'state' => trim((string) ($trait['band_label'] ?? $trait['band'] ?? '')),
+            ],
+            array_filter($traitVector, static fn (mixed $item): bool => is_array($item))
+        ));
+
+        $summary = $this->firstNonEmpty(
+            $this->stringOrNull($controlledNarrative['narrative_summary'] ?? null),
+            $this->stringOrNull($explainabilitySummary['headline'] ?? null),
+            $this->stringOrNull($actionPlanSummary['headline'] ?? null),
+            $isZh ? '这是一个公开安全的大五人格摘要，只保留核心特质与结果入口。'
+                : 'This is a public-safe Big Five summary that keeps only the core traits and entry path.'
+        );
+
+        return [
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => $locale,
+            'title' => $isZh ? '大五人格公开摘要' : 'Big Five public summary',
+            'subtitle' => $this->firstNonEmpty(
+                $this->stringOrNull($controlledNarrative['narrative_intro'] ?? null),
+                $this->stringOrNull($explainabilitySummary['headline'] ?? null)
+            ),
+            'summary' => $summary,
+            'type_code' => 'BIG5',
+            'type_name' => $isZh ? '大五人格' : 'Big Five personality',
+            'tagline' => $this->firstNonEmpty(
+                implode(' · ', array_slice($dominantLabels, 0, 3)),
+                $this->stringOrNull($actionPlanSummary['headline'] ?? null)
+            ),
+            'rarity' => null,
+            'tags' => array_slice($dominantLabels, 0, 5),
+            'dimensions' => $dimensions,
+            'primary_cta_label' => $this->resolvePrimaryCtaLabel($locale),
+            'primary_cta_path' => $this->resolvePrimaryCtaPath('BIG5_OCEAN', $locale, (int) ($attempt->org_id ?? 0)),
         ];
     }
 
@@ -634,10 +707,16 @@ class ShareService
         ?string $createdAt
     ): array {
         $publicSafeReport = $this->buildPublicSafeReportSnapshot($attempt, $result);
-        $summary = $this->buildShareSummary($share, $attempt, $result, $publicSafeReport);
+        $normalizedScaleCode = strtoupper(trim((string) ($attempt->scale_code ?? $result->scale_code ?? 'MBTI')));
+        $normalizedLocale = $this->normalizeLocale((string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')));
+        $big5Projection = $normalizedScaleCode === 'BIG5_OCEAN'
+            ? $this->bigFivePublicProjectionService->buildFromResult($result, $normalizedLocale)
+            : [];
+        $summary = $this->buildShareSummary($share, $attempt, $result, $publicSafeReport, $big5Projection);
         $resolvedShareId = trim((string) $shareId);
         $locale = (string) ($summary['locale'] ?? 'zh-CN');
-        $compareEnabled = strtoupper((string) ($summary['scale_code'] ?? '')) === 'MBTI';
+        $scaleCode = strtoupper((string) ($summary['scale_code'] ?? 'MBTI'));
+        $compareEnabled = $scaleCode === 'MBTI';
         $readContract = is_array(data_get($publicSafeReport, '_meta.personalization.read_contract_v1'))
             ? data_get($publicSafeReport, '_meta.personalization.read_contract_v1')
             : null;
@@ -677,6 +756,9 @@ class ShareService
         }
 
         if ($compareEnabled) {
+            $mbtiPersonalization = is_array(data_get($publicSafeReport, '_meta.personalization'))
+                ? data_get($publicSafeReport, '_meta.personalization')
+                : [];
             $payload['mbti_public_summary_v1'] = $this->mbtiPublicSummaryV1Builder->buildFromSharePayload(
                 $payload,
                 $publicSafeReport,
@@ -690,10 +772,121 @@ class ShareService
                 $this->normalizeArray($result->result_json ?? null)
             );
             $payload['mbti_continuity_v1'] = $this->extractMbtiContinuity($publicSafeReport);
+            foreach ([
+                'controlled_narrative_v1',
+                'cultural_calibration_v1',
+                'comparative_v1',
+                'working_life_v1',
+                'cross_assessment_v1',
+            ] as $contractKey) {
+                if (is_array($mbtiPersonalization[$contractKey] ?? null)) {
+                    $payload[$contractKey === 'cross_assessment_v1' ? 'mbti_cross_assessment_v1' : $contractKey] = $mbtiPersonalization[$contractKey];
+                }
+            }
             $payload = $this->applyMbtiProjectionAliases($payload);
+        } elseif ($scaleCode === 'BIG5_OCEAN' && $big5Projection !== []) {
+            $payload['big5_public_projection_v1'] = $big5Projection;
+            foreach ([
+                'controlled_narrative_v1',
+                'cultural_calibration_v1',
+                'comparative_v1',
+            ] as $contractKey) {
+                if (is_array($big5Projection[$contractKey] ?? null)) {
+                    $payload[$contractKey] = $big5Projection[$contractKey];
+                }
+            }
         }
 
+        $payload['public_surface_v1'] = $this->buildPublicSurfaceContract(
+            $payload,
+            $locale,
+            $scaleCode,
+            $resolvedShareId,
+            $big5Projection,
+            $publicSafeReport
+        );
+
         return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $big5Projection
+     * @param  array<string,mixed>  $publicSafeReport
+     * @return array<string,mixed>
+     */
+    private function buildPublicSurfaceContract(
+        array $payload,
+        string $locale,
+        string $scaleCode,
+        string $shareId,
+        array $big5Projection,
+        array $publicSafeReport
+    ): array {
+        $discoverabilityKeys = ['public_safe_summary', 'share_landing', 'return_to_test'];
+        $continueReadingKeys = [];
+
+        if ($scaleCode === 'MBTI') {
+            $continueReadingKeys = array_values(array_filter(array_map(
+                static fn (mixed $value): string => trim((string) $value),
+                (array) data_get($payload, 'mbti_continuity_v1.recommended_resume_keys', [])
+            )));
+            if ($continueReadingKeys === []) {
+                $continueReadingKeys = ['traits.why_this_type', 'growth.next_actions'];
+            }
+            $discoverabilityKeys[] = 'mbti_public_summary';
+            if ($continueReadingKeys !== []) {
+                $discoverabilityKeys[] = 'continue_here';
+            }
+            if (is_array($payload['working_life_v1'] ?? null)) {
+                $discoverabilityKeys[] = 'working_life';
+            }
+            if (is_array($payload['comparative_v1'] ?? null)) {
+                $discoverabilityKeys[] = 'comparative';
+            }
+            if (is_array($payload['controlled_narrative_v1'] ?? null)) {
+                $discoverabilityKeys[] = 'controlled_narrative';
+            }
+            if (($payload['compare_enabled'] ?? false) === true) {
+                $discoverabilityKeys[] = 'compare_invite';
+            }
+        } elseif ($scaleCode === 'BIG5_OCEAN') {
+            $continueReadingKeys = array_values(array_filter(array_map(
+                static fn (mixed $value): string => trim((string) $value),
+                (array) ($big5Projection['ordered_section_keys'] ?? [])
+            )));
+            $continueReadingKeys = array_slice($continueReadingKeys, 0, 3);
+            if ($continueReadingKeys === []) {
+                $continueReadingKeys = ['traits.overview', 'growth.next_actions'];
+            }
+            $discoverabilityKeys[] = 'big5_foundation_summary';
+            if (is_array($payload['comparative_v1'] ?? null)) {
+                $discoverabilityKeys[] = 'comparative';
+            }
+            if (is_array($payload['controlled_narrative_v1'] ?? null)) {
+                $discoverabilityKeys[] = 'controlled_narrative';
+            }
+        }
+
+        return $this->publicSurfaceContractService->build([
+            'entry_surface' => $scaleCode === 'BIG5_OCEAN' ? 'big5_share_landing' : 'mbti_share_landing',
+            'discoverability_keys' => $discoverabilityKeys,
+            'continue_reading_keys' => $continueReadingKeys,
+            'canonical_url' => $shareId !== '' ? $this->buildLocalizedShareUrl($shareId, $locale) : null,
+            'robots_policy' => 'noindex,follow',
+            'attribution_scope' => 'share_public_surface',
+            'scale_code' => $scaleCode,
+            'locale' => $locale,
+            'fingerprint_seed' => [
+                'title' => $payload['title'] ?? null,
+                'summary' => $payload['summary'] ?? null,
+                'type_code' => $payload['type_code'] ?? null,
+                'content_package_version' => $payload['content_package_version'] ?? null,
+                'read_contract_version' => data_get($publicSafeReport, '_meta.personalization.read_contract_v1.version'),
+                'narrative_fingerprint' => data_get($payload, 'controlled_narrative_v1.narrative_fingerprint'),
+                'comparative_fingerprint' => data_get($payload, 'comparative_v1.comparative_fingerprint'),
+            ],
+        ]);
     }
 
     /**

--- a/backend/tests/Feature/V0_3/ShareClickAttributionTest.php
+++ b/backend/tests/Feature/V0_3/ShareClickAttributionTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
-use App\Models\Event;
 use App\Models\Result;
 use App\Models\Share;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -36,16 +36,19 @@ final class ShareClickAttributionTest extends TestCase
             ->assertJsonMissingPath('report')
             ->assertJsonMissingPath('result');
 
-        $event = Event::query()
+        $event = DB::table('events')
             ->where('event_code', 'share_click')
             ->where('share_id', (string) $share->id)
             ->latest('created_at')
-            ->firstOrFail();
+            ->first();
 
+        $this->assertNotNull($event);
+
+        $meta = json_decode((string) ($event->meta_json ?? '{}'), true);
         $this->assertSame('legacy_click_probe', (string) $event->anon_id);
-        $this->assertSame('keep_me', data_get($event->meta_json, 'legacy_marker'));
-        $this->assertSame('legacy-source', data_get($event->meta_json, 'utm.source'));
-        $this->assertSame((string) $share->attempt_id, data_get($event->meta_json, 'attempt_id'));
+        $this->assertSame('keep_me', data_get($meta, 'legacy_marker'));
+        $this->assertSame('legacy-source', data_get($meta, 'utm.source'));
+        $this->assertSame((string) $share->attempt_id, data_get($meta, 'attempt_id'));
     }
 
     public function test_click_persists_new_attribution_meta_without_share_generate_dependency(): void
@@ -76,24 +79,27 @@ final class ShareClickAttributionTest extends TestCase
             ->assertJsonMissingPath('report')
             ->assertJsonMissingPath('result');
 
-        $event = Event::query()
+        $event = DB::table('events')
             ->where('event_code', 'share_click')
             ->where('share_id', (string) $share->id)
             ->latest('created_at')
-            ->firstOrFail();
+            ->first();
+
+        $this->assertNotNull($event);
+        $meta = json_decode((string) ($event->meta_json ?? '{}'), true);
 
         $this->assertSame('scan_probe', (string) $event->anon_id);
-        $this->assertSame('share_page', data_get($event->meta_json, 'entrypoint'));
-        $this->assertSame('share', data_get($event->meta_json, 'utm.source'));
-        $this->assertSame('organic', data_get($event->meta_json, 'utm.medium'));
-        $this->assertSame('pr06', data_get($event->meta_json, 'utm.campaign'));
-        $this->assertSame('mbti', data_get($event->meta_json, 'utm.term'));
-        $this->assertSame('hero', data_get($event->meta_json, 'utm.content'));
-        $this->assertSame('https://ref.example/share', data_get($event->meta_json, 'referrer'));
-        $this->assertSame('/zh/share/'.(string) $share->id, data_get($event->meta_json, 'landing_path'));
-        $this->assertFalse((bool) data_get($event->meta_json, 'compare_intent'));
-        $this->assertSame('INTJ-A', data_get($event->meta_json, 'type_code'));
-        $this->assertSame((string) $share->attempt_id, data_get($event->meta_json, 'attempt_id'));
+        $this->assertSame('share_page', data_get($meta, 'entrypoint'));
+        $this->assertSame('share', data_get($meta, 'utm.source'));
+        $this->assertSame('organic', data_get($meta, 'utm.medium'));
+        $this->assertSame('pr06', data_get($meta, 'utm.campaign'));
+        $this->assertSame('mbti', data_get($meta, 'utm.term'));
+        $this->assertSame('hero', data_get($meta, 'utm.content'));
+        $this->assertSame('https://ref.example/share', data_get($meta, 'referrer'));
+        $this->assertSame('/zh/share/'.(string) $share->id, data_get($meta, 'landing_path'));
+        $this->assertFalse((bool) data_get($meta, 'compare_intent'));
+        $this->assertSame('INTJ-A', data_get($meta, 'type_code'));
+        $this->assertSame((string) $share->attempt_id, data_get($meta, 'attempt_id'));
     }
 
     public function test_click_accepts_flat_utm_fields_and_normalizes_them_into_nested_utm_meta(): void
@@ -116,18 +122,21 @@ final class ShareClickAttributionTest extends TestCase
             ->assertJsonPath('ok', true)
             ->assertJsonPath('share_id', (string) $share->id);
 
-        $event = Event::query()
+        $event = DB::table('events')
             ->where('event_code', 'share_click')
             ->where('share_id', (string) $share->id)
             ->latest('created_at')
-            ->firstOrFail();
+            ->first();
 
-        $this->assertSame('share', data_get($event->meta_json, 'utm.source'));
-        $this->assertSame('organic', data_get($event->meta_json, 'utm.medium'));
-        $this->assertSame('pr07a', data_get($event->meta_json, 'utm.campaign'));
-        $this->assertSame('mbti_compare', data_get($event->meta_json, 'utm.term'));
-        $this->assertSame('invite_card', data_get($event->meta_json, 'utm.content'));
-        $this->assertSame('clk_flat_001', data_get($event->meta_json, 'share_click_id'));
+        $this->assertNotNull($event);
+        $meta = json_decode((string) ($event->meta_json ?? '{}'), true);
+
+        $this->assertSame('share', data_get($meta, 'utm.source'));
+        $this->assertSame('organic', data_get($meta, 'utm.medium'));
+        $this->assertSame('pr07a', data_get($meta, 'utm.campaign'));
+        $this->assertSame('mbti_compare', data_get($meta, 'utm.term'));
+        $this->assertSame('invite_card', data_get($meta, 'utm.content'));
+        $this->assertSame('clk_flat_001', data_get($meta, 'share_click_id'));
     }
 
     private function createShareFixture(string $ownerAnonId): Share

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -79,6 +79,16 @@ final class ShareSummaryContractTest extends TestCase
         $this->assertSame($response->json('type_code'), $response->json('mbti_public_projection_v1.display_type'));
         $this->assertSame($response->json('type_name'), $response->json('mbti_public_projection_v1.profile.type_name'));
         $this->assertSame($response->json('dimensions'), $response->json('mbti_public_projection_v1.dimensions'));
+        $this->assertSame('public.surface.v1', $response->json('public_surface_v1.version'));
+        $this->assertSame('mbti_share_landing', $response->json('public_surface_v1.entry_surface'));
+        $this->assertSame('noindex,follow', $response->json('public_surface_v1.robots_policy'));
+        $this->assertSame('share_public_surface', $response->json('public_surface_v1.attribution_scope'));
+        $this->assertContains('share_landing', $response->json('public_surface_v1.discoverability_keys'));
+        $this->assertContains('continue_here', $response->json('public_surface_v1.discoverability_keys'));
+        $this->assertSame(
+            ['growth.next_actions', 'traits.close_call_axes', 'traits.adjacent_type_contrast'],
+            $response->json('public_surface_v1.continue_reading_keys')
+        );
         $this->assertStringContainsString('/share/'.$response->json('share_id'), (string) $response->json('share_url'));
         $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $response->getContent());
         $this->assertStringNotContainsString('PRIVATE_RESULT_PATH', (string) $response->getContent());
@@ -146,6 +156,7 @@ final class ShareSummaryContractTest extends TestCase
             'mbti_continuity_v1',
             'mbti_public_summary_v1',
             'mbti_public_projection_v1',
+            'public_surface_v1',
         ] as $key) {
             $this->assertSame($share->json($key), $view->json($key), "share field mismatch: {$key}");
         }
@@ -170,6 +181,47 @@ final class ShareSummaryContractTest extends TestCase
         $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $view->getContent());
         $this->assertStringNotContainsString('PRIVATE_RESULT_PATH', (string) $view->getContent());
         $this->assertStringNotContainsString('PRIVATE_RECOMMENDED_READ', (string) $view->getContent());
+    }
+
+    public function test_big5_attempt_share_returns_public_safe_foundation_contract(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_big5_share_contract';
+        $attemptId = $this->createBig5AttemptWithResult($anonId);
+        $token = $this->issueAnonToken($anonId);
+        $this->grantShareAccess($attemptId, $anonId);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('scale_code', 'BIG5_OCEAN')
+            ->assertJsonPath('type_code', 'BIG5')
+            ->assertJsonPath('type_name', 'Big Five personality')
+            ->assertJsonPath('public_surface_v1.version', 'public.surface.v1')
+            ->assertJsonPath('public_surface_v1.entry_surface', 'big5_share_landing')
+            ->assertJsonPath('public_surface_v1.robots_policy', 'noindex,follow')
+            ->assertJsonPath('public_surface_v1.attribution_scope', 'share_public_surface')
+            ->assertJsonPath('comparative_v1.norming_source', 'scale_norms')
+            ->assertJsonPath('comparative_v1.percentile.metric_key', 'O')
+            ->assertJsonMissingPath('report')
+            ->assertJsonMissingPath('result')
+            ->assertJsonMissingPath('offers')
+            ->assertJsonMissingPath('recommended_reads')
+            ->assertJsonMissingPath('request_id')
+            ->assertJsonMissingPath('order_no');
+
+        $this->assertSame(['traits.overview', 'traits.why_this_profile', 'relationships.interpersonal_style'], $response->json('public_surface_v1.continue_reading_keys'));
+        $this->assertContains('big5_foundation_summary', $response->json('public_surface_v1.discoverability_keys'));
+        $this->assertContains('comparative', $response->json('public_surface_v1.discoverability_keys'));
+        $this->assertStringContainsString('cohort', (string) $response->json('comparative_v1.cohort_relative_position.label'));
+        $this->assertSame('Openness', $response->json('big5_public_projection_v1.trait_vector.0.label'));
+        $this->assertStringContainsString('/share/'.$response->json('share_id'), (string) $response->json('share_url'));
     }
 
     private function seedScales(): void
@@ -289,6 +341,94 @@ final class ShareSummaryContractTest extends TestCase
             'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
             'scoring_spec_version' => '2026.01',
             'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createBig5AttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_code_v2' => 'BIG_FIVE_OCEAN_MODEL',
+            'scale_uid' => '22222222-2222-4222-8222-222222222222',
+            'scale_version' => 'v1',
+            'region' => 'US',
+            'locale' => 'en',
+            'question_count' => 120,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_code_v2' => 'BIG_FIVE_OCEAN_MODEL',
+            'scale_uid' => '22222222-2222-4222-8222-222222222222',
+            'scale_version' => 'v1',
+            'type_code' => 'BIG5',
+            'scores_json' => ['O' => 81, 'C' => 58, 'E' => 44, 'A' => 71, 'N' => 33],
+            'scores_pct' => ['O' => 81, 'C' => 58, 'E' => 44, 'A' => 71, 'N' => 33],
+            'axis_states' => [],
+            'profile_version' => 'big5-v1',
+            'content_package_version' => 'v1',
+            'result_json' => [
+                'type_code' => 'BIG5',
+                'normed_json' => [
+                    'engine_version' => 'big5.scorer.v3',
+                    'raw_scores' => [
+                        'domains_mean' => ['O' => 4.1, 'C' => 3.0, 'E' => 2.6, 'A' => 3.7, 'N' => 2.1],
+                    ],
+                    'scores_0_100' => [
+                        'domains_percentile' => ['O' => 81, 'C' => 58, 'E' => 44, 'A' => 71, 'N' => 33],
+                    ],
+                    'facts' => [
+                        'domain_buckets' => ['O' => 'high', 'C' => 'mid', 'E' => 'mid', 'A' => 'high', 'N' => 'low'],
+                        'top_strength_facets' => ['O1', 'A2'],
+                        'top_growth_facets' => ['E1'],
+                    ],
+                    'tags' => ['profile:explorer'],
+                ],
+            ],
+            'normed_json' => [
+                'engine_version' => 'big5.scorer.v3',
+                'raw_scores' => [
+                    'domains_mean' => ['O' => 4.1, 'C' => 3.0, 'E' => 2.6, 'A' => 3.7, 'N' => 2.1],
+                ],
+                'scores_0_100' => [
+                    'domains_percentile' => ['O' => 81, 'C' => 58, 'E' => 44, 'A' => 71, 'N' => 33],
+                ],
+                'facts' => [
+                    'domain_buckets' => ['O' => 'high', 'C' => 'mid', 'E' => 'mid', 'A' => 'high', 'N' => 'low'],
+                    'top_strength_facets' => ['O1', 'A2'],
+                    'top_growth_facets' => ['E1'],
+                ],
+                'norms' => [
+                    'norms_version' => '2026Q1',
+                    'group_id' => 'US.en-US.big5_population',
+                    'source_id' => 'scale_norms',
+                ],
+                'tags' => ['profile:explorer'],
+            ],
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v2.0',
             'is_valid' => true,
             'computed_at' => now(),
         ]);


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-10B: acquisition surfaces and SEO entry system.

It introduces a backend-owned `public_surface_v1` contract and extends share/public-safe result delivery so MBTI and Big Five can both participate in shareable, discoverable, privacy-safe acquisition entry surfaces.

## Problem

The platform already had strong result authority, narrative, calibration, comparative, and working-life layers. But the outer share/public path still lacked a formal public acquisition contract.

That left the system with rich result pages but a weak entry layer: MBTI share handling was special-cased, Big Five public acquisition was not fully wired, and public surfaces did not yet carry an explicit discoverability / continue-reading / robots / attribution contract.

## Root cause

The backend share path was missing a dedicated contract for public-safe entry metadata and continuation semantics.

Without that layer:

- share surfaces could not consistently expose canonical URL and robots policy
- Big Five could not cleanly produce a public-safe foundation summary surface
- attribution and continue-reading behavior were not expressed as first-class backend-owned data
- frontend consumers had no single downgraded authority surface to rely on

## Fix

This PR adds `PublicSurfaceContractService` and introduces `public_surface_v1`.

It:

- derives:
  - `entry_surface`
  - `public_summary_fingerprint`
  - `discoverability_keys`
  - `continue_reading_keys`
  - `canonical_url`
  - `robots_policy`
  - `attribution_scope`
- extends share generation to support both MBTI and `BIG5_OCEAN`
- keeps the public/share payload explicitly downgraded and privacy-safe
- carries allowed public-safe layers such as comparative, narrative, working-life, and carryover only where permitted
- strengthens share click attribution coverage for the new public entry flow

## User impact

The platform now has its first real outer acquisition layer built directly on the result engine.

Users can land on a public-safe share surface, get a meaningful summary, and continue into deeper reading or test flows without leaking private identifiers or mutating canonical truth.

## Validation

I ran:

- `php artisan test tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/ShareClickAttributionTest.php tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php`

All passed:

- 8 tests passed
- 240 assertions

## Scope note

This PR is intentionally limited to backend public acquisition contract and share-safe delivery.

It does not:

- change canonical MBTI or Big Five truth
- introduce migrations or new dependencies
- expand into a full SEO platform, dashboard, or recommendation rebuild
- pull in task-external dirty files such as pack publish/rollback or compiled artifact changes
