### PR TITLE
[codex] Ship PR-11A content control plane and CMS-lite foundation (backend)

### DIFF
--- a/backend/app/Filament/Ops/Resources/ContentPackVersionResource.php
+++ b/backend/app/Filament/Ops/Resources/ContentPackVersionResource.php
@@ -6,12 +6,14 @@ namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\ContentPackVersionResource\Pages;
 use App\Models\ContentPackVersion;
+use App\Services\Content\ContentControlPlaneService;
 use App\Support\Rbac\PermissionNames;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
 
 class ContentPackVersionResource extends Resource
 {
@@ -22,6 +24,11 @@ class ContentPackVersionResource extends Resource
     protected static ?string $navigationGroup = 'Content';
 
     protected static ?string $navigationLabel = 'Content Pack Versions';
+
+    /**
+     * @var array<string,array<string,mixed>>
+     */
+    private static array $controlPlaneCache = [];
 
     public static function canViewAny(): bool
     {
@@ -49,6 +56,68 @@ class ContentPackVersionResource extends Resource
     public static function form(Form $form): Form
     {
         return $form->schema([
+            Forms\Components\Section::make('Content control plane')
+                ->description('DB-backed authoring metadata coordinates draft, review, release candidate, and rollback flow. Runtime truth still stays on compiled/versioned artifacts.')
+                ->schema([
+                    Forms\Components\Grid::make(3)
+                        ->schema([
+                            Forms\Components\Placeholder::make('cp.authoring_scope')
+                                ->label('Authoring scope')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'authoring_scope', 'backend_filament_ops')),
+                            Forms\Components\Placeholder::make('cp.content_object_type')
+                                ->label('Content object type')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'content_object_type', 'content_pack_authoring_bundle')),
+                            Forms\Components\Placeholder::make('cp.locale_scope')
+                                ->label('Locale scope')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'locale_scope', 'pending')),
+                            Forms\Components\Placeholder::make('cp.draft_state')
+                                ->label('Draft state')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'draft_state', 'draft_pending_ingest')),
+                            Forms\Components\Placeholder::make('cp.review_state')
+                                ->label('Review state')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'review_state', 'review_pending_ingest')),
+                            Forms\Components\Placeholder::make('cp.revision_no')
+                                ->label('Revision no')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'revision_no', 1)),
+                            Forms\Components\Placeholder::make('cp.compile_status')
+                                ->label('Compile status')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'compile_status', 'pending_compile')),
+                            Forms\Components\Placeholder::make('cp.governance_status')
+                                ->label('Governance status')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'governance_status', 'not_applicable')),
+                            Forms\Components\Placeholder::make('cp.release_candidate_status')
+                                ->label('Release candidate')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'release_candidate_status', 'not_ready')),
+                        ]),
+                    Forms\Components\Grid::make(2)
+                        ->schema([
+                            Forms\Components\Placeholder::make('cp.preview_target')
+                                ->label('Preview target')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'preview_target', 'ops://content-pack-versions/pending'))
+                                ->columnSpanFull(),
+                            Forms\Components\Placeholder::make('cp.publish_target')
+                                ->label('Publish target')
+                                ->content(fn (?ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'publish_target', 'default/pending/pending/pending'))
+                                ->columnSpanFull(),
+                            Forms\Components\Placeholder::make('cp.rollback_target')
+                                ->label('Rollback target')
+                                ->content(fn (?ContentPackVersion $record): string => self::renderRollbackTarget($record))
+                                ->columnSpanFull(),
+                            Forms\Components\Placeholder::make('cp.runtime_artifact_ref')
+                                ->label('Runtime artifact ref')
+                                ->content(fn (?ContentPackVersion $record): string => self::renderRuntimeArtifactRef($record))
+                                ->columnSpanFull(),
+                        ]),
+                    Forms\Components\Placeholder::make('cp.experiment_scope')
+                        ->label('Experiment / overlay scope')
+                        ->content(fn (?ContentPackVersion $record): HtmlString => self::renderExperimentScope($record))
+                        ->columnSpanFull(),
+                    Forms\Components\Placeholder::make('cp.content_object_inventory')
+                        ->label('First-wave managed objects')
+                        ->content(fn (?ContentPackVersion $record): HtmlString => self::renderObjectInventory($record))
+                        ->columnSpanFull(),
+                ])
+                ->columns(1),
             Forms\Components\Grid::make(2)
                 ->schema([
                     Forms\Components\TextInput::make('region')->required()->maxLength(32),
@@ -87,6 +156,21 @@ class ContentPackVersionResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('pack_id')->searchable(),
                 Tables\Columns\TextColumn::make('content_package_version')->label('Version')->searchable(),
+                Tables\Columns\TextColumn::make('control_plane_draft_state')
+                    ->label('Draft')
+                    ->badge()
+                    ->state(fn (ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'draft_state', 'draft_pending_ingest'))
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('control_plane_review_state')
+                    ->label('Review')
+                    ->badge()
+                    ->state(fn (ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'review_state', 'review_pending_ingest'))
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('control_plane_release_candidate_status')
+                    ->label('Release Candidate')
+                    ->badge()
+                    ->state(fn (ContentPackVersion $record): string => (string) self::controlPlaneValue($record, 'release_candidate_status', 'not_ready'))
+                    ->toggleable(),
                 Tables\Columns\TextColumn::make('dir_version_alias')->label('Dir Alias')->searchable(),
                 Tables\Columns\TextColumn::make('region')->sortable(),
                 Tables\Columns\TextColumn::make('locale')->sortable(),
@@ -107,5 +191,123 @@ class ContentPackVersionResource extends Resource
             'create' => Pages\CreateContentPackVersion::route('/create'),
             'edit' => Pages\EditContentPackVersion::route('/{record}/edit'),
         ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private static function controlPlane(?ContentPackVersion $record): array
+    {
+        if (! $record instanceof ContentPackVersion) {
+            return [
+                'authoring_scope' => 'backend_filament_ops',
+                'content_object_type' => 'content_pack_authoring_bundle',
+                'draft_state' => 'draft_pending_ingest',
+                'revision_no' => 1,
+                'review_state' => 'review_pending_ingest',
+                'preview_target' => 'ops://content-pack-versions/pending',
+                'compile_status' => 'pending_compile',
+                'governance_status' => 'not_applicable',
+                'release_candidate_status' => 'not_ready',
+                'publish_target' => 'default/pending/pending/pending',
+                'rollback_target' => null,
+                'locale_scope' => 'pending',
+                'experiment_scope' => [
+                    'stable_files' => 0,
+                    'experiment_files' => 0,
+                    'commercial_overlay_files' => 0,
+                    'experiment_keys' => [],
+                    'overlay_targets' => [],
+                ],
+                'runtime_artifact_ref' => null,
+                'content_object_inventory' => [],
+            ];
+        }
+
+        $key = (string) $record->getKey();
+        if (! isset(self::$controlPlaneCache[$key])) {
+            self::$controlPlaneCache[$key] = app(ContentControlPlaneService::class)->forVersion($record)['content_control_plane_v1'];
+        }
+
+        return self::$controlPlaneCache[$key];
+    }
+
+    private static function controlPlaneValue(?ContentPackVersion $record, string $key, mixed $default = null): mixed
+    {
+        return self::controlPlane($record)[$key] ?? $default;
+    }
+
+    private static function renderRuntimeArtifactRef(?ContentPackVersion $record): string
+    {
+        $artifact = self::controlPlaneValue($record, 'runtime_artifact_ref');
+        if (! is_array($artifact) || $artifact === []) {
+            return 'No published runtime artifact yet. Draft metadata remains control-plane only until compile + publish succeed.';
+        }
+
+        $parts = array_filter([
+            'release_id='.(string) ($artifact['release_id'] ?? ''),
+            'dir_alias='.(string) ($artifact['dir_alias'] ?? ''),
+            'pack_version='.(string) ($artifact['pack_version'] ?? ''),
+            'storage_path='.(string) ($artifact['storage_path'] ?? ''),
+        ], static fn (string $value): bool => ! str_ends_with($value, '='));
+
+        return implode(' | ', $parts);
+    }
+
+    private static function renderRollbackTarget(?ContentPackVersion $record): string
+    {
+        $target = self::controlPlaneValue($record, 'rollback_target');
+        if (! is_array($target) || $target === []) {
+            return 'No prior runtime artifact recorded for rollback.';
+        }
+
+        return implode(' | ', array_filter([
+            'release_id='.(string) ($target['release_id'] ?? ''),
+            'dir_alias='.(string) ($target['dir_alias'] ?? ''),
+            'pack_version='.(string) ($target['pack_version'] ?? ''),
+        ], static fn (string $value): bool => ! str_ends_with($value, '=')));
+    }
+
+    private static function renderExperimentScope(?ContentPackVersion $record): HtmlString
+    {
+        $scope = self::controlPlaneValue($record, 'experiment_scope', []);
+        if (! is_array($scope)) {
+            $scope = [];
+        }
+
+        $experimentKeys = implode(', ', (array) ($scope['experiment_keys'] ?? []));
+        $overlayTargets = implode(', ', (array) ($scope['overlay_targets'] ?? []));
+
+        $items = [
+            'stable_files='.(int) ($scope['stable_files'] ?? 0),
+            'experiment_files='.(int) ($scope['experiment_files'] ?? 0),
+            'commercial_overlay_files='.(int) ($scope['commercial_overlay_files'] ?? 0),
+            'experiment_keys='.($experimentKeys !== '' ? $experimentKeys : 'none'),
+            'overlay_targets='.($overlayTargets !== '' ? $overlayTargets : 'none'),
+        ];
+
+        return new HtmlString('<ul><li>'.implode('</li><li>', array_map('e', $items)).'</li></ul>');
+    }
+
+    private static function renderObjectInventory(?ContentPackVersion $record): HtmlString
+    {
+        $inventory = self::controlPlaneValue($record, 'content_object_inventory', []);
+        if (! is_array($inventory) || $inventory === []) {
+            return new HtmlString('<span>No control-plane managed objects discovered yet.</span>');
+        }
+
+        $items = array_map(static function (mixed $item): string {
+            if (! is_array($item)) {
+                return '';
+            }
+
+            $type = (string) ($item['type'] ?? 'unknown');
+            $enabled = (bool) ($item['enabled'] ?? false);
+
+            return e($type).': '.($enabled ? 'enabled' : 'not_in_scope');
+        }, $inventory);
+        $items = array_values(array_filter($items, static fn (string $item): bool => $item !== ''));
+
+        return new HtmlString('<ul><li>'.implode('</li><li>', $items).'</li></ul>');
     }
 }

--- a/backend/app/Filament/Ops/Resources/ContentPackVersionResource/Pages/ListContentPackVersions.php
+++ b/backend/app/Filament/Ops/Resources/ContentPackVersionResource/Pages/ListContentPackVersions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Resources\ContentPackVersionResource\Pages;
 
+use App\Filament\Ops\Resources\ContentPackReleaseResource;
 use App\Filament\Ops\Resources\ContentPackVersionResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
@@ -15,6 +16,10 @@ class ListContentPackVersions extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            Actions\Action::make('releaseQueue')
+                ->label('Open Release Queue')
+                ->icon('heroicon-o-archive-box-arrow-down')
+                ->url(ContentPackReleaseResource::getUrl('index')),
             Actions\CreateAction::make(),
         ];
     }

