### PR TITLE
[codex] add storage control-plane status reporting

### DIFF
--- a/backend/app/Console/Commands/StorageControlPlaneStatus.php
+++ b/backend/app/Console/Commands/StorageControlPlaneStatus.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\StorageControlPlaneStatusService;
+use Illuminate\Console\Command;
+
+final class StorageControlPlaneStatus extends Command
+{
+    protected $signature = 'storage:control-plane-status
+        {--json : Emit the full control-plane status payload as JSON}';
+
+    protected $description = 'Read-only storage control-plane status/reporting surface.';
+
+    public function __construct(
+        private readonly StorageControlPlaneStatusService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $payload = $this->service->buildStatus();
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode control-plane status json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return self::SUCCESS;
+        }
+
+        $this->line('schema_version='.(string) ($payload['schema_version'] ?? ''));
+        $this->line('generated_at='.(string) ($payload['generated_at'] ?? ''));
+        $this->line('inventory.status='.(string) data_get($payload, 'inventory.status', 'not_available'));
+        $this->line('retention.status='.(string) data_get($payload, 'retention.status', 'never_run'));
+        $this->line('blob_coverage.storage_blobs='.(int) data_get($payload, 'blob_coverage.counts.storage_blobs', 0));
+        $this->line('exact_authority.manifests='.(int) data_get($payload, 'exact_authority.counts.content_release_exact_manifests', 0));
+        $this->line('rehydrate.status='.(string) data_get($payload, 'rehydrate.status', 'never_run'));
+        $this->line('quarantine.item_root_count='.(int) data_get($payload, 'quarantine.item_root_count', 0));
+        $this->line('restore.run_count='.(int) data_get($payload, 'restore.restore_run_count', 0));
+        $this->line('purge.receipt_count='.(int) data_get($payload, 'purge.purge_receipt_count', 0));
+        $this->line('retirement.quarantine.status='.(string) data_get($payload, 'retirement.actions.quarantine.status', 'never_run'));
+        $this->line('retirement.purge.status='.(string) data_get($payload, 'retirement.actions.purge.status', 'never_run'));
+        $this->line('runtime_truth.v2_readiness='.(string) data_get($payload, 'runtime_truth.v2_readiness', 'local_only'));
+        $this->line('automation_readiness.auto_dry_run_ok='.(int) count((array) data_get($payload, 'automation_readiness.auto_dry_run_ok', [])));
+        $this->line('automation_readiness.manual_execute_only='.(int) count((array) data_get($payload, 'automation_readiness.manual_execute_only', [])));
+        $this->line('automation_readiness.not_in_scope_for_pr25='.(int) count((array) data_get($payload, 'automation_readiness.not_in_scope_for_pr25', [])));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -1,0 +1,634 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageControlPlaneStatusService
+{
+    private const SCHEMA_VERSION = 'storage_control_plane_status.v1';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildStatus(): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'generated_at' => now()->toIso8601String(),
+            'inventory' => $this->inventorySection(),
+            'retention' => $this->retentionSection(),
+            'blob_coverage' => $this->blobCoverageSection(),
+            'exact_authority' => $this->exactAuthoritySection(),
+            'rehydrate' => $this->rehydrateSection(),
+            'quarantine' => $this->quarantineSection(),
+            'restore' => $this->restoreSection(),
+            'purge' => $this->purgeSection(),
+            'retirement' => $this->retirementSection(),
+            'runtime_truth' => $this->runtimeTruthSection(),
+            'automation_readiness' => $this->automationReadinessSection(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function inventorySection(): array
+    {
+        $audit = $this->latestAuditForAction('storage_inventory');
+        if ($audit === null) {
+            return [
+                'status' => 'not_available',
+                'latest_action' => 'storage_inventory',
+                'latest_generated_at' => null,
+                'schema_version' => null,
+                'focus_scopes' => [],
+                'totals' => null,
+                'latest_summary' => null,
+            ];
+        }
+
+        $payload = $this->decodeAuditMeta($audit);
+
+        return [
+            'status' => 'ok',
+            'latest_action' => 'storage_inventory',
+            'latest_generated_at' => (string) ($payload['generated_at'] ?? $audit->created_at),
+            'schema_version' => $payload['schema_version'] ?? null,
+            'focus_scopes' => $this->normalizeScalarList((array) ($payload['focus_scopes'] ?? [])),
+            'totals' => is_array($payload['totals'] ?? null) ? $payload['totals'] : null,
+            'latest_summary' => [
+                'areas' => (int) ($payload['area_count'] ?? 0),
+                'files' => (int) data_get($payload, 'totals.files', 0),
+                'bytes' => (int) data_get($payload, 'totals.bytes', 0),
+                'duplicate_file_refs' => (int) data_get($payload, 'duplicate_summary.file_refs', 0),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function retentionSection(): array
+    {
+        $configuredScopes = [
+            'reports_backups' => [
+                'keep_timestamp_backups' => (int) config('storage_retention.reports.keep_timestamp_backups', 0),
+                'keep_days' => (int) config('storage_retention.reports.keep_days', 365),
+            ],
+            'content_releases_retention' => [
+                'keep_last_n' => (int) config('storage_retention.content_releases.keep_last_n', 20),
+                'keep_days' => (int) config('storage_retention.content_releases.keep_days', 180),
+            ],
+            'legacy_private_private_cleanup' => [
+                'policy' => 'no_config',
+            ],
+        ];
+
+        $scopes = [];
+        $hasAnyRun = false;
+        foreach ($configuredScopes as $scope => $policy) {
+            $audit = $this->latestAuditForAction('storage_prune', static fn (array $meta, object $row): bool => (string) $row->target_id === $scope);
+            $latestPlan = $this->latestJsonFileUnder(
+                storage_path('app/private/prune_plans'),
+                static fn (string $path, array $payload): bool => (string) ($payload['scope'] ?? '') === $scope
+            );
+
+            if ($audit === null && $latestPlan === null) {
+                $scopes[$scope] = [
+                    'status' => 'never_run',
+                    'policy' => $policy,
+                    'latest_generated_at' => null,
+                    'latest_plan_path' => null,
+                    'latest_execute_status' => null,
+                    'latest_summary' => null,
+                ];
+
+                continue;
+            }
+
+            $hasAnyRun = true;
+            $meta = $audit === null ? [] : $this->decodeAuditMeta($audit);
+            $scopes[$scope] = [
+                'status' => $audit === null ? 'partial' : 'ok',
+                'policy' => $policy,
+                'latest_generated_at' => $latestPlan['payload']['generated_at'] ?? ($audit->created_at ?? null),
+                'latest_plan_path' => $latestPlan['path'] ?? ($meta['plan'] ?? null),
+                'latest_execute_status' => $audit?->result,
+                'latest_summary' => [
+                    'deleted_files_count' => (int) ($meta['deleted_files_count'] ?? 0),
+                    'deleted_bytes' => (int) ($meta['deleted_bytes'] ?? 0),
+                    'missing_files' => (int) ($meta['missing_files'] ?? 0),
+                    'skipped_files' => (int) ($meta['skipped_files'] ?? 0),
+                    'planned_files' => (int) data_get($latestPlan, 'payload.summary.files', 0),
+                    'planned_bytes' => (int) data_get($latestPlan, 'payload.summary.bytes', 0),
+                ],
+            ];
+        }
+
+        return [
+            'status' => $hasAnyRun ? 'ok' : 'never_run',
+            'configured_scopes' => array_keys($configuredScopes),
+            'scopes' => $scopes,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function blobCoverageSection(): array
+    {
+        $storageBlobCount = $this->tableCount('storage_blobs');
+        $verifiedLocationCountsByDisk = [];
+        if (Schema::hasTable('storage_blob_locations')) {
+            $verifiedLocationCountsByDisk = DB::table('storage_blob_locations')
+                ->selectRaw('disk, count(*) as aggregate')
+                ->whereNotNull('verified_at')
+                ->groupBy('disk')
+                ->pluck('aggregate', 'disk')
+                ->map(static fn (mixed $count): int => (int) $count)
+                ->all();
+        }
+
+        $blobGcAudit = $this->latestAuditForAction('storage_blob_gc');
+        $blobGcMeta = $blobGcAudit === null ? [] : $this->decodeAuditMeta($blobGcAudit);
+
+        $offloadAudit = $this->latestAuditForAction('storage_blob_offload');
+        $offloadMeta = $offloadAudit === null ? [] : $this->decodeAuditMeta($offloadAudit);
+
+        return [
+            'status' => 'ok',
+            'counts' => [
+                'storage_blobs' => $storageBlobCount,
+                'verified_storage_blob_locations_by_disk' => $verifiedLocationCountsByDisk,
+            ],
+            'blob_gc' => $blobGcAudit === null
+                ? [
+                    'status' => 'never_run',
+                    'latest_generated_at' => null,
+                    'latest_summary' => null,
+                ]
+                : [
+                    'status' => 'ok',
+                    'latest_generated_at' => (string) $blobGcAudit->created_at,
+                    'latest_summary' => $blobGcMeta,
+                ],
+            'blob_offload' => $offloadAudit === null
+                ? [
+                    'status' => 'never_run',
+                    'latest_generated_at' => null,
+                    'latest_mode' => null,
+                    'latest_summary' => null,
+                ]
+                : [
+                    'status' => 'ok',
+                    'latest_generated_at' => (string) $offloadAudit->created_at,
+                    'latest_mode' => $offloadMeta['mode'] ?? null,
+                    'latest_summary' => $offloadMeta,
+                ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function exactAuthoritySection(): array
+    {
+        $audit = $this->latestAuditForAction('storage_backfill_exact_release_file_sets');
+        $meta = $audit === null ? [] : $this->decodeAuditMeta($audit);
+
+        return [
+            'status' => 'ok',
+            'counts' => [
+                'content_release_exact_manifests' => $this->tableCount('content_release_exact_manifests'),
+                'content_release_exact_manifest_files' => $this->tableCount('content_release_exact_manifest_files'),
+            ],
+            'latest_backfill' => $audit === null
+                ? [
+                    'status' => 'never_run',
+                    'latest_generated_at' => null,
+                    'latest_summary' => null,
+                ]
+                : [
+                    'status' => 'ok',
+                    'latest_generated_at' => (string) $audit->created_at,
+                    'latest_summary' => $meta,
+                ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function rehydrateSection(): array
+    {
+        $audit = $this->latestAuditForAction('storage_rehydrate_exact_release');
+        if ($audit === null) {
+            return [
+                'status' => 'never_run',
+                'latest_generated_at' => null,
+                'latest_mode' => null,
+                'latest_plan_path' => null,
+                'latest_run_path' => null,
+                'latest_summary' => null,
+            ];
+        }
+
+        $meta = $this->decodeAuditMeta($audit);
+        $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+
+        return [
+            'status' => 'ok',
+            'latest_generated_at' => (string) $audit->created_at,
+            'latest_mode' => $meta['mode'] ?? null,
+            'latest_plan_path' => $meta['plan_path'] ?? null,
+            'latest_run_path' => $result['run_dir'] ?? null,
+            'latest_summary' => [
+                'status' => $result['status'] ?? null,
+                'disk' => $meta['disk'] ?? null,
+                'target_root' => data_get($meta, 'plan.target_root'),
+                'verified_files' => (int) ($result['verified_files'] ?? 0),
+                'verified_bytes' => (int) ($result['verified_bytes'] ?? 0),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function quarantineSection(): array
+    {
+        $audit = $this->latestAuditForAction('storage_quarantine_exact_roots');
+        $meta = $audit === null ? [] : $this->decodeAuditMeta($audit);
+        $plan = is_array($meta['plan'] ?? null) ? $meta['plan'] : [];
+        $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+
+        return [
+            'status' => $audit === null ? 'never_run' : 'ok',
+            'item_root_count' => $this->countDirectoriesByGlob($this->quarantineRootBase().DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'items'.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'root'),
+            'latest_generated_at' => $audit?->created_at,
+            'latest_mode' => $meta['mode'] ?? null,
+            'latest_plan_path' => $meta['plan_path'] ?? null,
+            'latest_run_path' => $result['run_dir'] ?? null,
+            'latest_summary' => $audit === null ? null : [
+                'candidate_count' => (int) data_get($plan, 'summary.candidate_count', 0),
+                'blocked_count' => (int) data_get($plan, 'summary.blocked_count', 0),
+                'skipped_count' => (int) data_get($plan, 'summary.skipped_count', 0),
+                'quarantined_count' => is_array($result['quarantined'] ?? null) ? count($result['quarantined']) : 0,
+                'status' => $result['status'] ?? null,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function restoreSection(): array
+    {
+        $audit = $this->latestAuditForAction('storage_restore_quarantined_root');
+        $meta = $audit === null ? [] : $this->decodeAuditMeta($audit);
+        $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+
+        return [
+            'status' => $audit === null ? 'never_run' : 'ok',
+            'restore_run_count' => $this->countDirectoriesByGlob($this->restoreRootBase().DIRECTORY_SEPARATOR.'*'),
+            'latest_generated_at' => $audit?->created_at,
+            'latest_mode' => $meta['mode'] ?? null,
+            'latest_plan_path' => $meta['plan_path'] ?? null,
+            'latest_run_path' => $result['run_dir'] ?? null,
+            'latest_summary' => $audit === null ? null : [
+                'status' => $result['status'] ?? null,
+                'restored_root' => $result['restored_root'] ?? null,
+                'target_root' => $result['target_root'] ?? null,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function purgeSection(): array
+    {
+        $audit = $this->latestAuditForAction('storage_purge_quarantined_root');
+        $meta = $audit === null ? [] : $this->decodeAuditMeta($audit);
+        $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+
+        return [
+            'status' => $audit === null ? 'never_run' : 'ok',
+            'purge_receipt_count' => $this->countFilesByGlob($this->purgeRootBase().DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'items'.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'purge.json'),
+            'latest_generated_at' => $audit?->created_at,
+            'latest_mode' => $meta['mode'] ?? null,
+            'latest_plan_path' => $meta['plan_path'] ?? null,
+            'latest_run_path' => $result['run_dir'] ?? null,
+            'latest_summary' => $audit === null ? null : [
+                'status' => $result['status'] ?? null,
+                'receipt_path' => $result['receipt_path'] ?? null,
+                'blocked_reason' => data_get($meta, 'plan.blocked_reason'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function retirementSection(): array
+    {
+        return [
+            'status' => 'ok',
+            'actions' => [
+                'quarantine' => $this->latestRetirementSummaryForAction('quarantine'),
+                'purge' => $this->latestRetirementSummaryForAction('purge'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function runtimeTruthSection(): array
+    {
+        $resolverMaterializationEnabled = (bool) config('storage_rollout.resolver_materialization_enabled', false);
+        $packsV2RemoteRehydrateEnabled = (bool) config('storage_rollout.packs_v2_remote_rehydrate_enabled', false);
+
+        $readiness = match (true) {
+            $packsV2RemoteRehydrateEnabled => 'remote_rehydrate_enabled',
+            $resolverMaterializationEnabled => 'materialization_enabled_only',
+            default => 'local_only',
+        };
+
+        return [
+            'status' => 'ok',
+            'resolver_materialization_enabled' => $resolverMaterializationEnabled,
+            'packs_v2_remote_rehydrate_enabled' => $packsV2RemoteRehydrateEnabled,
+            'v2_readiness' => $readiness,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function automationReadinessSection(): array
+    {
+        return [
+            'status' => 'ok',
+            'auto_dry_run_ok' => [
+                'storage:inventory',
+                'storage:prune',
+                'storage:blob-gc',
+                'storage:blob-offload',
+                'storage:backfill-release-metadata',
+                'storage:backfill-exact-release-file-sets',
+                'storage:quarantine-exact-roots',
+                'storage:retire-exact-roots',
+            ],
+            'manual_execute_only' => [
+                'storage:prune',
+                'storage:blob-offload',
+                'storage:rehydrate-exact-release',
+                'storage:quarantine-exact-roots',
+                'storage:restore-quarantined-root',
+                'storage:purge-quarantined-root',
+                'storage:retire-exact-roots',
+                'storage:backfill-release-metadata',
+                'storage:backfill-exact-release-file-sets',
+            ],
+            'not_in_scope_for_pr25' => [
+                'scheduler_execute_automation',
+                'batch_restore',
+                'runtime_reader_changes',
+                'remote_read_cutover',
+                'storage:blob-gc execute',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function latestRetirementSummaryForAction(string $action): array
+    {
+        $audit = $this->latestAuditForAction(
+            'storage_retire_exact_roots',
+            static fn (array $meta, object $row): bool => (string) data_get($meta, 'plan.action', '') === $action
+        );
+
+        if ($audit === null) {
+            return [
+                'status' => 'never_run',
+                'latest_generated_at' => null,
+                'latest_mode' => null,
+                'latest_plan_path' => null,
+                'latest_run_path' => null,
+                'latest_summary' => null,
+            ];
+        }
+
+        $meta = $this->decodeAuditMeta($audit);
+        $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+
+        return [
+            'status' => 'ok',
+            'latest_generated_at' => (string) $audit->created_at,
+            'latest_mode' => $meta['mode'] ?? null,
+            'latest_plan_path' => $meta['plan_path'] ?? null,
+            'latest_run_path' => $result['run_dir'] ?? null,
+            'latest_summary' => [
+                'status' => $result['status'] ?? null,
+                'success_count' => (int) ($result['success_count'] ?? 0),
+                'failure_count' => (int) ($result['failure_count'] ?? 0),
+                'blocked_count' => (int) ($result['blocked_count'] ?? 0),
+                'skipped_count' => (int) ($result['skipped_count'] ?? 0),
+            ],
+        ];
+    }
+
+    private function latestAuditForAction(string $action, ?callable $filter = null): ?object
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return null;
+        }
+
+        $rows = DB::table('audit_logs')
+            ->where('action', $action)
+            ->orderByDesc('id')
+            ->limit(50)
+            ->get();
+
+        foreach ($rows as $row) {
+            $meta = $this->decodeAuditMeta($row);
+            if ($filter === null || $filter($meta, $row) === true) {
+                return $row;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeAuditMeta(object $row): array
+    {
+        $decoded = json_decode((string) ($row->meta_json ?? '{}'), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return array{path:string,payload:array<string,mixed>}|null
+     */
+    private function latestJsonFileUnder(string $dir, ?callable $filter = null): ?array
+    {
+        if (! is_dir($dir)) {
+            return null;
+        }
+
+        $latest = null;
+        foreach ($this->jsonFilesUnder($dir) as $path) {
+            $payload = $this->safeJsonDecodeFile($path);
+            if ($payload === null) {
+                continue;
+            }
+
+            if ($filter !== null && $filter($path, $payload) !== true) {
+                continue;
+            }
+
+            $mtime = @filemtime($path) ?: 0;
+            if ($latest === null || $mtime > $latest['mtime']) {
+                $latest = [
+                    'mtime' => $mtime,
+                    'path' => $path,
+                    'payload' => $payload,
+                ];
+            }
+        }
+
+        if ($latest === null) {
+            return null;
+        }
+
+        unset($latest['mtime']);
+
+        return $latest;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function safeJsonDecodeFile(string $path): ?array
+    {
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $decoded = json_decode((string) File::get($path), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function jsonFilesUnder(string $dir): array
+    {
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            if (strtolower($file->getExtension()) !== 'json') {
+                continue;
+            }
+
+            $files[] = $file->getPathname();
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    private function countDirectoriesByGlob(string $pattern): int
+    {
+        $matches = glob($pattern, GLOB_ONLYDIR);
+
+        return is_array($matches) ? count($matches) : 0;
+    }
+
+    private function countFilesByGlob(string $pattern): int
+    {
+        $matches = glob($pattern);
+        if (! is_array($matches)) {
+            return 0;
+        }
+
+        return count(array_filter($matches, 'is_file'));
+    }
+
+    private function tableCount(string $table): int
+    {
+        if (! Schema::hasTable($table)) {
+            return 0;
+        }
+
+        return (int) DB::table($table)->count();
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $values
+     * @return list<string>
+     */
+    private function normalizeScalarList(array $values): array
+    {
+        $normalized = [];
+        foreach ($values as $value) {
+            if (is_array($value) && array_key_exists('scope', $value)) {
+                $normalized[] = (string) $value['scope'];
+
+                continue;
+            }
+
+            if (is_scalar($value) || $value === null) {
+                $normalized[] = (string) $value;
+
+                continue;
+            }
+
+            $encoded = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $normalized[] = is_string($encoded) ? $encoded : '[complex]';
+        }
+
+        return array_values($normalized);
+    }
+
+    private function quarantineRootBase(): string
+    {
+        $relative = trim((string) config('storage_rollout.quarantine_root_dir', 'app/private/quarantine/release_roots'));
+
+        return storage_path(ltrim($relative, '/\\'));
+    }
+
+    private function restoreRootBase(): string
+    {
+        $relative = trim((string) config('storage_rollout.restore_root_dir', 'app/private/quarantine/restore_runs'));
+
+        return storage_path(ltrim($relative, '/\\'));
+    }
+
+    private function purgeRootBase(): string
+    {
+        $relative = trim((string) config('storage_rollout.purge_root_dir', 'app/private/quarantine/purge_runs'));
+
+        return storage_path(ltrim($relative, '/\\'));
+    }
+}

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageControlPlaneStatus;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageControlPlaneStatusCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-control-plane-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_rollout.resolver_materialization_enabled', false);
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', true);
+        Storage::forgetDisk('local');
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageControlPlaneStatus::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_outputs_full_json_without_mutation_or_audit_inserts(): void
+    {
+        $this->seedMinimalTruth();
+
+        $auditCountBefore = DB::table('audit_logs')->count();
+        $filesBefore = $this->storageFilesSnapshot();
+
+        $this->assertSame(0, Artisan::call('storage:control-plane-status', [
+            '--json' => true,
+        ]));
+
+        $output = trim(Artisan::output());
+        $payload = json_decode($output, true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('storage_control_plane_status.v1', $payload['schema_version']);
+        $this->assertArrayHasKey('inventory', $payload);
+        $this->assertArrayHasKey('retention', $payload);
+        $this->assertArrayHasKey('blob_coverage', $payload);
+        $this->assertArrayHasKey('exact_authority', $payload);
+        $this->assertArrayHasKey('rehydrate', $payload);
+        $this->assertArrayHasKey('quarantine', $payload);
+        $this->assertArrayHasKey('restore', $payload);
+        $this->assertArrayHasKey('purge', $payload);
+        $this->assertArrayHasKey('retirement', $payload);
+        $this->assertArrayHasKey('runtime_truth', $payload);
+        $this->assertArrayHasKey('automation_readiness', $payload);
+        $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
+
+        $this->assertSame($auditCountBefore, DB::table('audit_logs')->count());
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+    }
+
+    public function test_command_outputs_human_readable_summary(): void
+    {
+        $this->seedMinimalTruth();
+
+        $this->assertSame(0, Artisan::call('storage:control-plane-status'));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('schema_version=storage_control_plane_status.v1', $output);
+        $this->assertStringContainsString('inventory.status=ok', $output);
+        $this->assertStringContainsString('runtime_truth.v2_readiness=remote_rehydrate_enabled', $output);
+        $this->assertStringContainsString('automation_readiness.auto_dry_run_ok=', $output);
+    }
+
+    private function seedMinimalTruth(): void
+    {
+        $now = now();
+
+        $this->writeJson(storage_path('app/private/quarantine/release_roots/run-a/items/item-a/root/.quarantine.json'), [
+            'source_kind' => 'legacy.source_pack',
+        ]);
+        $this->writeJson(storage_path('app/private/quarantine/purge_runs/purge-a/items/item-a/purge.json'), [
+            'status' => 'success',
+        ]);
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_inventory',
+            'target_type' => 'storage',
+            'target_id' => 'inventory',
+            'meta_json' => json_encode([
+                'schema_version' => 2,
+                'generated_at' => $now->toIso8601String(),
+                'focus_scopes' => ['reports'],
+                'totals' => ['files' => 1, 'bytes' => 64],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_status',
+            'request_id' => null,
+            'reason' => 'seed',
+            'result' => 'success',
+            'created_at' => $now,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function writeJson(string $path, array $payload): void
+    {
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\StorageControlPlaneStatusService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageControlPlaneStatusServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-control-plane-status-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_rollout.resolver_materialization_enabled', true);
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', false);
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_aggregates_existing_truth_without_mutation(): void
+    {
+        $this->seedControlPlaneTruth();
+
+        $auditCountBefore = DB::table('audit_logs')->count();
+        $filesBefore = $this->storageFilesSnapshot();
+
+        $payload = app(StorageControlPlaneStatusService::class)->buildStatus();
+
+        $this->assertSame('storage_control_plane_status.v1', $payload['schema_version']);
+        $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertSame(['reports', 'artifacts'], data_get($payload, 'inventory.focus_scopes'));
+        $this->assertSame(1, data_get($payload, 'blob_coverage.counts.storage_blobs'));
+        $this->assertSame(1, data_get($payload, 'blob_coverage.counts.verified_storage_blob_locations_by_disk.s3'));
+        $this->assertSame(1, data_get($payload, 'exact_authority.counts.content_release_exact_manifests'));
+        $this->assertSame(1, data_get($payload, 'exact_authority.counts.content_release_exact_manifest_files'));
+        $this->assertSame(1, data_get($payload, 'quarantine.item_root_count'));
+        $this->assertSame(1, data_get($payload, 'restore.restore_run_count'));
+        $this->assertSame(1, data_get($payload, 'purge.purge_receipt_count'));
+        $this->assertSame('ok', data_get($payload, 'retirement.actions.quarantine.status'));
+        $this->assertSame('ok', data_get($payload, 'retirement.actions.purge.status'));
+        $this->assertTrue((bool) data_get($payload, 'runtime_truth.resolver_materialization_enabled'));
+        $this->assertFalse((bool) data_get($payload, 'runtime_truth.packs_v2_remote_rehydrate_enabled'));
+        $this->assertSame('materialization_enabled_only', data_get($payload, 'runtime_truth.v2_readiness'));
+        $this->assertSame([
+            'storage:inventory',
+            'storage:prune',
+            'storage:blob-gc',
+            'storage:blob-offload',
+            'storage:backfill-release-metadata',
+            'storage:backfill-exact-release-file-sets',
+            'storage:quarantine-exact-roots',
+            'storage:retire-exact-roots',
+        ], data_get($payload, 'automation_readiness.auto_dry_run_ok'));
+
+        $this->assertSame($auditCountBefore, DB::table('audit_logs')->count());
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+    }
+
+    public function test_service_reports_missing_truth_explicitly(): void
+    {
+        $payload = app(StorageControlPlaneStatusService::class)->buildStatus();
+
+        $this->assertSame('not_available', data_get($payload, 'inventory.status'));
+        $this->assertSame('never_run', data_get($payload, 'retention.status'));
+        $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_gc.status'));
+        $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_offload.status'));
+        $this->assertSame('never_run', data_get($payload, 'exact_authority.latest_backfill.status'));
+        $this->assertSame('never_run', data_get($payload, 'rehydrate.status'));
+        $this->assertSame('never_run', data_get($payload, 'quarantine.status'));
+        $this->assertSame('never_run', data_get($payload, 'restore.status'));
+        $this->assertSame('never_run', data_get($payload, 'purge.status'));
+        $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.status'));
+        $this->assertSame('never_run', data_get($payload, 'retirement.actions.purge.status'));
+    }
+
+    private function seedControlPlaneTruth(): void
+    {
+        $now = now();
+
+        DB::table('storage_blobs')->insert([
+            'hash' => str_repeat('a', 64),
+            'disk' => 'local',
+            'storage_path' => 'app/private/blobs/aa/blob-a',
+            'size_bytes' => 128,
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 1,
+            'first_seen_at' => $now,
+            'last_verified_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('storage_blob_locations')->insert([
+            'blob_hash' => str_repeat('a', 64),
+            'disk' => 's3',
+            'storage_path' => 'rollout/blobs/aa/blob-a',
+            'location_kind' => 'remote_copy',
+            'size_bytes' => 128,
+            'checksum' => 'sha256:'.str_repeat('a', 64),
+            'etag' => 'etag-a',
+            'storage_class' => 'STANDARD',
+            'verified_at' => $now,
+            'meta_json' => json_encode(['copied' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $manifestId = DB::table('content_release_exact_manifests')->insertGetId([
+            'content_pack_release_id' => null,
+            'source_identity_hash' => str_repeat('b', 64),
+            'manifest_hash' => str_repeat('c', 64),
+            'schema_version' => 'storage_exact_manifest.v1',
+            'source_kind' => 'legacy.source_pack',
+            'source_disk' => 'local',
+            'source_storage_path' => storage_path('app/private/content_releases/release-1/source_pack'),
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => str_repeat('d', 64),
+            'content_hash' => str_repeat('e', 64),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-seeded',
+            'file_count' => 1,
+            'total_size_bytes' => 128,
+            'payload_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'sealed_at' => $now,
+            'last_verified_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('content_release_exact_manifest_files')->insert([
+            'content_release_exact_manifest_id' => $manifestId,
+            'logical_path' => 'compiled/manifest.json',
+            'blob_hash' => str_repeat('a', 64),
+            'size_bytes' => 128,
+            'role' => 'manifest',
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'checksum' => 'sha256:'.str_repeat('c', 64),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $this->writeJson(storage_path('app/private/prune_plans/20260321_reports_backups_seed.json'), [
+            'schema' => 'storage_prune_plan.v2',
+            'scope' => 'reports_backups',
+            'strategy' => 'strict',
+            'generated_at' => $now->copy()->subMinutes(30)->toIso8601String(),
+            'summary' => ['files' => 2, 'bytes' => 512],
+        ]);
+
+        $this->writeJson(storage_path('app/private/quarantine/release_roots/run-1/items/item-1/root/.quarantine.json'), [
+            'source_kind' => 'legacy.source_pack',
+        ]);
+        $this->writeJson(storage_path('app/private/quarantine/restore_runs/restore-1/run.json'), [
+            'schema' => 'storage_restore_quarantined_root_run.v1',
+            'status' => 'success',
+        ]);
+        $this->writeJson(storage_path('app/private/quarantine/purge_runs/purge-1/items/item-1/purge.json'), [
+            'schema' => 'storage_purge_quarantined_root_run.v1',
+            'status' => 'success',
+        ]);
+        $this->writeJson(storage_path('app/private/retirement_runs/retire-1/run.json'), [
+            'schema' => 'storage_retire_exact_roots_run.v1',
+            'status' => 'success',
+        ]);
+        $this->writeJson(storage_path('app/private/rehydrate_runs/rehydrate-1/run.json'), [
+            'schema' => 'storage_rehydrate_exact_release_run.v1',
+            'status' => 'success',
+        ]);
+
+        $this->insertAudit('storage_inventory', 'inventory', [
+            'schema_version' => 2,
+            'generated_at' => $now->copy()->subHours(3)->toIso8601String(),
+            'focus_scopes' => ['reports', 'artifacts'],
+            'area_count' => 2,
+            'totals' => ['files' => 5, 'bytes' => 2048],
+            'duplicate_summary' => ['file_refs' => 1],
+        ], 'success', 'scheduled_or_manual', $now->copy()->subHours(3));
+
+        $this->insertAudit('storage_prune', 'reports_backups', [
+            'scope' => 'reports_backups',
+            'strategy' => 'strict',
+            'deleted_files_count' => 2,
+            'deleted_bytes' => 512,
+            'missing_files' => 0,
+            'skipped_files' => 0,
+            'plan' => storage_path('app/private/prune_plans/20260321_reports_backups_seed.json'),
+        ], 'success', 'retention_execute', $now->copy()->subHours(2));
+
+        $this->insertAudit('storage_blob_gc', 'blob_gc', [
+            'schema' => 'storage_blob_gc_plan.v1',
+            'plan' => storage_path('app/private/gc_plans/gc-plan.json'),
+            'reachable_blob_count' => 1,
+            'unreachable_blob_count' => 0,
+            'planned_deletion_count' => 0,
+            'dry_run_only' => true,
+        ], 'success', 'reachability_plan', $now->copy()->subHours(2));
+
+        $this->insertAudit('storage_blob_offload', 'blob_offload', [
+            'schema' => 'storage_blob_offload_plan.v1',
+            'mode' => 'executed',
+            'disk' => 's3',
+            'plan' => storage_path('app/private/offload_plans/offload-plan.json'),
+            'candidate_count' => 1,
+            'skipped_count' => 0,
+            'bytes' => 128,
+            'uploaded_count' => 1,
+            'verified_count' => 1,
+            'failed_count' => 0,
+            'warnings' => [],
+            'copy_only' => true,
+        ], 'success', 'blob_offload_copy_only', $now->copy()->subHours(2));
+
+        $this->insertAudit('storage_backfill_exact_release_file_sets', 'exact_release_file_sets', [
+            'scanned_roots' => 1,
+            'created_manifests' => 1,
+            'updated_manifests' => 0,
+        ], 'success', 'exact_release_file_set_backfill', $now->copy()->subHours(2));
+
+        $this->insertAudit('storage_rehydrate_exact_release', 'manifest-1', [
+            'mode' => 'executed',
+            'disk' => 's3',
+            'plan_path' => storage_path('app/private/rehydrate_plans/rehydrate-plan.json'),
+            'plan' => ['target_root' => storage_path('app/private/rehydrate_runs/rehydrate-1/root')],
+            'result' => [
+                'status' => 'success',
+                'run_dir' => storage_path('app/private/rehydrate_runs/rehydrate-1'),
+                'verified_files' => 1,
+                'verified_bytes' => 128,
+            ],
+        ], 'success', 'exact_release_rehydrate_verify', $now->copy()->subMinutes(90));
+
+        $this->insertAudit('storage_quarantine_exact_roots', 'exact_roots', [
+            'mode' => 'executed',
+            'plan_path' => storage_path('app/private/quarantine_plans/quarantine-plan.json'),
+            'plan' => ['summary' => ['candidate_count' => 1, 'blocked_count' => 0, 'skipped_count' => 0]],
+            'result' => [
+                'status' => 'success',
+                'run_dir' => storage_path('app/private/quarantine/release_roots/run-1'),
+                'quarantined' => [['target_root' => storage_path('app/private/quarantine/release_roots/run-1/items/item-1/root')]],
+            ],
+        ], 'success', 'exact_root_quarantine', $now->copy()->subMinutes(80));
+
+        $this->insertAudit('storage_restore_quarantined_root', 'quarantined_root', [
+            'mode' => 'executed',
+            'plan_path' => storage_path('app/private/restore_plans/restore-plan.json'),
+            'plan' => ['target_root' => storage_path('app/private/content_releases/release-1/source_pack')],
+            'result' => [
+                'status' => 'success',
+                'run_dir' => storage_path('app/private/quarantine/restore_runs/restore-1'),
+                'restored_root' => storage_path('app/private/content_releases/release-1/source_pack'),
+                'target_root' => storage_path('app/private/content_releases/release-1/source_pack'),
+            ],
+        ], 'success', 'quarantined_root_restore', $now->copy()->subMinutes(70));
+
+        $this->insertAudit('storage_purge_quarantined_root', 'quarantined_root', [
+            'mode' => 'executed',
+            'plan_path' => storage_path('app/private/purge_plans/purge-plan.json'),
+            'plan' => ['blocked_reason' => null],
+            'result' => [
+                'status' => 'success',
+                'run_dir' => storage_path('app/private/quarantine/purge_runs/purge-1'),
+                'receipt_path' => storage_path('app/private/quarantine/purge_runs/purge-1/items/item-1/purge.json'),
+            ],
+        ], 'success', 'quarantined_root_purge', $now->copy()->subMinutes(60));
+
+        $this->insertAudit('storage_retire_exact_roots', 'exact_roots', [
+            'mode' => 'executed',
+            'plan_path' => storage_path('app/private/retirement_plans/retire-quarantine-plan.json'),
+            'plan' => ['action' => 'quarantine'],
+            'result' => [
+                'status' => 'success',
+                'run_dir' => storage_path('app/private/retirement_runs/retire-1'),
+                'success_count' => 1,
+                'failure_count' => 0,
+                'blocked_count' => 0,
+                'skipped_count' => 0,
+            ],
+        ], 'success', 'exact_root_retirement', $now->copy()->subMinutes(50));
+
+        $this->insertAudit('storage_retire_exact_roots', 'exact_roots', [
+            'mode' => 'planned',
+            'plan_path' => storage_path('app/private/retirement_plans/retire-purge-plan.json'),
+            'plan' => ['action' => 'purge'],
+            'result' => [
+                'status' => 'planned',
+                'run_dir' => storage_path('app/private/retirement_runs/retire-1'),
+                'success_count' => 0,
+                'failure_count' => 0,
+                'blocked_count' => 1,
+                'skipped_count' => 0,
+            ],
+        ], 'success', 'exact_root_retirement', $now->copy()->subMinutes(40));
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     */
+    private function insertAudit(string $action, string $targetId, array $meta, string $result, string $reason, \Illuminate\Support\Carbon $createdAt): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => $action,
+            'target_type' => 'storage',
+            'target_id' => $targetId,
+            'meta_json' => json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_status',
+            'request_id' => null,
+            'reason' => $reason,
+            'result' => $result,
+            'created_at' => $createdAt,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function writeJson(string $path, array $payload): void
+    {
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}


### PR DESCRIPTION
## Summary
- add a read-only `storage:control-plane-status` command for unified storage control-plane visibility
- add `StorageControlPlaneStatusService` to aggregate existing truth from DB, audit logs, plan/run JSON, sentinels, and config
- keep all existing storage lifecycle, runtime reader, and scheduler contracts unchanged

## Tests
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/ExactRootRetirementOrchestratorServiceTest.php tests/Feature/Storage/StorageRetireExactRootsCommandTest.php tests/Feature/Storage/ExactRootQuarantineServiceTest.php tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php`
- `php artisan migrate`
- `php artisan storage:control-plane-status --json`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
