### PR TITLE
[codex] unblock openapi snapshot drift for private relationship route

### DIFF
--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -778,6 +778,27 @@
                 ]
             }
         },
+        "/api/v0.3/me/relationships/mbti/{inviteId}": {
+            "get": {
+                "operationId": "get_api_v0_3_me_relationships_mbti_inviteid_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\MbtiCompareInviteController@showPrivate",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:inviteId"
+                ]
+            }
+        },
         "/api/v0.3/orders": {
             "post": {
                 "operationId": "post_api_v0_3_orders",


### PR DESCRIPTION
## Summary
- refresh `backend/docs/contracts/openapi.snapshot.json` to match the current clean `main` route contract
- unblock the OpenAPI diff gate for the already-shipped private relationship endpoint `/api/v0.3/me/relationships/mbti/{inviteId}`
- keep the fix minimal by changing only the generated snapshot file

## Root cause
`/api/v0.3/me/relationships/mbti/{inviteId}` is already part of the real route contract on clean `main`.
It was introduced by the private relationship backend changes in `backend/routes/api.php` and `App\\Http\\Controllers\\API\\V0_3\\MbtiCompareInviteController@showPrivate`, and it already has feature coverage in `tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php`.

The OpenAPI gate was failing because `backend/docs/contracts/openapi.snapshot.json` had not been refreshed after that route landed.

## Exact contract changed
- no route contract change
- no controller behavior change
- no storage/runtime/scheduler/schema change
- only the generated OpenAPI snapshot was refreshed to include:
  - `GET /api/v0.3/me/relationships/mbti/{inviteId}`
  - action: `App\\Http\\Controllers\\API\\V0_3\\MbtiCompareInviteController@showPrivate`
  - middleware: `api`, `throttle:api_public`, `NormalizeApiErrorContract`, `FmTokenAuth`, `EnsureUuidRouteParams:inviteId`

## Validation
- `php artisan route:list > /tmp/pr29c_route_list.txt`
- `php artisan migrate`
- `bash scripts/export_openapi.sh --check`
- `php artisan test --filter OpenApiDiffTest --stop-on-failure`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`

## Scope
- one-file CI unblock only
- no unrelated business logic changes
- no main worktree pollution; patch built and verified in a clean worktree
