### PR TITLE
[codex] Ship PR-10D.1 partner-safe insight graph read API (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
+++ b/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
@@ -180,6 +180,7 @@ class AssessmentController extends Controller
 
         $teamDynamics = is_array($summary['team_dynamics_v1'] ?? null) ? $summary['team_dynamics_v1'] : null;
         $workspaceSurface = is_array($summary['workspace_surface_v1'] ?? null) ? $summary['workspace_surface_v1'] : null;
+        $partnerRead = is_array($summary['partner_read_v1'] ?? null) ? $summary['partner_read_v1'] : null;
         if ($teamDynamics !== null) {
             $this->events->record('team_dynamics_summary_view', $this->resolveUserId($request), [
                 'assessment_id' => (int) $assessment->id,
@@ -192,6 +193,11 @@ class AssessmentController extends Controller
                 'workspace_surface_version' => (string) ($workspaceSurface['version'] ?? ''),
                 'workspace_surface_fingerprint' => (string) ($workspaceSurface['workspace_surface_fingerprint'] ?? ''),
                 'manager_action_keys' => array_values((array) ($workspaceSurface['manager_action_keys'] ?? [])),
+                'partner_read_version' => (string) ($partnerRead['version'] ?? ''),
+                'partner_graph_scope' => (string) ($partnerRead['graph_scope'] ?? ''),
+                'partner_graph_fingerprint' => (string) ($partnerRead['graph_fingerprint'] ?? ''),
+                'partner_read_scope' => (string) ($partnerRead['read_scope'] ?? ''),
+                'partner_attribution_scope' => (string) ($partnerRead['attribution_scope'] ?? ''),
             ], [
                 'org_id' => $orgId,
                 'scale_code' => (string) ($assessment->scale_code ?? ''),

--- a/backend/app/Services/Assessments/AssessmentSummaryService.php
+++ b/backend/app/Services/Assessments/AssessmentSummaryService.php
@@ -5,6 +5,8 @@ namespace App\Services\Assessments;
 use App\Models\Assessment;
 use App\Models\AssessmentAssignment;
 use App\Models\Result;
+use App\Services\InsightGraph\InsightGraphContractService;
+use App\Services\InsightGraph\PartnerReadContractService;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\Team\TeamDynamicsSynthesisService;
 use Illuminate\Support\Collection;
@@ -15,6 +17,8 @@ class AssessmentSummaryService
         private ScaleRegistry $registry,
         private TeamDynamicsSynthesisService $teamDynamics,
         private WorkspaceSurfaceContractService $workspaceSurface,
+        private InsightGraphContractService $insightGraph,
+        private PartnerReadContractService $partnerRead,
     ) {}
 
     public function buildSummary(Assessment $assessment): array
@@ -57,6 +61,8 @@ class AssessmentSummaryService
             'total' => $total,
         ];
         $teamDynamics = $this->teamDynamics->buildForAssessment($assessment, $results, $total);
+        $workspaceSurface = $this->workspaceSurface->build($teamDynamics, $completionRate);
+        $insightGraph = $this->insightGraph->buildForWorkspaceSummary($teamDynamics, $workspaceSurface, $completionRate);
 
         return [
             'completion_rate' => [
@@ -71,7 +77,9 @@ class AssessmentSummaryService
             'score_distribution' => $this->scoreDistribution($driverType, $results),
             'dimension_means' => $this->dimensionMeans($driverType, $results),
             'team_dynamics_v1' => $teamDynamics,
-            'workspace_surface_v1' => $this->workspaceSurface->build($teamDynamics, $completionRate),
+            'workspace_surface_v1' => $workspaceSurface,
+            'insight_graph_v1' => $insightGraph,
+            'partner_read_v1' => $this->partnerRead->buildForTenantWorkspace($insightGraph, $workspaceSurface),
         ];
     }
 

--- a/backend/app/Services/InsightGraph/InsightGraphContractService.php
+++ b/backend/app/Services/InsightGraph/InsightGraphContractService.php
@@ -180,6 +180,133 @@ final class InsightGraphContractService
     }
 
     /**
+     * @param  array<string,mixed>|null  $teamDynamics
+     * @param  array<string,mixed>|null  $workspaceSurface
+     * @param  array{completed:int,total:int}  $completionRate
+     * @return array<string,mixed>
+     */
+    public function buildForWorkspaceSummary(?array $teamDynamics, ?array $workspaceSurface, array $completionRate): array
+    {
+        if (! is_array($teamDynamics) && ! is_array($workspaceSurface)) {
+            return [];
+        }
+
+        $nodes = [];
+        $edges = [];
+        $supportingScales = $this->normalizeStringList(
+            (is_array($teamDynamics) ? ($teamDynamics['supporting_scales'] ?? []) : [])
+        );
+        if ($supportingScales === [] && is_array($workspaceSurface)) {
+            $supportingScales = $this->normalizeStringList($workspaceSurface['supporting_scales'] ?? []);
+        }
+        if ($supportingScales === []) {
+            $supportingScales = ['MBTI'];
+        }
+
+        $teamFocusKey = $this->normalizeText(
+            is_array($workspaceSurface) ? ($workspaceSurface['workspace_focus_key'] ?? null) : null,
+            is_array($teamDynamics) ? ($teamDynamics['team_focus_key'] ?? null) : null
+        ) ?? 'team_alignment_review';
+
+        $this->pushNode(
+            $nodes,
+            'result_summary',
+            'result_summary',
+            'Protected team workspace',
+            'Focus: '.$teamFocusKey,
+            'workspace_surface_v1'
+        );
+
+        if (is_array($teamDynamics)) {
+            $teamSummaryParts = array_filter([
+                $this->normalizeText($teamDynamics['team_focus_key'] ?? null),
+                implode(' | ', $this->normalizeStringList($teamDynamics['communication_fit_keys'] ?? [])),
+                implode(' | ', $this->normalizeStringList($teamDynamics['decision_mix_keys'] ?? [])),
+                implode(' | ', $this->normalizeStringList($teamDynamics['stress_pattern_keys'] ?? [])),
+            ]);
+
+            $teamSummary = implode(' · ', array_slice(array_values($teamSummaryParts), 0, 4));
+            if ($teamSummary !== '') {
+                $this->pushNode(
+                    $nodes,
+                    'team_dynamics',
+                    'team_dynamics',
+                    'Team dynamics',
+                    $teamSummary,
+                    'team_dynamics_v1'
+                );
+                $edges[] = ['from' => 'team_dynamics', 'to' => 'result_summary', 'relation' => 'enriches'];
+            }
+        }
+
+        if (is_array($workspaceSurface)) {
+            $workspaceSummaryParts = $this->normalizeStringList($workspaceSurface['manager_action_keys'] ?? []);
+            $workspaceSummary = $workspaceSummaryParts !== []
+                ? implode(' -> ', array_slice($workspaceSummaryParts, 0, 3))
+                : $teamFocusKey;
+
+            $this->pushNode(
+                $nodes,
+                'workspace_surface',
+                'workspace_surface',
+                'Workspace focus',
+                $workspaceSummary,
+                'workspace_surface_v1'
+            );
+            $edges[] = ['from' => 'workspace_surface', 'to' => 'result_summary', 'relation' => 'supports'];
+        }
+
+        $completed = max(0, (int) ($completionRate['completed'] ?? 0));
+        $total = max(0, (int) ($completionRate['total'] ?? 0));
+        $pending = max(0, $total - $completed);
+        $memberProgressSummary = sprintf('completed:%d pending:%d total:%d', $completed, $pending, $total);
+        $this->pushNode(
+            $nodes,
+            'member_progress',
+            'member_progress',
+            'Member progress',
+            $memberProgressSummary,
+            'assessment_progress_v1'
+        );
+        $edges[] = ['from' => 'result_summary', 'to' => 'member_progress', 'relation' => 'continues_to'];
+
+        $continueKeys = $this->normalizeStringList(is_array($workspaceSurface) ? ($workspaceSurface['manager_action_keys'] ?? []) : []);
+        if ($continueKeys === []) {
+            $continueKeys = $this->normalizeStringList(is_array($workspaceSurface) ? ($workspaceSurface['member_drill_in_keys'] ?? []) : []);
+        }
+        $continueSummary = $continueKeys !== [] ? implode(' -> ', array_slice($continueKeys, 0, 3)) : 'check_member_progress';
+        $this->pushNode(
+            $nodes,
+            'continue_reading',
+            'continue_reading',
+            'Manager next',
+            $continueSummary,
+            'workspace_surface_v1'
+        );
+        $edges[] = ['from' => 'workspace_surface', 'to' => 'continue_reading', 'relation' => 'recommended_next'];
+        $edges[] = ['from' => 'member_progress', 'to' => 'continue_reading', 'relation' => 'recommended_next'];
+
+        $fingerprintSeed = [
+            'graph_scope' => 'tenant_protected',
+            'team_focus_key' => $teamFocusKey,
+            'supporting_scales' => $supportingScales,
+            'nodes' => $nodes,
+            'edges' => $edges,
+        ];
+
+        return [
+            'version' => 'insight.graph.v1',
+            'graph_contract_version' => 'insight.graph.v1',
+            'root_node' => 'result_summary',
+            'nodes' => $nodes,
+            'edges' => $edges,
+            'graph_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'graph_scope' => 'tenant_protected',
+            'supporting_scales' => $supportingScales,
+        ];
+    }
+
+    /**
      * @param  array<int,array<string,mixed>>  $nodes
      */
     private function hasNode(array $nodes, string $id): bool

--- a/backend/app/Services/InsightGraph/PartnerReadContractService.php
+++ b/backend/app/Services/InsightGraph/PartnerReadContractService.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InsightGraph;
+
+final class PartnerReadContractService
+{
+    /**
+     * @param  array<string,mixed>  $graph
+     * @param  array<string,mixed>  $publicSurface
+     * @return array<string,mixed>
+     */
+    public function buildForPublicShare(array $graph, array $publicSurface): array
+    {
+        return $this->build(
+            graph: $graph,
+            allowedKinds: [
+                'result_summary',
+                'narrative',
+                'comparative',
+                'working_life',
+                'continue_reading',
+            ],
+            graphScope: 'public_share_safe',
+            readScope: 'partner_public_read',
+            subjectScope: 'public_summary_only',
+            attributionScope: $this->normalizeText($publicSurface['attribution_scope'] ?? null) ?? 'share_public_surface'
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $graph
+     * @param  array<string,mixed>  $workspaceSurface
+     * @return array<string,mixed>
+     */
+    public function buildForTenantWorkspace(array $graph, array $workspaceSurface): array
+    {
+        return $this->build(
+            graph: $graph,
+            allowedKinds: [
+                'result_summary',
+                'team_dynamics',
+                'workspace_surface',
+                'member_progress',
+                'continue_reading',
+            ],
+            graphScope: 'tenant_protected',
+            readScope: 'partner_tenant_read',
+            subjectScope: 'tenant_aggregate_only',
+            attributionScope: $this->normalizeText($workspaceSurface['attribution_scope'] ?? null) ?? 'workspace_partner_surface'
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $graph
+     * @param  list<string>  $allowedKinds
+     * @return array<string,mixed>
+     */
+    private function build(
+        array $graph,
+        array $allowedKinds,
+        string $graphScope,
+        string $readScope,
+        string $subjectScope,
+        string $attributionScope
+    ): array {
+        if ($graph === []) {
+            return [];
+        }
+
+        $nodes = is_array($graph['nodes'] ?? null) ? $graph['nodes'] : [];
+        $edges = is_array($graph['edges'] ?? null) ? $graph['edges'] : [];
+        $kindAllowlist = array_fill_keys($allowedKinds, true);
+        $allowedNodeIds = [];
+
+        foreach ($nodes as $node) {
+            if (! is_array($node)) {
+                continue;
+            }
+
+            $kind = $this->normalizeText($node['kind'] ?? null);
+            $id = $this->normalizeText($node['id'] ?? null);
+            if ($kind === null || $id === null) {
+                continue;
+            }
+
+            if (! isset($kindAllowlist[$kind])) {
+                continue;
+            }
+
+            $allowedNodeIds[$id] = true;
+        }
+
+        $allowedEdgeTypes = [];
+        foreach ($edges as $edge) {
+            if (! is_array($edge)) {
+                continue;
+            }
+
+            $from = $this->normalizeText($edge['from'] ?? null);
+            $to = $this->normalizeText($edge['to'] ?? null);
+            $relation = $this->normalizeText($edge['relation'] ?? null);
+            if ($from === null || $to === null || $relation === null) {
+                continue;
+            }
+
+            if (! isset($allowedNodeIds[$from]) || ! isset($allowedNodeIds[$to])) {
+                continue;
+            }
+
+            $allowedEdgeTypes[$relation] = true;
+        }
+
+        return [
+            'version' => 'partner.read.v1',
+            'graph_scope' => $graphScope,
+            'graph_contract_version' => $this->normalizeText($graph['graph_contract_version'] ?? null) ?? 'insight.graph.v1',
+            'graph_fingerprint' => $this->normalizeText($graph['graph_fingerprint'] ?? null) ?? '',
+            'supporting_scales' => $this->normalizeStringList($graph['supporting_scales'] ?? []),
+            'allowed_node_ids' => array_keys($allowedNodeIds),
+            'allowed_edge_types' => array_keys($allowedEdgeTypes),
+            'read_scope' => $readScope,
+            'subject_scope' => $subjectScope,
+            'attribution_scope' => $attributionScope,
+        ];
+    }
+
+    private function normalizeText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeStringList(mixed $values): array
+    {
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($values as $value) {
+            $item = $this->normalizeText($value);
+            if ($item === null) {
+                continue;
+            }
+
+            $normalized[$item] = true;
+        }
+
+        return array_keys($normalized);
+    }
+}

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -12,6 +12,7 @@ use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\InsightGraph\InsightGraphContractService;
+use App\Services\InsightGraph\PartnerReadContractService;
 use App\Services\PublicSurface\PublicSurfaceContractService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportComposer;
@@ -35,6 +36,7 @@ class ShareService
         private readonly BigFivePublicProjectionService $bigFivePublicProjectionService,
         private readonly PublicSurfaceContractService $publicSurfaceContractService,
         private readonly InsightGraphContractService $insightGraphContractService,
+        private readonly PartnerReadContractService $partnerReadContractService,
     ) {}
 
     public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
@@ -815,6 +817,10 @@ class ShareService
             is_array($payload['insight_graph_v1'] ?? null) ? $payload['insight_graph_v1'] : [],
             is_array($payload['public_surface_v1'] ?? null) ? $payload['public_surface_v1'] : [],
             $payload
+        );
+        $payload['partner_read_v1'] = $this->partnerReadContractService->buildForPublicShare(
+            is_array($payload['insight_graph_v1'] ?? null) ? $payload['insight_graph_v1'] : [],
+            is_array($payload['public_surface_v1'] ?? null) ? $payload['public_surface_v1'] : []
         );
 
         return $payload;

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -92,6 +92,15 @@ final class ShareSummaryContractTest extends TestCase
         $this->assertSame('embed.surface.v1', $response->json('embed_surface_v1.version'));
         $this->assertSame('mbti_share_embed_card', $response->json('embed_surface_v1.surface_key'));
         $this->assertSame('growth.next_actions', $response->json('embed_surface_v1.continue_target'));
+        $this->assertSame('partner.read.v1', $response->json('partner_read_v1.version'));
+        $this->assertSame('public_share_safe', $response->json('partner_read_v1.graph_scope'));
+        $this->assertSame('partner_public_read', $response->json('partner_read_v1.read_scope'));
+        $this->assertSame('public_summary_only', $response->json('partner_read_v1.subject_scope'));
+        $this->assertSame('share_public_surface', $response->json('partner_read_v1.attribution_scope'));
+        $this->assertSame('insight.graph.v1', $response->json('partner_read_v1.graph_contract_version'));
+        $this->assertContains('result_summary', (array) $response->json('partner_read_v1.allowed_node_ids'));
+        $this->assertContains('continue_reading', (array) $response->json('partner_read_v1.allowed_node_ids'));
+        $this->assertContains('recommended_next', (array) $response->json('partner_read_v1.allowed_edge_types'));
         $this->assertSame(
             ['growth.next_actions', 'traits.close_call_axes', 'traits.adjacent_type_contrast'],
             $response->json('public_surface_v1.continue_reading_keys')
@@ -166,6 +175,7 @@ final class ShareSummaryContractTest extends TestCase
             'public_surface_v1',
             'insight_graph_v1',
             'embed_surface_v1',
+            'partner_read_v1',
         ] as $key) {
             $this->assertSame($share->json($key), $view->json($key), "share field mismatch: {$key}");
         }
@@ -222,6 +232,9 @@ final class ShareSummaryContractTest extends TestCase
             ->assertJsonPath('insight_graph_v1.graph_scope', 'public_share_safe')
             ->assertJsonPath('embed_surface_v1.version', 'embed.surface.v1')
             ->assertJsonPath('embed_surface_v1.surface_key', 'big5_share_embed_card')
+            ->assertJsonPath('partner_read_v1.version', 'partner.read.v1')
+            ->assertJsonPath('partner_read_v1.graph_scope', 'public_share_safe')
+            ->assertJsonPath('partner_read_v1.read_scope', 'partner_public_read')
             ->assertJsonMissingPath('report')
             ->assertJsonMissingPath('result')
             ->assertJsonMissingPath('offers')

--- a/backend/tests/Feature/V0_4/AssessmentTeamDynamicsSummaryTest.php
+++ b/backend/tests/Feature/V0_4/AssessmentTeamDynamicsSummaryTest.php
@@ -46,6 +46,15 @@ final class AssessmentTeamDynamicsSummaryTest extends TestCase
         $summary->assertJsonPath('summary.workspace_surface_v1.manager_action_keys.0', 'team.action.sync_communication_cadence');
         $summary->assertJsonPath('summary.workspace_surface_v1.member_drill_in_keys.0', 'completed_assignments');
         $this->assertNotEmpty((string) $summary->json('summary.workspace_surface_v1.workspace_surface_fingerprint'));
+        $summary->assertJsonPath('summary.insight_graph_v1.graph_contract_version', 'insight.graph.v1');
+        $summary->assertJsonPath('summary.insight_graph_v1.graph_scope', 'tenant_protected');
+        $summary->assertJsonPath('summary.partner_read_v1.version', 'partner.read.v1');
+        $summary->assertJsonPath('summary.partner_read_v1.graph_scope', 'tenant_protected');
+        $summary->assertJsonPath('summary.partner_read_v1.read_scope', 'partner_tenant_read');
+        $summary->assertJsonPath('summary.partner_read_v1.subject_scope', 'tenant_aggregate_only');
+        $summary->assertJsonPath('summary.partner_read_v1.attribution_scope', 'workspace_partner_surface');
+        $this->assertContains('team_dynamics', (array) $summary->json('summary.partner_read_v1.allowed_node_ids'));
+        $this->assertContains('continues_to', (array) $summary->json('summary.partner_read_v1.allowed_edge_types'));
     }
 
     public function test_summary_team_dynamics_respects_org_boundary(): void

--- a/backend/tests/Unit/Services/InsightGraph/InsightGraphContractServiceTest.php
+++ b/backend/tests/Unit/Services/InsightGraph/InsightGraphContractServiceTest.php
@@ -53,4 +53,34 @@ final class InsightGraphContractServiceTest extends TestCase
         $this->assertSame('career.next_step', $embed['continue_target']);
         $this->assertSame(['result_summary', 'narrative', 'comparative', 'working_life', 'continue_reading'], $embed['allowed_node_ids']);
     }