--- a/backend/app/Services/Content/ContentControlPlaneService.php
+++ b/backend/app/Services/Content/ContentControlPlaneService.php
@@ -1,0 +1,476 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use App\Models\ContentPackVersion;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+
+final class ContentControlPlaneService
+{
+    public function __construct(
+        private readonly MbtiContentGovernanceService $mbtiGovernance,
+    ) {
+    }
+
+    /**
+     * @return array{content_control_plane_v1:array<string,mixed>}
+     */
+    public function forVersion(ContentPackVersion|array $version): array
+    {
+        $versionData = $this->normalizeVersion($version);
+        $pack = $this->buildPackContext($versionData);
+        $governance = $this->inspectGovernance($pack);
+        $compile = $this->inspectCompile($pack['base_dir']);
+        $release = $this->inspectRelease($versionData);
+
+        $draftState = $this->resolveDraftState($compile['status'], $governance['status'], $release);
+        $reviewState = $this->resolveReviewState($compile['status'], $governance['status'], $release);
+
+        return [
+            'content_control_plane_v1' => [
+                'authoring_scope' => 'backend_filament_ops',
+                'content_object_type' => 'content_pack_authoring_bundle',
+                'draft_state' => $draftState,
+                'revision_no' => $this->resolveRevisionNo($versionData),
+                'review_state' => $reviewState,
+                'preview_target' => $this->resolvePreviewTarget($versionData),
+                'compile_status' => $compile['status'],
+                'governance_status' => $governance['status'],
+                'release_candidate_status' => $this->resolveReleaseCandidateStatus($release, $compile['status'], $governance['status']),
+                'publish_target' => $this->resolvePublishTarget($versionData),
+                'rollback_target' => $release['rollback_target'],
+                'locale_scope' => $this->resolveLocaleScope($versionData),
+                'experiment_scope' => $governance['experiment_scope'],
+                'runtime_artifact_ref' => $release['runtime_artifact_ref'],
+                'cultural_context' => $governance['cultural_context'],
+                'content_object_inventory' => $governance['content_object_inventory'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function normalizeVersion(ContentPackVersion|array $version): array
+    {
+        if ($version instanceof ContentPackVersion) {
+            return [
+                'id' => (string) $version->getKey(),
+                'region' => (string) $version->region,
+                'locale' => (string) $version->locale,
+                'pack_id' => (string) $version->pack_id,
+                'content_package_version' => (string) $version->content_package_version,
+                'dir_version_alias' => (string) $version->dir_version_alias,
+                'extracted_rel_path' => (string) ($version->extracted_rel_path ?? ''),
+                'manifest_json' => is_array($version->manifest_json) ? $version->manifest_json : [],
+                'created_at' => $version->created_at,
+            ];
+        }
+
+        $payload = (array) $version;
+        $manifest = $payload['manifest_json'] ?? [];
+        if (is_string($manifest) && trim($manifest) !== '') {
+            $decoded = json_decode($manifest, true);
+            $manifest = is_array($decoded) ? $decoded : [];
+        }
+
+        return [
+            'id' => (string) ($payload['id'] ?? ''),
+            'region' => (string) ($payload['region'] ?? ''),
+            'locale' => (string) ($payload['locale'] ?? ''),
+            'pack_id' => (string) ($payload['pack_id'] ?? ''),
+            'content_package_version' => (string) ($payload['content_package_version'] ?? ''),
+            'dir_version_alias' => (string) ($payload['dir_version_alias'] ?? ''),
+            'extracted_rel_path' => (string) ($payload['extracted_rel_path'] ?? ''),
+            'manifest_json' => is_array($manifest) ? $manifest : [],
+            'created_at' => $payload['created_at'] ?? null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $versionData
+     * @return array<string,mixed>
+     */
+    private function buildPackContext(array $versionData): array
+    {
+        $manifest = is_array($versionData['manifest_json'] ?? null) ? $versionData['manifest_json'] : [];
+
+        return [
+            'pack_id' => (string) ($versionData['pack_id'] ?? ($manifest['pack_id'] ?? '')),
+            'version' => (string) ($versionData['content_package_version'] ?? ($manifest['content_package_version'] ?? '')),
+            'base_dir' => $this->absoluteFromPrivate((string) ($versionData['extracted_rel_path'] ?? '')),
+            'manifest' => $manifest,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $pack
+     * @return array{
+     *   status:string,
+     *   cultural_context:?string,
+     *   experiment_scope:array<string,mixed>,
+     *   content_object_inventory:list<array<string,mixed>>
+     * }
+     */
+    private function inspectGovernance(array $pack): array
+    {
+        $manifest = is_array($pack['manifest'] ?? null) ? $pack['manifest'] : [];
+        $baseDir = trim((string) ($pack['base_dir'] ?? ''));
+
+        if ($baseDir === '' || ! File::isDirectory($baseDir) || ! $this->mbtiGovernance->appliesTo($pack)) {
+            return [
+                'status' => 'not_applicable',
+                'cultural_context' => null,
+                'experiment_scope' => [
+                    'stable_files' => 0,
+                    'experiment_files' => 0,
+                    'commercial_overlay_files' => 0,
+                    'experiment_keys' => [],
+                    'overlay_targets' => [],
+                ],
+                'content_object_inventory' => $this->defaultObjectInventory(
+                    trim((string) ($manifest['region'] ?? '')) !== '' && trim((string) ($manifest['locale'] ?? '')) !== '',
+                    false,
+                    false,
+                    false,
+                    true,
+                ),
+            ];
+        }
+
+        $errors = $this->mbtiGovernance->lintPack($pack);
+        $document = $this->mbtiGovernance->loadDocument($baseDir);
+        $filePolicies = is_array($document['file_policies'] ?? null) ? $document['file_policies'] : [];
+
+        $stableFiles = 0;
+        $experimentFiles = 0;
+        $commercialOverlayFiles = 0;
+        $experimentKeys = [];
+        $overlayTargets = [];
+        $narrativeFiles = 0;
+
+        foreach ($filePolicies as $fileName => $policy) {
+            if (! is_array($policy)) {
+                continue;
+            }
+
+            $tier = trim((string) ($policy['content_tier'] ?? ''));
+            $layers = array_values(array_filter(array_map('strval', (array) ($policy['layers'] ?? []))));
+
+            if ($tier === 'stable') {
+                $stableFiles++;
+            } elseif ($tier === 'experiment') {
+                $experimentFiles++;
+                $experimentKey = trim((string) ($policy['experiment_key'] ?? ''));
+                if ($experimentKey !== '') {
+                    $experimentKeys[] = $experimentKey;
+                }
+            } elseif ($tier === 'commercial_overlay') {
+                $commercialOverlayFiles++;
+                foreach ((array) ($policy['targets'] ?? []) as $target) {
+                    $target = trim((string) $target);
+                    if ($target !== '') {
+                        $overlayTargets[] = $target;
+                    }
+                }
+            }
+
+            if (array_intersect($layers, ['scene', 'explainability', 'action']) !== []) {
+                $narrativeFiles++;
+            }
+        }
+
+        $experimentKeys = array_values(array_unique($experimentKeys));
+        $overlayTargets = array_values(array_unique($overlayTargets));
+
+        return [
+            'status' => $errors === [] ? 'passing' : 'failing',
+            'cultural_context' => trim((string) ($document['cultural_context'] ?? '')) ?: null,
+            'experiment_scope' => [
+                'stable_files' => $stableFiles,
+                'experiment_files' => $experimentFiles,
+                'commercial_overlay_files' => $commercialOverlayFiles,
+                'experiment_keys' => $experimentKeys,
+                'overlay_targets' => $overlayTargets,
+            ],
+            'content_object_inventory' => $this->defaultObjectInventory(
+                trim((string) ($document['cultural_context'] ?? '')) !== '',
+                $narrativeFiles > 0,
+                $experimentFiles > 0,
+                $commercialOverlayFiles > 0,
+                true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array{status:string,compiled_dir:?string,compiled_manifest:?string}
+     */
+    private function inspectCompile(string $baseDir): array
+    {
+        $baseDir = trim($baseDir);
+        if ($baseDir === '' || ! File::isDirectory($baseDir)) {
+            return [
+                'status' => 'source_missing',
+                'compiled_dir' => null,
+                'compiled_manifest' => null,
+            ];
+        }
+
+        $compiledDir = $baseDir.DIRECTORY_SEPARATOR.'compiled';
+        $compiledManifest = $compiledDir.DIRECTORY_SEPARATOR.'manifest.json';
+
+        if (File::exists($compiledManifest)) {
+            return [
+                'status' => 'compiled',
+                'compiled_dir' => $compiledDir,
+                'compiled_manifest' => $compiledManifest,
+            ];
+        }
+
+        return [
+            'status' => 'pending_compile',
+            'compiled_dir' => File::isDirectory($compiledDir) ? $compiledDir : null,
+            'compiled_manifest' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $versionData
+     * @return array{latest_publish:?object,current_runtime:?object,rollback_target:?array<string,mixed>,runtime_artifact_ref:?array<string,mixed>}
+     */
+    private function inspectRelease(array $versionData): array
+    {
+        $versionId = trim((string) ($versionData['id'] ?? ''));
+        $region = trim((string) ($versionData['region'] ?? ''));
+        $locale = trim((string) ($versionData['locale'] ?? ''));
+        $dirAlias = trim((string) ($versionData['dir_version_alias'] ?? ''));
+        $packId = trim((string) ($versionData['pack_id'] ?? ''));
+
+        if ($versionId === '') {
+            return [
+                'latest_publish' => null,
+                'current_runtime' => null,
+                'rollback_target' => null,
+                'runtime_artifact_ref' => null,
+            ];
+        }
+
+        $latestPublish = DB::table('content_pack_releases')
+            ->where('action', 'publish')
+            ->where('to_version_id', $versionId)
+            ->orderByDesc('created_at')
+            ->first();
+
+        $currentRuntime = $latestPublish && (string) ($latestPublish->status ?? '') === 'success'
+            ? $latestPublish
+            : null;
+
+        $rollbackRelease = null;
+        if ($currentRuntime !== null) {
+            $rollbackRelease = DB::table('content_pack_releases')
+                ->where('action', 'publish')
+                ->where('status', 'success')
+                ->where('region', $region)
+                ->where('locale', $locale)
+                ->when($dirAlias !== '', fn ($query) => $query->where('dir_alias', $dirAlias))
+                ->where('id', '!=', (string) ($currentRuntime->id ?? ''))
+                ->orderByDesc('created_at')
+                ->first();
+        }
+
+        return [
+            'latest_publish' => $latestPublish,
+            'current_runtime' => $currentRuntime,
+            'rollback_target' => $rollbackRelease ? $this->artifactRefFromRelease($rollbackRelease) : null,
+            'runtime_artifact_ref' => $currentRuntime ? $this->artifactRefFromRelease($currentRuntime) : null,
+        ];
+    }
+
+    private function resolveDraftState(string $compileStatus, string $governanceStatus, array $release): string
+    {
+        if ($release['current_runtime'] !== null) {
+            return 'published';
+        }
+
+        if ($governanceStatus === 'failing') {
+            return 'draft_needs_governance_fix';
+        }
+
+        if ($compileStatus !== 'compiled') {
+            return 'draft_needs_compile';
+        }
+
+        return 'draft_ready';
+    }
+
+    private function resolveReviewState(string $compileStatus, string $governanceStatus, array $release): string
+    {
+        if ($release['current_runtime'] !== null) {
+            return 'released';
+        }
+
+        if ($governanceStatus === 'failing') {
+            return 'review_blocked_by_governance';
+        }
+
+        if ($compileStatus !== 'compiled') {
+            return 'review_blocked_by_compile';
+        }
+
+        return 'ready_for_release_review';
+    }
+
+    private function resolveReleaseCandidateStatus(array $release, string $compileStatus, string $governanceStatus): string
+    {
+        if ($release['current_runtime'] !== null) {
+            return 'published';
+        }
+
+        $latestPublish = $release['latest_publish'];
+        if ($latestPublish && (string) ($latestPublish->status ?? '') === 'failed') {
+            return 'publish_failed';
+        }
+
+        if ($compileStatus === 'compiled' && $governanceStatus !== 'failing') {
+            return 'ready';
+        }
+
+        return 'not_ready';
+    }
+
+    /**
+     * @param  array<string,mixed>  $versionData
+     */
+    private function resolveRevisionNo(array $versionData): int
+    {
+        $packId = trim((string) ($versionData['pack_id'] ?? ''));
+        $region = trim((string) ($versionData['region'] ?? ''));
+        $locale = trim((string) ($versionData['locale'] ?? ''));
+        $versionId = trim((string) ($versionData['id'] ?? ''));
+
+        if ($packId === '' || $region === '' || $locale === '' || $versionId === '') {
+            return 1;
+        }
+
+        $createdAt = $versionData['created_at'] ?? null;
+
+        $query = DB::table('content_pack_versions')
+            ->where('pack_id', $packId)
+            ->where('region', $region)
+            ->where('locale', $locale);
+
+        if ($createdAt !== null) {
+            $query->where('created_at', '<=', $createdAt);
+        }
+
+        return max(1, (int) $query->count());
+    }
+
+    /**
+     * @param  array<string,mixed>  $versionData
+     */
+    private function resolvePreviewTarget(array $versionData): string
+    {
+        $versionId = trim((string) ($versionData['id'] ?? ''));
+        if ($versionId === '') {
+            return 'ops://content-pack-versions/pending';
+        }
+
+        return 'ops://content-pack-versions/'.$versionId;
+    }
+
+    /**
+     * @param  array<string,mixed>  $versionData
+     */
+    private function resolvePublishTarget(array $versionData): string
+    {
+        $region = trim((string) ($versionData['region'] ?? ''));
+        $locale = trim((string) ($versionData['locale'] ?? ''));
+        $dirAlias = trim((string) ($versionData['dir_version_alias'] ?? ''));
+
+        if ($region === '' || $locale === '' || $dirAlias === '') {
+            return 'default/pending/pending/pending';
+        }
+
+        return 'default/'.$region.'/'.$locale.'/'.$dirAlias;
+    }
+
+    /**
+     * @param  array<string,mixed>  $versionData
+     */
+    private function resolveLocaleScope(array $versionData): string
+    {
+        $region = trim((string) ($versionData['region'] ?? ''));
+        $locale = trim((string) ($versionData['locale'] ?? ''));
+
+        return trim($region.'.'.$locale, '.');
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function defaultObjectInventory(
+        bool $hasLocaleVariant,
+        bool $hasNarrative,
+        bool $hasExperimentOverlay,
+        bool $hasCtaOverlay,
+        bool $hasReleaseCandidate
+    ): array {
+        return [
+            [
+                'type' => 'narrative_fragment',
+                'enabled' => $hasNarrative,
+            ],
+            [
+                'type' => 'calibration_copy',
+                'enabled' => $hasLocaleVariant,
+            ],
+            [
+                'type' => 'cta_overlay',
+                'enabled' => $hasCtaOverlay,
+            ],
+            [
+                'type' => 'experiment_overlay',
+                'enabled' => $hasExperimentOverlay,
+            ],
+            [
+                'type' => 'locale_variant_draft',
+                'enabled' => $hasLocaleVariant,
+            ],
+            [
+                'type' => 'release_candidate_metadata',
+                'enabled' => $hasReleaseCandidate,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function artifactRefFromRelease(object $release): array
+    {
+        return [
+            'release_id' => (string) ($release->id ?? ''),
+            'dir_alias' => (string) ($release->dir_alias ?? ''),
+            'storage_path' => (string) ($release->storage_path ?? ''),
+            'manifest_hash' => (string) ($release->manifest_hash ?? ''),
+            'compiled_hash' => (string) ($release->compiled_hash ?? ''),
+            'content_hash' => (string) ($release->content_hash ?? ''),
+            'pack_version' => (string) ($release->pack_version ?? ''),
+        ];
+    }
+
+    private function absoluteFromPrivate(string $relPath): string
+    {
+        $relPath = trim($relPath);
+        if ($relPath === '') {
+            return '';
+        }
+
+        return rtrim(storage_path('app/private'), '/\\').DIRECTORY_SEPARATOR.ltrim($relPath, '/\\');
+    }
+}

--- a/backend/tests/Feature/Ops/ContentPackControlPlaneWorkspaceTest.php
+++ b/backend/tests/Feature/Ops/ContentPackControlPlaneWorkspaceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Models\AdminUser;
+use App\Models\ContentPackVersion;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ContentPackControlPlaneWorkspaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_content_pack_version_workspace_renders_control_plane_surface_for_authorized_admin(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_PUBLISH,
+        ]);
+        $selectedOrg = $this->createSelectedOrg();
+
+        $version = ContentPackVersion::query()->create([
+            'id' => (string) Str::uuid(),
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'content_package_version' => 'content_2026_03',
+            'dir_version_alias' => 'MBTI-CN-v0.3-control-plane',
+            'source_type' => 'upload',
+            'source_ref' => 'private://content-control-plane/pack.zip',
+            'sha256' => str_repeat('b', 64),
+            'manifest_json' => [
+                'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'content_package_version' => 'content_2026_03',
+                'region' => 'CN_MAINLAND',
+                'locale' => 'zh-CN',
+                'schemas' => [
+                    'content_governance' => 'fap.mbti.content_governance.v1',
+                ],
+            ],
+            'extracted_rel_path' => '',
+            'created_by' => 'ops_admin',
+        ]);
+
+        $session = [
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+
+        $this->withSession($session)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-pack-versions')
+            ->assertOk()
+            ->assertSee('Open Release Queue')
+            ->assertSee('Release Candidate');
+
+        $this->withSession($session)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-pack-versions/'.$version->id.'/edit')
+            ->assertOk()
+            ->assertSee('Content control plane')
+            ->assertSee('Draft state')
+            ->assertSee('Runtime artifact ref')
+            ->assertSee('First-wave managed objects');
+    }
+
+    private function createSelectedOrg(): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'Content Control Plane Org',
+            'owner_user_id' => 9001,
+            'status' => 'active',
+            'domain' => 'content-control-plane.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'content_control_plane_'.Str::lower(Str::random(6)),
+            'guard_name' => (string) config('admin.guard', 'admin'),
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate([
+                'name' => $permissionName,
+                'guard_name' => (string) config('admin.guard', 'admin'),
+            ]);
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+}

--- a/backend/tests/Unit/Services/Content/ContentControlPlaneServiceTest.php
+++ b/backend/tests/Unit/Services/Content/ContentControlPlaneServiceTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Content;
+
+use App\Models\ContentPackVersion;
+use App\Services\Content\ContentControlPlaneService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ContentControlPlaneServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var list<string>
+     */
+    private array $tmpRoots = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpRoots as $path) {
+            if (File::isDirectory($path)) {
+                File::deleteDirectory($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_contract_exposes_control_plane_metadata_without_replacing_runtime_truth(): void
+    {
+        $version = $this->seedVersionFromRealMbtiPack([
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'content_package_version' => 'content_2026_03',
+            'dir_version_alias' => 'MBTI-CN-v0.3-control-plane',
+        ]);
+
+        /** @var ContentControlPlaneService $service */
+        $service = app(ContentControlPlaneService::class);
+        $contract = $service->forVersion($version)['content_control_plane_v1'];
+
+        $this->assertSame('backend_filament_ops', $contract['authoring_scope']);
+        $this->assertSame('content_pack_authoring_bundle', $contract['content_object_type']);
+        $this->assertArrayHasKey('draft_state', $contract);
+        $this->assertArrayHasKey('revision_no', $contract);
+        $this->assertArrayHasKey('review_state', $contract);
+        $this->assertArrayHasKey('preview_target', $contract);
+        $this->assertArrayHasKey('compile_status', $contract);
+        $this->assertArrayHasKey('governance_status', $contract);
+        $this->assertArrayHasKey('release_candidate_status', $contract);
+        $this->assertArrayHasKey('publish_target', $contract);
+        $this->assertArrayHasKey('rollback_target', $contract);
+        $this->assertArrayHasKey('locale_scope', $contract);
+        $this->assertArrayHasKey('experiment_scope', $contract);
+        $this->assertArrayHasKey('runtime_artifact_ref', $contract);
+        $this->assertSame('compiled', $contract['compile_status']);
+        $this->assertSame('passing', $contract['governance_status']);
+        $this->assertNull($contract['runtime_artifact_ref']);
+        $this->assertNotEmpty($contract['content_object_inventory']);
+    }
+
+    public function test_draft_requires_publish_before_runtime_artifact_ref_exists(): void
+    {
+        $version = $this->seedVersionFromRealMbtiPack([
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'content_package_version' => 'content_2026_04',
+            'dir_version_alias' => 'MBTI-CN-v0.3-control-plane-draft',
+        ]);
+
+        /** @var ContentControlPlaneService $service */
+        $service = app(ContentControlPlaneService::class);
+        $draftContract = $service->forVersion($version)['content_control_plane_v1'];
+
+        $this->assertSame('draft_ready', $draftContract['draft_state']);
+        $this->assertNull($draftContract['runtime_artifact_ref']);
+
+        $this->insertSuccessfulPublishRelease(
+            (string) $version->id,
+            (string) $version->pack_id,
+            (string) $version->content_package_version,
+            (string) $version->region,
+            (string) $version->locale,
+            (string) $version->dir_version_alias,
+            'app/private/content_releases/'.$version->id.'/source_pack'
+        );
+
+        $publishedContract = $service->forVersion($version->fresh())['content_control_plane_v1'];
+
+        $this->assertSame('published', $publishedContract['draft_state']);
+        $this->assertIsArray($publishedContract['runtime_artifact_ref']);
+        $this->assertSame((string) $version->content_package_version, $publishedContract['runtime_artifact_ref']['pack_version']);
+    }
+
+    public function test_published_version_exposes_previous_release_as_rollback_target(): void
+    {
+        $previous = $this->seedVersionFromRealMbtiPack([
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'content_package_version' => 'content_2026_05',
+            'dir_version_alias' => 'MBTI-CN-v0.3-runtime',
+        ]);
+        $current = $this->seedVersionFromRealMbtiPack([
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'content_package_version' => 'content_2026_06',
+            'dir_version_alias' => 'MBTI-CN-v0.3-runtime',
+        ]);
+
+        $previousReleaseId = $this->insertSuccessfulPublishRelease(
+            (string) $previous->id,
+            (string) $previous->pack_id,
+            (string) $previous->content_package_version,
+            (string) $previous->region,
+            (string) $previous->locale,
+            (string) $previous->dir_version_alias,
+            'app/private/content_releases/'.$previous->id.'/source_pack',
+            now()->subHour()
+        );
+        $this->insertSuccessfulPublishRelease(
+            (string) $current->id,
+            (string) $current->pack_id,
+            (string) $current->content_package_version,
+            (string) $current->region,
+            (string) $current->locale,
+            (string) $current->dir_version_alias,
+            'app/private/content_releases/'.$current->id.'/source_pack',
+            now()
+        );
+
+        /** @var ContentControlPlaneService $service */
+        $service = app(ContentControlPlaneService::class);
+        $contract = $service->forVersion($current)['content_control_plane_v1'];
+
+        $this->assertSame('published', $contract['release_candidate_status']);
+        $this->assertIsArray($contract['rollback_target']);
+        $this->assertSame($previousReleaseId, $contract['rollback_target']['release_id']);
+    }
+
+    /**
+     * @param  array<string,string>  $overrides
+     */
+    private function seedVersionFromRealMbtiPack(array $overrides = []): ContentPackVersion
+    {
+        $sourceDir = base_path('../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3');
+        $versionId = (string) Str::uuid();
+        $relativePath = 'content_control_plane_tests/'.$versionId.'/source_pack';
+        $targetDir = storage_path('app/private/'.$relativePath);
+
+        File::ensureDirectoryExists(dirname($targetDir));
+        File::copyDirectory($sourceDir, $targetDir);
+        $this->tmpRoots[] = dirname(dirname($targetDir));
+
+        $manifest = json_decode((string) file_get_contents($sourceDir.'/manifest.json'), true);
+        $this->assertIsArray($manifest);
+
+        return ContentPackVersion::query()->create([
+            'id' => $versionId,
+            'region' => $overrides['region'] ?? 'CN_MAINLAND',
+            'locale' => $overrides['locale'] ?? 'zh-CN',
+            'pack_id' => $overrides['pack_id'] ?? (string) ($manifest['pack_id'] ?? 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'content_package_version' => $overrides['content_package_version'] ?? 'content_2026_03',
+            'dir_version_alias' => $overrides['dir_version_alias'] ?? 'MBTI-CN-v0.3-control-plane',
+            'source_type' => 'upload',
+            'source_ref' => 'private://content_control_plane_tests/'.$versionId.'/pack.zip',
+            'sha256' => str_repeat('a', 64),
+            'manifest_json' => $manifest,
+            'extracted_rel_path' => $relativePath,
+            'created_by' => 'ops_admin',
+        ]);
+    }
+
+    private function insertSuccessfulPublishRelease(
+        string $versionId,
+        string $packId,
+        string $packVersion,
+        string $region,
+        string $locale,
+        string $dirAlias,
+        string $storagePath,
+        ?\Illuminate\Support\Carbon $createdAt = null
+    ): string {
+        $releaseId = (string) Str::uuid();
+        $createdAt ??= now();
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => 'publish',
+            'region' => $region,
+            'locale' => $locale,
+            'dir_alias' => $dirAlias,
+            'from_version_id' => null,
+            'to_version_id' => $versionId,
+            'from_pack_id' => null,
+            'to_pack_id' => $packId,
+            'status' => 'success',
+            'message' => 'published',
+            'created_by' => 'ops_admin',
+            'probe_ok' => true,
+            'probe_json' => json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'probe_run_at' => $createdAt,
+            'manifest_hash' => 'manifest_'.$versionId,
+            'compiled_hash' => 'compiled_'.$versionId,
+            'content_hash' => 'content_'.$versionId,
+            'norms_version' => '2026Q1',
+            'git_sha' => 'git_'.$versionId,
+            'pack_version' => $packVersion,
+            'manifest_json' => json_encode(['pack_id' => $packId, 'content_package_version' => $packVersion], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $storagePath,
+            'source_commit' => 'git_'.$versionId,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ]);
+
+        return $releaseId;
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-11A: content control plane / CMS-lite foundation.

It establishes the first backend/Filament control-plane layer for content authoring and release coordination, while keeping compiled and versioned artifacts as the only runtime truth.

## Problem

The repo already had strong content engineering foundations:

- content packs and compiled artifacts
- governance and tier boundaries
- lint / compile / self-check
- publish / rollback / exact-release infrastructure
- isolated authoring patterns in Filament resources such as Career Jobs

But those capabilities were still fragmented. There was no single control-plane contract that told operators:

- whether a content bundle is still a draft
- whether governance or compile is blocking review
- whether the bundle is a release candidate
- what runtime artifact ref is currently live
- what rollback target exists

That meant the platform had content governance and release machinery, but not yet a proper CMS-lite control plane.

## Root cause

The system had runtime truth and release truth, but no dedicated authoring/release-coordination contract above them.

`content_pack_versions` tracked staged inputs and `content_pack_releases` tracked published artifacts, yet Filament did not expose a single backend-owned view that formalized the separation between:

- DB/control-plane authoring truth
- compiled artifact runtime truth

Without that layer, the product still lacked a real content control plane even though the low-level infrastructure already existed.

## Fix

This PR adds `ContentControlPlaneService` and introduces `content_control_plane_v1`.

The contract includes:

- `authoring_scope`
- `content_object_type`
- `draft_state`
- `revision_no`
- `review_state`
- `preview_target`
- `compile_status`
- `governance_status`
- `release_candidate_status`
- `publish_target`
- `rollback_target`
- `locale_scope`
- `experiment_scope`
- `runtime_artifact_ref`

The implementation is intentionally constrained:

- control-plane metadata is backend-owned
- runtime truth still comes only from compiled/versioned artifacts
- draft/control-plane state never becomes runtime truth directly
- existing lint / compile / governance / publish / rollback flows remain the backbone

On the surface side, the existing Filament `Content Pack Versions` resource is upgraded into a first-wave CMS-lite workspace by:

- showing control-plane status on the list page
- showing a detailed control-plane section on the edit page
- linking directly into the existing release queue

## Why this matters

This gives the platform its first real content control plane.

It is the correct first step toward a CMS-lite system:

- DB/control-plane for authoring and coordination
- compiled artifacts for runtime truth
- publish/rollback still centered on versioned releases

## Validation

I ran:

- `php artisan test tests/Unit/Services/Content/ContentControlPlaneServiceTest.php tests/Feature/Ops/ContentPackControlPlaneWorkspaceTest.php tests/Feature/Content/MbtiContentGovernanceContractTest.php tests/Feature/Content/PacksPublishBig5Test.php`

All passed:

- 8 tests passed
- 336 assertions

## Scope note

This PR is intentionally limited to backend/Filament CMS-lite foundation.

It does not:

- make the database the runtime truth
- add a new CMS framework
- add migrations or dependencies
- introduce a `fap-web` authoring shell
- change result/runtime read paths
- pull in task-external dirty files such as pack publish/rollback worktree edits or compiled artifact changes
