### PR TITLE
[codex] add storage control-plane snapshot scheduler

### DIFF
--- a/backend/app/Console/Commands/StorageControlPlaneSnapshot.php
+++ b/backend/app/Console/Commands/StorageControlPlaneSnapshot.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\StorageControlPlaneSnapshotService;
+use Illuminate\Console\Command;
+
+final class StorageControlPlaneSnapshot extends Command
+{
+    protected $signature = 'storage:control-plane-snapshot
+        {--json : Emit the full control-plane snapshot payload as JSON}';
+
+    protected $description = 'Persist a read-only storage control-plane snapshot and audit the capture.';
+
+    public function __construct(
+        private readonly StorageControlPlaneSnapshotService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $payload = $this->service->createSnapshot();
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode control-plane snapshot json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return self::SUCCESS;
+        }
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('snapshot='.(string) ($payload['snapshot_path'] ?? ''));
+        $this->line('schema_version='.(string) ($payload['snapshot_schema'] ?? ''));
+        $this->line('generated_at='.(string) ($payload['generated_at'] ?? ''));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -19,8 +19,8 @@ use App\Console\Commands\FapResolvePack;
 use App\Console\Commands\FapSelfCheck;
 use App\Console\Commands\FapValidateReport;
 use App\Console\Commands\FapWeeklyReport;
-use App\Console\Commands\MetricsWeeklyValidity;
 use App\Console\Commands\MbtiUpgradeLegacyPartialUnlocks;
+use App\Console\Commands\MetricsWeeklyValidity;
 use App\Console\Commands\NormsBig5BootstrapBuild;
 use App\Console\Commands\NormsBig5DriftCheck;
 use App\Console\Commands\NormsBig5MonthlyDriftCheck;
@@ -61,6 +61,7 @@ use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
+use App\Console\Commands\StorageControlPlaneSnapshot;
 use App\Console\Commands\StorageInventory;
 use App\Console\Commands\StorageMigrateLegacyArtifacts;
 use App\Console\Commands\StoragePrune;
@@ -123,6 +124,7 @@ class Kernel extends ConsoleKernel
         StoragePrune::class,
         StorageMigrateLegacyArtifacts::class,
         StorageInventory::class,
+        StorageControlPlaneSnapshot::class,
         QualityDailySummary::class,
         CiScaleImpact::class,
         ContentPathMirror::class,
@@ -158,6 +160,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('storage:prune --execute --scope=content_releases_retention')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('storage:prune --execute --scope=legacy_private_private_cleanup')->dailyAt('03:30')->withoutOverlapping();
         $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
+        $schedule->exec(PHP_BINARY.' '.base_path('artisan').' storage:control-plane-snapshot --json')->dailyAt('04:20')->withoutOverlapping();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();

--- a/backend/app/Services/Storage/StorageControlPlaneSnapshotService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneSnapshotService.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageControlPlaneSnapshotService
+{
+    private const SNAPSHOT_SCHEMA = 'storage_control_plane_snapshot.v1';
+
+    private const SNAPSHOT_DIR = 'app/private/control_plane_snapshots';
+
+    public function __construct(
+        private readonly StorageControlPlaneStatusService $statusService,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function createSnapshot(): array
+    {
+        $statusPayload = $this->statusService->buildStatus();
+        $generatedAt = (string) ($statusPayload['generated_at'] ?? now()->toIso8601String());
+        $snapshotPath = $this->nextSnapshotPath();
+
+        $snapshot = array_merge($statusPayload, [
+            'snapshot_schema' => self::SNAPSHOT_SCHEMA,
+            'status' => 'snapshotted',
+            'generated_at' => $generatedAt,
+            'snapshot_path' => $snapshotPath,
+        ]);
+
+        File::ensureDirectoryExists(dirname($snapshotPath));
+        File::put($snapshotPath, $this->encodeSnapshot($snapshot).PHP_EOL);
+
+        $this->recordAudit($snapshotPath, $generatedAt, $snapshot);
+
+        return $snapshot;
+    }
+
+    private function nextSnapshotPath(): string
+    {
+        $filename = now()->format('Ymd_His').'_control_plane_snapshot_'.bin2hex(random_bytes(4)).'.json';
+
+        return storage_path(self::SNAPSHOT_DIR.'/'.$filename);
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     */
+    private function encodeSnapshot(array $snapshot): string
+    {
+        $encoded = json_encode($snapshot, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('Failed to encode storage control-plane snapshot JSON.');
+        }
+
+        return $encoded;
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     */
+    private function recordAudit(string $snapshotPath, string $generatedAt, array $snapshot): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_control_plane_snapshot',
+            'target_type' => 'storage',
+            'target_id' => 'control_plane_snapshot',
+            'meta_json' => json_encode([
+                'snapshot_schema' => self::SNAPSHOT_SCHEMA,
+                'generated_at' => $generatedAt,
+                'snapshot_path' => $snapshotPath,
+                'status_schema_version' => $snapshot['schema_version'] ?? null,
+                'sections' => array_values(array_filter(array_keys($snapshot), static fn (string $key): bool => ! in_array($key, [
+                    'snapshot_schema',
+                    'status',
+                    'generated_at',
+                    'snapshot_path',
+                    'schema_version',
+                ], true))),
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_control_plane_snapshot',
+            'request_id' => null,
+            'reason' => 'control_plane_snapshot',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -37,6 +37,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('storage:prune --execute --scope=content_releases_retention')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('storage:prune --execute --scope=legacy_private_private_cleanup')->dailyAt('03:30')->withoutOverlapping();
         $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
+        $schedule->command('storage:control-plane-snapshot --json')->dailyAt('04:20')->withoutOverlapping();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageControlPlaneSnapshot;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageControlPlaneSnapshotCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-control-plane-snapshot-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_rollout.resolver_materialization_enabled', false);
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', true);
+        Storage::forgetDisk('local');
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageControlPlaneSnapshot::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_outputs_full_json_and_persists_snapshot(): void
+    {
+        $this->seedMinimalTruth();
+
+        $auditCountBefore = DB::table('audit_logs')->count();
+        $filesBefore = $this->storageFilesSnapshot();
+
+        $this->assertSame(0, Artisan::call('storage:control-plane-snapshot', [
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(trim(Artisan::output()), true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('storage_control_plane_snapshot.v1', $payload['snapshot_schema']);
+        $this->assertSame('snapshotted', $payload['status']);
+        $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
+        $this->assertFileExists((string) $payload['snapshot_path']);
+        $this->assertSame($auditCountBefore + 1, DB::table('audit_logs')->count());
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_control_plane_snapshot',
+            'target_id' => 'control_plane_snapshot',
+            'result' => 'success',
+        ]);
+
+        $filesAfter = $this->storageFilesSnapshot();
+        $newFiles = array_values(array_diff($filesAfter, $filesBefore));
+        $this->assertCount(1, $newFiles);
+        $this->assertStringStartsWith('app/private/control_plane_snapshots/', $newFiles[0]);
+        $this->assertSame([], $this->existingFilesUnder('app/private/prune_plans'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/retirement_runs'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/blobs'));
+    }
+
+    public function test_command_outputs_human_readable_summary(): void
+    {
+        $this->seedMinimalTruth();
+
+        $this->assertSame(0, Artisan::call('storage:control-plane-snapshot'));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=snapshotted', $output);
+        $this->assertStringContainsString('snapshot=', $output);
+        $this->assertStringContainsString('schema_version=storage_control_plane_snapshot.v1', $output);
+        $this->assertStringContainsString('generated_at=', $output);
+    }
+
+    private function seedMinimalTruth(): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_inventory',
+            'target_type' => 'storage',
+            'target_id' => 'inventory',
+            'meta_json' => json_encode([
+                'schema_version' => 2,
+                'generated_at' => now()->toIso8601String(),
+                'focus_scopes' => ['reports'],
+                'totals' => ['files' => 1, 'bytes' => 64],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_snapshot_command',
+            'request_id' => null,
+            'reason' => 'seed',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function existingFilesUnder(string $relativeDir): array
+    {
+        $dir = $this->isolatedStoragePath.'/'.$relativeDir;
+        if (! is_dir($dir)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\StorageControlPlaneSnapshotService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageControlPlaneSnapshotServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-control-plane-snapshot-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_rollout.resolver_materialization_enabled', true);
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', false);
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_creates_snapshot_file_and_audit_without_other_mutation(): void
+    {
+        $this->seedMinimalTruth();
+
+        $auditCountBefore = DB::table('audit_logs')->count();
+        $filesBefore = $this->storageFilesSnapshot();
+
+        $payload = app(StorageControlPlaneSnapshotService::class)->createSnapshot();
+
+        $this->assertSame('storage_control_plane_snapshot.v1', $payload['snapshot_schema']);
+        $this->assertSame('snapshotted', $payload['status']);
+        $this->assertIsString($payload['snapshot_path']);
+        $this->assertFileExists($payload['snapshot_path']);
+        $this->assertArrayHasKey('inventory', $payload);
+        $this->assertArrayHasKey('retention', $payload);
+        $this->assertArrayHasKey('blob_coverage', $payload);
+        $this->assertArrayHasKey('exact_authority', $payload);
+        $this->assertArrayHasKey('rehydrate', $payload);
+        $this->assertArrayHasKey('quarantine', $payload);
+        $this->assertArrayHasKey('restore', $payload);
+        $this->assertArrayHasKey('purge', $payload);
+        $this->assertArrayHasKey('retirement', $payload);
+        $this->assertArrayHasKey('runtime_truth', $payload);
+        $this->assertArrayHasKey('automation_readiness', $payload);
+        $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertSame('never_run', data_get($payload, 'rehydrate.status'));
+        $this->assertSame('never_run', data_get($payload, 'retention.status'));
+        $this->assertSame('never_run', data_get($payload, 'restore.status'));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_control_plane_snapshot')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $this->assertSame($auditCountBefore + 1, DB::table('audit_logs')->count());
+        $this->assertSame('success', $audit->result);
+        $this->assertSame('control_plane_snapshot', $audit->reason);
+
+        $auditMeta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($auditMeta);
+        $this->assertSame($payload['snapshot_path'], $auditMeta['snapshot_path'] ?? null);
+
+        $storedPayload = json_decode((string) File::get($payload['snapshot_path']), true);
+        $this->assertSame($payload, $storedPayload);
+
+        $filesAfter = $this->storageFilesSnapshot();
+        $newFiles = array_values(array_diff($filesAfter, $filesBefore));
+        $this->assertCount(1, $newFiles);
+        $this->assertStringStartsWith('app/private/control_plane_snapshots/', $newFiles[0]);
+        $this->assertSame([], glob($this->isolatedStoragePath.'/app/private/blobs/**/*'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/prune_plans'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/rehydrate_runs'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/quarantine'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/retirement_runs'));
+    }
+
+    public function test_service_preserves_explicit_missing_truth_markers(): void
+    {
+        $payload = app(StorageControlPlaneSnapshotService::class)->createSnapshot();
+
+        $this->assertSame('not_available', data_get($payload, 'inventory.status'));
+        $this->assertSame('never_run', data_get($payload, 'retention.status'));
+        $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_gc.status'));
+        $this->assertSame('never_run', data_get($payload, 'quarantine.status'));
+        $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.status'));
+    }
+
+    private function seedMinimalTruth(): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_inventory',
+            'target_type' => 'storage',
+            'target_id' => 'inventory',
+            'meta_json' => json_encode([
+                'schema_version' => 2,
+                'generated_at' => now()->toIso8601String(),
+                'focus_scopes' => ['reports'],
+                'totals' => ['files' => 1, 'bytes' => 64],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_snapshot_service',
+            'request_id' => null,
+            'reason' => 'seed',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function existingFilesUnder(string $relativeDir): array
+    {
+        $dir = $this->isolatedStoragePath.'/'.$relativeDir;
+        if (! is_dir($dir)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}


### PR DESCRIPTION
## Summary
- add a read-mostly `storage:control-plane-snapshot` command and `StorageControlPlaneSnapshotService`
- persist durable control-plane snapshots under `storage/app/private/control_plane_snapshots/*` and audit them with `storage_control_plane_snapshot`
- add one read-only scheduler entry for the snapshot command without changing any existing execute contracts or runtime readers

## Why
PR-25 unified storage control-plane truth into a read-only status payload, but it still produced only an on-demand view. There was no durable snapshot artifact, no dedicated audit action for snapshot capture, and no scheduler-produced control-plane record that operators could trace later.

This PR keeps the control-plane read-only and adds only the missing durability layer: a snapshot file plus one audit row. It does not introduce any execute automation, new lifecycle primitives, or runtime behavior changes.

## Implementation
- add `StorageControlPlaneSnapshotService` that reuses `StorageControlPlaneStatusService::buildStatus()` and only adds snapshot metadata plus persistence
- add `storage:control-plane-snapshot` with default key=value output and `--json` full payload output
- write snapshots to `storage/app/private/control_plane_snapshots/{timestamp}_control_plane_snapshot_{rand}.json`
- write one audit row with `action=storage_control_plane_snapshot`
- add one scheduler entry at `04:20`

## Scheduler note
This repo currently has two scheduler entry points in practice:
- `app/Console/Kernel.php`
- `bootstrap/app.php` via `withSchedule(...)`

`Kernel.php` alone was not enough to make `php artisan schedule:list` surface the new snapshot job. The same read-only snapshot schedule was therefore added to `bootstrap/app.php` so the live scheduler truth and `schedule:list` stay aligned.

## Safety
- no migrations
- no routes or middleware changes
- no execute automation
- no plan/run/receipt writes beyond the new snapshot file
- no writes to `private/blobs/**`
- no activation changes
- no `content_pack_releases.storage_path` changes
- no runtime reader, publisher, resolver, or artifact contract changes

## Tests
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/ExactRootRetirementOrchestratorServiceTest.php tests/Feature/Storage/StorageRetireExactRootsCommandTest.php tests/Feature/Storage/ExactRootQuarantineServiceTest.php tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php`
- `php artisan route:list > /tmp/pr26_route_list.txt`
- `php artisan migrate`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan schedule:list | rg "storage:control-plane-snapshot"`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
