### PR TITLE
[codex] Ship PR-10D.2 embeddable widget surface and host integration contract (backend)

### DIFF
--- a/backend/app/Services/InsightGraph/WidgetSurfaceContractService.php
+++ b/backend/app/Services/InsightGraph/WidgetSurfaceContractService.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InsightGraph;
+
+final class WidgetSurfaceContractService
+{
+    /**
+     * @param  array<string,mixed>  $embedSurface
+     * @param  array<string,mixed>  $partnerRead
+     * @param  array<string,mixed>  $publicSurface
+     * @return array<string,mixed>
+     */
+    public function buildForPublicShare(array $embedSurface, array $partnerRead, array $publicSurface): array
+    {
+        if ($embedSurface === [] || $partnerRead === [] || $publicSurface === []) {
+            return [];
+        }
+
+        $widgetScope = $this->normalizeText($partnerRead['graph_scope'] ?? null, $embedSurface['graph_scope'] ?? null);
+        if ($widgetScope !== 'public_share_safe') {
+            return [];
+        }
+
+        return [
+            'version' => 'widget.surface.v1',
+            'widget_scope' => 'public_share_safe',
+            'widget_contract_version' => 'widget.surface.v1',
+            'surface_key' => $this->normalizeText($embedSurface['surface_key'] ?? null) ?? '',
+            'host_mode' => $this->normalizeText($embedSurface['render_mode'] ?? null, 'card') ?? 'card',
+            'slot_key' => 'public_share_primary',
+            'size_preset' => 'summary_card',
+            'entry_surface' => $this->normalizeText($publicSurface['entry_surface'] ?? null) ?? '',
+            'title' => $this->normalizeText($embedSurface['title'] ?? null) ?? '',
+            'summary' => $this->normalizeText($embedSurface['summary'] ?? null) ?? '',
+            'primary_cta_label' => $this->normalizeText($embedSurface['primary_cta_label'] ?? null) ?? '',
+            'primary_cta_path' => $this->normalizeText($embedSurface['primary_cta_path'] ?? null) ?? '',
+            'continue_target' => $this->normalizeText($embedSurface['continue_target'] ?? null) ?? '',
+            'allowed_node_ids' => $this->normalizeStringList($partnerRead['allowed_node_ids'] ?? []),
+            'allowed_edge_types' => $this->normalizeStringList($partnerRead['allowed_edge_types'] ?? []),
+            'graph_fingerprint' => $this->normalizeText($partnerRead['graph_fingerprint'] ?? null) ?? '',
+            'embed_fingerprint' => $this->normalizeText($embedSurface['embed_fingerprint'] ?? null) ?? '',
+            'attribution_scope' => $this->normalizeText(
+                $partnerRead['attribution_scope'] ?? null,
+                $publicSurface['attribution_scope'] ?? null
+            ) ?? '',
+        ];
+    }
+
+    private function normalizeText(mixed ...$values): ?string
+    {
+        foreach ($values as $value) {
+            if (! is_scalar($value)) {
+                continue;
+            }
+
+            $normalized = trim((string) $value);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeStringList(mixed $values): array
+    {
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($values as $value) {
+            if (! is_scalar($value)) {
+                continue;
+            }
+
+            $item = trim((string) $value);
+            if ($item === '') {
+                continue;
+            }
+
+            $normalized[$item] = true;
+        }
+
+        return array_keys($normalized);
+    }
+}

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -13,6 +13,7 @@ use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\InsightGraph\InsightGraphContractService;
 use App\Services\InsightGraph\PartnerReadContractService;
+use App\Services\InsightGraph\WidgetSurfaceContractService;
 use App\Services\PublicSurface\PublicSurfaceContractService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportComposer;
@@ -37,6 +38,7 @@ class ShareService
         private readonly PublicSurfaceContractService $publicSurfaceContractService,
         private readonly InsightGraphContractService $insightGraphContractService,
         private readonly PartnerReadContractService $partnerReadContractService,
+        private readonly WidgetSurfaceContractService $widgetSurfaceContractService,
     ) {}
 
     public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
@@ -820,6 +822,11 @@ class ShareService
         );
         $payload['partner_read_v1'] = $this->partnerReadContractService->buildForPublicShare(
             is_array($payload['insight_graph_v1'] ?? null) ? $payload['insight_graph_v1'] : [],
+            is_array($payload['public_surface_v1'] ?? null) ? $payload['public_surface_v1'] : []
+        );
+        $payload['widget_surface_v1'] = $this->widgetSurfaceContractService->buildForPublicShare(
+            is_array($payload['embed_surface_v1'] ?? null) ? $payload['embed_surface_v1'] : [],
+            is_array($payload['partner_read_v1'] ?? null) ? $payload['partner_read_v1'] : [],
             is_array($payload['public_surface_v1'] ?? null) ? $payload['public_surface_v1'] : []
         );
 

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -92,6 +92,16 @@ final class ShareSummaryContractTest extends TestCase
         $this->assertSame('embed.surface.v1', $response->json('embed_surface_v1.version'));
         $this->assertSame('mbti_share_embed_card', $response->json('embed_surface_v1.surface_key'));
         $this->assertSame('growth.next_actions', $response->json('embed_surface_v1.continue_target'));
