### PR TITLE
[codex] Ship PR-10D insight graph API and embeddable OS (backend)

### DIFF
--- a/backend/app/Services/InsightGraph/InsightGraphContractService.php
+++ b/backend/app/Services/InsightGraph/InsightGraphContractService.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InsightGraph;
+
+final class InsightGraphContractService
+{
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $publicSurface
+     * @return array<string,mixed>
+     */
+    public function buildForShare(array $payload, array $publicSurface): array
+    {
+        $scaleCode = strtoupper(trim((string) ($payload['scale_code'] ?? '')));
+        if ($scaleCode === '') {
+            return [];
+        }
+
+        $nodes = [];
+        $edges = [];
+
+        $this->pushNode(
+            $nodes,
+            'result_summary',
+            'result_summary',
+            $this->normalizeText($payload['title'] ?? null, $payload['type_name'] ?? null, $payload['type_code'] ?? null) ?? $scaleCode,
+            $this->normalizeText($payload['summary'] ?? null, $payload['subtitle'] ?? null) ?? '',
+            'share_summary'
+        );
+
+        $narrativeSummary = $this->normalizeText(data_get($payload, 'controlled_narrative_v1.narrative_summary'));
+        if ($narrativeSummary !== null) {
+            $this->pushNode(
+                $nodes,
+                'narrative',
+                'narrative',
+                'Public narrative',
+                $narrativeSummary,
+                'controlled_narrative_v1'
+            );
+            $edges[] = ['from' => 'narrative', 'to' => 'result_summary', 'relation' => 'enriches'];
+        }
+
+        $comparativeSummary = $this->normalizeText(
+            data_get($payload, 'comparative_v1.cohort_relative_position.summary'),
+            data_get($payload, 'comparative_v1.same_type_contrast.summary')
+        );
+        if ($comparativeSummary !== null) {
+            $this->pushNode(
+                $nodes,
+                'comparative',
+                'comparative',
+                $this->normalizeText(
+                    data_get($payload, 'comparative_v1.cohort_relative_position.label'),
+                    data_get($payload, 'comparative_v1.same_type_contrast.label'),
+                    'Relative position'
+                ) ?? 'Relative position',
+                $comparativeSummary,
+                'comparative_v1'
+            );
+            $edges[] = ['from' => 'comparative', 'to' => 'result_summary', 'relation' => 'supports'];
+        }
+
+        $workingLifeSummary = $this->normalizeText(
+            data_get($payload, 'cultural_calibration_v1.working_life_summary')
+        );
+        if ($workingLifeSummary === null) {
+            $careerFocusKey = $this->normalizeText(data_get($payload, 'working_life_v1.career_focus_key'));
+            if ($careerFocusKey !== null) {
+                $workingLifeSummary = 'Current focus: '.$careerFocusKey;
+            }
+        }
+
+        if ($workingLifeSummary !== null) {
+            $this->pushNode(
+                $nodes,
+                'working_life',
+                'working_life',
+                'Working-life cue',
+                $workingLifeSummary,
+                'working_life_v1'
+            );
+            $edges[] = ['from' => 'working_life', 'to' => 'result_summary', 'relation' => 'recommended_next'];
+        }
+
+        $continueReadingKeys = $this->normalizeStringList($publicSurface['continue_reading_keys'] ?? []);
+        $continueSummary = $continueReadingKeys !== []
+            ? implode(' -> ', array_slice($continueReadingKeys, 0, 3))
+            : $this->normalizeText($payload['primary_cta_label'] ?? null, $payload['primary_cta_path'] ?? null);
+        if ($continueSummary !== null) {
+            $this->pushNode(
+                $nodes,
+                'continue_reading',
+                'continue_reading',
+                'Continue path',
+                $continueSummary,
+                'public_surface_v1'
+            );
+            $edges[] = ['from' => 'result_summary', 'to' => 'continue_reading', 'relation' => 'continues_to'];
+            if ($this->hasNode($nodes, 'working_life')) {
+                $edges[] = ['from' => 'working_life', 'to' => 'continue_reading', 'relation' => 'recommended_next'];
+            }
+        }
+
+        $supportingScales = $this->resolveSupportingScales($scaleCode, $payload);
+        $fingerprintSeed = [
+            'scale_code' => $scaleCode,
+            'graph_scope' => 'public_share_safe',
+            'supporting_scales' => $supportingScales,
+            'public_summary_fingerprint' => $this->normalizeText($publicSurface['public_summary_fingerprint'] ?? null),
+            'nodes' => $nodes,
+            'edges' => $edges,
+        ];
+
+        return [
+            'version' => 'insight.graph.v1',
+            'graph_contract_version' => 'insight.graph.v1',
+            'root_node' => 'result_summary',
+            'nodes' => $nodes,
+            'edges' => $edges,
+            'graph_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'graph_scope' => 'public_share_safe',
+            'supporting_scales' => $supportingScales,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $graph
+     * @param  array<string,mixed>  $publicSurface
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    public function buildEmbedSurface(array $graph, array $publicSurface, array $payload): array
+    {
+        if ($graph === []) {
+            return [];
+        }
+
+        $nodeIds = array_values(array_filter(array_map(
+            static fn (mixed $node): string => is_array($node) ? trim((string) ($node['id'] ?? '')) : '',
+            is_array($graph['nodes'] ?? null) ? $graph['nodes'] : []
+        )));
+        $continueTarget = $this->normalizeText(
+            data_get($publicSurface, 'continue_reading_keys.0'),
+            $payload['primary_cta_path'] ?? null
+        ) ?? '';
+        $summary = $this->normalizeText(
+            data_get($payload, 'controlled_narrative_v1.narrative_summary'),
+            $payload['summary'] ?? null,
+            data_get($payload, 'comparative_v1.cohort_relative_position.summary')
+        ) ?? '';
+        $scaleCode = strtoupper(trim((string) ($payload['scale_code'] ?? '')));
+        $surfaceKey = $scaleCode === 'BIG5_OCEAN' ? 'big5_share_embed_card' : 'mbti_share_embed_card';
+        $title = $this->normalizeText($payload['title'] ?? null, $payload['type_name'] ?? null, $payload['type_code'] ?? null) ?? 'Insight graph';
+
+        $fingerprintSeed = [
+            'surface_key' => $surfaceKey,
+            'entry_surface' => $this->normalizeText($publicSurface['entry_surface'] ?? null),
+            'graph_fingerprint' => $this->normalizeText($graph['graph_fingerprint'] ?? null),
+            'continue_target' => $continueTarget,
+            'allowed_node_ids' => $nodeIds,
+        ];
+
+        return [
+            'version' => 'embed.surface.v1',
+            'surface_key' => $surfaceKey,
+            'graph_scope' => $this->normalizeText($graph['graph_scope'] ?? null) ?? 'public_share_safe',
+            'entry_surface' => $this->normalizeText($publicSurface['entry_surface'] ?? null) ?? '',
+            'title' => $title,
+            'summary' => $summary,
+            'primary_cta_label' => $this->normalizeText($payload['primary_cta_label'] ?? null) ?? '',
+            'primary_cta_path' => $this->normalizeText($payload['primary_cta_path'] ?? null) ?? '',
+            'continue_target' => $continueTarget,
+            'allowed_node_ids' => $nodeIds,
+            'embed_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'render_mode' => 'card',
+        ];
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $nodes
+     */
+    private function hasNode(array $nodes, string $id): bool
+    {
+        foreach ($nodes as $node) {
+            if (trim((string) ($node['id'] ?? '')) === $id) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $nodes
+     */
+    private function pushNode(
+        array &$nodes,
+        string $id,
+        string $kind,
+        string $title,
+        string $summary,
+        string $sourceContract
+    ): void {
+        if ($title === '' || $summary === '') {
+            return;
+        }
+
+        $nodes[] = [
+            'id' => $id,
+            'kind' => $kind,
+            'title' => $title,
+            'summary' => $summary,
+            'source_contract' => $sourceContract,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<int,string>
+     */
+    private function resolveSupportingScales(string $scaleCode, array $payload): array
+    {
+        $supporting = [$scaleCode];
+
+        foreach ([
+            data_get($payload, 'working_life_v1.supporting_scales'),
+            data_get($payload, 'mbti_cross_assessment_v1.supporting_scales'),
+        ] as $candidate) {
+            foreach ($this->normalizeStringList(is_array($candidate) ? $candidate : []) as $value) {
+                $supporting[] = strtoupper($value);
+            }
+        }
+
+        $unique = [];
+        foreach ($supporting as $value) {
+            $normalized = trim(strtoupper((string) $value));
+            if ($normalized === '') {
+                continue;
+            }
+            $unique[$normalized] = true;
+        }
+
+        return array_keys($unique);
+    }
+
+    private function normalizeText(mixed ...$values): ?string
+    {
+        foreach ($values as $value) {
+            if (! is_scalar($value)) {
+                continue;
+            }
+
+            $normalized = trim((string) $value);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int,mixed>  $values
+     * @return array<int,string>
+     */
+    private function normalizeStringList(array $values): array
+    {
+        $normalized = [];
+
+        foreach ($values as $value) {
+            $item = $this->normalizeText($value);
+            if ($item === null) {
+                continue;
+            }
+
+            $normalized[$item] = true;
+        }
+
+        return array_keys($normalized);
+    }
+}

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -11,6 +11,7 @@ use App\Services\Mbti\MbtiPrivacyConsentContractService;
 use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\BigFive\BigFivePublicProjectionService;
+use App\Services\InsightGraph\InsightGraphContractService;
 use App\Services\PublicSurface\PublicSurfaceContractService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportComposer;
@@ -33,6 +34,7 @@ class ShareService
         private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private readonly BigFivePublicProjectionService $bigFivePublicProjectionService,
         private readonly PublicSurfaceContractService $publicSurfaceContractService,
+        private readonly InsightGraphContractService $insightGraphContractService,
     ) {}
 
     public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
@@ -804,6 +806,15 @@ class ShareService
             $resolvedShareId,
             $big5Projection,
             $publicSafeReport
+        );
+        $payload['insight_graph_v1'] = $this->insightGraphContractService->buildForShare(
+            $payload,
+            is_array($payload['public_surface_v1'] ?? null) ? $payload['public_surface_v1'] : []
+        );
+        $payload['embed_surface_v1'] = $this->insightGraphContractService->buildEmbedSurface(
+            is_array($payload['insight_graph_v1'] ?? null) ? $payload['insight_graph_v1'] : [],
+            is_array($payload['public_surface_v1'] ?? null) ? $payload['public_surface_v1'] : [],
+            $payload
         );
 
         return $payload;

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -85,6 +85,13 @@ final class ShareSummaryContractTest extends TestCase
         $this->assertSame('share_public_surface', $response->json('public_surface_v1.attribution_scope'));
         $this->assertContains('share_landing', $response->json('public_surface_v1.discoverability_keys'));
         $this->assertContains('continue_here', $response->json('public_surface_v1.discoverability_keys'));
+        $this->assertSame('insight.graph.v1', $response->json('insight_graph_v1.graph_contract_version'));
+        $this->assertSame('public_share_safe', $response->json('insight_graph_v1.graph_scope'));
+        $this->assertSame('result_summary', $response->json('insight_graph_v1.root_node'));
+        $this->assertContains('working_life', array_column((array) $response->json('insight_graph_v1.nodes'), 'id'));
+        $this->assertSame('embed.surface.v1', $response->json('embed_surface_v1.version'));
+        $this->assertSame('mbti_share_embed_card', $response->json('embed_surface_v1.surface_key'));
+        $this->assertSame('growth.next_actions', $response->json('embed_surface_v1.continue_target'));
         $this->assertSame(
             ['growth.next_actions', 'traits.close_call_axes', 'traits.adjacent_type_contrast'],
             $response->json('public_surface_v1.continue_reading_keys')
@@ -157,6 +164,8 @@ final class ShareSummaryContractTest extends TestCase
             'mbti_public_summary_v1',
             'mbti_public_projection_v1',
             'public_surface_v1',
+            'insight_graph_v1',
+            'embed_surface_v1',
         ] as $key) {
             $this->assertSame($share->json($key), $view->json($key), "share field mismatch: {$key}");
         }
@@ -209,6 +218,10 @@ final class ShareSummaryContractTest extends TestCase
             ->assertJsonPath('public_surface_v1.attribution_scope', 'share_public_surface')
             ->assertJsonPath('comparative_v1.norming_source', 'scale_norms')
             ->assertJsonPath('comparative_v1.percentile.metric_key', 'O')
+            ->assertJsonPath('insight_graph_v1.graph_contract_version', 'insight.graph.v1')
+            ->assertJsonPath('insight_graph_v1.graph_scope', 'public_share_safe')
+            ->assertJsonPath('embed_surface_v1.version', 'embed.surface.v1')
+            ->assertJsonPath('embed_surface_v1.surface_key', 'big5_share_embed_card')
             ->assertJsonMissingPath('report')
             ->assertJsonMissingPath('result')
             ->assertJsonMissingPath('offers')

--- a/backend/tests/Unit/Services/InsightGraph/InsightGraphContractServiceTest.php
+++ b/backend/tests/Unit/Services/InsightGraph/InsightGraphContractServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\InsightGraph;
+
+use App\Services\InsightGraph\InsightGraphContractService;
+use Tests\TestCase;
+
+final class InsightGraphContractServiceTest extends TestCase
+{
+    public function test_it_builds_a_public_share_safe_graph_and_embed_surface(): void
+    {
+        $service = new InsightGraphContractService;
+        $payload = [
+            'scale_code' => 'MBTI',
+            'title' => 'Campaigner',
+            'type_name' => 'Campaigner',
+            'summary' => 'A public-safe summary.',
+            'primary_cta_label' => 'Start MBTI test',
+            'primary_cta_path' => '/en/tests/mbti-personality-test-16-personality-types/take',
+            'controlled_narrative_v1' => [
+                'narrative_summary' => 'Narrative layer summary.',
+            ],
+            'comparative_v1' => [
+                'cohort_relative_position' => [
+                    'label' => 'Above about 62% of the cohort',
+                    'summary' => 'Above roughly 62% of the anonymized cohort.',
+                ],
+            ],
+            'working_life_v1' => [
+                'career_focus_key' => 'career.next_step',
+                'supporting_scales' => ['BIG5_OCEAN'],
+            ],
+        ];
+        $publicSurface = [
+            'entry_surface' => 'mbti_share_landing',
+            'public_summary_fingerprint' => 'share-fingerprint-123',
+            'continue_reading_keys' => ['career.next_step', 'career.work_experiments'],
+        ];
+
+        $graph = $service->buildForShare($payload, $publicSurface);
+        $embed = $service->buildEmbedSurface($graph, $publicSurface, $payload);
+
+        $this->assertSame('insight.graph.v1', $graph['graph_contract_version']);
+        $this->assertSame('result_summary', $graph['root_node']);
+        $this->assertSame('public_share_safe', $graph['graph_scope']);
+        $this->assertSame(['MBTI', 'BIG5_OCEAN'], $graph['supporting_scales']);
+        $this->assertCount(5, $graph['nodes']);
+        $this->assertSame('narrative', $graph['nodes'][1]['id']);
+        $this->assertSame('embed.surface.v1', $embed['version']);
+        $this->assertSame('mbti_share_embed_card', $embed['surface_key']);
+        $this->assertSame('career.next_step', $embed['continue_target']);
+        $this->assertSame(['result_summary', 'narrative', 'comparative', 'working_life', 'continue_reading'], $embed['allowed_node_ids']);
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-10D: insight graph API and embeddable OS.

It introduces the first backend-owned `insight_graph_v1` and `embed_surface_v1` contracts on the existing share/public-safe result path, so the result engine can be consumed as a graph-backed reusable surface without changing canonical truth.

## Problem

The platform already had strong backend-owned authority for public summaries, controlled narrative, comparative guidance, working-life cues, and continue-reading paths. But those capabilities were still delivered as parallel fields.

That meant the system had rich result authority, yet no unified graph contract and no first embeddable operating-system-style surface that another UI could safely consume.

## Root cause

The share/public-safe delivery path had `public_surface_v1`, but it still lacked:

- a versioned graph contract that organizes the existing authority
- a minimal embed contract that points to a stable subset of graph nodes
- explicit graph scope / fingerprint metadata for replay and telemetry

Without that layer, every future embed or downstream surface would have to understand multiple separate contracts directly instead of consuming a single graph-backed object.

## Fix

This PR adds `InsightGraphContractService` and wires two new contracts into the share/public-safe payload:

- `insight_graph_v1`
- `embed_surface_v1`

The first-wave graph organizes existing public-safe authority into nodes and edges, including:

- result summary
- controlled narrative
- comparative guidance
- working-life cue
- continue-reading path

The embed contract exposes a minimal graph-backed card surface with:

- surface key
- graph scope
- allowed node ids
- summary
- continue target
- embed fingerprint

This remains strictly additive:

- no canonical MBTI or Big Five truth is changed
- no new route is introduced
- no tenant-only data is moved into public share scope
- no new dependency or migration is introduced

## Why this matters

This is the first step from “result pages with many authority layers” to “a reusable insight OS surface”.

The platform can now expose a graph-backed summary that downstream surfaces can consume without re-assembling truth client-side.

## Validation

I ran:

- `php artisan test tests/Unit/Services/InsightGraph/InsightGraphContractServiceTest.php tests/Feature/V0_3/ShareSummaryContractTest.php`

All passed:

- 4 tests passed
- 159 assertions

## Scope note

This PR is intentionally limited to backend graph/embed foundation on the existing share/public-safe path.

It does not:

- add OAuth, SDKs, or a developer portal
- create a new API platform shell
- change canonical scoring or result truth
- pull in task-external dirty files such as pack publish/rollback or compiled artifact changes
