### PR TITLE
[codex] add storage control-plane refresh orchestration

### DIFF
--- a/backend/app/Console/Commands/StorageRefreshControlPlane.php
+++ b/backend/app/Console/Commands/StorageRefreshControlPlane.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\StorageControlPlaneRefreshService;
+use Illuminate\Console\Command;
+
+final class StorageRefreshControlPlane extends Command
+{
+    protected $signature = 'storage:refresh-control-plane
+        {--dry-run : Execute the fixed safe dry-run refresh batch}
+        {--json : Emit the full refresh payload as JSON}';
+
+    protected $description = 'Manually refresh safe storage control-plane dry-run truth and then snapshot it.';
+
+    public function __construct(
+        private readonly StorageControlPlaneRefreshService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! (bool) $this->option('dry-run')) {
+            $this->error('--dry-run is required. PR-28 only implements manual dry-run orchestration.');
+
+            return self::FAILURE;
+        }
+
+        $payload = $this->service->run();
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode control-plane refresh json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return (string) ($payload['status'] ?? 'failure') === 'success'
+                ? self::SUCCESS
+                : self::FAILURE;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+        $this->line('status='.(string) ($payload['status'] ?? 'failure'));
+        $this->line('mode='.(string) ($payload['mode'] ?? ''));
+        $this->line('schema='.(string) ($payload['schema'] ?? ''));
+        $this->line('generated_at='.(string) ($payload['generated_at'] ?? ''));
+        $this->line('step_count='.(int) ($payload['step_count'] ?? 0));
+        $this->line('successful_step_count='.(int) ($summary['successful_step_count'] ?? 0));
+        $this->line('failed_step='.(string) ($payload['failed_step'] ?? ''));
+        $this->line('snapshot_path='.(string) ($payload['snapshot_path'] ?? ''));
+
+        return (string) ($payload['status'] ?? 'failure') === 'success'
+            ? self::SUCCESS
+            : self::FAILURE;
+    }
+}