+        $this->assertSame('widget.surface.v1', $response->json('widget_surface_v1.version'));
+        $this->assertSame('public_share_safe', $response->json('widget_surface_v1.widget_scope'));
+        $this->assertSame('widget.surface.v1', $response->json('widget_surface_v1.widget_contract_version'));
+        $this->assertSame('card', $response->json('widget_surface_v1.host_mode'));
+        $this->assertSame('public_share_primary', $response->json('widget_surface_v1.slot_key'));
+        $this->assertSame('summary_card', $response->json('widget_surface_v1.size_preset'));
+        $this->assertSame('mbti_share_embed_card', $response->json('widget_surface_v1.surface_key'));
+        $this->assertSame('share_public_surface', $response->json('widget_surface_v1.attribution_scope'));
+        $this->assertContains('comparative', (array) $response->json('widget_surface_v1.allowed_node_ids'));
+        $this->assertContains('continues_to', (array) $response->json('widget_surface_v1.allowed_edge_types'));
         $this->assertSame('partner.read.v1', $response->json('partner_read_v1.version'));
         $this->assertSame('public_share_safe', $response->json('partner_read_v1.graph_scope'));
         $this->assertSame('partner_public_read', $response->json('partner_read_v1.read_scope'));
@@ -175,6 +185,7 @@ final class ShareSummaryContractTest extends TestCase
             'public_surface_v1',
             'insight_graph_v1',
             'embed_surface_v1',
