### PR TITLE
[codex] Ship PR-11D private relationship surface and consent ledger foundation (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\V0_3\CreateMbtiCompareInviteRequest;
 use App\Services\V0_3\MbtiCompareInviteService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 final class MbtiCompareInviteController extends Controller
 {
@@ -23,6 +24,17 @@ final class MbtiCompareInviteController extends Controller
     public function show(string $inviteId): JsonResponse
     {
         $result = $this->service->show($inviteId);
+
+        return response()->json(array_merge(['ok' => true], $result));
+    }
+
+    public function showPrivate(Request $request, string $inviteId): JsonResponse
+    {
+        $result = $this->service->showPrivate(
+            $inviteId,
+            $request->attributes->get('user_id'),
+            $request->attributes->get('anon_id')
+        );
 
         return response()->json(array_merge(['ok' => true], $result));
     }

--- a/backend/app/Services/InsightGraph/PrivateRelationshipContractService.php
+++ b/backend/app/Services/InsightGraph/PrivateRelationshipContractService.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InsightGraph;
+
+use App\Models\MbtiCompareInvite;
+
+final class PrivateRelationshipContractService
+{
+    /**
+     * @param  array<string,mixed>  $inviterSummary
+     * @param  array<string,mixed>  $inviteeSummary
+     * @param  array<string,mixed>  $relationshipSync
+     * @return array<string,mixed>
+     */
+    public function buildPrivateRelationship(
+        array $inviterSummary,
+        array $inviteeSummary,
+        array $relationshipSync,
+        string $participantRole,
+        string $accessState,
+        string $subjectJoinMode,
+        string $locale,
+        ?string $defaultActionCtaPath = null,
+        ?string $defaultActionCtaLabel = null
+    ): array {
+        $sections = $this->normalizeSections($relationshipSync['sections'] ?? []);
+        $actionPrompt = $this->normalizeActionPrompt(
+            $relationshipSync['action_prompt'] ?? null,
+            $defaultActionCtaPath,
+            $defaultActionCtaLabel
+        );
+
+        $fingerprintSeed = [
+            'scope' => 'private_relationship_protected',
+            'participant_role' => $participantRole,
+            'access_state' => $accessState,
+            'subject_join_mode' => $subjectJoinMode,
+            'inviter_type_code' => $this->normalizeText(data_get($inviterSummary, 'type_code')),
+            'invitee_type_code' => $this->normalizeText(data_get($inviteeSummary, 'type_code')),
+            'friction_keys' => $this->normalizeStringArray($relationshipSync['friction_keys'] ?? []),
+            'complement_keys' => $this->normalizeStringArray($relationshipSync['complement_keys'] ?? []),
+            'communication_bridge_keys' => $this->normalizeStringArray($relationshipSync['communication_bridge_keys'] ?? []),
+            'decision_tension_keys' => $this->normalizeStringArray($relationshipSync['decision_tension_keys'] ?? []),
+            'stress_interplay_keys' => $this->normalizeStringArray($relationshipSync['stress_interplay_keys'] ?? []),
+            'dyadic_action_prompt_keys' => $this->normalizeStringArray($relationshipSync['dyadic_action_prompt_keys'] ?? []),
+            'sections' => $sections,
+            'locale' => $locale,
+        ];
+
+        return [
+            'version' => 'private.relationship.v1',
+            'relationship_scope' => 'private_relationship_protected',
+            'relationship_contract_version' => 'private.relationship.v1',
+            'relationship_fingerprint_version' => 'private.relationship.fp.v1',
+            'relationship_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'access_state' => $accessState,
+            'subject_join_mode' => $subjectJoinMode,
+            'participant_role' => $participantRole,
+            'inviter_summary' => $inviterSummary,
+            'invitee_summary' => $inviteeSummary,
+            'shared_count' => $this->normalizeCount($relationshipSync['shared_count'] ?? null),
+            'diverging_count' => $this->normalizeCount($relationshipSync['diverging_count'] ?? null),
+            'overview' => [
+                'title' => $this->normalizeText(data_get($relationshipSync, 'overview.title')),
+                'summary' => $this->normalizeText(data_get($relationshipSync, 'overview.summary')),
+            ],
+            'friction_keys' => $this->normalizeStringArray($relationshipSync['friction_keys'] ?? []),
+            'complement_keys' => $this->normalizeStringArray($relationshipSync['complement_keys'] ?? []),
+            'communication_bridge_keys' => $this->normalizeStringArray($relationshipSync['communication_bridge_keys'] ?? []),
+            'decision_tension_keys' => $this->normalizeStringArray($relationshipSync['decision_tension_keys'] ?? []),
+            'stress_interplay_keys' => $this->normalizeStringArray($relationshipSync['stress_interplay_keys'] ?? []),
+            'private_sync_sections' => $sections,
+            'private_action_prompt' => $actionPrompt,
+        ];
+    }
+
+    public function buildDyadicConsent(
+        MbtiCompareInvite $invite,
+        string $consentState,
+        string $accessState,
+        string $subjectJoinMode
+    ): array {
+        return [
+            'version' => 'dyadic.consent.v1',
+            'consent_scope' => 'private_relationship_protected',
+            'access_state' => $accessState,
+            'consent_state' => $consentState,
+            'revocation_state' => 'not_supported_yet',
+            'expiry_state' => 'not_enforced_yet',
+            'subject_join_mode' => $subjectJoinMode,
+            'accepted_at' => $invite->accepted_at?->toISOString(),
+            'completed_at' => $invite->completed_at?->toISOString(),
+            'purchased_at' => $invite->purchased_at?->toISOString(),
+            'consent_artifact_version' => 'dyadic.consent.v1',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $privateRelationship
+     * @return array<string,mixed>
+     */
+    public function buildProtectedGraph(array $privateRelationship): array
+    {
+        if ($privateRelationship === []) {
+            return [];
+        }
+
+        $nodes = [];
+        $edges = [];
+
+        $this->pushNode(
+            $nodes,
+            'private_relationship',
+            'private_relationship',
+            $this->normalizeText(data_get($privateRelationship, 'overview.title')) ?? 'Private relationship',
+            $this->normalizeText(data_get($privateRelationship, 'overview.summary')) ?? '',
+            'private_relationship_v1'
+        );
+
+        foreach ([
+            'inviter_summary' => 'participant',
+            'invitee_summary' => 'participant',
+        ] as $key => $kind) {
+            $summary = data_get($privateRelationship, $key);
+            if (! is_array($summary)) {
+                continue;
+            }
+
+            $title = $this->normalizeText($summary['title'] ?? null, $summary['type_name'] ?? null, $summary['type_code'] ?? null);
+            if ($title === null) {
+                continue;
+            }
+
+            $nodeId = $key === 'inviter_summary' ? 'participant_inviter' : 'participant_invitee';
+            $this->pushNode(
+                $nodes,
+                $nodeId,
+                $kind,
+                $title,
+                $this->normalizeText($summary['summary'] ?? null) ?? '',
+                'private_relationship_v1'
+            );
+            $edges[] = ['from' => $nodeId, 'to' => 'private_relationship', 'relation' => 'supports'];
+        }
+
+        foreach ((array) ($privateRelationship['private_sync_sections'] ?? []) as $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+
+            $key = $this->normalizeText($section['key'] ?? null);
+            $title = $this->normalizeText($section['title'] ?? null);
+            if ($key === null || $title === null) {
+                continue;
+            }
+
+            $this->pushNode(
+                $nodes,
+                $key,
+                $key,
+                $title,
+                $this->normalizeText($section['summary'] ?? null) ?? '',
+                'private_relationship_v1'
+            );
+            $edges[] = ['from' => $key, 'to' => 'private_relationship', 'relation' => 'supports'];
+        }
+
+        $actionPrompt = $privateRelationship['private_action_prompt'] ?? null;
+        if (is_array($actionPrompt)) {
+            $actionTitle = $this->normalizeText($actionPrompt['title'] ?? null);
+            if ($actionTitle !== null) {
+                $this->pushNode(
+                    $nodes,
+                    'next_step',
+                    'next_step',
+                    $actionTitle,
+                    $this->normalizeText($actionPrompt['summary'] ?? null) ?? '',
+                    'private_relationship_v1'
+                );
+                $edges[] = ['from' => 'private_relationship', 'to' => 'next_step', 'relation' => 'recommended_next'];
+            }
+        }
+
+        $fingerprintSeed = [
+            'scope' => 'private_relationship_protected',
+            'relationship_fingerprint' => $this->normalizeText($privateRelationship['relationship_fingerprint'] ?? null),
+            'nodes' => $nodes,
+            'edges' => $edges,
+        ];
+
+        return [
+            'version' => 'dyadic.graph.v1',
+            'graph_scope' => 'private_relationship_protected',
+            'graph_contract_version' => 'dyadic.graph.v1',
+            'graph_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'root_node' => 'private_relationship',
+            'nodes' => $nodes,
+            'edges' => $edges,
+            'supporting_scales' => ['MBTI'],
+        ];
+    }
+
+    /**
+     * @param  array<int,mixed>  $sections
+     * @return list<array<string,mixed>>
+     */
+    private function normalizeSections(mixed $sections): array
+    {
+        if (! is_array($sections)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($sections as $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+
+            $key = $this->normalizeText($section['key'] ?? null);
+            $title = $this->normalizeText($section['title'] ?? null);
+            if ($key === null || $title === null) {
+                continue;
+            }
+
+            $normalized[] = [
+                'key' => $key,
+                'title' => $title,
+                'summary' => $this->normalizeText($section['summary'] ?? null),
+                'bullets' => $this->normalizeStringArray($section['bullets'] ?? []),
+            ];
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @param  array<string,mixed>|mixed  $actionPrompt
+     * @return array<string,mixed>|null
+     */
+    private function normalizeActionPrompt(
+        mixed $actionPrompt,
+        ?string $defaultActionCtaPath,
+        ?string $defaultActionCtaLabel
+    ): ?array {
+        if (! is_array($actionPrompt)) {
+            return null;
+        }
+
+        $key = $this->normalizeText($actionPrompt['key'] ?? null);
+        $title = $this->normalizeText($actionPrompt['title'] ?? null);
+        $summary = $this->normalizeText($actionPrompt['summary'] ?? null);
+        if ($key === null && $title === null && $summary === null) {
+            return null;
+        }
+
+        return [
+            'key' => $key,
+            'title' => $title,
+            'summary' => $summary,
+            'cta_label' => $this->normalizeText($actionPrompt['cta_label'] ?? null, $defaultActionCtaLabel),
+            'cta_path' => $this->normalizeText($actionPrompt['cta_path'] ?? null, $defaultActionCtaPath),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $nodes
+     */
+    private function pushNode(array &$nodes, string $id, string $kind, string $title, string $summary, string $sourceContract): void
+    {
+        $nodes[] = [
+            'id' => $id,
+            'kind' => $kind,
+            'title' => $title,
+            'summary' => $summary,
+            'source_contract' => $sourceContract,
+        ];
+    }
+
+    /**
+     * @param  array<int,mixed>  $values
+     * @return list<string>
+     */
+    private function normalizeStringArray(mixed $values): array
+    {
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($values as $value) {
+            $text = $this->normalizeText($value);
+            if ($text !== null) {
+                $normalized[] = $text;
+            }
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    private function normalizeText(mixed ...$values): ?string
+    {
+        foreach ($values as $value) {
+            if (! is_string($value) && ! is_numeric($value)) {
+                continue;
+            }
+
+            $normalized = trim((string) $value);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeCount(mixed $value): ?int
+    {
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        return max(0, (int) $value);
+    }
+}

--- a/backend/app/Services/V0_3/MbtiCompareInviteService.php
+++ b/backend/app/Services/V0_3/MbtiCompareInviteService.php
@@ -9,6 +9,7 @@ use App\Models\Attempt;
 use App\Models\MbtiCompareInvite;
 use App\Models\Result;
 use App\Models\Share;
+use App\Services\InsightGraph\PrivateRelationshipContractService;
 use App\Services\InsightGraph\RelationshipSyncContractService;
 use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
@@ -23,6 +24,7 @@ final class MbtiCompareInviteService
         private readonly MbtiPublicProjectionService $mbtiPublicProjectionService,
         private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private readonly RelationshipSyncContractService $relationshipSyncContractService,
+        private readonly PrivateRelationshipContractService $privateRelationshipContractService,
     ) {}
 
     /**
@@ -73,48 +75,7 @@ final class MbtiCompareInviteService
         );
 
         $status = $this->normalizeStatus((string) ($invite->status ?? 'pending'));
-        $inviter = $this->toSummaryLiteWithProjection(
-            $inviterPayload,
-            true,
-            (int) ($attempt->org_id ?? 0),
-            $locale
-        );
-        $invitee = $this->pendingInviteePayload();
-        $compare = [
-            'mbti_public_summary_v1' => $this->mbtiPublicSummaryV1Builder->buildFromComparePayload([
-                'title' => null,
-                'summary' => null,
-                'axes' => [],
-            ], $locale),
-        ];
-
-        if (in_array($status, ['ready', 'purchased'], true)) {
-            $inviteeAttemptId = trim((string) ($invite->invitee_attempt_id ?? ''));
-            if ($inviteeAttemptId !== '') {
-                $inviteeAttempt = Attempt::query()->where('id', $inviteeAttemptId)->first();
-                if ($inviteeAttempt instanceof Attempt) {
-                    $inviteeResult = Result::query()
-                        ->where('attempt_id', (string) $inviteeAttempt->id)
-                        ->where('org_id', (int) ($inviteeAttempt->org_id ?? 0))
-                        ->first();
-
-                    if ($inviteeResult instanceof Result) {
-                        $inviteePayload = $this->shareService->buildPublicSummaryPayload($inviteeAttempt, $inviteeResult);
-                        $invitee = $this->toSummaryLiteWithProjection(
-                            $inviteePayload,
-                            false,
-                            (int) ($inviteeAttempt->org_id ?? 0),
-                            $locale
-                        );
-                        $compare = $this->buildComparePayload(
-                            $inviter,
-                            $invitee,
-                            $locale
-                        );
-                    }
-                }
-            }
-        }
+        [$inviter, $invitee, $compare] = $this->buildInviteReadContext($invite, $attempt, $result, $locale, true);
 
         $primaryCtaPath = $this->buildTakePath(
             $locale,
@@ -144,6 +105,74 @@ final class MbtiCompareInviteService
             'dyadic_graph_v1' => $this->relationshipSyncContractService->buildGraph($relationshipSync),
             'primary_cta_label' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
             'primary_cta_path' => $primaryCtaPath,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function showPrivate(string $inviteId, mixed $userId, mixed $anonId): array
+    {
+        $invite = MbtiCompareInvite::query()->findOrFail($inviteId);
+        [, $inviterAttempt, $inviterResult] = $this->resolveMbtiShareContext((string) $invite->share_id);
+        $inviterPayload = $this->shareService->buildPublicSummaryPayload($inviterAttempt, $inviterResult, (string) $invite->share_id);
+        $locale = $this->normalizeLocale(
+            $this->nullableString($invite->locale)
+                ?? $this->nullableString($inviterPayload['locale'] ?? null)
+                ?? 'zh-CN'
+        );
+        $status = $this->normalizeStatus((string) ($invite->status ?? 'pending'));
+        $participantContext = $this->resolveParticipantContext($invite, $userId, $anonId);
+        if ($participantContext === null) {
+            throw new ApiProblemException(404, 'PRIVATE_RELATIONSHIP_NOT_FOUND', 'private relationship not found.');
+        }
+
+        [$inviter, $invitee, $compare] = $this->buildInviteReadContext($invite, $inviterAttempt, $inviterResult, $locale, false);
+        $relationshipSync = $this->relationshipSyncContractService->build(
+            $inviter,
+            $invitee,
+            $compare,
+            $status === 'purchased' ? 'ready' : $status,
+            $locale,
+            null
+        );
+
+        $accessState = $this->resolvePrivateAccessState(
+            $status,
+            (bool) ($participantContext['has_invitee'] ?? false),
+            data_get($compare, 'title')
+        );
+        $subjectJoinMode = $this->resolvePrivateJoinMode($status);
+        $participantAttempt = $participantContext['attempt'] ?? null;
+        $privateRelationship = $this->privateRelationshipContractService->buildPrivateRelationship(
+            $inviter,
+            $invitee,
+            $relationshipSync,
+            (string) ($participantContext['participant_role'] ?? 'inviter'),
+            $accessState,
+            $subjectJoinMode,
+            $locale,
+            $participantAttempt instanceof Attempt
+                ? $this->buildProtectedResultPath($locale, (string) $participantAttempt->id)
+                : $this->buildProtectedHistoryPath($locale),
+            $locale === 'zh-CN' ? '进入我的 MBTI 报告' : 'Open my MBTI reports'
+        );
+        $dyadicConsent = $this->privateRelationshipContractService->buildDyadicConsent(
+            $invite,
+            $this->normalizeConsentState($status),
+            $accessState,
+            $subjectJoinMode
+        );
+
+        return [
+            'invite_id' => (string) $invite->id,
+            'share_id' => (string) $invite->share_id,
+            'scale_code' => 'MBTI',
+            'locale' => $locale,
+            'status' => $status,
+            'private_relationship_v1' => $privateRelationship,
+            'dyadic_consent_v1' => $dyadicConsent,
+            'dyadic_graph_v1' => $this->privateRelationshipContractService->buildProtectedGraph($privateRelationship),
         ];
     }
 
@@ -347,6 +376,144 @@ final class MbtiCompareInviteService
         ];
     }
 
+    /**
+     * @return array{0:array<string,mixed>,1:array<string,mixed>,2:array<string,mixed>}
+     */
+    private function buildInviteReadContext(
+        MbtiCompareInvite $invite,
+        Attempt $inviterAttempt,
+        Result $inviterResult,
+        string $locale,
+        bool $includeShareIdForInviter
+    ): array {
+        $share = Share::query()->where('id', (string) $invite->share_id)->first();
+        $inviterPayload = $this->shareService->buildPublicSummaryPayload(
+            $inviterAttempt,
+            $inviterResult,
+            (string) $invite->share_id,
+            $share?->created_at?->toISOString()
+        );
+        $inviter = $this->toSummaryLiteWithProjection(
+            $inviterPayload,
+            $includeShareIdForInviter,
+            (int) ($inviterAttempt->org_id ?? 0),
+            $locale
+        );
+        $invitee = $this->pendingInviteePayload();
+        $compare = [
+            'mbti_public_summary_v1' => $this->mbtiPublicSummaryV1Builder->buildFromComparePayload([
+                'title' => null,
+                'summary' => null,
+                'axes' => [],
+            ], $locale),
+        ];
+
+        $inviteeContext = $this->resolveInviteeContext($invite);
+        if ($inviteeContext !== null) {
+            [$inviteeAttempt, $inviteeResult] = $inviteeContext;
+            $inviteePayload = $this->shareService->buildPublicSummaryPayload($inviteeAttempt, $inviteeResult);
+            $invitee = $this->toSummaryLiteWithProjection(
+                $inviteePayload,
+                false,
+                (int) ($inviteeAttempt->org_id ?? 0),
+                $locale
+            );
+            $compare = $this->buildComparePayload($inviter, $invitee, $locale);
+        }
+
+        return [$inviter, $invitee, $compare];
+    }
+
+    /**
+     * @return array{0:Attempt,1:Result}|null
+     */
+    private function resolveInviteeContext(MbtiCompareInvite $invite): ?array
+    {
+        if (! in_array($this->normalizeStatus((string) ($invite->status ?? 'pending')), ['ready', 'purchased'], true)) {
+            return null;
+        }
+
+        $inviteeAttemptId = trim((string) ($invite->invitee_attempt_id ?? ''));
+        if ($inviteeAttemptId === '') {
+            return null;
+        }
+
+        $inviteeAttempt = Attempt::query()->where('id', $inviteeAttemptId)->first();
+        if (! $inviteeAttempt instanceof Attempt) {
+            return null;
+        }
+
+        $inviteeResult = Result::query()
+            ->where('attempt_id', (string) $inviteeAttempt->id)
+            ->where('org_id', (int) ($inviteeAttempt->org_id ?? 0))
+            ->first();
+
+        if (! $inviteeResult instanceof Result) {
+            return null;
+        }
+
+        return [$inviteeAttempt, $inviteeResult];
+    }
+
+    /**
+     * @return array{participant_role:string,attempt:?Attempt,has_invitee:bool}|null
+     */
+    private function resolveParticipantContext(MbtiCompareInvite $invite, mixed $userId, mixed $anonId): ?array
+    {
+        $normalizedUserId = $this->nullableString($userId);
+        $normalizedAnonId = $this->nullableString($anonId);
+        if ($normalizedUserId === null && $normalizedAnonId === null) {
+            return null;
+        }
+
+        $inviterAttempt = Attempt::query()->where('id', (string) $invite->inviter_attempt_id)->first();
+        $inviteeContext = $this->resolveInviteeContext($invite);
+
+        if ($inviterAttempt instanceof Attempt && $this->attemptBelongsToActor($inviterAttempt, $normalizedUserId, $normalizedAnonId)) {
+            return [
+                'participant_role' => 'inviter',
+                'attempt' => $inviterAttempt,
+                'has_invitee' => $inviteeContext !== null,
+            ];
+        }
+
+        if ($inviteeContext !== null) {
+            [$inviteeAttempt] = $inviteeContext;
+            if ($this->attemptBelongsToActor($inviteeAttempt, $normalizedUserId, $normalizedAnonId)) {
+                return [
+                    'participant_role' => 'invitee',
+                    'attempt' => $inviteeAttempt,
+                    'has_invitee' => true,
+                ];
+            }
+        }
+
+        if (
+            ($normalizedUserId !== null && $normalizedUserId === $this->nullableString($invite->invitee_user_id))
+            || ($normalizedAnonId !== null && $normalizedAnonId === $this->nullableString($invite->invitee_anon_id))
+        ) {
+            return [
+                'participant_role' => 'invitee',
+                'attempt' => $inviteeContext[0] ?? null,
+                'has_invitee' => $inviteeContext !== null,
+            ];
+        }
+
+        return null;
+    }
+
+    private function attemptBelongsToActor(Attempt $attempt, ?string $userId, ?string $anonId): bool
+    {
+        $attemptUserId = $this->nullableString($attempt->user_id ?? null);
+        if ($userId !== null && $attemptUserId !== null && $attemptUserId === $userId) {
+            return true;
+        }
+
+        $attemptAnonId = $this->nullableString($attempt->anon_id ?? null);
+
+        return $anonId !== null && $attemptAnonId !== null && $attemptAnonId === $anonId;
+    }
+
     private function buildTakePath(string $locale, string $shareId, string $inviteId, string $primaryCtaPath): string
     {
         $basePath = trim($primaryCtaPath);
@@ -365,11 +532,58 @@ final class MbtiCompareInviteService
         return '/'.$segment.'/compare/mbti/'.rawurlencode($inviteId);
     }
 
+    private function buildProtectedResultPath(string $locale, string $attemptId): string
+    {
+        $segment = $locale === 'zh-CN' ? 'zh' : 'en';
+
+        return '/'.$segment.'/result/'.rawurlencode($attemptId);
+    }
+
+    private function buildProtectedHistoryPath(string $locale): string
+    {
+        $segment = $locale === 'zh-CN' ? 'zh' : 'en';
+
+        return '/'.$segment.'/history/mbti';
+    }
+
     private function normalizeStatus(string $status): string
     {
         $normalized = strtolower(trim($status));
 
         return in_array($normalized, ['pending', 'ready', 'purchased'], true) ? $normalized : 'pending';
+    }
+
+    private function normalizeConsentState(string $status): string
+    {
+        return match ($status) {
+            'purchased' => 'purchased',
+            'ready' => 'joined',
+            default => 'pending',
+        };
+    }
+
+    private function resolvePrivateAccessState(string $status, bool $hasInvitee, mixed $compareTitle): string
+    {
+        if ($status === 'pending' || ! $hasInvitee) {
+            return 'awaiting_second_subject';
+        }
+
+        if ($status === 'purchased') {
+            return 'private_access_ready';
+        }
+
+        return trim((string) $compareTitle) === ''
+            ? 'private_access_partial'
+            : 'joined_public_only';
+    }
+
+    private function resolvePrivateJoinMode(string $status): string
+    {
+        return match ($status) {
+            'purchased' => 'share_compare_invite_purchased',
+            'ready' => 'share_compare_invite_joined',
+            default => 'share_compare_invite_pending',
+        };
     }
 
     private function normalizeLocale(string $locale): string
@@ -378,7 +592,7 @@ final class MbtiCompareInviteService
     }
 
     /**
-     * @param  array<string, mixed>  $payload
+     * @param  array<string, mixed>  $inviter
      * @param  array<string, mixed>  $invitee
      * @return array<string, mixed>
      */

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -121,6 +121,8 @@ Route::prefix('v0.3')->middleware([
 
     Route::middleware(\App\Http\Middleware\FmTokenAuth::class)->group(function () {
         Route::get('/me/attempts', [MeV03Controller::class, 'attempts']);
+        Route::get('/me/relationships/mbti/{inviteId}', [MbtiCompareInviteController::class, 'showPrivate'])
+            ->middleware('uuid:inviteId');
     });
 
     Route::middleware([

--- a/backend/tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php
+++ b/backend/tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiPrivateRelationshipAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_private_relationship_requires_authenticated_participant_access(): void
+    {
+        $this->seedScales();
+
+        [$inviterAttemptId, $inviterAnonId, $inviterToken] = $this->createOwnerContext('anon_private_inviter', 'INTJ-A');
+        $shareId = $this->createShareViaApi($inviterAttemptId, $inviterAnonId, $inviterToken);
+
+        $invite = $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'utm_source' => 'share',
+        ]);
+        $invite->assertOk();
+
+        $inviteId = (string) $invite->json('invite_id');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer invalid',
+        ])->getJson("/api/v0.3/me/relationships/mbti/{$inviteId}")
+            ->assertUnauthorized();
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviterToken,
+            'X-Anon-Id' => $inviterAnonId,
+        ])->getJson("/api/v0.3/me/relationships/mbti/{$inviteId}")
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('status', 'pending')
+            ->assertJsonPath('private_relationship_v1.relationship_scope', 'private_relationship_protected')
+            ->assertJsonPath('private_relationship_v1.access_state', 'awaiting_second_subject')
+            ->assertJsonPath('private_relationship_v1.participant_role', 'inviter')
+            ->assertJsonPath('dyadic_consent_v1.consent_scope', 'private_relationship_protected')
+            ->assertJsonPath('dyadic_consent_v1.consent_state', 'pending')
+            ->assertJsonPath('dyadic_consent_v1.revocation_state', 'not_supported_yet')
+            ->assertJsonPath('dyadic_consent_v1.expiry_state', 'not_enforced_yet')
+            ->assertJsonMissingPath('private_relationship_v1.invitee_summary.invitee_user_id');
+
+        [$inviteeAttemptId, $inviteeAnonId, $inviteeToken] = $this->createOwnerContext('anon_private_invitee', 'ENFP-T');
+
+        DB::table('mbti_compare_invites')
+            ->where('id', $inviteId)
+            ->update([
+                'invitee_attempt_id' => $inviteeAttemptId,
+                'invitee_anon_id' => $inviteeAnonId,
+                'status' => 'purchased',
+                'accepted_at' => now()->subMinutes(5),
+                'completed_at' => now()->subMinutes(4),
+                'purchased_at' => now()->subMinutes(3),
+            ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviteeToken,
+            'X-Anon-Id' => $inviteeAnonId,
+        ])->getJson("/api/v0.3/me/relationships/mbti/{$inviteId}")
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('status', 'purchased')
+            ->assertJsonPath('private_relationship_v1.access_state', 'private_access_ready')
+            ->assertJsonPath('private_relationship_v1.participant_role', 'invitee')
+            ->assertJsonPath('dyadic_consent_v1.consent_state', 'purchased')
+            ->assertJsonPath('dyadic_consent_v1.access_state', 'private_access_ready')
+            ->assertJsonPath('dyadic_graph_v1.graph_scope', 'private_relationship_protected')
+            ->assertJsonMissingPath('invitee_attempt_id')
+            ->assertJsonMissingPath('invitee_anon_id')
+            ->assertJsonMissingPath('invitee_user_id')
+            ->assertJsonMissingPath('invitee_order_no');
+
+        [, $outsiderAnonId, $outsiderToken] = $this->createOwnerContext('anon_private_outsider', 'INFJ-A');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$outsiderToken,
+            'X-Anon-Id' => $outsiderAnonId,
+        ])->getJson("/api/v0.3/me/relationships/mbti/{$inviteId}")
+            ->assertNotFound()
+            ->assertJsonPath('error_code', 'PRIVATE_RELATIONSHIP_NOT_FOUND');
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createShareViaApi(string $attemptId, string $anonId, string $token): string
+    {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $response->assertOk();
+
+        return (string) $response->json('share_id');
+    }
+
+    /**
+     * @return array{0:string,1:string,2:string}
+     */
+    private function createOwnerContext(string $anonId, string $typeCode): array
+    {
+        $attemptId = $this->createMbtiAttemptWithResult($anonId, $typeCode);
+        $token = $this->issueAnonToken($anonId);
+
+        return [$attemptId, $anonId, $token];
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId, string $typeCode): string
+    {
+        $attemptId = (string) Str::uuid();
+        $resultProfile = match ($typeCode) {
+            'ENFP-T' => [
+                'type_name' => '竞选者型',
+                'summary' => 'Invitee public-safe share summary.',
+                'tagline' => '热情的连接者',
+                'rarity' => '约 8%',
+                'keywords' => ['热情', '灵感', '共情'],
+                'scores_pct' => ['EI' => 72, 'SN' => 74, 'TF' => 41, 'JP' => 38, 'AT' => 43],
+            ],
+            'INFJ-A' => [
+                'type_name' => '提倡者型',
+                'summary' => 'Outsider public-safe share summary.',
+                'tagline' => '安静而坚定',
+                'rarity' => '约 2%',
+                'keywords' => ['洞察', '共情', '结构'],
+                'scores_pct' => ['EI' => 28, 'SN' => 79, 'TF' => 39, 'JP' => 62, 'AT' => 61],
+            ],
+            default => [
+                'type_name' => '建筑师型',
+                'summary' => 'Public-safe share summary.',
+                'tagline' => '冷静的长期规划者',
+                'rarity' => '约 2%',
+                'keywords' => ['战略', '独立', '前瞻'],
+                'scores_pct' => ['EI' => 35, 'SN' => 72, 'TF' => 68, 'JP' => 63, 'AT' => 58],
+            ],
+        };
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => $typeCode,
+            'scores_json' => ['total' => 100],
+            'scores_pct' => $resultProfile['scores_pct'],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'moderate',
+                'AT' => 'moderate',
+            ],
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'type_code' => $typeCode,
+                'type_name' => $resultProfile['type_name'],
+                'summary' => $resultProfile['summary'],
+                'tagline' => $resultProfile['tagline'],
+                'rarity' => $resultProfile['rarity'],
+                'keywords' => $resultProfile['keywords'],
+                'layers' => [
+                    'identity' => [
+                        'body' => 'PRIVATE_PAID_SECTION_BODY',
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+}

--- a/backend/tests/Unit/Services/InsightGraph/PrivateRelationshipContractServiceTest.php
+++ b/backend/tests/Unit/Services/InsightGraph/PrivateRelationshipContractServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\InsightGraph;
+
+use App\Models\MbtiCompareInvite;
+use App\Services\InsightGraph\PrivateRelationshipContractService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class PrivateRelationshipContractServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_private_relationship_and_consent_contracts(): void
+    {
+        $service = new PrivateRelationshipContractService;
+
+        $relationship = $service->buildPrivateRelationship(
+            [
+                'type_code' => 'ENFP-T',
+                'mbti_public_projection_v1' => [
+                    'summary_card' => ['title' => 'Campaigner'],
+                ],
+            ],
+            [
+                'type_code' => 'INFJ-A',
+                'mbti_public_projection_v1' => [
+                    'summary_card' => ['title' => 'Advocate'],
+                ],
+            ],
+            [
+                'shared_count' => 2,
+                'diverging_count' => 2,
+                'overview' => [
+                    'title' => 'Private relationship sync',
+                    'summary' => 'A protected relationship overview.',
+                ],
+                'friction_keys' => ['friction.energy_mismatch'],
+                'complement_keys' => ['complement.heart_head_balance'],
+                'communication_bridge_keys' => ['communication_bridge.energy_pacing'],
+                'decision_tension_keys' => ['decision_tension.logic_vs_empathy'],
+                'stress_interplay_keys' => ['stress_interplay.shared_recovery_rhythm'],
+                'dyadic_action_prompt_keys' => ['dyadic_action.name_decision_rule'],
+                'sections' => [
+                    [
+                        'key' => 'communication_bridge',
+                        'title' => 'Communication bridge',
+                        'summary' => 'Name the response pace.',
+                        'bullets' => ['Say clearly whether you need to think first or speak first.'],
+                    ],
+                ],
+                'action_prompt' => [
+                    'key' => 'dyadic_action.name_decision_rule',
+                    'title' => 'Name the decision rule first',
+                    'summary' => 'Say what each person is optimizing for before debating the answer.',
+                    'cta_label' => 'Open my MBTI reports',
+                    'cta_path' => '/en/result/attempt-001',
+                ],
+            ],
+            'inviter',
+            'private_access_ready',
+            'share_compare_invite_purchased',
+            'en',
+            '/en/result/attempt-001',
+            'Open my MBTI reports'
+        );
+
+        $this->assertSame('private_relationship_protected', $relationship['relationship_scope']);
+        $this->assertSame('private.relationship.v1', $relationship['relationship_contract_version']);
+        $this->assertSame('private_access_ready', $relationship['access_state']);
+        $this->assertSame('share_compare_invite_purchased', $relationship['subject_join_mode']);
+        $this->assertSame('inviter', $relationship['participant_role']);
+        $this->assertSame('Private relationship sync', data_get($relationship, 'overview.title'));
+        $this->assertSame('communication_bridge', data_get($relationship, 'private_sync_sections.0.key'));
+        $this->assertSame('dyadic_action.name_decision_rule', data_get($relationship, 'private_action_prompt.key'));
+        $this->assertNotSame('', (string) ($relationship['relationship_fingerprint'] ?? ''));
+
+        $invite = new MbtiCompareInvite;
+        $invite->accepted_at = Carbon::parse('2026-03-21T08:00:00+08:00');
+        $invite->completed_at = Carbon::parse('2026-03-21T08:05:00+08:00');
+        $invite->purchased_at = Carbon::parse('2026-03-21T08:10:00+08:00');
+
+        $consent = $service->buildDyadicConsent(
+            $invite,
+            'purchased',
+            'private_access_ready',
+            'share_compare_invite_purchased'
+        );
+
+        $this->assertSame('private_relationship_protected', $consent['consent_scope']);
+        $this->assertSame('purchased', $consent['consent_state']);
+        $this->assertSame('not_supported_yet', $consent['revocation_state']);
+        $this->assertSame('not_enforced_yet', $consent['expiry_state']);
+        $this->assertSame('dyadic.consent.v1', $consent['consent_artifact_version']);
+
+        $graph = $service->buildProtectedGraph($relationship);
+
+        $this->assertSame('private_relationship_protected', $graph['graph_scope']);
+        $this->assertSame('dyadic.graph.v1', $graph['graph_contract_version']);
+        $this->assertSame('private_relationship', $graph['root_node']);
+        $this->assertSame('MBTI', data_get($graph, 'supporting_scales.0'));
+        $this->assertNotEmpty($graph['nodes']);
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-11D: private relationship surface and consent ledger foundation.

It upgrades the existing MBTI compare-invite lifecycle from public-safe dyadic compare into the first protected/private relationship surface, while keeping scope strictly MBTI-only, dyadic-only, and lifecycle-derived.

## Problem

PR-11B already established a public-safe dyadic foundation:

- compare-invite lifecycle
- `relationship_sync_v1`
- additive `dyadic_graph_v1`
- compare attribution / attach / purchase status

But the platform still stopped at a public-safe compare surface.

There was no protected/private dyadic read path for the two participants, and no explicit consent/access contract saying when private relationship access was available, what scope it was in, or what lifecycle state it was derived from.

That meant the platform could explain a dyad publicly, but not yet expose a participant-only private relationship surface.

## Root cause

The repo already had the right primitives in `MbtiCompareInvite`:

- `status`
- `accepted_at`
- `completed_at`
- `purchased_at`
- invitee attach fields

But it lacked:

- a protected route under the existing auth family
- a backend-owned private relationship contract
- a backend-owned consent artifact derived from the invite lifecycle

Without that layer, the compare foundation still had no first-class private relationship surface.

## Fix

This PR adds a protected dyadic read path under the existing `FmTokenAuth` family:

- `GET /api/v0.3/me/relationships/mbti/{inviteId}`

It then adds two first-wave contracts:

- `private_relationship_v1`
- `dyadic_consent_v1`

And an additive protected graph contract:

- protected `dyadic_graph_v1`

The implementation stays intentionally constrained:

- access is limited to valid invite participants only
- consent/access state is derived from the existing compare-invite lifecycle
- no new auth system
- no new ledger table
- no revoke / expiry implementation beyond explicit contract placeholders
- public-safe compare remains unchanged

`private_relationship_v1` includes:

- `relationship_scope`
- `relationship_contract_version`
- `relationship_fingerprint`
- `access_state`
- `subject_join_mode`
- `participant_role`
- `inviter_summary`
- `invitee_summary`
- `private_sync_sections`
- `private_action_prompt`

`dyadic_consent_v1` includes:

- `consent_scope`
- `access_state`
- `consent_state`
- `revocation_state`
- `expiry_state`
- `subject_join_mode`
- `accepted_at`
- `completed_at`
- `purchased_at`
- `consent_artifact_version`

## User impact

The compare-invite lifecycle now has its first participant-only relationship surface.

Both sides can keep using the public-safe compare page for lightweight sharing, while authenticated participants can access a protected/private dyadic summary, richer sync sections, and a private action prompt without exposing hidden identifiers or raw result payloads.

## Validation

I ran:

- `php artisan test tests/Unit/Services/InsightGraph/PrivateRelationshipContractServiceTest.php tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`

All passed:

- 5 tests passed
- 234 assertions

## Scope note

This PR is intentionally limited to the first protected/private dyadic layer.

It does not add:

- Big Five dyadic
- revoke / expiry system implementation
- chat / notifications / messaging
- friend graph / social feed
- multi-party relationship graphs
- a second auth system

It also does not touch task-external dirty files already present in the backend worktree.