--- a/backend/app/Services/Storage/StorageControlPlaneRefreshService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneRefreshService.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Closure;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageControlPlaneRefreshService
+{
+    private const SCHEMA = 'storage_refresh_control_plane.v1';
+
+    public function __construct(
+        private readonly ?Closure $commandInvoker = null,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function run(): array
+    {
+        $generatedAt = now()->toIso8601String();
+        $steps = [];
+
+        foreach ($this->stepDefinitions() as $definition) {
+            ['exit_code' => $exitCode, 'stdout' => $stdout] = $this->invokeCommand(
+                $definition['command'],
+                $definition['arguments']
+            );
+            $status = $exitCode === 0 ? 'success' : 'failure';
+            $parsedOutput = $this->parseOutput($stdout);
+
+            $step = [
+                'name' => $definition['name'],
+                'command' => $definition['command'],
+                'arguments' => $definition['arguments'],
+                'invocation' => $this->renderInvocation($definition['command'], $definition['arguments']),
+                'exit_code' => $exitCode,
+                'status' => $status,
+                'stdout' => $stdout,
+                'parsed_output' => $parsedOutput,
+            ];
+
+            $steps[] = $step;
+
+            if ($status !== 'success') {
+                $payload = [
+                    'schema' => self::SCHEMA,
+                    'mode' => 'dry_run',
+                    'generated_at' => $generatedAt,
+                    'status' => 'failure',
+                    'failed_step' => $definition['name'],
+                    'snapshot_path' => null,
+                    'step_count' => count($steps),
+                    'steps' => $steps,
+                    'summary' => [
+                        'successful_step_count' => count(array_filter($steps, static fn (array $entry): bool => (string) ($entry['status'] ?? '') === 'success')),
+                        'failed_step_count' => 1,
+                    ],
+                ];
+
+                $this->recordAudit($payload);
+
+                return $payload;
+            }
+        }
+
+        $snapshotPath = (string) data_get($steps, '11.parsed_output.snapshot_path', '');
+        if ($snapshotPath === '') {
+            $snapshotPath = null;
+        }
+
+        $payload = [
+            'schema' => self::SCHEMA,
+            'mode' => 'dry_run',
+            'generated_at' => $generatedAt,
+            'status' => 'success',
+            'failed_step' => null,
+            'snapshot_path' => $snapshotPath,
+            'step_count' => count($steps),
+            'steps' => $steps,
+            'summary' => [
+                'successful_step_count' => count($steps),
+                'failed_step_count' => 0,
+            ],
+        ];
+
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return list<array{name:string,command:string,arguments:array<string,mixed>}>
+     */
+    private function stepDefinitions(): array
+    {
+        return [
+            [
+                'name' => 'inventory',
+                'command' => 'storage:inventory',
+                'arguments' => ['--json' => true],
+            ],
+            [
+                'name' => 'prune_reports_backups',
+                'command' => 'storage:prune',
+                'arguments' => ['--dry-run' => true, '--scope' => 'reports_backups'],
+            ],
+            [
+                'name' => 'prune_content_releases_retention',
+                'command' => 'storage:prune',
+                'arguments' => ['--dry-run' => true, '--scope' => 'content_releases_retention'],
+            ],
+            [
+                'name' => 'prune_legacy_private_private_cleanup',
+                'command' => 'storage:prune',
+                'arguments' => ['--dry-run' => true, '--scope' => 'legacy_private_private_cleanup'],
+            ],
+            [
+                'name' => 'blob_gc',
+                'command' => 'storage:blob-gc',
+                'arguments' => ['--dry-run' => true],
+            ],
+            [
+                'name' => 'blob_offload',
+                'command' => 'storage:blob-offload',
+                'arguments' => ['--dry-run' => true],
+            ],
+            [
+                'name' => 'backfill_release_metadata',
+                'command' => 'storage:backfill-release-metadata',
+                'arguments' => ['--dry-run' => true],
+            ],
+            [
+                'name' => 'backfill_exact_release_file_sets',
+                'command' => 'storage:backfill-exact-release-file-sets',
+                'arguments' => ['--dry-run' => true],
+            ],
+            [
+                'name' => 'quarantine_exact_roots',
+                'command' => 'storage:quarantine-exact-roots',
+                'arguments' => ['--dry-run' => true],
+            ],
+            [
+                'name' => 'retire_exact_roots_quarantine',
+                'command' => 'storage:retire-exact-roots',
+                'arguments' => ['--dry-run' => true, '--action' => 'quarantine'],
+            ],
+            [
+                'name' => 'retire_exact_roots_purge',
+                'command' => 'storage:retire-exact-roots',
+                'arguments' => ['--dry-run' => true, '--action' => 'purge'],
+            ],
+            [
+                'name' => 'control_plane_snapshot',
+                'command' => 'storage:control-plane-snapshot',
+                'arguments' => ['--json' => true],
+            ],
+        ];
+    }
+
+    private function renderInvocation(string $command, array $arguments): string
+    {
+        $parts = [$command];
+
+        foreach ($arguments as $key => $value) {
+            if ($value === true) {
+                $parts[] = $key;
+
+                continue;
+            }
+
+            if ($value === false || $value === null) {
+                continue;
+            }
+
+            $parts[] = $key.'='.$value;
+        }
+
+        return implode(' ', $parts);
+    }
+
+    /**
+     * @param  array<string,mixed>  $arguments
+     * @return array{exit_code:int,stdout:string}
+     */
+    private function invokeCommand(string $command, array $arguments): array
+    {
+        if ($this->commandInvoker instanceof Closure) {
+            $result = ($this->commandInvoker)($command, $arguments);
+
+            return [
+                'exit_code' => (int) ($result['exit_code'] ?? 1),
+                'stdout' => trim((string) ($result['stdout'] ?? '')),
+            ];
+        }
+
+        $exitCode = Artisan::call($command, $arguments);
+
+        return [
+            'exit_code' => $exitCode,
+            'stdout' => trim(Artisan::output()),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function parseOutput(string $stdout): array
+    {
+        if ($stdout === '') {
+            return [];
+        }
+
+        $decoded = json_decode($stdout, true);
+        if (is_array($decoded)) {
+            return $decoded;
+        }
+
+        $parsed = [];
+        foreach (preg_split('/\r\n|\r|\n/', $stdout) as $line) {
+            $line = trim((string) $line);
+            if ($line === '' || ! str_contains($line, '=')) {
+                continue;
+            }
+
+            [$key, $value] = explode('=', $line, 2);
+            $key = trim($key);
+            if ($key === '') {
+                continue;
+            }
+
+            $parsed[$key] = $this->coerceScalar(trim($value));
+        }
+
+        return $parsed;
+    }
+
+    private function coerceScalar(string $value): mixed
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        if ($value === 'true') {
+            return true;
+        }
+
+        if ($value === 'false') {
+            return false;
+        }
+
+        if (preg_match('/^-?\d+$/', $value) === 1) {
+            return (int) $value;
+        }
+
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $stepSummary = array_map(static fn (array $step): array => [
+            'name' => (string) ($step['name'] ?? ''),
+            'command' => (string) ($step['command'] ?? ''),
+            'invocation' => (string) ($step['invocation'] ?? ''),
+            'exit_code' => (int) ($step['exit_code'] ?? 1),
+            'status' => (string) ($step['status'] ?? 'failure'),
+        ], (array) ($payload['steps'] ?? []));
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_refresh_control_plane',
+            'target_type' => 'storage',
+            'target_id' => 'control_plane_refresh',
+            'meta_json' => json_encode([
+                'schema' => self::SCHEMA,
+                'mode' => $payload['mode'] ?? null,
+                'generated_at' => $payload['generated_at'] ?? null,
+                'status' => $payload['status'] ?? null,
+                'failed_step' => $payload['failed_step'] ?? null,
+                'snapshot_path' => $payload['snapshot_path'] ?? null,
+                'step_count' => $payload['step_count'] ?? 0,
+                'summary' => $payload['summary'] ?? [],
+                'steps' => $stepSummary,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_refresh_control_plane',
+            'request_id' => null,
+            'reason' => 'control_plane_refresh',
+            'result' => (string) ($payload['status'] ?? 'failure') === 'success' ? 'success' : 'failure',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\StorageControlPlaneRefreshService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageControlPlaneRefreshServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-control-plane-refresh-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_runs_allowlisted_commands_in_fixed_order_and_records_single_batch_audit(): void
+    {
+        $filesBefore = $this->storageFilesSnapshot();
+        $payload = $this->makeServiceForSequence($this->successfulSequence())->run();
+
+        $this->assertSame('storage_refresh_control_plane.v1', $payload['schema']);
+        $this->assertSame('dry_run', $payload['mode']);
+        $this->assertSame('success', $payload['status']);
+        $this->assertNull($payload['failed_step']);
+        $this->assertSame(12, $payload['step_count']);
+        $this->assertSame('/tmp/control-plane-snapshot.json', $payload['snapshot_path']);
+        $this->assertCount(12, $payload['steps']);
+        $this->assertSame('inventory', data_get($payload, 'steps.0.name'));
+        $this->assertSame('control_plane_snapshot', data_get($payload, 'steps.11.name'));
+        $this->assertSame('storage:control-plane-snapshot --json', data_get($payload, 'steps.11.invocation'));
+
+        $this->assertDatabaseCount('audit_logs', 1);
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_refresh_control_plane',
+            'target_id' => 'control_plane_refresh',
+            'result' => 'success',
+        ]);
+
+        $audit = DB::table('audit_logs')->latest('id')->first();
+        $this->assertNotNull($audit);
+        $meta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($meta);
+        $this->assertSame('success', $meta['status'] ?? null);
+        $this->assertSame('/tmp/control-plane-snapshot.json', $meta['snapshot_path'] ?? null);
+        $this->assertCount(12, (array) ($meta['steps'] ?? []));
+
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+        $this->assertSame([], $this->existingFilesUnder('app/private/refresh_runs'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/refresh_plans'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/blobs'));
+    }
+
+    public function test_service_stops_on_first_failure_and_skips_snapshot(): void
+    {
+        $filesBefore = $this->storageFilesSnapshot();
+        $payload = $this->makeServiceForSequence([
+            ['storage:inventory', ['--json' => true], 0, "{\"status\":\"ok\"}\n"],
+            ['storage:prune', ['--dry-run' => true, '--scope' => 'reports_backups'], 0, "status=planned\nscope=reports_backups\n"],
+            ['storage:prune', ['--dry-run' => true, '--scope' => 'content_releases_retention'], 1, "status=failure\nerror=boom\n"],
+        ])->run();
+
+        $this->assertSame('failure', $payload['status']);
+        $this->assertSame('prune_content_releases_retention', $payload['failed_step']);
+        $this->assertNull($payload['snapshot_path']);
+        $this->assertCount(3, $payload['steps']);
+        $this->assertSame('failure', data_get($payload, 'steps.2.status'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/control_plane_snapshots'));
+
+        $this->assertDatabaseCount('audit_logs', 1);
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_refresh_control_plane',
+            'target_id' => 'control_plane_refresh',
+            'result' => 'failure',
+        ]);
+
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+        $this->assertSame([], $this->existingFilesUnder('app/private/refresh_runs'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/refresh_plans'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/blobs'));
+    }
+
+    /**
+     * @param  list<array{0:string,1:array<string,mixed>,2:int,3:string}>  $sequence
+     */
+    private function makeServiceForSequence(array $sequence): StorageControlPlaneRefreshService
+    {
+        $index = 0;
+
+        return new StorageControlPlaneRefreshService(
+            function (string $command, array $arguments) use (&$index, $sequence): array {
+                if (! array_key_exists($index, $sequence)) {
+                    self::fail('unexpected extra command invocation: '.$command);
+                }
+
+                [$expectedCommand, $expectedArguments, $exitCode, $stdout] = $sequence[$index];
+                self::assertSame($expectedCommand, $command);
+                self::assertSame($expectedArguments, $arguments);
+                $index++;
+
+                return [
+                    'exit_code' => $exitCode,
+                    'stdout' => $stdout,
+                ];
+            }
+        );
+    }
+
+    /**
+     * @return list<array{0:string,1:array<string,mixed>,2:int,3:string}>
+     */
+    private function successfulSequence(): array
+    {
+        return [
+            ['storage:inventory', ['--json' => true], 0, "{\"schema_version\":\"storage_inventory.v1\"}\n"],
+            ['storage:prune', ['--dry-run' => true, '--scope' => 'reports_backups'], 0, "status=planned\nscope=reports_backups\n"],
+            ['storage:prune', ['--dry-run' => true, '--scope' => 'content_releases_retention'], 0, "status=planned\nscope=content_releases_retention\n"],
+            ['storage:prune', ['--dry-run' => true, '--scope' => 'legacy_private_private_cleanup'], 0, "status=planned\nscope=legacy_private_private_cleanup\n"],
+            ['storage:blob-gc', ['--dry-run' => true], 0, "status=planned\nplan=/tmp/blob-gc.json\n"],
+            ['storage:blob-offload', ['--dry-run' => true], 0, "status=planned\nplan=/tmp/blob-offload.json\n"],
+            ['storage:backfill-release-metadata', ['--dry-run' => true], 0, "status=planned\nmode=dry_run\n"],
+            ['storage:backfill-exact-release-file-sets', ['--dry-run' => true], 0, "status=planned\nmode=dry_run\n"],
+            ['storage:quarantine-exact-roots', ['--dry-run' => true], 0, "status=planned\nplan=/tmp/quarantine-plan.json\n"],
+            ['storage:retire-exact-roots', ['--dry-run' => true, '--action' => 'quarantine'], 0, "status=planned\naction=quarantine\n"],
+            ['storage:retire-exact-roots', ['--dry-run' => true, '--action' => 'purge'], 0, "status=planned\naction=purge\n"],
+            ['storage:control-plane-snapshot', ['--json' => true], 0, "{\"status\":\"snapshotted\",\"snapshot_path\":\"/tmp/control-plane-snapshot.json\"}\n"],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function existingFilesUnder(string $relativeDir): array
+    {
+        $dir = $this->isolatedStoragePath.'/'.$relativeDir;
+        if (! is_dir($dir)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}

--- a/backend/tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageRefreshControlPlane;
+use App\Services\Storage\StorageControlPlaneRefreshService;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageRefreshControlPlaneCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-control-plane-refresh-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+
+        $this->registerCommand();
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_outputs_full_json_and_records_batch_audit(): void
+    {
+        $filesBefore = $this->storageFilesSnapshot();
+        $this->app->instance(
+            StorageControlPlaneRefreshService::class,
+            $this->makeServiceForSequence($this->successfulSequence())
+        );
+        $this->registerCommand();
+
+        $this->assertSame(0, Artisan::call('storage:refresh-control-plane', [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(trim(Artisan::output()), true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('storage_refresh_control_plane.v1', $payload['schema']);
+        $this->assertSame('success', $payload['status']);
+        $this->assertSame('/tmp/control-plane-snapshot.json', $payload['snapshot_path']);
+        $this->assertCount(12, $payload['steps']);
+
+        $this->assertDatabaseCount('audit_logs', 1);
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_refresh_control_plane',
+            'target_id' => 'control_plane_refresh',
+            'result' => 'success',
+        ]);
+
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+        $this->assertSame([], $this->existingFilesUnder('app/private/refresh_runs'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/refresh_plans'));
+        $this->assertSame([], $this->existingFilesUnder('app/private/blobs'));
+    }
+
+    public function test_command_outputs_human_summary_and_requires_dry_run_flag(): void
+    {
+        $this->assertSame(1, Artisan::call('storage:refresh-control-plane'));
+        $this->assertStringContainsString('--dry-run is required', Artisan::output());
+
+        $this->app->instance(
+            StorageControlPlaneRefreshService::class,
+            $this->makeServiceForSequence($this->successfulSequence())
+        );
+        $this->registerCommand();
+        $this->assertSame(0, Artisan::call('storage:refresh-control-plane', [
+            '--dry-run' => true,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=success', $output);
+        $this->assertStringContainsString('mode=dry_run', $output);
+        $this->assertStringContainsString('schema=storage_refresh_control_plane.v1', $output);
+        $this->assertStringContainsString('snapshot_path=/tmp/control-plane-snapshot.json', $output);
+    }
+
+    /**
+     * @param  list<array{0:string,1:array<string,mixed>,2:int,3:string}>  $sequence
+     */
+    private function makeServiceForSequence(array $sequence): StorageControlPlaneRefreshService
+    {
+        $index = 0;
+
+        return new StorageControlPlaneRefreshService(
+            function (string $command, array $arguments) use (&$index, $sequence): array {
+                if (! array_key_exists($index, $sequence)) {
+                    self::fail('unexpected extra command invocation: '.$command);
+                }
+
+                [$expectedCommand, $expectedArguments, $exitCode, $stdout] = $sequence[$index];
+                self::assertSame($expectedCommand, $command);
+                self::assertSame($expectedArguments, $arguments);
+                $index++;
+
+                return [
+                    'exit_code' => $exitCode,
+                    'stdout' => $stdout,
+                ];
+            }
+        );
+    }
+
+    private function registerCommand(): void
+    {
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageRefreshControlPlane::class)
+        );
+    }
+
+    /**
+     * @return list<array{0:string,1:array<string,mixed>,2:int,3:string}>
+     */
+    private function successfulSequence(): array
+    {
+        return [
+            ['storage:inventory', ['--json' => true], 0, "{\"schema_version\":\"storage_inventory.v1\"}\n"],
+            ['storage:prune', ['--dry-run' => true, '--scope' => 'reports_backups'], 0, "status=planned\nscope=reports_backups\n"],
+            ['storage:prune', ['--dry-run' => true, '--scope' => 'content_releases_retention'], 0, "status=planned\nscope=content_releases_retention\n"],
+            ['storage:prune', ['--dry-run' => true, '--scope' => 'legacy_private_private_cleanup'], 0, "status=planned\nscope=legacy_private_private_cleanup\n"],
+            ['storage:blob-gc', ['--dry-run' => true], 0, "status=planned\nplan=/tmp/blob-gc.json\n"],
+            ['storage:blob-offload', ['--dry-run' => true], 0, "status=planned\nplan=/tmp/blob-offload.json\n"],
+            ['storage:backfill-release-metadata', ['--dry-run' => true], 0, "status=planned\nmode=dry_run\n"],
+            ['storage:backfill-exact-release-file-sets', ['--dry-run' => true], 0, "status=planned\nmode=dry_run\n"],
+            ['storage:quarantine-exact-roots', ['--dry-run' => true], 0, "status=planned\nplan=/tmp/quarantine-plan.json\n"],
+            ['storage:retire-exact-roots', ['--dry-run' => true, '--action' => 'quarantine'], 0, "status=planned\naction=quarantine\n"],
+            ['storage:retire-exact-roots', ['--dry-run' => true, '--action' => 'purge'], 0, "status=planned\naction=purge\n"],
+            ['storage:control-plane-snapshot', ['--json' => true], 0, "{\"status\":\"snapshotted\",\"snapshot_path\":\"/tmp/control-plane-snapshot.json\"}\n"],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function existingFilesUnder(string $relativeDir): array
+    {
+        $dir = $this->isolatedStoragePath.'/'.$relativeDir;
+        if (! is_dir($dir)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}


### PR DESCRIPTION
## Summary
- add `storage:refresh-control-plane` for manual dry-run orchestration of existing safe storage control-plane refresh steps
- add `StorageControlPlaneRefreshService` to call the allowlisted commands in-process via `Artisan::call(...)`, stop on first failure, and snapshot only on success
- add focused tests covering fixed ordering, allowlist enforcement, failure short-circuiting, batch audit writes, and no extra refresh artifact tree

## Safety
- no scheduler changes
- no execute orchestration
- no migrations
- no route or middleware changes
- no runtime reader contract changes
- no lifecycle primitive outward contract changes
- no refresh receipt tree

## Tests
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php tests/Feature/Storage/ExactRootRetirementOrchestratorServiceTest.php tests/Feature/Storage/StorageRetireExactRootsCommandTest.php tests/Feature/Storage/ExactRootQuarantineServiceTest.php tests/Feature/Storage/QuarantinedRootRestoreServiceTest.php tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php`
- `php artisan route:list > /tmp/pr28_route_list.txt`
- `php artisan migrate`
- `php artisan storage:refresh-control-plane --dry-run --json`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan schedule:list`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