+            'widget_surface_v1',
             'partner_read_v1',
         ] as $key) {
             $this->assertSame($share->json($key), $view->json($key), "share field mismatch: {$key}");
@@ -232,6 +243,12 @@ final class ShareSummaryContractTest extends TestCase
             ->assertJsonPath('insight_graph_v1.graph_scope', 'public_share_safe')
             ->assertJsonPath('embed_surface_v1.version', 'embed.surface.v1')
             ->assertJsonPath('embed_surface_v1.surface_key', 'big5_share_embed_card')
+            ->assertJsonPath('widget_surface_v1.version', 'widget.surface.v1')
+            ->assertJsonPath('widget_surface_v1.widget_scope', 'public_share_safe')
+            ->assertJsonPath('widget_surface_v1.surface_key', 'big5_share_embed_card')
+            ->assertJsonPath('widget_surface_v1.host_mode', 'card')
+            ->assertJsonPath('widget_surface_v1.slot_key', 'public_share_primary')
+            ->assertJsonPath('widget_surface_v1.size_preset', 'summary_card')
             ->assertJsonPath('partner_read_v1.version', 'partner.read.v1')
             ->assertJsonPath('partner_read_v1.graph_scope', 'public_share_safe')
             ->assertJsonPath('partner_read_v1.read_scope', 'partner_public_read')

--- a/backend/tests/Unit/Services/InsightGraph/WidgetSurfaceContractServiceTest.php
+++ b/backend/tests/Unit/Services/InsightGraph/WidgetSurfaceContractServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\InsightGraph;
+
+use App\Services\InsightGraph\WidgetSurfaceContractService;
+use Tests\TestCase;
+
+final class WidgetSurfaceContractServiceTest extends TestCase
+{
+    public function test_it_builds_a_public_share_safe_widget_surface_contract(): void
+    {
+        $service = new WidgetSurfaceContractService;
+
+        $contract = $service->buildForPublicShare([
+            'surface_key' => 'mbti_share_embed_card',
+            'graph_scope' => 'public_share_safe',
+            'entry_surface' => 'mbti_share_landing',
+            'title' => 'Campaigner',
+            'summary' => 'A public-safe widget summary.',
+            'primary_cta_label' => 'Start MBTI test',
+            'primary_cta_path' => '/en/tests/mbti-personality-test-16-personality-types/take',
+            'continue_target' => 'career.next_step',
+            'allowed_node_ids' => ['result_summary', 'narrative'],
+            'embed_fingerprint' => 'embed-fingerprint-123',
+            'render_mode' => 'card',
+        ], [
+            'graph_scope' => 'public_share_safe',
+            'graph_fingerprint' => 'graph-fingerprint-123',
+            'allowed_node_ids' => ['result_summary', 'narrative', 'comparative', 'working_life', 'continue_reading'],
+            'allowed_edge_types' => ['enriches', 'supports', 'recommended_next', 'continues_to'],
+            'attribution_scope' => 'share_public_surface',
+        ], [
+            'entry_surface' => 'mbti_share_landing',
+            'attribution_scope' => 'share_public_surface',
+        ]);
+
+        $this->assertSame('widget.surface.v1', $contract['version']);
+        $this->assertSame('widget.surface.v1', $contract['widget_contract_version']);
+        $this->assertSame('public_share_safe', $contract['widget_scope']);
+        $this->assertSame('card', $contract['host_mode']);
+        $this->assertSame('public_share_primary', $contract['slot_key']);
+        $this->assertSame('summary_card', $contract['size_preset']);
+        $this->assertSame('mbti_share_embed_card', $contract['surface_key']);
+        $this->assertSame('share_public_surface', $contract['attribution_scope']);
+        $this->assertSame(['result_summary', 'narrative', 'comparative', 'working_life', 'continue_reading'], $contract['allowed_node_ids']);
+        $this->assertSame(['enriches', 'supports', 'recommended_next', 'continues_to'], $contract['allowed_edge_types']);
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-10D.2: embeddable widget surface and host integration contract.

It adds the first real `widget_surface_v1` on top of the existing `public_share_safe` share/public graph path, without introducing SDKs, OAuth, postMessage runtime, migrations, or new dependencies.

## Problem

PR-10D and PR-10D.1 already established:

- `insight_graph_v1`
- `embed_surface_v1`
- `partner_read_v1`
- `public_surface_v1`

But the share/public-safe payload still stopped one layer short of a true widget contract.

`embed_surface_v1` was still a render-oriented card contract. It had useful surface metadata, but it did not yet declare explicit host/widget semantics such as:

- widget scope
- widget contract version
- host mode
- slot key
- size preset

That meant the platform still had a graph-backed card surface, but not yet a proper host-aware widget foundation.

## Root cause

The backend already had the right source layers, but no composition layer dedicated to widget semantics.

The share path could already express:

- graph authority
- partner-read whitelist
- public attribution metadata
- CTA and continue targets

What it was missing was a backend-owned contract that combined those layers into a single widget-safe object for embeddable consumption.

## Fix

This PR adds `WidgetSurfaceContractService` and introduces `widget_surface_v1` on the existing share/public-safe payload.

It:

- keeps widget scope explicitly limited to `public_share_safe`
- composes widget metadata from:
  - `embed_surface_v1`
  - `partner_read_v1`
  - `public_surface_v1`
- exposes:
  - `widget_scope`
  - `widget_contract_version`
  - `surface_key`
  - `host_mode`
  - `slot_key`
  - `size_preset`
  - `entry_surface`
  - `title`
  - `summary`
  - `primary_cta_label`
  - `primary_cta_path`
  - `continue_target`
  - `allowed_node_ids`
  - `allowed_edge_types`
  - `graph_fingerprint`
  - `embed_fingerprint`
  - `attribution_scope`

## Guardrails

This remains strictly additive:

- no canonical MBTI or Big Five truth changes
- no tenant widget in this PR
- no new route family
- no new auth system
- no SDK / OAuth / billing / postMessage runtime
- no migration
- no new dependency

## Validation

I ran:

- `php artisan test tests/Unit/Services/InsightGraph/InsightGraphContractServiceTest.php tests/Unit/Services/InsightGraph/PartnerReadContractServiceTest.php tests/Unit/Services/InsightGraph/WidgetSurfaceContractServiceTest.php tests/Feature/V0_3/ShareSummaryContractTest.php`

All passed:

- 8 tests passed
- 220 assertions

## Scope note

This PR is intentionally limited to the backend widget contract on the existing public share path.

It does not:

- add tenant-protected widget support
- introduce SDKs, OAuth, developer-platform work, or host runtime protocols
- expand into a generalized open widget platform
- pull in task-external dirty files such as pack publish/rollback or compiled artifact changes
