### PR TITLE
[codex] add control-plane artifacts janitor

### DIFF
--- a/backend/app/Console/Commands/StorageControlPlaneArtifactsJanitor.php
+++ b/backend/app/Console/Commands/StorageControlPlaneArtifactsJanitor.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\StorageControlPlaneArtifactsJanitorService;
+use Illuminate\Console\Command;
+
+final class StorageControlPlaneArtifactsJanitor extends Command
+{
+    protected $signature = 'storage:janitor-control-plane-artifacts
+        {--dry-run : Preview eligible control-plane artifact deletions only}
+        {--execute : Delete eligible control-plane artifact files}';
+
+    protected $description = 'Janitor rebuildable control-plane snapshots and plan artifacts without touching runtime or receipt paths.';
+
+    public function __construct(
+        private readonly StorageControlPlaneArtifactsJanitorService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $payload = $this->service->run($execute);
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('mode='.(string) ($payload['mode'] ?? ''));
+        $this->line('schema='.(string) ($payload['schema'] ?? ''));
+        $this->line('generated_at='.(string) ($payload['generated_at'] ?? ''));
+        $this->line('scanned_file_count='.(int) ($summary['scanned_file_count'] ?? 0));
+        $this->line('kept_file_count='.(int) ($summary['kept_file_count'] ?? 0));
+        $this->line('candidate_delete_count='.(int) ($summary['candidate_delete_count'] ?? 0));
+        $this->line('deleted_file_count='.(int) ($summary['deleted_file_count'] ?? 0));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Services/Storage/StorageControlPlaneArtifactsJanitorService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneArtifactsJanitorService.php
@@ -1,0 +1,452 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageControlPlaneArtifactsJanitorService
+{
+    private const SCHEMA = 'storage_control_plane_artifacts_janitor.v1';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function run(bool $execute): array
+    {
+        $directories = $this->directoryDefinitions();
+        $results = [];
+        $keptPaths = [];
+        $candidateDeletePaths = [];
+        $deletedPaths = [];
+
+        foreach ($directories as $directoryKey => $definition) {
+            $files = $this->jsonFilesUnder($definition['relative_dir']);
+            $keepSet = $this->buildKeepSet($directoryKey, $files);
+            $candidates = array_values(array_filter($files, static fn (string $path): bool => ! isset($keepSet[$path])));
+            $deleted = [];
+
+            if ($execute) {
+                foreach ($candidates as $path) {
+                    if (! $this->isEligiblePath($path, $definition['relative_dir'])) {
+                        continue;
+                    }
+
+                    File::delete($path);
+                    if (! is_file($path)) {
+                        $deleted[] = $path;
+                    }
+                }
+            }
+
+            $results[$directoryKey] = [
+                'relative_dir' => $definition['relative_dir'],
+                'scanned_file_count' => count($files),
+                'kept_file_count' => count($keepSet),
+                'candidate_delete_count' => count($candidates),
+                'deleted_file_count' => count($deleted),
+                'kept_paths' => array_values(array_keys($keepSet)),
+                'candidate_delete_paths' => $candidates,
+                'deleted_paths' => $deleted,
+            ];
+
+            $keptPaths = array_merge($keptPaths, array_keys($keepSet));
+            $candidateDeletePaths = array_merge($candidateDeletePaths, $candidates);
+            $deletedPaths = array_merge($deletedPaths, $deleted);
+        }
+
+        sort($keptPaths);
+        sort($candidateDeletePaths);
+        sort($deletedPaths);
+
+        $payload = [
+            'schema' => self::SCHEMA,
+            'mode' => $execute ? 'execute' : 'dry_run',
+            'status' => $execute ? 'executed' : 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'summary' => [
+                'directory_count' => count($results),
+                'scanned_file_count' => count($keptPaths) + count($candidateDeletePaths),
+                'kept_file_count' => count($keptPaths),
+                'candidate_delete_count' => count($candidateDeletePaths),
+                'deleted_file_count' => count($deletedPaths),
+            ],
+            'directories' => $results,
+            'kept_paths' => $keptPaths,
+            'candidate_delete_paths' => $candidateDeletePaths,
+            'deleted_paths' => $deletedPaths,
+        ];
+
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return array<string,array{relative_dir:string}>
+     */
+    private function directoryDefinitions(): array
+    {
+        return [
+            'control_plane_snapshots' => ['relative_dir' => 'app/private/control_plane_snapshots'],
+            'gc_plans' => ['relative_dir' => 'app/private/gc_plans'],
+            'offload_plans' => ['relative_dir' => 'app/private/offload_plans'],
+            'rehydrate_plans' => ['relative_dir' => 'app/private/rehydrate_plans'],
+            'quarantine_plans' => ['relative_dir' => 'app/private/quarantine_plans'],
+            'quarantine_restore_plans' => ['relative_dir' => 'app/private/quarantine_restore_plans'],
+            'quarantine_purge_plans' => ['relative_dir' => 'app/private/quarantine_purge_plans'],
+            'retirement_plans' => ['relative_dir' => 'app/private/retirement_plans'],
+            'prune_plans' => ['relative_dir' => 'app/private/prune_plans'],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $files
+     * @return array<string,true>
+     */
+    private function buildKeepSet(string $directoryKey, array $files): array
+    {
+        return match ($directoryKey) {
+            'control_plane_snapshots' => $this->keepSetForSnapshots($files),
+            'prune_plans' => $this->keepSetForPrunePlans($files),
+            default => $this->keepSetForGenericPlans($files, $this->auditReferencedPlanPathForDirectory($directoryKey)),
+        };
+    }
+
+    /**
+     * @param  list<string>  $files
+     * @return array<string,true>
+     */
+    private function keepSetForSnapshots(array $files): array
+    {
+        $keep = [];
+
+        foreach ($this->latestFiles($files, max(1, $this->snapshotKeepLastN())) as $path) {
+            $keep[$path] = true;
+        }
+
+        if ($this->retainLatestAuditReferenced()) {
+            $audit = $this->latestAuditForAction('storage_control_plane_snapshot');
+            $snapshotPath = is_array($audit) ? $this->normalizeExistingFilePath((string) ($audit['snapshot_path'] ?? '')) : null;
+            if ($snapshotPath !== null) {
+                $keep[$snapshotPath] = true;
+            }
+        }
+
+        return $keep;
+    }
+
+    /**
+     * @param  list<string>  $files
+     * @return array<string,true>
+     */
+    private function keepSetForGenericPlans(array $files, ?string $auditReferencedPath): array
+    {
+        $keep = [];
+
+        foreach ($this->latestFiles($files, max(0, $this->planKeepLastN())) as $path) {
+            $keep[$path] = true;
+        }
+
+        if ($this->retainLatestAuditReferenced() && $auditReferencedPath !== null) {
+            $keep[$auditReferencedPath] = true;
+        }
+
+        return $keep;
+    }
+
+    /**
+     * @param  list<string>  $files
+     * @return array<string,true>
+     */
+    private function keepSetForPrunePlans(array $files): array
+    {
+        $keep = [];
+        $keepLastPerScope = max(1, $this->prunePlansKeepLastNPerScope());
+
+        foreach ($this->filesGroupedByPruneScope($files) as $scopeFiles) {
+            foreach ($this->latestFiles($scopeFiles, $keepLastPerScope) as $path) {
+                $keep[$path] = true;
+            }
+        }
+
+        if (! $this->retainLatestAuditReferenced()) {
+            return $keep;
+        }
+
+        foreach ($this->latestAuditReferencedPrunePlanPaths() as $path) {
+            $keep[$path] = true;
+        }
+
+        return $keep;
+    }
+
+    /**
+     * @param  list<string>  $files
+     * @return array<string,list<string>>
+     */
+    private function filesGroupedByPruneScope(array $files): array
+    {
+        $grouped = [];
+
+        foreach ($files as $path) {
+            $payload = $this->safeJsonDecodeFile($path);
+            $scope = trim((string) ($payload['scope'] ?? ''));
+            if ($scope === '') {
+                continue;
+            }
+
+            $grouped[$scope] ??= [];
+            $grouped[$scope][] = $path;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function latestAuditReferencedPrunePlanPaths(): array
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return [];
+        }
+
+        $paths = [];
+        $rows = DB::table('audit_logs')
+            ->where('action', 'storage_prune')
+            ->orderByDesc('id')
+            ->get();
+
+        $latestByScope = [];
+        foreach ($rows as $row) {
+            $meta = $this->decodeAuditMeta($row);
+            $scope = trim((string) ($meta['scope'] ?? $row->target_id ?? ''));
+            if ($scope === '' || isset($latestByScope[$scope])) {
+                continue;
+            }
+
+            $path = $this->normalizeExistingFilePath((string) ($meta['plan'] ?? ''));
+            if ($path === null) {
+                continue;
+            }
+
+            $latestByScope[$scope] = $path;
+        }
+
+        foreach ($latestByScope as $path) {
+            $paths[] = $path;
+        }
+
+        sort($paths);
+
+        return $paths;
+    }
+
+    private function auditReferencedPlanPathForDirectory(string $directoryKey): ?string
+    {
+        if (! $this->retainLatestAuditReferenced()) {
+            return null;
+        }
+
+        $mapping = [
+            'gc_plans' => ['action' => 'storage_blob_gc', 'field' => 'plan'],
+            'offload_plans' => ['action' => 'storage_blob_offload', 'field' => 'plan'],
+            'rehydrate_plans' => ['action' => 'storage_rehydrate_exact_release', 'field' => 'plan_path'],
+            'quarantine_plans' => ['action' => 'storage_quarantine_exact_roots', 'field' => 'plan_path'],
+            'quarantine_restore_plans' => ['action' => 'storage_restore_quarantined_root', 'field' => 'plan_path'],
+            'quarantine_purge_plans' => ['action' => 'storage_purge_quarantined_root', 'field' => 'plan_path'],
+            'retirement_plans' => ['action' => 'storage_retire_exact_roots', 'field' => 'plan_path'],
+        ];
+
+        $config = $mapping[$directoryKey] ?? null;
+        if ($config === null) {
+            return null;
+        }
+
+        $meta = $this->latestAuditForAction($config['action']);
+        if ($meta === null) {
+            return null;
+        }
+
+        return $this->normalizeExistingFilePath((string) ($meta[$config['field']] ?? ''));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function jsonFilesUnder(string $relativeDir): array
+    {
+        $absoluteDir = storage_path($relativeDir);
+        if (! is_dir($absoluteDir)) {
+            return [];
+        }
+
+        $files = glob($absoluteDir.DIRECTORY_SEPARATOR.'*.json');
+        if (! is_array($files)) {
+            return [];
+        }
+
+        $files = array_values(array_filter($files, static fn (string $path): bool => is_file($path)));
+
+        usort($files, fn (string $left, string $right): int => $this->fileMTime($right) <=> $this->fileMTime($left));
+
+        return $files;
+    }
+
+    /**
+     * @param  list<string>  $files
+     * @return list<string>
+     */
+    private function latestFiles(array $files, int $limit): array
+    {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        return array_slice($files, 0, $limit);
+    }
+
+    private function fileMTime(string $path): int
+    {
+        return (int) (@filemtime($path) ?: 0);
+    }
+
+    private function isEligiblePath(string $path, string $relativeDir): bool
+    {
+        if (! is_file($path) || strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'json') {
+            return false;
+        }
+
+        $expectedDir = str_replace('\\', '/', rtrim(storage_path($relativeDir), '/\\'));
+        $actualDir = str_replace('\\', '/', dirname($path));
+
+        return $expectedDir === $actualDir;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function safeJsonDecodeFile(string $path): ?array
+    {
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $decoded = json_decode((string) File::get($path), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function normalizeExistingFilePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return null;
+        }
+
+        if (! str_starts_with($path, DIRECTORY_SEPARATOR)) {
+            $path = base_path($path);
+        }
+
+        return is_file($path) ? $path : null;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function latestAuditForAction(string $action): ?array
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return null;
+        }
+
+        $row = DB::table('audit_logs')
+            ->where('action', $action)
+            ->orderByDesc('id')
+            ->first();
+
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->decodeAuditMeta($row);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeAuditMeta(object $row): array
+    {
+        $decoded = json_decode((string) ($row->meta_json ?? '{}'), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function snapshotKeepLastN(): int
+    {
+        return (int) config('storage_retention.control_plane_artifacts.control_plane_snapshots.keep_last_n', 30);
+    }
+
+    private function planKeepLastN(): int
+    {
+        return (int) config('storage_retention.control_plane_artifacts.plan_dirs.keep_last_n', 5);
+    }
+
+    private function prunePlansKeepLastNPerScope(): int
+    {
+        return (int) config('storage_retention.control_plane_artifacts.prune_plans.keep_last_n_per_scope', 3);
+    }
+
+    private function retainLatestAuditReferenced(): bool
+    {
+        return (bool) config('storage_retention.control_plane_artifacts.retain_latest_audit_referenced', true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $directorySummary = Collection::make((array) ($payload['directories'] ?? []))
+            ->map(static fn (array $entry): array => [
+                'relative_dir' => (string) ($entry['relative_dir'] ?? ''),
+                'scanned_file_count' => (int) ($entry['scanned_file_count'] ?? 0),
+                'kept_file_count' => (int) ($entry['kept_file_count'] ?? 0),
+                'candidate_delete_count' => (int) ($entry['candidate_delete_count'] ?? 0),
+                'deleted_file_count' => (int) ($entry['deleted_file_count'] ?? 0),
+            ])
+            ->all();
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_janitor_control_plane_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'control_plane_artifacts',
+            'meta_json' => json_encode([
+                'schema' => self::SCHEMA,
+                'mode' => $payload['mode'] ?? null,
+                'generated_at' => $payload['generated_at'] ?? null,
+                'summary' => $payload['summary'] ?? [],
+                'directories' => $directorySummary,
+                'candidate_delete_paths' => $payload['candidate_delete_paths'] ?? [],
+                'deleted_paths' => $payload['deleted_paths'] ?? [],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_janitor_control_plane_artifacts',
+            'request_id' => null,
+            'reason' => 'control_plane_artifact_retention',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/config/storage_retention.php
+++ b/backend/config/storage_retention.php
@@ -17,4 +17,19 @@ return [
         'policy' => (string) env('STORAGE_RETENTION_ROTATION_AUDITS_POLICY', 'ttl'),
         'keep_days' => (int) env('STORAGE_RETENTION_ROTATION_AUDITS_DAYS', 180),
     ],
+    'control_plane_artifacts' => [
+        'control_plane_snapshots' => [
+            'keep_last_n' => (int) env('STORAGE_RETENTION_CONTROL_PLANE_SNAPSHOTS_KEEP_LAST', 30),
+        ],
+        'plan_dirs' => [
+            'keep_last_n' => (int) env('STORAGE_RETENTION_CONTROL_PLANE_PLAN_DIRS_KEEP_LAST', 5),
+        ],
+        'prune_plans' => [
+            'keep_last_n_per_scope' => (int) env('STORAGE_RETENTION_CONTROL_PLANE_PRUNE_PLANS_KEEP_LAST_PER_SCOPE', 3),
+        ],
+        'retain_latest_audit_referenced' => filter_var(
+            env('STORAGE_RETENTION_CONTROL_PLANE_RETAIN_LATEST_AUDIT_REFERENCED', true),
+            FILTER_VALIDATE_BOOL
+        ),
+    ],
 ];

--- a/backend/tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageControlPlaneArtifactsJanitor;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageControlPlaneArtifactsJanitorCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-control-plane-janitor-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_retention.control_plane_artifacts.control_plane_snapshots.keep_last_n', 1);
+        config()->set('storage_retention.control_plane_artifacts.plan_dirs.keep_last_n', 1);
+        config()->set('storage_retention.control_plane_artifacts.prune_plans.keep_last_n_per_scope', 1);
+        config()->set('storage_retention.control_plane_artifacts.retain_latest_audit_referenced', true);
+        Storage::forgetDisk('local');
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageControlPlaneArtifactsJanitor::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_dry_run_outputs_summary_and_keeps_files_intact(): void
+    {
+        $fixture = $this->seedArtifacts();
+        $filesBefore = $this->storageFilesSnapshot();
+        $auditCountBefore = DB::table('audit_logs')->count();
+
+        $this->assertSame(0, Artisan::call('storage:janitor-control-plane-artifacts', [
+            '--dry-run' => true,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=planned', $output);
+        $this->assertStringContainsString('mode=dry_run', $output);
+        $this->assertStringContainsString('candidate_delete_count=', $output);
+        $this->assertStringContainsString('deleted_file_count=0', $output);
+
+        $this->assertSame($auditCountBefore + 1, DB::table('audit_logs')->count());
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_janitor_control_plane_artifacts',
+            'target_id' => 'control_plane_artifacts',
+            'result' => 'success',
+        ]);
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+        $this->assertFileExists($fixture['snapshot_old']);
+        $this->assertFileExists($fixture['quarantine_sentinel']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    public function test_command_execute_deletes_only_candidate_artifacts_and_writes_audit(): void
+    {
+        $fixture = $this->seedArtifacts();
+
+        $this->assertSame(0, Artisan::call('storage:janitor-control-plane-artifacts', [
+            '--execute' => true,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=executed', $output);
+        $this->assertStringContainsString('mode=execute', $output);
+        $this->assertStringContainsString('deleted_file_count=', $output);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_janitor_control_plane_artifacts',
+            'target_id' => 'control_plane_artifacts',
+            'result' => 'success',
+        ]);
+
+        $this->assertFileDoesNotExist($fixture['snapshot_old']);
+        $this->assertFileDoesNotExist($fixture['gc_old']);
+        $this->assertFileDoesNotExist($fixture['prune_reports_old']);
+        $this->assertFileExists($fixture['snapshot_audit']);
+        $this->assertFileExists($fixture['snapshot_latest']);
+        $this->assertFileExists($fixture['quarantine_sentinel']);
+        $this->assertFileExists($fixture['restore_run']);
+        $this->assertFileExists($fixture['purge_receipt']);
+        $this->assertFileExists($fixture['retirement_run']);
+        $this->assertFileExists($fixture['rehydrate_sentinel']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function seedArtifacts(): array
+    {
+        $now = now()->getTimestamp();
+        $paths = [
+            'snapshot_old' => $this->writeJsonAt('app/private/control_plane_snapshots/20260318_snapshot_old.json', ['kind' => 'snapshot_old'], $now - 500),
+            'snapshot_audit' => $this->writeJsonAt('app/private/control_plane_snapshots/20260319_snapshot_audit.json', ['kind' => 'snapshot_audit'], $now - 400),
+            'snapshot_latest' => $this->writeJsonAt('app/private/control_plane_snapshots/20260320_snapshot_latest.json', ['kind' => 'snapshot_latest'], $now - 100),
+            'gc_old' => $this->writeJsonAt('app/private/gc_plans/20260318_gc_old.json', ['kind' => 'gc_old'], $now - 500),
+            'gc_audit' => $this->writeJsonAt('app/private/gc_plans/20260319_gc_audit.json', ['kind' => 'gc_audit'], $now - 100),
+            'prune_reports_old' => $this->writeJsonAt('app/private/prune_plans/20260318_reports_old.json', ['scope' => 'reports_backups'], $now - 500),
+            'prune_reports_audit' => $this->writeJsonAt('app/private/prune_plans/20260319_reports_audit.json', ['scope' => 'reports_backups'], $now - 400),
+            'prune_reports_latest' => $this->writeJsonAt('app/private/prune_plans/20260320_reports_latest.json', ['scope' => 'reports_backups'], $now - 100),
+            'quarantine_sentinel' => $this->writeJsonAt('app/private/quarantine/release_roots/run-1/items/item-1/root/.quarantine.json', ['schema' => 'storage_quarantine_exact_root_run.v1'], $now - 100),
+            'restore_run' => $this->writeJsonAt('app/private/quarantine/restore_runs/restore-1/run.json', ['schema' => 'storage_restore_quarantined_root_run.v1'], $now - 100),
+            'purge_receipt' => $this->writeJsonAt('app/private/quarantine/purge_runs/purge-1/items/item-1/purge.json', ['schema' => 'storage_purge_quarantined_root_run.v1'], $now - 100),
+            'retirement_run' => $this->writeJsonAt('app/private/retirement_runs/retire-1/run.json', ['schema' => 'storage_retire_exact_roots_run.v1'], $now - 100),
+            'rehydrate_sentinel' => $this->writeJsonAt('app/private/rehydrate_runs/rehydrate-1/.rehydrate.json', ['schema' => 'storage_rehydrate_exact_release_plan.v1'], $now - 100),
+        ];
+
+        $this->insertAudit('storage_control_plane_snapshot', 'control_plane_snapshot', [
+            'snapshot_path' => $paths['snapshot_audit'],
+        ]);
+        $this->insertAudit('storage_blob_gc', 'blob_gc', [
+            'plan' => $paths['gc_audit'],
+        ]);
+        $this->insertAudit('storage_prune', 'reports_backups', [
+            'scope' => 'reports_backups',
+            'plan' => $paths['prune_reports_audit'],
+        ]);
+
+        return $paths;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function insertAudit(string $action, string $targetId, array $payload): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => $action,
+            'target_type' => 'storage',
+            'target_id' => $targetId,
+            'meta_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_artifacts_janitor_command',
+            'request_id' => null,
+            'reason' => 'seed',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function writeJsonAt(string $relativePath, array $payload, int $mtime): string
+    {
+        $path = storage_path($relativePath);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+        touch($path, $mtime);
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}

--- a/backend/tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\StorageControlPlaneArtifactsJanitorService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageControlPlaneArtifactsJanitorServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-control-plane-janitor-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_retention.control_plane_artifacts.control_plane_snapshots.keep_last_n', 1);
+        config()->set('storage_retention.control_plane_artifacts.plan_dirs.keep_last_n', 1);
+        config()->set('storage_retention.control_plane_artifacts.prune_plans.keep_last_n_per_scope', 1);
+        config()->set('storage_retention.control_plane_artifacts.retain_latest_audit_referenced', true);
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_dry_run_only_marks_allowed_json_artifacts_and_keeps_protected_files(): void
+    {
+        $fixture = $this->seedArtifacts();
+        $auditCountBefore = DB::table('audit_logs')->count();
+        $filesBefore = $this->storageFilesSnapshot();
+
+        $payload = app(StorageControlPlaneArtifactsJanitorService::class)->run(false);
+
+        $this->assertSame('storage_control_plane_artifacts_janitor.v1', $payload['schema']);
+        $this->assertSame('dry_run', $payload['mode']);
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame($auditCountBefore + 1, DB::table('audit_logs')->count());
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_janitor_control_plane_artifacts',
+            'target_id' => 'control_plane_artifacts',
+            'result' => 'success',
+        ]);
+
+        $this->assertContains($fixture['paths']['snapshot_audit'], $payload['kept_paths']);
+        $this->assertContains($fixture['paths']['snapshot_latest'], $payload['kept_paths']);
+        $this->assertContains($fixture['paths']['gc_audit'], $payload['kept_paths']);
+        $this->assertContains($fixture['paths']['quarantine_plan_audit'], $payload['kept_paths']);
+        $this->assertContains($fixture['paths']['retirement_plan_audit'], $payload['kept_paths']);
+        $this->assertContains($fixture['paths']['prune_reports_audit'], $payload['kept_paths']);
+        $this->assertContains($fixture['paths']['prune_reports_latest'], $payload['kept_paths']);
+        $this->assertContains($fixture['paths']['prune_content_latest'], $payload['kept_paths']);
+
+        $this->assertContains($fixture['paths']['snapshot_old'], $payload['candidate_delete_paths']);
+        $this->assertContains($fixture['paths']['gc_old'], $payload['candidate_delete_paths']);
+        $this->assertContains($fixture['paths']['offload_old'], $payload['candidate_delete_paths']);
+        $this->assertContains($fixture['paths']['prune_reports_old'], $payload['candidate_delete_paths']);
+        $this->assertContains($fixture['paths']['prune_content_old'], $payload['candidate_delete_paths']);
+        $this->assertSame([], $payload['deleted_paths']);
+
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+        $this->assertFileExists($fixture['paths']['quarantine_sentinel']);
+        $this->assertFileExists($fixture['paths']['quarantine_run']);
+        $this->assertFileExists($fixture['paths']['restore_run']);
+        $this->assertFileExists($fixture['paths']['purge_run']);
+        $this->assertFileExists($fixture['paths']['purge_receipt']);
+        $this->assertFileExists($fixture['paths']['retirement_run']);
+        $this->assertFileExists($fixture['paths']['rehydrate_sentinel']);
+        $this->assertFileExists($fixture['paths']['offload_blob']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+        $this->assertSame(0, DB::table('content_pack_activations')->count());
+        $this->assertSame(0, DB::table('content_pack_releases')->count());
+    }
+
+    public function test_service_execute_deletes_only_candidate_json_artifacts(): void
+    {
+        $fixture = $this->seedArtifacts();
+
+        $payload = app(StorageControlPlaneArtifactsJanitorService::class)->run(true);
+
+        $this->assertSame('execute', $payload['mode']);
+        $this->assertSame('executed', $payload['status']);
+        $this->assertGreaterThan(0, (int) data_get($payload, 'summary.deleted_file_count', 0));
+        $this->assertContains($fixture['paths']['snapshot_old'], $payload['deleted_paths']);
+        $this->assertContains($fixture['paths']['gc_old'], $payload['deleted_paths']);
+        $this->assertContains($fixture['paths']['offload_old'], $payload['deleted_paths']);
+        $this->assertContains($fixture['paths']['prune_reports_old'], $payload['deleted_paths']);
+        $this->assertContains($fixture['paths']['prune_content_old'], $payload['deleted_paths']);
+
+        $this->assertFileDoesNotExist($fixture['paths']['snapshot_old']);
+        $this->assertFileDoesNotExist($fixture['paths']['gc_old']);
+        $this->assertFileDoesNotExist($fixture['paths']['offload_old']);
+        $this->assertFileDoesNotExist($fixture['paths']['prune_reports_old']);
+        $this->assertFileDoesNotExist($fixture['paths']['prune_content_old']);
+
+        $this->assertFileExists($fixture['paths']['snapshot_audit']);
+        $this->assertFileExists($fixture['paths']['snapshot_latest']);
+        $this->assertFileExists($fixture['paths']['gc_audit']);
+        $this->assertFileExists($fixture['paths']['quarantine_plan_audit']);
+        $this->assertFileExists($fixture['paths']['retirement_plan_audit']);
+        $this->assertFileExists($fixture['paths']['prune_reports_audit']);
+        $this->assertFileExists($fixture['paths']['prune_reports_latest']);
+        $this->assertFileExists($fixture['paths']['prune_content_latest']);
+        $this->assertFileExists($fixture['paths']['quarantine_sentinel']);
+        $this->assertFileExists($fixture['paths']['rehydrate_sentinel']);
+        $this->assertFileExists($fixture['paths']['restore_run']);
+        $this->assertFileExists($fixture['paths']['purge_receipt']);
+        $this->assertFileExists($fixture['paths']['retirement_run']);
+        $this->assertFileExists($fixture['paths']['offload_blob']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/blobs'));
+    }
+
+    /**
+     * @return array{paths:array<string,string>}
+     */
+    private function seedArtifacts(): array
+    {
+        $now = now()->getTimestamp();
+        $paths = [
+            'snapshot_old' => $this->writeJsonAt('app/private/control_plane_snapshots/20260318_snapshot_old.json', ['kind' => 'snapshot_old'], $now - 500),
+            'snapshot_audit' => $this->writeJsonAt('app/private/control_plane_snapshots/20260319_snapshot_audit.json', ['kind' => 'snapshot_audit'], $now - 400),
+            'snapshot_latest' => $this->writeJsonAt('app/private/control_plane_snapshots/20260320_snapshot_latest.json', ['kind' => 'snapshot_latest'], $now - 100),
+            'gc_old' => $this->writeJsonAt('app/private/gc_plans/20260318_gc_old.json', ['kind' => 'gc_old'], $now - 500),
+            'gc_audit' => $this->writeJsonAt('app/private/gc_plans/20260319_gc_audit.json', ['kind' => 'gc_audit'], $now - 100),
+            'offload_old' => $this->writeJsonAt('app/private/offload_plans/20260318_offload_old.json', ['kind' => 'offload_old'], $now - 500),
+            'offload_latest' => $this->writeJsonAt('app/private/offload_plans/20260319_offload_latest.json', ['kind' => 'offload_latest'], $now - 100),
+            'rehydrate_old' => $this->writeJsonAt('app/private/rehydrate_plans/20260318_rehydrate_old.json', ['kind' => 'rehydrate_old'], $now - 500),
+            'rehydrate_latest' => $this->writeJsonAt('app/private/rehydrate_plans/20260319_rehydrate_latest.json', ['kind' => 'rehydrate_latest'], $now - 100),
+            'quarantine_plan_audit' => $this->writeJsonAt('app/private/quarantine_plans/20260318_quarantine_audit.json', ['kind' => 'quarantine_audit'], $now - 500),
+            'quarantine_plan_latest' => $this->writeJsonAt('app/private/quarantine_plans/20260319_quarantine_latest.json', ['kind' => 'quarantine_latest'], $now - 100),
+            'restore_plan_old' => $this->writeJsonAt('app/private/quarantine_restore_plans/20260318_restore_old.json', ['kind' => 'restore_old'], $now - 500),
+            'restore_plan_latest' => $this->writeJsonAt('app/private/quarantine_restore_plans/20260319_restore_latest.json', ['kind' => 'restore_latest'], $now - 100),
+            'purge_plan_old' => $this->writeJsonAt('app/private/quarantine_purge_plans/20260318_purge_old.json', ['kind' => 'purge_old'], $now - 500),
+            'purge_plan_latest' => $this->writeJsonAt('app/private/quarantine_purge_plans/20260319_purge_latest.json', ['kind' => 'purge_latest'], $now - 100),
+            'retirement_plan_old' => $this->writeJsonAt('app/private/retirement_plans/20260318_retire_old.json', ['kind' => 'retire_old'], $now - 700),
+            'retirement_plan_audit' => $this->writeJsonAt('app/private/retirement_plans/20260319_retire_audit.json', ['kind' => 'retire_audit'], $now - 500),
+            'retirement_plan_latest' => $this->writeJsonAt('app/private/retirement_plans/20260320_retire_latest.json', ['kind' => 'retire_latest'], $now - 100),
+            'prune_reports_old' => $this->writeJsonAt('app/private/prune_plans/20260318_reports_old.json', ['scope' => 'reports_backups'], $now - 700),
+            'prune_reports_audit' => $this->writeJsonAt('app/private/prune_plans/20260319_reports_audit.json', ['scope' => 'reports_backups'], $now - 500),
+            'prune_reports_latest' => $this->writeJsonAt('app/private/prune_plans/20260320_reports_latest.json', ['scope' => 'reports_backups'], $now - 100),
+            'prune_content_old' => $this->writeJsonAt('app/private/prune_plans/20260318_content_old.json', ['scope' => 'content_releases_retention'], $now - 500),
+            'prune_content_latest' => $this->writeJsonAt('app/private/prune_plans/20260319_content_latest.json', ['scope' => 'content_releases_retention'], $now - 100),
+            'quarantine_run' => $this->writeJsonAt('app/private/quarantine/release_roots/run-1/run.json', ['schema' => 'storage_quarantine_exact_root_run.v1'], $now - 100),
+            'quarantine_sentinel' => $this->writeJsonAt('app/private/quarantine/release_roots/run-1/items/item-1/root/.quarantine.json', ['schema' => 'storage_quarantine_exact_root_run.v1'], $now - 100),
+            'restore_run' => $this->writeJsonAt('app/private/quarantine/restore_runs/restore-1/run.json', ['schema' => 'storage_restore_quarantined_root_run.v1'], $now - 100),
+            'purge_run' => $this->writeJsonAt('app/private/quarantine/purge_runs/purge-1/run.json', ['schema' => 'storage_purge_quarantined_root_run.v1'], $now - 100),
+            'purge_receipt' => $this->writeJsonAt('app/private/quarantine/purge_runs/purge-1/items/item-1/purge.json', ['schema' => 'storage_purge_quarantined_root_run.v1'], $now - 100),
+            'retirement_run' => $this->writeJsonAt('app/private/retirement_runs/retire-1/run.json', ['schema' => 'storage_retire_exact_roots_run.v1'], $now - 100),
+            'rehydrate_sentinel' => $this->writeJsonAt('app/private/rehydrate_runs/rehydrate-1/.rehydrate.json', ['schema' => 'storage_rehydrate_exact_release_plan.v1'], $now - 100),
+        ];
+
+        $offloadBlob = storage_path('app/private/offload/blobs/sha256/aa/blob-a');
+        File::ensureDirectoryExists(dirname($offloadBlob));
+        File::put($offloadBlob, 'blob-copy');
+        touch($offloadBlob, $now - 100);
+        $paths['offload_blob'] = $offloadBlob;
+
+        $this->insertAudit('storage_control_plane_snapshot', 'control_plane_snapshot', [
+            'snapshot_path' => $paths['snapshot_audit'],
+        ]);
+        $this->insertAudit('storage_blob_gc', 'blob_gc', [
+            'plan' => $paths['gc_audit'],
+        ]);
+        $this->insertAudit('storage_quarantine_exact_roots', 'exact_roots', [
+            'plan_path' => $paths['quarantine_plan_audit'],
+        ]);
+        $this->insertAudit('storage_retire_exact_roots', 'exact_roots', [
+            'plan_path' => $paths['retirement_plan_audit'],
+            'plan' => ['action' => 'quarantine'],
+        ]);
+        $this->insertAudit('storage_prune', 'reports_backups', [
+            'scope' => 'reports_backups',
+            'plan' => $paths['prune_reports_audit'],
+        ]);
+
+        return ['paths' => $paths];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function insertAudit(string $action, string $targetId, array $payload): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => $action,
+            'target_type' => 'storage',
+            'target_id' => $targetId,
+            'meta_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_artifacts_janitor_service',
+            'request_id' => null,
+            'reason' => 'seed',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function writeJsonAt(string $relativePath, array $payload, int $mtime): string
+    {
+        $path = storage_path($relativePath);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+        touch($path, $mtime);
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}


### PR DESCRIPTION
## Summary
- add `storage:janitor-control-plane-artifacts` for manual dry-run/execute cleanup of rebuildable control-plane JSON artifacts
- add `StorageControlPlaneArtifactsJanitorService` with a strict allowlist and keep-set rules for snapshots and plan JSON files
- add focused tests proving no-touch paths, audit retention, and per-scope prune plan preservation
- add minimal `control_plane_artifacts` retention config to `storage_retention.php`

## Safety
- no scheduler changes
- no migrations
- no route or middleware changes
- no lifecycle contract changes
- no runtime or data truth changes
- no deletes under quarantined roots, restore/purge/retirement runs, rehydrate runs, blobs, artifacts, reports, or sentinels

## Tests
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/ExactRootRetirementOrchestratorServiceTest.php tests/Feature/Storage/StorageRetireExactRootsCommandTest.php tests/Feature/Storage/ExactRootQuarantineServiceTest.php tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php`
- `php artisan route:list > /tmp/pr27_route_list.txt`
- `php artisan migrate`
- `php artisan storage:janitor-control-plane-artifacts --dry-run`
- `php artisan storage:janitor-control-plane-artifacts --execute`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
