### PR TITLE
[codex] add storage control-plane freshness metadata

### DIFF
--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Storage;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
@@ -11,6 +12,15 @@ use Illuminate\Support\Facades\Schema;
 final class StorageControlPlaneStatusService
 {
     private const SCHEMA_VERSION = 'storage_control_plane_status.v1';
+
+    // Inventory is scheduled weekly, so allow a wider freshness window.
+    private const INVENTORY_STALE_AFTER_SECONDS = 8 * 24 * 60 * 60;
+
+    // Retention plans are expected to refresh more often than inventory.
+    private const RETENTION_STALE_AFTER_SECONDS = 36 * 60 * 60;
+
+    // Manual dry-run and operator-driven control-plane surfaces age out more slowly.
+    private const MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS = 30 * 24 * 60 * 60;
 
     /**
      * @return array<string,mixed>
@@ -41,7 +51,7 @@ final class StorageControlPlaneStatusService
     {
         $audit = $this->latestAuditForAction('storage_inventory');
         if ($audit === null) {
-            return [
+            return array_merge([
                 'status' => 'not_available',
                 'latest_action' => 'storage_inventory',
                 'latest_generated_at' => null,
@@ -49,15 +59,16 @@ final class StorageControlPlaneStatusService
                 'focus_scopes' => [],
                 'totals' => null,
                 'latest_summary' => null,
-            ];
+            ], $this->freshnessFromTimestamp(null, 'audit-derived', self::INVENTORY_STALE_AFTER_SECONDS, 'not_available'));
         }
 
         $payload = $this->decodeAuditMeta($audit);
+        $latestGeneratedAt = $this->normalizeTimestamp($payload['generated_at'] ?? $audit->created_at);
 
-        return [
+        return array_merge([
             'status' => 'ok',
             'latest_action' => 'storage_inventory',
-            'latest_generated_at' => (string) ($payload['generated_at'] ?? $audit->created_at),
+            'latest_generated_at' => $latestGeneratedAt,
             'schema_version' => $payload['schema_version'] ?? null,
             'focus_scopes' => $this->normalizeScalarList((array) ($payload['focus_scopes'] ?? [])),
             'totals' => is_array($payload['totals'] ?? null) ? $payload['totals'] : null,
@@ -67,7 +78,7 @@ final class StorageControlPlaneStatusService
                 'bytes' => (int) data_get($payload, 'totals.bytes', 0),
                 'duplicate_file_refs' => (int) data_get($payload, 'duplicate_summary.file_refs', 0),
             ],
-        ];
+        ], $this->freshnessFromTimestamp($latestGeneratedAt, 'audit-derived', self::INVENTORY_STALE_AFTER_SECONDS));
     }
 
     /**
@@ -99,24 +110,26 @@ final class StorageControlPlaneStatusService
             );
 
             if ($audit === null && $latestPlan === null) {
-                $scopes[$scope] = [
+                $scopes[$scope] = array_merge([
                     'status' => 'never_run',
                     'policy' => $policy,
                     'latest_generated_at' => null,
                     'latest_plan_path' => null,
                     'latest_execute_status' => null,
                     'latest_summary' => null,
-                ];
+                ], $this->freshnessFromTimestamp(null, 'mixed-derived', self::RETENTION_STALE_AFTER_SECONDS));
 
                 continue;
             }
 
             $hasAnyRun = true;
             $meta = $audit === null ? [] : $this->decodeAuditMeta($audit);
-            $scopes[$scope] = [
-                'status' => $audit === null ? 'partial' : 'ok',
+            $status = $audit === null ? 'partial' : 'ok';
+            $latestGeneratedAt = $this->normalizeTimestamp($latestPlan['payload']['generated_at'] ?? ($audit->created_at ?? null));
+            $scopes[$scope] = array_merge([
+                'status' => $status,
                 'policy' => $policy,
-                'latest_generated_at' => $latestPlan['payload']['generated_at'] ?? ($audit->created_at ?? null),
+                'latest_generated_at' => $latestGeneratedAt,
                 'latest_plan_path' => $latestPlan['path'] ?? ($meta['plan'] ?? null),
                 'latest_execute_status' => $audit?->result,
                 'latest_summary' => [
@@ -127,7 +140,7 @@ final class StorageControlPlaneStatusService
                     'planned_files' => (int) data_get($latestPlan, 'payload.summary.files', 0),
                     'planned_bytes' => (int) data_get($latestPlan, 'payload.summary.bytes', 0),
                 ],
-            ];
+            ], $this->freshnessFromTimestamp($latestGeneratedAt, 'mixed-derived', self::RETENTION_STALE_AFTER_SECONDS));
         }
 
         return [
@@ -167,29 +180,29 @@ final class StorageControlPlaneStatusService
                 'verified_storage_blob_locations_by_disk' => $verifiedLocationCountsByDisk,
             ],
             'blob_gc' => $blobGcAudit === null
-                ? [
+                ? array_merge([
                     'status' => 'never_run',
                     'latest_generated_at' => null,
                     'latest_summary' => null,
-                ]
-                : [
+                ], $this->freshnessFromTimestamp(null, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS))
+                : array_merge([
                     'status' => 'ok',
-                    'latest_generated_at' => (string) $blobGcAudit->created_at,
+                    'latest_generated_at' => $this->normalizeTimestamp($blobGcAudit->created_at),
                     'latest_summary' => $blobGcMeta,
-                ],
+                ], $this->freshnessFromTimestamp($this->normalizeTimestamp($blobGcAudit->created_at), 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS)),
             'blob_offload' => $offloadAudit === null
-                ? [
+                ? array_merge([
                     'status' => 'never_run',
                     'latest_generated_at' => null,
                     'latest_mode' => null,
                     'latest_summary' => null,
-                ]
-                : [
+                ], $this->freshnessFromTimestamp(null, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS))
+                : array_merge([
                     'status' => 'ok',
-                    'latest_generated_at' => (string) $offloadAudit->created_at,
+                    'latest_generated_at' => $this->normalizeTimestamp($offloadAudit->created_at),
                     'latest_mode' => $offloadMeta['mode'] ?? null,
                     'latest_summary' => $offloadMeta,
-                ],
+                ], $this->freshnessFromTimestamp($this->normalizeTimestamp($offloadAudit->created_at), 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS)),
         ];
     }
 
@@ -208,16 +221,16 @@ final class StorageControlPlaneStatusService
                 'content_release_exact_manifest_files' => $this->tableCount('content_release_exact_manifest_files'),
             ],
             'latest_backfill' => $audit === null
-                ? [
+                ? array_merge([
                     'status' => 'never_run',
                     'latest_generated_at' => null,
                     'latest_summary' => null,
-                ]
-                : [
+                ], $this->freshnessFromTimestamp(null, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS))
+                : array_merge([
                     'status' => 'ok',
-                    'latest_generated_at' => (string) $audit->created_at,
+                    'latest_generated_at' => $this->normalizeTimestamp($audit->created_at),
                     'latest_summary' => $meta,
-                ],
+                ], $this->freshnessFromTimestamp($this->normalizeTimestamp($audit->created_at), 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS)),
         ];
     }
 
@@ -228,22 +241,23 @@ final class StorageControlPlaneStatusService
     {
         $audit = $this->latestAuditForAction('storage_rehydrate_exact_release');
         if ($audit === null) {
-            return [
+            return array_merge([
                 'status' => 'never_run',
                 'latest_generated_at' => null,
                 'latest_mode' => null,
                 'latest_plan_path' => null,
                 'latest_run_path' => null,
                 'latest_summary' => null,
-            ];
+            ], $this->freshnessFromTimestamp(null, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS));
         }
 
         $meta = $this->decodeAuditMeta($audit);
         $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+        $latestGeneratedAt = $this->normalizeTimestamp($audit->created_at);
 
-        return [
+        return array_merge([
             'status' => 'ok',
-            'latest_generated_at' => (string) $audit->created_at,
+            'latest_generated_at' => $latestGeneratedAt,
             'latest_mode' => $meta['mode'] ?? null,
             'latest_plan_path' => $meta['plan_path'] ?? null,
             'latest_run_path' => $result['run_dir'] ?? null,
@@ -254,7 +268,7 @@ final class StorageControlPlaneStatusService
                 'verified_files' => (int) ($result['verified_files'] ?? 0),
                 'verified_bytes' => (int) ($result['verified_bytes'] ?? 0),
             ],
-        ];
+        ], $this->freshnessFromTimestamp($latestGeneratedAt, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS));
     }
 
     /**
@@ -266,11 +280,12 @@ final class StorageControlPlaneStatusService
         $meta = $audit === null ? [] : $this->decodeAuditMeta($audit);
         $plan = is_array($meta['plan'] ?? null) ? $meta['plan'] : [];
         $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+        $latestGeneratedAt = $this->normalizeTimestamp($audit?->created_at);
 
-        return [
+        return array_merge([
             'status' => $audit === null ? 'never_run' : 'ok',
             'item_root_count' => $this->countDirectoriesByGlob($this->quarantineRootBase().DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'items'.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'root'),
-            'latest_generated_at' => $audit?->created_at,
+            'latest_generated_at' => $latestGeneratedAt,
             'latest_mode' => $meta['mode'] ?? null,
             'latest_plan_path' => $meta['plan_path'] ?? null,
             'latest_run_path' => $result['run_dir'] ?? null,
@@ -281,7 +296,7 @@ final class StorageControlPlaneStatusService
                 'quarantined_count' => is_array($result['quarantined'] ?? null) ? count($result['quarantined']) : 0,
                 'status' => $result['status'] ?? null,
             ],
-        ];
+        ], $this->freshnessFromTimestamp($latestGeneratedAt, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS));
     }
 
     /**
@@ -292,11 +307,12 @@ final class StorageControlPlaneStatusService
         $audit = $this->latestAuditForAction('storage_restore_quarantined_root');
         $meta = $audit === null ? [] : $this->decodeAuditMeta($audit);
         $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+        $latestGeneratedAt = $this->normalizeTimestamp($audit?->created_at);
 
-        return [
+        return array_merge([
             'status' => $audit === null ? 'never_run' : 'ok',
             'restore_run_count' => $this->countDirectoriesByGlob($this->restoreRootBase().DIRECTORY_SEPARATOR.'*'),
-            'latest_generated_at' => $audit?->created_at,
+            'latest_generated_at' => $latestGeneratedAt,
             'latest_mode' => $meta['mode'] ?? null,
             'latest_plan_path' => $meta['plan_path'] ?? null,
             'latest_run_path' => $result['run_dir'] ?? null,
@@ -305,7 +321,7 @@ final class StorageControlPlaneStatusService
                 'restored_root' => $result['restored_root'] ?? null,
                 'target_root' => $result['target_root'] ?? null,
             ],
-        ];
+        ], $this->freshnessFromTimestamp($latestGeneratedAt, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS));
     }
 
     /**
@@ -316,11 +332,12 @@ final class StorageControlPlaneStatusService
         $audit = $this->latestAuditForAction('storage_purge_quarantined_root');
         $meta = $audit === null ? [] : $this->decodeAuditMeta($audit);
         $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+        $latestGeneratedAt = $this->normalizeTimestamp($audit?->created_at);
 
-        return [
+        return array_merge([
             'status' => $audit === null ? 'never_run' : 'ok',
             'purge_receipt_count' => $this->countFilesByGlob($this->purgeRootBase().DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'items'.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'purge.json'),
-            'latest_generated_at' => $audit?->created_at,
+            'latest_generated_at' => $latestGeneratedAt,
             'latest_mode' => $meta['mode'] ?? null,
             'latest_plan_path' => $meta['plan_path'] ?? null,
             'latest_run_path' => $result['run_dir'] ?? null,
@@ -329,7 +346,7 @@ final class StorageControlPlaneStatusService
                 'receipt_path' => $result['receipt_path'] ?? null,
                 'blocked_reason' => data_get($meta, 'plan.blocked_reason'),
             ],
-        ];
+        ], $this->freshnessFromTimestamp($latestGeneratedAt, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS));
     }
 
     /**
@@ -365,7 +382,7 @@ final class StorageControlPlaneStatusService
             'resolver_materialization_enabled' => $resolverMaterializationEnabled,
             'packs_v2_remote_rehydrate_enabled' => $packsV2RemoteRehydrateEnabled,
             'v2_readiness' => $readiness,
-        ];
+        ] + $this->unknownFreshness('config-derived');
     }
 
     /**
@@ -403,7 +420,7 @@ final class StorageControlPlaneStatusService
                 'remote_read_cutover',
                 'storage:blob-gc execute',
             ],
-        ];
+        ] + $this->unknownFreshness('config-derived');
     }
 
     /**
@@ -417,22 +434,23 @@ final class StorageControlPlaneStatusService
         );
 
         if ($audit === null) {
-            return [
+            return array_merge([
                 'status' => 'never_run',
                 'latest_generated_at' => null,
                 'latest_mode' => null,
                 'latest_plan_path' => null,
                 'latest_run_path' => null,
                 'latest_summary' => null,
-            ];
+            ], $this->freshnessFromTimestamp(null, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS));
         }
 
         $meta = $this->decodeAuditMeta($audit);
         $result = is_array($meta['result'] ?? null) ? $meta['result'] : [];
+        $latestGeneratedAt = $this->normalizeTimestamp($audit->created_at);
 
-        return [
+        return array_merge([
             'status' => 'ok',
-            'latest_generated_at' => (string) $audit->created_at,
+            'latest_generated_at' => $latestGeneratedAt,
             'latest_mode' => $meta['mode'] ?? null,
             'latest_plan_path' => $meta['plan_path'] ?? null,
             'latest_run_path' => $result['run_dir'] ?? null,
@@ -443,7 +461,77 @@ final class StorageControlPlaneStatusService
                 'blocked_count' => (int) ($result['blocked_count'] ?? 0),
                 'skipped_count' => (int) ($result['skipped_count'] ?? 0),
             ],
+        ], $this->freshnessFromTimestamp($latestGeneratedAt, 'audit-derived', self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS));
+    }
+
+    /**
+     * @return array{
+     *   last_updated_at:?string,
+     *   freshness_age_seconds:?int,
+     *   freshness_state:string,
+     *   freshness_source_type:string
+     * }
+     */
+    private function freshnessFromTimestamp(?string $timestamp, string $sourceType, ?int $staleAfterSeconds, string $missingState = 'never_run'): array
+    {
+        $timestamp = $this->normalizeTimestamp($timestamp);
+        if ($timestamp === null) {
+            return [
+                'last_updated_at' => null,
+                'freshness_age_seconds' => null,
+                'freshness_state' => $missingState,
+                'freshness_source_type' => $sourceType,
+            ];
+        }
+
+        try {
+            $updatedAt = Carbon::parse($timestamp);
+        } catch (\Throwable) {
+            return $this->unknownFreshness($sourceType);
+        }
+
+        $ageSeconds = (int) $updatedAt->diffInSeconds(now());
+        $state = $staleAfterSeconds !== null && $ageSeconds > $staleAfterSeconds ? 'stale' : 'fresh';
+
+        return [
+            'last_updated_at' => $updatedAt->toIso8601String(),
+            'freshness_age_seconds' => $ageSeconds,
+            'freshness_state' => $state,
+            'freshness_source_type' => $sourceType,
         ];
+    }
+
+    /**
+     * @return array{
+     *   last_updated_at:null,
+     *   freshness_age_seconds:null,
+     *   freshness_state:string,
+     *   freshness_source_type:string
+     * }
+     */
+    private function unknownFreshness(string $sourceType = 'config-derived'): array
+    {
+        return [
+            'last_updated_at' => null,
+            'freshness_age_seconds' => null,
+            'freshness_state' => 'unknown_freshness',
+            'freshness_source_type' => $sourceType,
+        ];
+    }
+
+    private function normalizeTimestamp(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(DATE_ATOM);
+        }
+
+        if (! is_scalar($value) || $value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
     }
 
     private function latestAuditForAction(string $action, ?callable $filter = null): ?object

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -75,6 +75,12 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame('storage_control_plane_snapshot.v1', $payload['snapshot_schema']);
         $this->assertSame('snapshotted', $payload['status']);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertArrayHasKey('last_updated_at', $payload['inventory']);
+        $this->assertArrayHasKey('freshness_age_seconds', $payload['inventory']);
+        $this->assertArrayHasKey('freshness_state', $payload['inventory']);
+        $this->assertArrayHasKey('freshness_source_type', $payload['inventory']);
+        $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
         $this->assertFileExists((string) $payload['snapshot_path']);
         $this->assertSame($auditCountBefore + 1, DB::table('audit_logs')->count());

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -77,9 +77,19 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertArrayHasKey('last_updated_at', $payload['inventory']);
+        $this->assertArrayHasKey('freshness_age_seconds', $payload['inventory']);
+        $this->assertArrayHasKey('freshness_state', $payload['inventory']);
+        $this->assertArrayHasKey('freshness_source_type', $payload['inventory']);
+        $this->assertSame('fresh', data_get($payload, 'inventory.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'rehydrate.status'));
+        $this->assertSame('never_run', data_get($payload, 'rehydrate.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retention.status'));
+        $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'restore.status'));
+        $this->assertSame('never_run', data_get($payload, 'restore.freshness_state'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
 
         $audit = DB::table('audit_logs')
             ->where('action', 'storage_control_plane_snapshot')
@@ -114,10 +124,15 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $payload = app(StorageControlPlaneSnapshotService::class)->createSnapshot();
 
         $this->assertSame('not_available', data_get($payload, 'inventory.status'));
+        $this->assertSame('not_available', data_get($payload, 'inventory.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retention.status'));
+        $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_gc.status'));
+        $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_gc.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'quarantine.status'));
+        $this->assertSame('never_run', data_get($payload, 'quarantine.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.status'));
+        $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.freshness_state'));
     }
 
     private function seedMinimalTruth(): void

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -86,7 +86,19 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertArrayHasKey('last_updated_at', $payload['inventory']);
+        $this->assertArrayHasKey('freshness_age_seconds', $payload['inventory']);
+        $this->assertArrayHasKey('freshness_state', $payload['inventory']);
+        $this->assertArrayHasKey('freshness_source_type', $payload['inventory']);
+        $this->assertArrayHasKey('last_updated_at', data_get($payload, 'retention.scopes.reports_backups', []));
+        $this->assertArrayHasKey('freshness_age_seconds', data_get($payload, 'retention.scopes.reports_backups', []));
+        $this->assertArrayHasKey('freshness_state', data_get($payload, 'retention.scopes.reports_backups', []));
+        $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'retention.scopes.reports_backups', []));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
+        $this->assertSame('config-derived', data_get($payload, 'runtime_truth.freshness_source_type'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
+        $this->assertSame('config-derived', data_get($payload, 'automation_readiness.freshness_source_type'));
 
         $this->assertSame($auditCountBefore, DB::table('audit_logs')->count());
         $this->assertSame($filesBefore, $this->storageFilesSnapshot());

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -63,19 +63,37 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
 
         $this->assertSame('storage_control_plane_status.v1', $payload['schema_version']);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertSame('fresh', data_get($payload, 'inventory.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'inventory.freshness_source_type'));
+        $this->assertIsString(data_get($payload, 'inventory.last_updated_at'));
+        $this->assertIsInt(data_get($payload, 'inventory.freshness_age_seconds'));
+        $this->assertSame('fresh', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
+        $this->assertSame('mixed-derived', data_get($payload, 'retention.scopes.reports_backups.freshness_source_type'));
         $this->assertSame(['reports', 'artifacts'], data_get($payload, 'inventory.focus_scopes'));
         $this->assertSame(1, data_get($payload, 'blob_coverage.counts.storage_blobs'));
         $this->assertSame(1, data_get($payload, 'blob_coverage.counts.verified_storage_blob_locations_by_disk.s3'));
+        $this->assertSame('fresh', data_get($payload, 'blob_coverage.blob_gc.freshness_state'));
+        $this->assertSame('fresh', data_get($payload, 'blob_coverage.blob_offload.freshness_state'));
         $this->assertSame(1, data_get($payload, 'exact_authority.counts.content_release_exact_manifests'));
         $this->assertSame(1, data_get($payload, 'exact_authority.counts.content_release_exact_manifest_files'));
+        $this->assertSame('fresh', data_get($payload, 'exact_authority.latest_backfill.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'exact_authority.latest_backfill.freshness_source_type'));
+        $this->assertSame('fresh', data_get($payload, 'rehydrate.freshness_state'));
         $this->assertSame(1, data_get($payload, 'quarantine.item_root_count'));
+        $this->assertSame('fresh', data_get($payload, 'quarantine.freshness_state'));
         $this->assertSame(1, data_get($payload, 'restore.restore_run_count'));
+        $this->assertSame('fresh', data_get($payload, 'restore.freshness_state'));
         $this->assertSame(1, data_get($payload, 'purge.purge_receipt_count'));
+        $this->assertSame('fresh', data_get($payload, 'purge.freshness_state'));
         $this->assertSame('ok', data_get($payload, 'retirement.actions.quarantine.status'));
         $this->assertSame('ok', data_get($payload, 'retirement.actions.purge.status'));
+        $this->assertSame('fresh', data_get($payload, 'retirement.actions.quarantine.freshness_state'));
+        $this->assertSame('fresh', data_get($payload, 'retirement.actions.purge.freshness_state'));
         $this->assertTrue((bool) data_get($payload, 'runtime_truth.resolver_materialization_enabled'));
         $this->assertFalse((bool) data_get($payload, 'runtime_truth.packs_v2_remote_rehydrate_enabled'));
         $this->assertSame('materialization_enabled_only', data_get($payload, 'runtime_truth.v2_readiness'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
+        $this->assertSame('config-derived', data_get($payload, 'runtime_truth.freshness_source_type'));
         $this->assertSame([
             'storage:inventory',
             'storage:prune',
@@ -86,6 +104,8 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
             'storage:quarantine-exact-roots',
             'storage:retire-exact-roots',
         ], data_get($payload, 'automation_readiness.auto_dry_run_ok'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
+        $this->assertSame('config-derived', data_get($payload, 'automation_readiness.freshness_source_type'));
 
         $this->assertSame($auditCountBefore, DB::table('audit_logs')->count());
         $this->assertSame($filesBefore, $this->storageFilesSnapshot());
@@ -96,16 +116,31 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $payload = app(StorageControlPlaneStatusService::class)->buildStatus();
 
         $this->assertSame('not_available', data_get($payload, 'inventory.status'));
+        $this->assertSame('not_available', data_get($payload, 'inventory.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retention.status'));
+        $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
+        $this->assertSame('never_run', data_get($payload, 'retention.scopes.content_releases_retention.freshness_state'));
+        $this->assertSame('never_run', data_get($payload, 'retention.scopes.legacy_private_private_cleanup.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_gc.status'));
+        $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_gc.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_offload.status'));
+        $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_offload.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'exact_authority.latest_backfill.status'));
+        $this->assertSame('never_run', data_get($payload, 'exact_authority.latest_backfill.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'rehydrate.status'));
+        $this->assertSame('never_run', data_get($payload, 'rehydrate.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'quarantine.status'));
+        $this->assertSame('never_run', data_get($payload, 'quarantine.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'restore.status'));
+        $this->assertSame('never_run', data_get($payload, 'restore.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'purge.status'));
+        $this->assertSame('never_run', data_get($payload, 'purge.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.status'));
+        $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.purge.status'));
+        $this->assertSame('never_run', data_get($payload, 'retirement.actions.purge.freshness_state'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
     }
 
     private function seedControlPlaneTruth(): void


### PR DESCRIPTION
## Summary
- add additive freshness metadata to the storage control-plane status read model
- expose `last_updated_at`, `freshness_age_seconds`, `freshness_state`, and `freshness_source_type` on audit/file-backed sections and subsections
- preserve existing `not_available` / `never_run` semantics and use `unknown_freshness` for config-derived sections
- let control-plane snapshots inherit the new freshness fields automatically through the existing status payload reuse

## Scope
- no new command or service
- no scheduler changes
- no execute-path changes
- no migrations, routes, or middleware
- no runtime reader or lifecycle contract changes

## Tests
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php`
- `php artisan route:list > /tmp/pr29a_route_list.txt`
- `php artisan migrate`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
