### PR TITLE
[codex] Ship PR-10C team dynamics and B2B workspace (backend)

### DIFF
--- a/backend/app/Filament/Tenant/Pages/TenantDashboard.php
+++ b/backend/app/Filament/Tenant/Pages/TenantDashboard.php
@@ -4,9 +4,17 @@ declare(strict_types=1);
 
 namespace App\Filament\Tenant\Pages;
 
+use App\Filament\Tenant\Widgets\TeamDynamicsOverviewWidget;
 use Filament\Pages\Dashboard;
 
 class TenantDashboard extends Dashboard
 {
     protected static ?string $title = 'Tenant Console';
+
+    public function getWidgets(): array
+    {
+        return [
+            TeamDynamicsOverviewWidget::class,
+        ];
+    }
 }

--- a/backend/app/Filament/Tenant/Widgets/TeamDynamicsOverviewWidget.php
+++ b/backend/app/Filament/Tenant/Widgets/TeamDynamicsOverviewWidget.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Tenant\Widgets;
+
+use App\Models\Assessment;
+use App\Services\Analytics\EventRecorder;
+use App\Services\Assessments\AssessmentService;
+use App\Support\OrgContext;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+final class TeamDynamicsOverviewWidget extends BaseWidget
+{
+    protected static ?string $pollingInterval = null;
+
+    protected function getHeading(): ?string
+    {
+        return 'Team dynamics';
+    }
+
+    protected function getStats(): array
+    {
+        $orgId = app(OrgContext::class)->orgId();
+        if ($orgId <= 0) {
+            return [
+                Stat::make('Team dynamics', 'No tenant context')->color('gray'),
+            ];
+        }
+
+        $assessment = $this->resolveAssessment($orgId);
+        if (! $assessment instanceof Assessment) {
+            return [
+                Stat::make('Team dynamics', 'No completed team summary yet')
+                    ->description('Invite at least two members to the same MBTI or Big Five assessment.')
+                    ->color('gray'),
+            ];
+        }
+
+        $summary = app(AssessmentService::class)->summary($assessment);
+        $teamDynamics = is_array($summary['team_dynamics_v1'] ?? null) ? $summary['team_dynamics_v1'] : null;
+        if ($teamDynamics === null) {
+            return [
+                Stat::make('Team dynamics', 'Not enough analyzed members')
+                    ->description('Complete at least two results in the same assessment.')
+                    ->color('warning'),
+            ];
+        }
+
+        $this->recordExposure($orgId, $assessment, $teamDynamics);
+
+        return [
+            Stat::make('Team focus', $this->humanizeKey((string) ($teamDynamics['team_focus_key'] ?? 'team.focus')))
+                ->description(sprintf(
+                    'Assessment #%d · %d/%d analyzed',
+                    (int) $assessment->id,
+                    (int) ($teamDynamics['analyzed_member_count'] ?? 0),
+                    (int) ($teamDynamics['team_member_count'] ?? 0)
+                ))
+                ->color('primary'),
+            Stat::make('Communication', $this->firstHumanized($teamDynamics['communication_fit_keys'] ?? [], 'No signal yet'))
+                ->description($this->firstHumanized($teamDynamics['decision_mix_keys'] ?? [], 'Decision mix pending'))
+                ->color('info'),
+            Stat::make('Stress / blindspot', $this->firstHumanized($teamDynamics['stress_pattern_keys'] ?? [], 'No stress signal yet'))
+                ->description($this->firstHumanized($teamDynamics['team_blindspot_keys'] ?? [], 'No blindspot signal yet'))
+                ->color('warning'),
+            Stat::make('Next action', $this->firstHumanized($teamDynamics['team_action_prompt_keys'] ?? [], 'No team action prompt'))
+                ->description(implode(', ', array_values((array) ($teamDynamics['supporting_scales'] ?? []))))
+                ->color('success'),
+        ];
+    }
+
+    private function resolveAssessment(int $orgId): ?Assessment
+    {
+        $candidates = Assessment::query()
+            ->where('org_id', $orgId)
+            ->orderByDesc('updated_at')
+            ->limit(10)
+            ->get();
+
+        foreach ($candidates as $assessment) {
+            $summary = app(AssessmentService::class)->summary($assessment);
+            if (is_array($summary['team_dynamics_v1'] ?? null)) {
+                return $assessment;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $teamDynamics
+     */
+    private function recordExposure(int $orgId, Assessment $assessment, array $teamDynamics): void
+    {
+        $user = auth((string) config('tenant.guard', 'tenant'))->user();
+        $userId = is_object($user) && method_exists($user, 'getAuthIdentifier')
+            ? (int) $user->getAuthIdentifier()
+            : null;
+
+        app(EventRecorder::class)->record('team_workspace_surface_view', $userId, [
+            'assessment_id' => (int) $assessment->id,
+            'team_focus_key' => (string) ($teamDynamics['team_focus_key'] ?? ''),
+            'supporting_scales' => array_values((array) ($teamDynamics['supporting_scales'] ?? [])),
+            'version' => (string) ($teamDynamics['version'] ?? ''),
+            'workspace_scope' => (string) ($teamDynamics['workspace_scope'] ?? ''),
+        ], [
+            'org_id' => $orgId,
+            'scale_code' => (string) ($assessment->scale_code ?? ''),
+        ]);
+    }
+
+    /**
+     * @param  list<string>|array<int,string>  $keys
+     */
+    private function firstHumanized(array $keys, string $fallback): string
+    {
+        foreach ($keys as $key) {
+            $normalized = trim((string) $key);
+            if ($normalized !== '') {
+                return $this->humanizeKey($normalized);
+            }
+        }
+
+        return $fallback;
+    }
+
+    private function humanizeKey(string $key): string
+    {
+        $tail = trim((string) preg_replace('/^[^.]+\./', '', $key));
+        $tail = str_replace(['.', '_'], ' ', $tail);
+        $tail = preg_replace('/\s+/', ' ', $tail) ?? $tail;
+
+        return ucfirst(trim($tail));
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
+++ b/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API\V0_4;
 
 use App\Http\Controllers\Controller;
 use App\Models\Assessment;
+use App\Services\Analytics\EventRecorder;
 use App\Services\Assessments\AssessmentService;
 use App\Services\Scale\ScaleCodeInputGuard;
 use App\Services\Scale\ScaleCodeResponseProjector;
@@ -21,6 +22,7 @@ class AssessmentController extends Controller
         private ScaleCodeInputGuard $inputGuard,
         private ScaleCodeResponseProjector $responseProjector,
         private OrgContext $orgContext,
+        private EventRecorder $events,
     ) {}
 
     /**
@@ -175,6 +177,22 @@ class AssessmentController extends Controller
         }
 
         $summary = $this->assessments->summary($assessment);
+
+        $teamDynamics = is_array($summary['team_dynamics_v1'] ?? null) ? $summary['team_dynamics_v1'] : null;
+        if ($teamDynamics !== null) {
+            $this->events->record('team_dynamics_summary_view', $this->resolveUserId($request), [
+                'assessment_id' => (int) $assessment->id,
+                'team_focus_key' => (string) ($teamDynamics['team_focus_key'] ?? ''),
+                'supporting_scales' => array_values((array) ($teamDynamics['supporting_scales'] ?? [])),
+                'team_member_count' => (int) ($teamDynamics['team_member_count'] ?? 0),
+                'analyzed_member_count' => (int) ($teamDynamics['analyzed_member_count'] ?? 0),
+                'version' => (string) ($teamDynamics['version'] ?? ''),
+                'workspace_scope' => (string) ($teamDynamics['workspace_scope'] ?? ''),
+            ], [
+                'org_id' => $orgId,
+                'scale_code' => (string) ($assessment->scale_code ?? ''),
+            ]);
+        }
 
         return response()->json([
             'ok' => true,

--- a/backend/app/Models/TenantUser.php
+++ b/backend/app/Models/TenantUser.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\DB;
 
 class TenantUser extends User implements FilamentUser
 {
+    protected $table = 'users';
+
     public function canAccessPanel(Panel $panel): bool
     {
         if ($panel->getId() !== 'tenant') {

--- a/backend/app/Services/Assessments/AssessmentSummaryService.php
+++ b/backend/app/Services/Assessments/AssessmentSummaryService.php
@@ -6,13 +6,15 @@ use App\Models\Assessment;
 use App\Models\AssessmentAssignment;
 use App\Models\Result;
 use App\Services\Scale\ScaleRegistry;
+use App\Services\Team\TeamDynamicsSynthesisService;
 use Illuminate\Support\Collection;
 
 class AssessmentSummaryService
 {
-    public function __construct(private ScaleRegistry $registry)
-    {
-    }
+    public function __construct(
+        private ScaleRegistry $registry,
+        private TeamDynamicsSynthesisService $teamDynamics,
+    ) {}
 
     public function buildSummary(Assessment $assessment): array
     {
@@ -61,6 +63,7 @@ class AssessmentSummaryService
             ],
             'score_distribution' => $this->scoreDistribution($driverType, $results),
             'dimension_means' => $this->dimensionMeans($driverType, $results),
+            'team_dynamics_v1' => $this->teamDynamics->buildForAssessment($assessment, $results, $total),
         ];
     }
 

--- a/backend/app/Services/Team/TeamDynamicsSynthesisService.php
+++ b/backend/app/Services/Team/TeamDynamicsSynthesisService.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Team;
+
+use App\Models\Assessment;
+use Illuminate\Support\Collection;
+
+final class TeamDynamicsSynthesisService
+{
+    private const VERSION = 'team_dynamics.v1';
+
+    /**
+     * @param  Collection<int,object>  $results
+     * @return array<string,mixed>|null
+     */
+    public function buildForAssessment(Assessment $assessment, Collection $results, int $teamMemberCount): ?array
+    {
+        $scaleCode = strtoupper(trim((string) ($assessment->scale_code ?? '')));
+        $analyzedMemberCount = $results->count();
+
+        if ($teamMemberCount < 2 || $analyzedMemberCount < 2) {
+            return null;
+        }
+
+        return match ($scaleCode) {
+            'MBTI' => $this->buildForMbti($results, $teamMemberCount, $analyzedMemberCount),
+            'BIG5_OCEAN' => $this->buildForBigFive($results, $teamMemberCount, $analyzedMemberCount),
+            default => null,
+        };
+    }
+
+    /**
+     * @param  Collection<int,object>  $results
+     * @return array<string,mixed>
+     */
+    private function buildForMbti(Collection $results, int $teamMemberCount, int $analyzedMemberCount): array
+    {
+        $axisCounts = [
+            'E' => 0, 'I' => 0,
+            'S' => 0, 'N' => 0,
+            'T' => 0, 'F' => 0,
+            'J' => 0, 'P' => 0,
+            'A' => 0, 'TURB' => 0,
+        ];
+
+        foreach ($results as $row) {
+            $typeCode = strtoupper(trim((string) ($row->type_code ?? '')));
+            if ($typeCode === '') {
+                $typeCode = strtoupper(trim((string) data_get($this->normalizeJson($row->result_json ?? null), 'type_code', '')));
+            }
+
+            if (preg_match('/^[EI][SN][TF][JP](?:-[AT])?$/', $typeCode) !== 1) {
+                continue;
+            }
+
+            $axisCounts[$typeCode[0]]++;
+            $axisCounts[$typeCode[1]]++;
+            $axisCounts[$typeCode[2]]++;
+            $axisCounts[$typeCode[3]]++;
+            if (str_ends_with($typeCode, '-A')) {
+                $axisCounts['A']++;
+            } elseif (str_ends_with($typeCode, '-T')) {
+                $axisCounts['TURB']++;
+            }
+        }
+
+        $communicationFitKeys = [];
+        if ($axisCounts['E'] > 0 && $axisCounts['I'] > 0) {
+            $communicationFitKeys[] = 'team.communication.energy_translation';
+        }
+        $communicationFitKeys[] = $axisCounts['N'] >= $axisCounts['S']
+            ? 'team.communication.abstract_first'
+            : 'team.communication.concrete_first';
+
+        $decisionMixKeys = [];
+        if ($axisCounts['T'] > 0 && $axisCounts['F'] > 0) {
+            $decisionMixKeys[] = 'team.decision.logic_empathy_mix';
+        }
+        $decisionMixKeys[] = $axisCounts['J'] >= $axisCounts['P']
+            ? 'team.decision.structured_closure'
+            : 'team.decision.iterative_exploration';
+
+        $stressPatternKeys = [];
+        if ($axisCounts['TURB'] > 0 && $axisCounts['A'] > 0) {
+            $stressPatternKeys[] = 'team.stress.stability_gap';
+        }
+        $stressPatternKeys[] = $axisCounts['TURB'] >= $axisCounts['A']
+            ? 'team.stress.reactivity_spikes'
+            : 'team.stress.steady_recovery';
+
+        $blindspotKeys = [];
+        if ($axisCounts['N'] > 0 && $axisCounts['S'] > 0) {
+            $blindspotKeys[] = 'team.blindspot.context_translation';
+        }
+        if ($axisCounts['T'] > 0 && $axisCounts['F'] > 0) {
+            $blindspotKeys[] = 'team.blindspot.decision_friction';
+        }
+        if ($axisCounts['J'] > 0 && $axisCounts['P'] > 0) {
+            $blindspotKeys[] = 'team.blindspot.execution_alignment';
+        }
+
+        $teamFocusKey = $this->resolveFocusKey([
+            ...$communicationFitKeys,
+            ...$decisionMixKeys,
+            ...$stressPatternKeys,
+            ...$blindspotKeys,
+        ], 'team.communication.energy_translation');
+
+        $actionPromptKeys = $this->buildActionPromptKeys($teamFocusKey, 'MBTI');
+
+        return $this->finalize(
+            $teamMemberCount,
+            $analyzedMemberCount,
+            ['MBTI'],
+            $teamFocusKey,
+            $communicationFitKeys,
+            $decisionMixKeys,
+            $stressPatternKeys,
+            $blindspotKeys,
+            $actionPromptKeys
+        );
+    }
+
+    /**
+     * @param  Collection<int,object>  $results
+     * @return array<string,mixed>
+     */
+    private function buildForBigFive(Collection $results, int $teamMemberCount, int $analyzedMemberCount): array
+    {
+        $domains = ['O', 'C', 'E', 'A', 'N'];
+        $sum = array_fill_keys($domains, 0.0);
+        $count = array_fill_keys($domains, 0);
+        $high = array_fill_keys($domains, 0);
+        $low = array_fill_keys($domains, 0);
+
+        foreach ($results as $row) {
+            $scores = $this->normalizeJson($row->scores_pct ?? null);
+            foreach ($domains as $domain) {
+                $value = $scores[$domain] ?? null;
+                if (! is_numeric($value)) {
+                    continue;
+                }
+                $numeric = (float) $value;
+                $sum[$domain] += $numeric;
+                $count[$domain]++;
+                if ($numeric >= 67) {
+                    $high[$domain]++;
+                } elseif ($numeric <= 33) {
+                    $low[$domain]++;
+                }
+            }
+        }
+
+        $means = [];
+        foreach ($domains as $domain) {
+            $means[$domain] = $count[$domain] > 0 ? round($sum[$domain] / $count[$domain], 2) : 0.0;
+        }
+
+        $communicationFitKeys = [];
+        if ($high['E'] > 0 && $low['E'] > 0) {
+            $communicationFitKeys[] = 'team.communication.energy_range';
+        }
+        $communicationFitKeys[] = $means['A'] >= 50
+            ? 'team.communication.harmony_bias'
+            : 'team.communication.direct_challenge';
+
+        $decisionMixKeys = [];
+        if ($means['O'] >= 60 && $means['C'] >= 60) {
+            $decisionMixKeys[] = 'team.decision.idea_execution_mix';
+        } elseif ($means['O'] >= $means['C']) {
+            $decisionMixKeys[] = 'team.decision.exploratory_ideation';
+        } else {
+            $decisionMixKeys[] = 'team.decision.execution_rigor';
+        }
+        if ($means['A'] < 45) {
+            $decisionMixKeys[] = 'team.decision.challenge_tolerance';
+        }
+
+        $stressPatternKeys = [];
+        if ($high['N'] > 0 && $low['N'] > 0) {
+            $stressPatternKeys[] = 'team.stress.reactivity_range';
+        }
+        $stressPatternKeys[] = $means['N'] >= 55
+            ? 'team.stress.emotional_load'
+            : 'team.stress.steady_baseline';
+
+        $blindspotKeys = [];
+        if ($means['C'] < 45) {
+            $blindspotKeys[] = 'team.blindspot.follow_through_drift';
+        }
+        if ($means['A'] < 45) {
+            $blindspotKeys[] = 'team.blindspot.relational_friction';
+        }
+        if ($means['O'] >= 65 && $means['C'] < 50) {
+            $blindspotKeys[] = 'team.blindspot.ideation_overhang';
+        }
+
+        $teamFocusKey = $this->resolveFocusKey([
+            ...$communicationFitKeys,
+            ...$decisionMixKeys,
+            ...$stressPatternKeys,
+            ...$blindspotKeys,
+        ], 'team.decision.idea_execution_mix');
+
+        $actionPromptKeys = $this->buildActionPromptKeys($teamFocusKey, 'BIG5_OCEAN');
+
+        return $this->finalize(
+            $teamMemberCount,
+            $analyzedMemberCount,
+            ['BIG5_OCEAN'],
+            $teamFocusKey,
+            $communicationFitKeys,
+            $decisionMixKeys,
+            $stressPatternKeys,
+            $blindspotKeys,
+            $actionPromptKeys
+        );
+    }
+
+    /**
+     * @param  list<string>  $candidateKeys
+     */
+    private function resolveFocusKey(array $candidateKeys, string $fallback): string
+    {
+        foreach ($candidateKeys as $key) {
+            $normalized = trim((string) $key);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return $fallback;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildActionPromptKeys(string $teamFocusKey, string $scaleCode): array
+    {
+        return match ($teamFocusKey) {
+            'team.communication.energy_translation' => [
+                'team.action.sync_communication_cadence',
+                'team.action.document_async_then_discuss',
+            ],
+            'team.decision.logic_empathy_mix', 'team.decision.idea_execution_mix' => [
+                'team.action.separate_idea_and_decision_rounds',
+                'team.action.assign_decision_owner',
+            ],
+            'team.stress.stability_gap', 'team.stress.reactivity_range' => [
+                'team.action.define_escalation_norms',
+                'team.action.add_recovery_buffer',
+            ],
+            default => $scaleCode === 'BIG5_OCEAN'
+                ? ['team.action.clarify_success_criteria', 'team.action.reduce_context_switching']
+                : ['team.action.align_decision_rules', 'team.action.close_execution_gaps'],
+        };
+    }
+
+    /**
+     * @param  list<string>  $supportingScales
+     * @param  list<string>  $communicationFitKeys
+     * @param  list<string>  $decisionMixKeys
+     * @param  list<string>  $stressPatternKeys
+     * @param  list<string>  $blindspotKeys
+     * @param  list<string>  $actionPromptKeys
+     * @return array<string,mixed>
+     */
+    private function finalize(
+        int $teamMemberCount,
+        int $analyzedMemberCount,
+        array $supportingScales,
+        string $teamFocusKey,
+        array $communicationFitKeys,
+        array $decisionMixKeys,
+        array $stressPatternKeys,
+        array $blindspotKeys,
+        array $actionPromptKeys
+    ): array {
+        $authority = [
+            'version' => self::VERSION,
+            'team_focus_key' => $teamFocusKey,
+            'team_member_count' => $teamMemberCount,
+            'analyzed_member_count' => $analyzedMemberCount,
+            'supporting_scales' => array_values(array_unique(array_map('strval', $supportingScales))),
+            'communication_fit_keys' => array_values(array_unique(array_filter(array_map('strval', $communicationFitKeys)))),
+            'decision_mix_keys' => array_values(array_unique(array_filter(array_map('strval', $decisionMixKeys)))),
+            'stress_pattern_keys' => array_values(array_unique(array_filter(array_map('strval', $stressPatternKeys)))),
+            'team_blindspot_keys' => array_values(array_unique(array_filter(array_map('strval', $blindspotKeys)))),
+            'team_action_prompt_keys' => array_values(array_unique(array_filter(array_map('strval', $actionPromptKeys)))),
+            'workspace_scope' => 'assessment.summary.v0_4',
+        ];
+
+        $authority['fingerprint'] = sha1(json_encode($authority, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: self::VERSION);
+
+        return $authority;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function normalizeJson(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        return [];
+    }
+}

--- a/backend/tests/Feature/Tenant/TenantDashboardTeamDynamicsTest.php
+++ b/backend/tests/Feature/Tenant/TenantDashboardTeamDynamicsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenant;
+
+use App\Filament\Tenant\Widgets\TeamDynamicsOverviewWidget;
+use App\Models\Assessment;
+use App\Models\TenantUser;
+use App\Support\OrgContext;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use ReflectionClass;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class TenantDashboardTeamDynamicsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tenant_dashboard_widget_resolves_team_dynamics_for_single_org_member(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+
+        $user = TenantUser::query()->create([
+            'name' => 'Tenant Member',
+            'email' => 'tenant-member@test.local',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $orgId = (int) DB::table('organizations')->insertGetId([
+            'name' => 'Tenant Org',
+            'owner_user_id' => (int) $user->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => (int) $user->id,
+            'role' => 'owner',
+            'is_active' => 1,
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $assessment = Assessment::query()->create([
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'title' => 'Tenant Team MBTI',
+            'created_by' => (int) $user->id,
+            'status' => 'open',
+        ]);
+
+        $inviteTokens = [];
+        foreach ([0, 1] as $index) {
+            $token = (string) Str::uuid();
+            $inviteTokens[] = $token;
+            DB::table('assessment_assignments')->insert([
+                'org_id' => $orgId,
+                'assessment_id' => (int) $assessment->id,
+                'subject_type' => 'email',
+                'subject_value' => "member{$index}@tenant.test",
+                'invite_token' => $token,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $this->attachMbtiResult($orgId, (int) $user->id, $inviteTokens[0], 'INTJ-A', ['EI' => 33, 'SN' => 71, 'TF' => 79, 'JP' => 68, 'AT' => 25]);
+        $this->attachMbtiResult($orgId, (int) $user->id, $inviteTokens[1], 'ENFP-T', ['EI' => 81, 'SN' => 63, 'TF' => 29, 'JP' => 21, 'AT' => 82]);
+
+        $this->actingAs($user, (string) config('tenant.guard', 'tenant'));
+        app(OrgContext::class)->set($orgId, (int) $user->id, 'owner', null, OrgContext::KIND_TENANT);
+        request()->attributes->set('org_id', $orgId);
+        request()->attributes->set('fm_org_id', $orgId);
+        request()->attributes->set('org_context_resolved', true);
+        request()->attributes->set('org_context_kind', OrgContext::KIND_TENANT);
+
+        $widget = app(TeamDynamicsOverviewWidget::class);
+        $reflection = new ReflectionClass($widget);
+        $method = $reflection->getMethod('getStats');
+        $method->setAccessible(true);
+        $stats = $method->invoke($widget);
+
+        $this->assertIsArray($stats);
+        $this->assertCount(4, $stats);
+        $this->assertSame('Team focus', $stats[0]->getLabel());
+        $this->assertStringContainsString('Assessment #', (string) $stats[0]->getDescription());
+        $this->assertSame('Next action', $stats[3]->getLabel());
+    }
+
+    /**
+     * @param  array<string,int>  $scoresPct
+     */
+    private function attachMbtiResult(int $orgId, int $userId, string $inviteToken, string $typeCode, array $scoresPct): void
+    {
+        $attemptId = (string) Str::uuid();
+        $now = now();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'anon_id' => 'anon_'.$attemptId,
+            'user_id' => (string) $userId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['stage' => 'submit']),
+            'client_platform' => 'test',
+            'started_at' => $now,
+            'submitted_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('results')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => $typeCode,
+            'scores_json' => json_encode($scoresPct),
+            'scores_pct' => json_encode($scoresPct),
+            'axis_states' => json_encode(['EI' => 'clear', 'SN' => 'clear', 'TF' => 'clear', 'JP' => 'clear', 'AT' => 'clear']),
+            'content_package_version' => 'v0.3',
+            'result_json' => json_encode([
+                'type_code' => $typeCode,
+                'axis_scores_json' => ['scores_pct' => $scoresPct],
+            ]),
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => 1,
+            'computed_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('assessment_assignments')
+            ->where('invite_token', $inviteToken)
+            ->update([
+                'attempt_id' => $attemptId,
+                'started_at' => $now,
+                'completed_at' => $now,
+                'updated_at' => $now,
+            ]);
+    }
+}

--- a/backend/tests/Feature/V0_4/AssessmentTeamDynamicsSummaryTest.php
+++ b/backend/tests/Feature/V0_4/AssessmentTeamDynamicsSummaryTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_4;
+
+use App\Services\Auth\FmTokenService;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AssessmentTeamDynamicsSummaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mbti_assessment_summary_exposes_team_dynamics_v1(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+
+        $adminId = $this->createUser('team-dynamics-admin@test.local');
+        $orgId = $this->createOrg($adminId, 'Team Dynamics Org');
+        $token = $this->issueToken($adminId);
+
+        $assessmentId = $this->createAssessment($orgId, $token, 'MBTI', 'Team MBTI Dynamics');
+        $invites = $this->inviteSubjects($orgId, $assessmentId, $token, 3);
+
+        $this->attachMbtiResult($orgId, $adminId, (string) ($invites[0]['invite_token'] ?? ''), 'INTJ-A', ['EI' => 38, 'SN' => 77, 'TF' => 81, 'JP' => 66, 'AT' => 24]);
+        $this->attachMbtiResult($orgId, $adminId, (string) ($invites[1]['invite_token'] ?? ''), 'ENFP-T', ['EI' => 79, 'SN' => 69, 'TF' => 31, 'JP' => 18, 'AT' => 84]);
+        $this->attachMbtiResult($orgId, $adminId, (string) ($invites[2]['invite_token'] ?? ''), 'ISTJ-A', ['EI' => 24, 'SN' => 35, 'TF' => 74, 'JP' => 82, 'AT' => 28]);
+
+        $summary = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.4/orgs/{$orgId}/assessments/{$assessmentId}/summary");
+
+        $summary->assertStatus(200);
+        $summary->assertJsonPath('summary.team_dynamics_v1.version', 'team_dynamics.v1');
+        $summary->assertJsonPath('summary.team_dynamics_v1.team_member_count', 3);
+        $summary->assertJsonPath('summary.team_dynamics_v1.analyzed_member_count', 3);
+        $summary->assertJsonPath('summary.team_dynamics_v1.supporting_scales.0', 'MBTI');
+        $this->assertNotEmpty((array) $summary->json('summary.team_dynamics_v1.communication_fit_keys'));
+        $this->assertNotEmpty((array) $summary->json('summary.team_dynamics_v1.team_action_prompt_keys'));
+    }
+
+    public function test_summary_team_dynamics_respects_org_boundary(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+
+        $ownerId = $this->createUser('owner@test.local');
+        $orgId = $this->createOrg($ownerId, 'Primary Org');
+        $token = $this->issueToken($ownerId);
+        $assessmentId = $this->createAssessment($orgId, $token, 'MBTI', 'Protected Team MBTI');
+
+        $otherUserId = $this->createUser('other@test.local');
+        $otherOrgId = $this->createOrg($otherUserId, 'Other Org');
+        $otherToken = $this->issueToken($otherUserId);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$otherToken,
+        ])->getJson("/api/v0.4/orgs/{$orgId}/assessments/{$assessmentId}/summary");
+
+        $response->assertStatus(404)
+            ->assertJsonPath('error_code', 'ORG_NOT_FOUND');
+    }
+
+    private function createUser(string $email): int
+    {
+        return (int) DB::table('users')->insertGetId([
+            'name' => $email,
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createOrg(int $ownerUserId, string $name): int
+    {
+        $orgId = (int) DB::table('organizations')->insertGetId([
+            'name' => $name,
+            'owner_user_id' => $ownerUserId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $ownerUserId,
+            'role' => 'admin',
+            'is_active' => 1,
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $orgId;
+    }
+
+    private function issueToken(int $userId): string
+    {
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId);
+
+        return (string) ($issued['token'] ?? '');
+    }
+
+    private function createAssessment(int $orgId, string $token, string $scaleCode, string $title): int
+    {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson("/api/v0.4/orgs/{$orgId}/assessments", [
+            'scale_code' => $scaleCode,
+            'title' => $title,
+            'due_at' => now()->addDays(7)->toISOString(),
+        ]);
+
+        $response->assertStatus(200);
+
+        return (int) $response->json('assessment.id');
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function inviteSubjects(int $orgId, int $assessmentId, string $token, int $count): array
+    {
+        $subjects = [];
+        for ($index = 0; $index < $count; $index++) {
+            $subjects[] = [
+                'subject_type' => 'email',
+                'subject_value' => "member{$index}@team.test",
+            ];
+        }
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson("/api/v0.4/orgs/{$orgId}/assessments/{$assessmentId}/invite", [
+            'subjects' => $subjects,
+        ]);
+
+        $response->assertStatus(200);
+
+        return (array) $response->json('invites');
+    }
+
+    /**
+     * @param  array<string,int>  $scoresPct
+     */
+    private function attachMbtiResult(int $orgId, int $userId, string $inviteToken, string $typeCode, array $scoresPct): void
+    {
+        $attemptId = (string) Str::uuid();
+        $now = now();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'anon_id' => 'anon_'.$attemptId,
+            'user_id' => (string) $userId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['stage' => 'submit']),
+            'client_platform' => 'test',
+            'started_at' => $now,
+            'submitted_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('results')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => $typeCode,
+            'scores_json' => json_encode($scoresPct),
+            'scores_pct' => json_encode($scoresPct),
+            'axis_states' => json_encode(['EI' => 'clear', 'SN' => 'clear', 'TF' => 'clear', 'JP' => 'clear', 'AT' => 'clear']),
+            'content_package_version' => 'v0.3',
+            'result_json' => json_encode([
+                'type_code' => $typeCode,
+                'axis_scores_json' => ['scores_pct' => $scoresPct],
+            ]),
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => 1,
+            'computed_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('assessment_assignments')
+            ->where('invite_token', $inviteToken)
+            ->update([
+                'attempt_id' => $attemptId,
+                'started_at' => $now,
+                'completed_at' => $now,
+                'updated_at' => $now,
+            ]);
+    }
+}

--- a/backend/tests/Unit/Services/Team/TeamDynamicsSynthesisServiceTest.php
+++ b/backend/tests/Unit/Services/Team/TeamDynamicsSynthesisServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Team;
+
+use App\Models\Assessment;
+use App\Services\Team\TeamDynamicsSynthesisService;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+final class TeamDynamicsSynthesisServiceTest extends TestCase
+{
+    public function test_builds_mbti_team_dynamics_for_mixed_team(): void
+    {
+        $assessment = new Assessment([
+            'org_id' => 101,
+            'scale_code' => 'MBTI',
+            'title' => 'Team MBTI',
+        ]);
+
+        $results = new Collection([
+            (object) ['type_code' => 'INTJ-A', 'result_json' => []],
+            (object) ['type_code' => 'ENFP-T', 'result_json' => []],
+            (object) ['type_code' => 'ISTJ-A', 'result_json' => []],
+        ]);
+
+        $authority = app(TeamDynamicsSynthesisService::class)->buildForAssessment($assessment, $results, 3);
+
+        $this->assertIsArray($authority);
+        $this->assertSame('team_dynamics.v1', $authority['version'] ?? null);
+        $this->assertSame(3, $authority['team_member_count'] ?? null);
+        $this->assertSame(3, $authority['analyzed_member_count'] ?? null);
+        $this->assertContains('MBTI', $authority['supporting_scales'] ?? []);
+        $this->assertContains('team.communication.energy_translation', $authority['communication_fit_keys'] ?? []);
+        $this->assertContains('team.decision.logic_empathy_mix', $authority['decision_mix_keys'] ?? []);
+        $this->assertContains('team.blindspot.execution_alignment', $authority['team_blindspot_keys'] ?? []);
+        $this->assertNotSame('', trim((string) ($authority['fingerprint'] ?? '')));
+    }
+
+    public function test_builds_big_five_team_dynamics_for_trait_mix(): void
+    {
+        $assessment = new Assessment([
+            'org_id' => 202,
+            'scale_code' => 'BIG5_OCEAN',
+            'title' => 'Team Big Five',
+        ]);
+
+        $results = new Collection([
+            (object) ['scores_pct' => ['O' => 72, 'C' => 75, 'E' => 28, 'A' => 70, 'N' => 30]],
+            (object) ['scores_pct' => ['O' => 66, 'C' => 61, 'E' => 78, 'A' => 39, 'N' => 74]],
+            (object) ['scores_pct' => ['O' => 58, 'C' => 44, 'E' => 62, 'A' => 42, 'N' => 69]],
+        ]);
+
+        $authority = app(TeamDynamicsSynthesisService::class)->buildForAssessment($assessment, $results, 3);
+
+        $this->assertIsArray($authority);
+        $this->assertContains('BIG5_OCEAN', $authority['supporting_scales'] ?? []);
+        $this->assertNotEmpty($authority['communication_fit_keys'] ?? []);
+        $this->assertNotEmpty($authority['decision_mix_keys'] ?? []);
+        $this->assertNotEmpty($authority['stress_pattern_keys'] ?? []);
+        $this->assertNotEmpty($authority['team_action_prompt_keys'] ?? []);
+    }
+
+    public function test_returns_null_when_not_enough_members_are_analyzed(): void
+    {
+        $assessment = new Assessment([
+            'org_id' => 303,
+            'scale_code' => 'MBTI',
+            'title' => 'Too Small',
+        ]);
+
+        $results = new Collection([
+            (object) ['type_code' => 'INTJ-A', 'result_json' => []],
+        ]);
+
+        $authority = app(TeamDynamicsSynthesisService::class)->buildForAssessment($assessment, $results, 1);
+
+        $this->assertNull($authority);
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-10C: team dynamics and B2B workspace.

It adds the first backend-owned team synthesis layer on top of the existing org / tenant / assessment foundations and makes it visible in the tenant workspace without changing any member-level canonical truth.

## What changed

Backend:
- adds `team_dynamics_v1`
- derives:
  - `team_focus_key`
  - `team_member_count`
  - `analyzed_member_count`
  - `supporting_scales`
  - `communication_fit_keys`
  - `decision_mix_keys`
  - `stress_pattern_keys`
  - `team_blindspot_keys`
  - `team_action_prompt_keys`
- wires team synthesis into `v0.4` assessment summary
- adds a minimal tenant dashboard widget for team dynamics
- records team summary / workspace exposure telemetry foundation
- keeps team synthesis inside org / tenant boundaries only

## Why this matters

The platform can now move beyond individual result interpretation and produce a first team-level collaboration authority.

This is not a full B2B admin platform. It is the minimum working workspace layer that turns multiple member results into a stable, replayable team dynamics summary.

## Guardrails

- no canonical MBTI or Big Five scoring changes
- no frontend-local team synthesis
- no migration
- no new dependency
- no public team share surface
- tenant / org isolation remains enforced

## Validation

I ran:

- `php artisan test tests/Unit/Services/Team/TeamDynamicsSynthesisServiceTest.php tests/Feature/V0_4/AssessmentTeamDynamicsSummaryTest.php tests/Feature/Tenant/TenantDashboardTeamDynamicsTest.php tests/Feature/V0_4/AssessmentsProgressSummaryTest.php tests/Feature/V0_4/AssessmentsRbacIsolationTest.php`

All passed:
- 8 tests passed
- 56 assertions

## Scope note

This PR is intentionally backend-only.

The existing in-scope workspace surface is the backend tenant panel. `fap-web` does not currently contain a protected B2B workspace shell that fits PR-10C without expanding scope into a new product shell.