+
+    public function test_it_builds_a_tenant_protected_workspace_graph(): void
+    {
+        $service = new InsightGraphContractService;
+
+        $graph = $service->buildForWorkspaceSummary([
+            'team_focus_key' => 'team.communication.energy_translation',
+            'supporting_scales' => ['MBTI', 'BIG5_OCEAN'],
+            'communication_fit_keys' => ['team.communication.energy_translation'],
+            'decision_mix_keys' => ['team.decision.logic_empathy_mix'],
+            'stress_pattern_keys' => ['team.stress.stability_gap'],
+        ], [
+            'workspace_focus_key' => 'team.communication.energy_translation',
+            'manager_action_keys' => ['team.action.sync_communication_cadence', 'check_member_progress'],
+            'member_drill_in_keys' => ['completed_assignments', 'pending_assignments'],
+            'supporting_scales' => ['MBTI', 'BIG5_OCEAN'],
+        ], [
+            'completed' => 2,
+            'total' => 3,
+        ]);
+
+        $this->assertSame('insight.graph.v1', $graph['graph_contract_version']);
+        $this->assertSame('tenant_protected', $graph['graph_scope']);
+        $this->assertSame('result_summary', $graph['root_node']);
+        $this->assertSame(['MBTI', 'BIG5_OCEAN'], $graph['supporting_scales']);
+        $this->assertContains('team_dynamics', array_column($graph['nodes'], 'id'));
+        $this->assertContains('workspace_surface', array_column($graph['nodes'], 'id'));
+        $this->assertContains('member_progress', array_column($graph['nodes'], 'id'));
+        $this->assertContains('continue_reading', array_column($graph['nodes'], 'id'));
+    }
 }

