### PR TITLE
[codex] Ship PR-10C.1 protected team workspace surface and manager loop (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
+++ b/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
@@ -179,6 +179,7 @@ class AssessmentController extends Controller
         $summary = $this->assessments->summary($assessment);
 
         $teamDynamics = is_array($summary['team_dynamics_v1'] ?? null) ? $summary['team_dynamics_v1'] : null;
+        $workspaceSurface = is_array($summary['workspace_surface_v1'] ?? null) ? $summary['workspace_surface_v1'] : null;
         if ($teamDynamics !== null) {
             $this->events->record('team_dynamics_summary_view', $this->resolveUserId($request), [
                 'assessment_id' => (int) $assessment->id,
@@ -188,6 +189,9 @@ class AssessmentController extends Controller
                 'analyzed_member_count' => (int) ($teamDynamics['analyzed_member_count'] ?? 0),
                 'version' => (string) ($teamDynamics['version'] ?? ''),
                 'workspace_scope' => (string) ($teamDynamics['workspace_scope'] ?? ''),
+                'workspace_surface_version' => (string) ($workspaceSurface['version'] ?? ''),
+                'workspace_surface_fingerprint' => (string) ($workspaceSurface['workspace_surface_fingerprint'] ?? ''),
+                'manager_action_keys' => array_values((array) ($workspaceSurface['manager_action_keys'] ?? [])),
             ], [
                 'org_id' => $orgId,
                 'scale_code' => (string) ($assessment->scale_code ?? ''),

--- a/backend/app/Services/Assessments/AssessmentSummaryService.php
+++ b/backend/app/Services/Assessments/AssessmentSummaryService.php
@@ -14,6 +14,7 @@ class AssessmentSummaryService
     public function __construct(
         private ScaleRegistry $registry,
         private TeamDynamicsSynthesisService $teamDynamics,
+        private WorkspaceSurfaceContractService $workspaceSurface,
     ) {}
 
     public function buildSummary(Assessment $assessment): array
@@ -51,6 +52,12 @@ class AssessmentSummaryService
 
         $driverType = $this->resolveDriverType($assessment);
 
+        $completionRate = [
+            'completed' => $completed,
+            'total' => $total,
+        ];
+        $teamDynamics = $this->teamDynamics->buildForAssessment($assessment, $results, $total);
+
         return [
             'completion_rate' => [
                 'completed' => $completed,
@@ -63,7 +70,8 @@ class AssessmentSummaryService
             ],
             'score_distribution' => $this->scoreDistribution($driverType, $results),
             'dimension_means' => $this->dimensionMeans($driverType, $results),
-            'team_dynamics_v1' => $this->teamDynamics->buildForAssessment($assessment, $results, $total),
+            'team_dynamics_v1' => $teamDynamics,
+            'workspace_surface_v1' => $this->workspaceSurface->build($teamDynamics, $completionRate),
         ];
     }
 

--- a/backend/app/Services/Assessments/WorkspaceSurfaceContractService.php
+++ b/backend/app/Services/Assessments/WorkspaceSurfaceContractService.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assessments;
+
+final class WorkspaceSurfaceContractService
+{
+    /**
+     * @param  array<string,mixed>|null  $teamDynamics
+     * @param  array{completed:int,total:int}  $completionRate
+     * @return array<string,mixed>
+     */
+    public function build(?array $teamDynamics, array $completionRate): array
+    {
+        $completed = max(0, (int) ($completionRate['completed'] ?? 0));
+        $total = max(0, (int) ($completionRate['total'] ?? 0));
+        $pending = max(0, $total - $completed);
+
+        $workspaceFocusKey = $this->normalizeString($teamDynamics['team_focus_key'] ?? null)
+            ?? ($completed > 0 ? 'team_alignment_review' : 'team_setup_incomplete');
+
+        $managerActionKeys = $this->normalizeStringList($teamDynamics['team_action_prompt_keys'] ?? []);
+        if ($managerActionKeys === []) {
+            $managerActionKeys = $completed > 0
+                ? ['review_team_action_prompts', 'check_member_progress']
+                : ['invite_more_members', 'check_member_progress'];
+        }
+
+        $memberDrillInKeys = [];
+        if ($completed > 0) {
+            $memberDrillInKeys[] = 'completed_assignments';
+        }
+        if ($pending > 0) {
+            $memberDrillInKeys[] = 'pending_assignments';
+        }
+        if ($memberDrillInKeys === []) {
+            $memberDrillInKeys[] = 'assignment_progress';
+        }
+
+        $supportingScales = $this->normalizeStringList($teamDynamics['supporting_scales'] ?? []);
+        $analyzedMemberCount = max(0, (int) ($teamDynamics['analyzed_member_count'] ?? 0));
+        $teamMemberCount = max(0, (int) ($teamDynamics['team_member_count'] ?? $total));
+        $workspaceScope = $this->normalizeString($teamDynamics['workspace_scope'] ?? 'tenant_protected')
+            ?? 'tenant_protected';
+
+        $fingerprintSeed = [
+            'workspace_focus_key' => $workspaceFocusKey,
+            'manager_action_keys' => $managerActionKeys,
+            'member_drill_in_keys' => $memberDrillInKeys,
+            'supporting_scales' => $supportingScales,
+            'team_member_count' => $teamMemberCount,
+            'analyzed_member_count' => $analyzedMemberCount,
+            'workspace_scope' => $workspaceScope,
+            'completed' => $completed,
+            'pending' => $pending,
+            'team_dynamics_version' => $this->normalizeString($teamDynamics['version'] ?? null),
+        ];
+
+        return [
+            'version' => 'workspace.surface.v1',
+            'workspace_focus_key' => $workspaceFocusKey,
+            'manager_action_keys' => $managerActionKeys,
+            'member_drill_in_keys' => $memberDrillInKeys,
+            'workspace_surface_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'workspace_scope' => $workspaceScope,
+            'supporting_scales' => $supportingScales,
+            'team_member_count' => $teamMemberCount,
+            'analyzed_member_count' => $analyzedMemberCount,
+        ];
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  mixed  $values
+     * @return array<int,string>
+     */
+    private function normalizeStringList(mixed $values): array
+    {
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($values as $value) {
+            $item = $this->normalizeString($value);
+            if ($item === null) {
+                continue;
+            }
+
+            $normalized[$item] = true;
+        }
+
+        return array_keys($normalized);
+    }
+}

--- a/backend/tests/Feature/V0_4/AssessmentTeamDynamicsSummaryTest.php
+++ b/backend/tests/Feature/V0_4/AssessmentTeamDynamicsSummaryTest.php
@@ -41,6 +41,11 @@ final class AssessmentTeamDynamicsSummaryTest extends TestCase
         $summary->assertJsonPath('summary.team_dynamics_v1.supporting_scales.0', 'MBTI');
         $this->assertNotEmpty((array) $summary->json('summary.team_dynamics_v1.communication_fit_keys'));
         $this->assertNotEmpty((array) $summary->json('summary.team_dynamics_v1.team_action_prompt_keys'));
+        $summary->assertJsonPath('summary.workspace_surface_v1.version', 'workspace.surface.v1');
+        $summary->assertJsonPath('summary.workspace_surface_v1.workspace_focus_key', 'team.communication.energy_translation');
+        $summary->assertJsonPath('summary.workspace_surface_v1.manager_action_keys.0', 'team.action.sync_communication_cadence');
+        $summary->assertJsonPath('summary.workspace_surface_v1.member_drill_in_keys.0', 'completed_assignments');
+        $this->assertNotEmpty((string) $summary->json('summary.workspace_surface_v1.workspace_surface_fingerprint'));
     }
 
     public function test_summary_team_dynamics_respects_org_boundary(): void

--- a/backend/tests/Unit/Services/Assessments/WorkspaceSurfaceContractServiceTest.php
+++ b/backend/tests/Unit/Services/Assessments/WorkspaceSurfaceContractServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Assessments;
+
+use App\Services\Assessments\WorkspaceSurfaceContractService;
+use Tests\TestCase;
+
+final class WorkspaceSurfaceContractServiceTest extends TestCase
+{
+    public function test_builds_workspace_surface_v1_from_team_dynamics(): void
+    {
+        $service = app(WorkspaceSurfaceContractService::class);
+
+        $surface = $service->build([
+            'version' => 'team_dynamics.v1',
+            'team_focus_key' => 'decision_balance',
+            'team_member_count' => 4,
+            'analyzed_member_count' => 3,
+            'supporting_scales' => ['MBTI', 'BIG5_OCEAN'],
+            'team_action_prompt_keys' => ['review_team_action_prompts', 'align_decision_norms'],
+            'workspace_scope' => 'tenant_protected',
+        ], [
+            'completed' => 3,
+            'total' => 4,
+        ]);
+
+        $this->assertSame('workspace.surface.v1', $surface['version'] ?? null);
+        $this->assertSame('decision_balance', $surface['workspace_focus_key'] ?? null);
+        $this->assertSame(['review_team_action_prompts', 'align_decision_norms'], $surface['manager_action_keys'] ?? null);
+        $this->assertSame(['completed_assignments', 'pending_assignments'], $surface['member_drill_in_keys'] ?? null);
+        $this->assertSame('tenant_protected', $surface['workspace_scope'] ?? null);
+        $this->assertNotEmpty($surface['workspace_surface_fingerprint'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-10C.1: protected team workspace surface and manager loop.

It turns the existing PR-10C team synthesis into a web-consumable protected workspace contract on the existing `v0.4` assessment summary path, without changing any member-level canonical truth.

## Problem

PR-10C already established `team_dynamics_v1`, but that authority was still effectively trapped in the backend tenant panel first wave.

There was no dedicated workspace-surface contract for a real `fap-web` team page, which meant the web product still lacked:

- a stable protected workspace summary contract
- manager-action metadata for a minimal loop
- a replayable fingerprint/version boundary for the workspace surface itself

## Root cause

The backend had team-level authority, org scoping, and summary telemetry, but the assessment summary payload still exposed only the raw team synthesis block.

That was enough for a widget, but not enough for a protected product surface that needed to understand:

- workspace focus
- manager next-action keys
- allowed member drill-in keys
- workspace fingerprint / version metadata

## Fix

This PR adds `WorkspaceSurfaceContractService` and extends the existing summary path with `workspace_surface_v1`.

It:

- derives:
  - `workspace_focus_key`
  - `manager_action_keys`
  - `member_drill_in_keys`
  - `workspace_surface_fingerprint`
  - `workspace_scope`
- keeps `team_dynamics_v1` unchanged
- carries workspace-surface metadata into the existing team summary exposure telemetry
- preserves existing org / tenant role boundaries on the assessment summary route

This remains strictly additive:

- no new persistence
- no migration
- no new dependency
- no change to MBTI or Big Five canonical scoring
- no member-private result detail leakage

## Why this matters

This is the contract layer that lets the web product expose a real protected team workspace instead of relying on a backend-only widget.

The platform now has a backend-owned workspace surface that managers can consume safely while staying within the existing org / tenant boundary.

## Validation

I ran:

- `php artisan test tests/Unit/Services/Assessments/WorkspaceSurfaceContractServiceTest.php tests/Feature/V0_4/AssessmentTeamDynamicsSummaryTest.php tests/Feature/V0_4/AssessmentsRbacIsolationTest.php`

All passed:

- 4 tests passed
- 28 assertions

## Scope note

This PR is intentionally limited to the backend workspace surface contract.

It does not:

- introduce a new auth system
- add member management, invites, billing, or public team sharing
- expand beyond the existing protected org-scoped assessment summary path
- pull in task-external dirty files such as pack publish/rollback or compiled artifact changes
