### PR TITLE
[codex] add storage control-plane attention digest

### DIFF
--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -27,7 +27,7 @@ final class StorageControlPlaneStatusService
      */
     public function buildStatus(): array
     {
-        return [
+        $payload = [
             'schema_version' => self::SCHEMA_VERSION,
             'generated_at' => now()->toIso8601String(),
             'inventory' => $this->inventorySection(),
@@ -42,6 +42,10 @@ final class StorageControlPlaneStatusService
             'runtime_truth' => $this->runtimeTruthSection(),
             'automation_readiness' => $this->automationReadinessSection(),
         ];
+
+        $payload['attention_digest'] = $this->buildAttentionDigest($payload);
+
+        return $payload;
     }
 
     /**
@@ -532,6 +536,97 @@ final class StorageControlPlaneStatusService
         $normalized = trim((string) $value);
 
         return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    private function buildAttentionDigest(array $payload): array
+    {
+        $staleSections = [];
+        $neverRunSections = [];
+        $notAvailableSections = [];
+        $attentionItems = [];
+
+        foreach ($this->attentionDigestDescriptors() as $descriptor) {
+            $node = data_get($payload, $descriptor['path']);
+            if (! is_array($node)) {
+                continue;
+            }
+
+            $state = (string) ($node['freshness_state'] ?? '');
+            if (! in_array($state, ['stale', 'never_run', 'not_available'], true)) {
+                continue;
+            }
+
+            if ($state === 'stale') {
+                $staleSections[] = $descriptor['path'];
+            } elseif ($state === 'never_run') {
+                $neverRunSections[] = $descriptor['path'];
+            } else {
+                $notAvailableSections[] = $descriptor['path'];
+            }
+
+            $attentionItems[] = [
+                'path' => $descriptor['path'],
+                'freshness_state' => $state,
+                'last_updated_at' => $node['last_updated_at'] ?? null,
+                'message' => $this->attentionDigestMessage($descriptor['label'], $state),
+            ];
+        }
+
+        $overallState = match (true) {
+            $notAvailableSections !== [] => 'degraded',
+            $staleSections !== [] || $neverRunSections !== [] => 'attention_required',
+            default => 'healthy',
+        };
+
+        return [
+            'overall_state' => $overallState,
+            'stale_sections' => $staleSections,
+            'never_run_sections' => $neverRunSections,
+            'not_available_sections' => $notAvailableSections,
+            'attention_items' => $attentionItems,
+            'counts' => [
+                'stale' => count($staleSections),
+                'never_run' => count($neverRunSections),
+                'not_available' => count($notAvailableSections),
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array{path:string,label:string}>
+     */
+    private function attentionDigestDescriptors(): array
+    {
+        return [
+            ['path' => 'inventory', 'label' => 'inventory'],
+            ['path' => 'retention.scopes.reports_backups', 'label' => 'reports backups retention dry-run'],
+            ['path' => 'retention.scopes.content_releases_retention', 'label' => 'content releases retention dry-run'],
+            ['path' => 'retention.scopes.legacy_private_private_cleanup', 'label' => 'legacy private cleanup dry-run'],
+            ['path' => 'blob_coverage.blob_gc', 'label' => 'blob gc dry-run'],
+            ['path' => 'blob_coverage.blob_offload', 'label' => 'blob offload dry-run'],
+            ['path' => 'exact_authority.latest_backfill', 'label' => 'exact authority backfill'],
+            ['path' => 'rehydrate', 'label' => 'rehydrate'],
+            ['path' => 'quarantine', 'label' => 'quarantine'],
+            ['path' => 'restore', 'label' => 'restore'],
+            ['path' => 'purge', 'label' => 'purge'],
+            ['path' => 'retirement.actions.quarantine', 'label' => 'retirement quarantine action'],
+            ['path' => 'retirement.actions.purge', 'label' => 'retirement purge action'],
+            ['path' => 'runtime_truth', 'label' => 'runtime truth'],
+            ['path' => 'automation_readiness', 'label' => 'automation readiness'],
+        ];
+    }
+
+    private function attentionDigestMessage(string $label, string $state): string
+    {
+        return match ($state) {
+            'stale' => $label.' is stale',
+            'not_available' => $label.' is not available',
+            default => $label.' has never run',
+        };
     }
 
     private function latestAuditForAction(string $action, ?callable $filter = null): ?object

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -75,6 +75,7 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame('storage_control_plane_snapshot.v1', $payload['snapshot_schema']);
         $this->assertSame('snapshotted', $payload['status']);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertArrayHasKey('attention_digest', $payload);
         $this->assertArrayHasKey('last_updated_at', $payload['inventory']);
         $this->assertArrayHasKey('freshness_age_seconds', $payload['inventory']);
         $this->assertArrayHasKey('freshness_state', $payload['inventory']);
@@ -82,6 +83,10 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
+        $this->assertSame('attention_required', data_get($payload, 'attention_digest.overall_state'));
+        $this->assertContains('retention.scopes.reports_backups', data_get($payload, 'attention_digest.never_run_sections', []));
+        $this->assertContains('rehydrate', data_get($payload, 'attention_digest.never_run_sections', []));
+        $this->assertSame([], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertFileExists((string) $payload['snapshot_path']);
         $this->assertSame($auditCountBefore + 1, DB::table('audit_logs')->count());
         $this->assertDatabaseHas('audit_logs', [

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -76,6 +76,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertArrayHasKey('retirement', $payload);
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
+        $this->assertArrayHasKey('attention_digest', $payload);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
         $this->assertArrayHasKey('last_updated_at', $payload['inventory']);
         $this->assertArrayHasKey('freshness_age_seconds', $payload['inventory']);
@@ -90,6 +91,10 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('never_run', data_get($payload, 'restore.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
+        $this->assertSame('attention_required', data_get($payload, 'attention_digest.overall_state'));
+        $this->assertContains('rehydrate', data_get($payload, 'attention_digest.never_run_sections', []));
+        $this->assertContains('retention.scopes.reports_backups', data_get($payload, 'attention_digest.never_run_sections', []));
+        $this->assertSame([], data_get($payload, 'attention_digest.not_available_sections'));
 
         $audit = DB::table('audit_logs')
             ->where('action', 'storage_control_plane_snapshot')
@@ -133,6 +138,9 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('never_run', data_get($payload, 'quarantine.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.status'));
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.freshness_state'));
+        $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
+        $this->assertSame(['inventory'], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertContains('quarantine', data_get($payload, 'attention_digest.never_run_sections', []));
     }
 
     private function seedMinimalTruth(): void

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -85,6 +85,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('retirement', $payload);
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
+        $this->assertArrayHasKey('attention_digest', $payload);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
         $this->assertArrayHasKey('last_updated_at', $payload['inventory']);
         $this->assertArrayHasKey('freshness_age_seconds', $payload['inventory']);
@@ -99,6 +100,11 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertSame('config-derived', data_get($payload, 'runtime_truth.freshness_source_type'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('config-derived', data_get($payload, 'automation_readiness.freshness_source_type'));
+        $this->assertSame('attention_required', data_get($payload, 'attention_digest.overall_state'));
+        $this->assertContains('retention.scopes.reports_backups', data_get($payload, 'attention_digest.never_run_sections', []));
+        $this->assertContains('rehydrate', data_get($payload, 'attention_digest.never_run_sections', []));
+        $this->assertSame([], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertSame('reports backups retention dry-run has never run', data_get($payload, 'attention_digest.attention_items.0.message'));
 
         $this->assertSame($auditCountBefore, DB::table('audit_logs')->count());
         $this->assertSame($filesBefore, $this->storageFilesSnapshot());

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -106,6 +106,16 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         ], data_get($payload, 'automation_readiness.auto_dry_run_ok'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('config-derived', data_get($payload, 'automation_readiness.freshness_source_type'));
+        $this->assertSame('healthy', data_get($payload, 'attention_digest.overall_state'));
+        $this->assertSame([], data_get($payload, 'attention_digest.stale_sections'));
+        $this->assertSame([], data_get($payload, 'attention_digest.never_run_sections'));
+        $this->assertSame([], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertSame([
+            'stale' => 0,
+            'never_run' => 0,
+            'not_available' => 0,
+        ], data_get($payload, 'attention_digest.counts'));
+        $this->assertSame([], data_get($payload, 'attention_digest.attention_items'));
 
         $this->assertSame($auditCountBefore, DB::table('audit_logs')->count());
         $this->assertSame($filesBefore, $this->storageFilesSnapshot());
@@ -141,6 +151,14 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.purge.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
+        $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
+        $this->assertSame(['inventory'], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertContains('rehydrate', data_get($payload, 'attention_digest.never_run_sections', []));
+        $this->assertContains('retention.scopes.reports_backups', data_get($payload, 'attention_digest.never_run_sections', []));
+        $this->assertSame([], data_get($payload, 'attention_digest.stale_sections'));
+        $this->assertSame(1, data_get($payload, 'attention_digest.counts.not_available'));
+        $this->assertGreaterThan(0, (int) data_get($payload, 'attention_digest.counts.never_run'));
+        $this->assertSame('inventory is not available', data_get($payload, 'attention_digest.attention_items.0.message'));
     }
 
     private function seedControlPlaneTruth(): void
@@ -219,6 +237,20 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
             'generated_at' => $now->copy()->subMinutes(30)->toIso8601String(),
             'summary' => ['files' => 2, 'bytes' => 512],
         ]);
+        $this->writeJson(storage_path('app/private/prune_plans/20260321_content_releases_retention_seed.json'), [
+            'schema' => 'storage_prune_plan.v2',
+            'scope' => 'content_releases_retention',
+            'strategy' => 'strict',
+            'generated_at' => $now->copy()->subMinutes(25)->toIso8601String(),
+            'summary' => ['files' => 3, 'bytes' => 1024],
+        ]);
+        $this->writeJson(storage_path('app/private/prune_plans/20260321_legacy_private_private_cleanup_seed.json'), [
+            'schema' => 'storage_prune_plan.v2',
+            'scope' => 'legacy_private_private_cleanup',
+            'strategy' => 'strict',
+            'generated_at' => $now->copy()->subMinutes(20)->toIso8601String(),
+            'summary' => ['files' => 1, 'bytes' => 256],
+        ]);
 
         $this->writeJson(storage_path('app/private/quarantine/release_roots/run-1/items/item-1/root/.quarantine.json'), [
             'source_kind' => 'legacy.source_pack',
@@ -258,6 +290,24 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
             'skipped_files' => 0,
             'plan' => storage_path('app/private/prune_plans/20260321_reports_backups_seed.json'),
         ], 'success', 'retention_execute', $now->copy()->subHours(2));
+        $this->insertAudit('storage_prune', 'content_releases_retention', [
+            'scope' => 'content_releases_retention',
+            'strategy' => 'strict',
+            'deleted_files_count' => 0,
+            'deleted_bytes' => 0,
+            'missing_files' => 0,
+            'skipped_files' => 1,
+            'plan' => storage_path('app/private/prune_plans/20260321_content_releases_retention_seed.json'),
+        ], 'success', 'retention_execute', $now->copy()->subHours(2)->addMinutes(5));
+        $this->insertAudit('storage_prune', 'legacy_private_private_cleanup', [
+            'scope' => 'legacy_private_private_cleanup',
+            'strategy' => 'strict',
+            'deleted_files_count' => 0,
+            'deleted_bytes' => 0,
+            'missing_files' => 0,
+            'skipped_files' => 0,
+            'plan' => storage_path('app/private/prune_plans/20260321_legacy_private_private_cleanup_seed.json'),
+        ], 'success', 'retention_execute', $now->copy()->subHours(2)->addMinutes(10));
 
         $this->insertAudit('storage_blob_gc', 'blob_gc', [
             'schema' => 'storage_blob_gc_plan.v1',


### PR DESCRIPTION
## Summary
- add a top-level `attention_digest` to the storage control-plane status payload
- summarize existing freshness metadata into `overall_state`, section lists, stable `attention_items`, and counts
- let control-plane snapshots inherit the digest automatically through the existing status payload reuse
- keep the change read-only and additive with no scheduler, execute, runtime, or schema changes

## Why
PR-29A exposed freshness at each section and subsection, but the operator still had to manually scan the full payload to decide whether the control plane was healthy, needed attention, or was degraded.

This PR adds one top-level digest that reuses the existing freshness truth instead of inventing a second model. The result is a faster operator read path without changing any storage lifecycle behavior.

## Root cause
The underlying truth already existed in `freshness_state`, but there was no single aggregation layer for:
- stale sections
- never-run sections
- not-available sections
- the overall operator health state

That made the control plane readable but still not quickly actionable.

## Fix
- build `attention_digest` inside `StorageControlPlaneStatusService`
- classify tracked paths into `stale_sections`, `never_run_sections`, and `not_available_sections`
- derive `overall_state` as:
  - `degraded` when any `not_available` section exists
  - `attention_required` when any `stale` or `never_run` section exists
  - `healthy` otherwise
- emit stable `attention_items` with `path`, `freshness_state`, `last_updated_at`, and `message`
- keep the change additive so `storage:control-plane-snapshot` inherits the digest automatically through the existing status payload

## Scope
- no new command or service
- no scheduler changes
- no snapshot write-path changes
- no execute-path changes
- no migrations, routes, or middleware
- no runtime reader or lifecycle contract changes

## Validation
Focused tests:
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`

Regression:
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php`

Live acceptance:
- `php artisan route:list > /tmp/pr29b_route_list.txt`
- `php artisan migrate`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`

## Validation note
The current main working tree contains unrelated local OpenAPI drift and other uncommitted changes. To keep this PR isolated, the patch was committed from a clean worktree. The PR patch itself passed the full acceptance chain in that isolated environment.