--- a/backend/tests/Unit/Services/InsightGraph/PartnerReadContractServiceTest.php
+++ b/backend/tests/Unit/Services/InsightGraph/PartnerReadContractServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\InsightGraph;
+
+use App\Services\InsightGraph\PartnerReadContractService;
+use Tests\TestCase;
+
+final class PartnerReadContractServiceTest extends TestCase
+{
+    public function test_it_builds_public_share_safe_partner_read_contract(): void
+    {
+        $service = new PartnerReadContractService;
+
+        $contract = $service->buildForPublicShare([
+            'graph_contract_version' => 'insight.graph.v1',
+            'graph_fingerprint' => 'graph-fingerprint-123',
+            'graph_scope' => 'public_share_safe',
+            'supporting_scales' => ['MBTI', 'BIG5_OCEAN'],
+            'nodes' => [
+                ['id' => 'result_summary', 'kind' => 'result_summary'],
+                ['id' => 'narrative', 'kind' => 'narrative'],
+                ['id' => 'comparative', 'kind' => 'comparative'],
+                ['id' => 'working_life', 'kind' => 'working_life'],
+                ['id' => 'continue_reading', 'kind' => 'continue_reading'],
+                ['id' => 'team_dynamics', 'kind' => 'team_dynamics'],
+            ],
+            'edges' => [
+                ['from' => 'narrative', 'to' => 'result_summary', 'relation' => 'enriches'],
+                ['from' => 'working_life', 'to' => 'continue_reading', 'relation' => 'recommended_next'],
+                ['from' => 'team_dynamics', 'to' => 'result_summary', 'relation' => 'enriches'],
+            ],
+        ], [
+            'attribution_scope' => 'share_public_surface',
+        ]);
+
+        $this->assertSame('partner.read.v1', $contract['version']);
+        $this->assertSame('public_share_safe', $contract['graph_scope']);
+        $this->assertSame('partner_public_read', $contract['read_scope']);
+        $this->assertSame('public_summary_only', $contract['subject_scope']);
+        $this->assertSame('share_public_surface', $contract['attribution_scope']);
+        $this->assertSame(
+            ['result_summary', 'narrative', 'comparative', 'working_life', 'continue_reading'],
+            $contract['allowed_node_ids']
+        );
+        $this->assertSame(['enriches', 'recommended_next'], $contract['allowed_edge_types']);
+    }
+
+    public function test_it_builds_tenant_protected_partner_read_contract(): void
+    {
+        $service = new PartnerReadContractService;
+
+        $contract = $service->buildForTenantWorkspace([
+            'graph_contract_version' => 'insight.graph.v1',
+            'graph_fingerprint' => 'workspace-graph-fingerprint-123',
+            'graph_scope' => 'tenant_protected',
+            'supporting_scales' => ['MBTI'],
+            'nodes' => [
+                ['id' => 'result_summary', 'kind' => 'result_summary'],
+                ['id' => 'team_dynamics', 'kind' => 'team_dynamics'],
+                ['id' => 'workspace_surface', 'kind' => 'workspace_surface'],
+                ['id' => 'member_progress', 'kind' => 'member_progress'],
+                ['id' => 'continue_reading', 'kind' => 'continue_reading'],
+            ],
+            'edges' => [
+                ['from' => 'team_dynamics', 'to' => 'result_summary', 'relation' => 'enriches'],
+                ['from' => 'workspace_surface', 'to' => 'continue_reading', 'relation' => 'recommended_next'],
+                ['from' => 'result_summary', 'to' => 'member_progress', 'relation' => 'continues_to'],
+            ],
+        ], []);
+
+        $this->assertSame('tenant_protected', $contract['graph_scope']);
+        $this->assertSame('partner_tenant_read', $contract['read_scope']);
+        $this->assertSame('tenant_aggregate_only', $contract['subject_scope']);
+        $this->assertSame('workspace_partner_surface', $contract['attribution_scope']);
+        $this->assertSame(
+            ['result_summary', 'team_dynamics', 'workspace_surface', 'member_progress', 'continue_reading'],
+            $contract['allowed_node_ids']
+        );
+        $this->assertSame(['enriches', 'recommended_next', 'continues_to'], $contract['allowed_edge_types']);
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-10D.1: partner-safe insight graph read API.

It adds the first backend-owned `partner_read_v1` whitelist contract on top of the existing graph, share, and protected workspace foundations, without introducing OAuth, SDKs, a developer portal, migrations, or new dependencies.

## Problem

PR-10D already established `insight_graph_v1` and `embed_surface_v1`, but those contracts were still surface-oriented:

- `insight_graph_v1` was implemented mainly for share/public-safe delivery
- `embed_surface_v1` was a render contract for share cards
- there was no dedicated partner-safe read boundary that explicitly separated `public_share_safe` from `tenant_protected`

That meant downstream partner-style consumers still lacked a formal backend whitelist for what graph nodes and edges could be read safely.

## Root cause

The platform already had the right building blocks:

- `insight_graph_v1`
- `public_surface_v1`
- `workspace_surface_v1`
- `team_dynamics_v1`
- org / tenant protected summary routes
- public-safe share routes
- privacy / consent / anonymization contracts

What it did not yet have was a dedicated read contract that could sit above those layers and say, in a replayable and scope-aware way:

- which graph nodes are allowed
- which edge relations are allowed
- what the graph scope is
- what the read scope is
- what the subject scope is
- what attribution scope applies

## Fix

This PR adds `partner_read_v1` and wires it into both existing read paths.

For `public_share_safe`:
- the existing `v0.3` share/public-safe payload now includes a public partner-read whitelist
- public-safe node exposure remains limited to downgraded summary, narrative, comparative, working-life, and continue-reading nodes

For `tenant_protected`:
- the existing `v0.4` org assessment summary path now includes a protected graph-backed partner-read whitelist
- tenant-safe partner reads can include team/workspace aggregate nodes and masked progress metadata, but not member-private canonical truth

The contract explicitly carries:
- `graph_scope`
- `graph_contract_version`
- `graph_fingerprint`
- `supporting_scales`
- `allowed_node_ids`
- `allowed_edge_types`
- `read_scope`
- `subject_scope`
- `attribution_scope`

This is strictly additive:
- no canonical MBTI or Big Five truth changes
- no new auth system
- no new route family
- no migration
- no dependency changes
- no upgrade of `embed_surface_v1` into a generic partner API

## User impact

The platform now has its first real partner-safe graph read contract.

This gives future partner, coach, or HR-facing consumers a backend-owned whitelist layer that can be consumed safely from existing protected and public-safe read paths, while preserving privacy boundaries and replay guarantees.

## Validation

I ran:

- `php artisan test tests/Unit/Services/InsightGraph/InsightGraphContractServiceTest.php tests/Unit/Services/InsightGraph/PartnerReadContractServiceTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_4/AssessmentTeamDynamicsSummaryTest.php tests/Feature/V0_4/AssessmentsRbacIsolationTest.php`

All passed:
- 10 tests passed
- 224 assertions

## Scope note

This PR is intentionally limited to the backend partner-safe read contract and protected/public path integration.

It does not:
- add OAuth, SDKs, billing, or a developer portal
- create an open platform shell
- expose tenant-only truth on public paths
- expose member-private canonical truth on tenant partner reads
- pull in task-external dirty files such as pack publish/rollback or compiled artifact changes
