### PR TITLE
[codex] Ship PR-11E dyadic consent lifecycle and access revocation foundation (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\V0_3\CreateMbtiCompareInviteRequest;
 use App\Services\V0_3\MbtiCompareInviteService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 final class MbtiCompareInviteController extends Controller
 {
@@ -34,6 +35,22 @@ final class MbtiCompareInviteController extends Controller
             $inviteId,
             $request->attributes->get('user_id'),
             $request->attributes->get('anon_id')
+        );
+
+        return response()->json(array_merge(['ok' => true], $result));
+    }
+
+    public function mutatePrivateConsent(Request $request, string $inviteId): JsonResponse
+    {
+        $validated = $request->validate([
+            'action' => ['required', 'string', Rule::in(['revoke_access', 'acknowledge_refresh'])],
+        ]);
+
+        $result = $this->service->mutatePrivateConsent(
+            $inviteId,
+            $request->attributes->get('user_id'),
+            $request->attributes->get('anon_id'),
+            $validated
         );
 
         return response()->json(array_merge(['ok' => true], $result));

--- a/backend/app/Services/InsightGraph/PrivateRelationshipContractService.php
+++ b/backend/app/Services/InsightGraph/PrivateRelationshipContractService.php
@@ -80,16 +80,43 @@ final class PrivateRelationshipContractService
         MbtiCompareInvite $invite,
         string $consentState,
         string $accessState,
-        string $subjectJoinMode
+        string $subjectJoinMode,
+        string $currentConsentPolicyVersion,
+        array $lifecycle = []
     ): array {
+        $revocationState = $this->normalizeText($lifecycle['revocation_state'] ?? null) ?? 'active';
+        $expiryState = $this->normalizeText($lifecycle['expiry_state'] ?? null) ?? 'active';
+        $consentRefreshRequired = (bool) ($lifecycle['consent_refresh_required'] ?? false);
+        $privateRelationshipAccessVersion = $this->normalizeText($lifecycle['private_relationship_access_version'] ?? null)
+            ?? 'private.relationship.access.v1';
+        $consentPolicyVersion = $this->normalizeText($lifecycle['consent_policy_version'] ?? null) ?? $currentConsentPolicyVersion;
+
+        $fingerprintSeed = [
+            'scope' => 'private_relationship_protected',
+            'consent_state' => $consentState,
+            'access_state' => $accessState,
+            'revocation_state' => $revocationState,
+            'expiry_state' => $expiryState,
+            'subject_join_mode' => $subjectJoinMode,
+            'consent_refresh_required' => $consentRefreshRequired,
+            'private_relationship_access_version' => $privateRelationshipAccessVersion,
+            'consent_policy_version' => $consentPolicyVersion,
+            'accepted_at' => $invite->accepted_at?->toISOString(),
+            'completed_at' => $invite->completed_at?->toISOString(),
+            'purchased_at' => $invite->purchased_at?->toISOString(),
+        ];
+
         return [
             'version' => 'dyadic.consent.v1',
             'consent_scope' => 'private_relationship_protected',
             'access_state' => $accessState,
             'consent_state' => $consentState,
-            'revocation_state' => 'not_supported_yet',
-            'expiry_state' => 'not_enforced_yet',
+            'revocation_state' => $revocationState,
+            'expiry_state' => $expiryState,
             'subject_join_mode' => $subjectJoinMode,
+            'consent_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'consent_refresh_required' => $consentRefreshRequired,
+            'private_relationship_access_version' => $privateRelationshipAccessVersion,
             'accepted_at' => $invite->accepted_at?->toISOString(),
             'completed_at' => $invite->completed_at?->toISOString(),
             'purchased_at' => $invite->purchased_at?->toISOString(),

--- a/backend/app/Services/V0_3/MbtiCompareInviteService.php
+++ b/backend/app/Services/V0_3/MbtiCompareInviteService.php
@@ -128,6 +128,8 @@ final class MbtiCompareInviteService
         }
 
         [$inviter, $invitee, $compare] = $this->buildInviteReadContext($invite, $inviterAttempt, $inviterResult, $locale, false);
+        $currentConsentPolicyVersion = $this->resolvePrivacyPolicyVersion($inviterAttempt);
+        $consentLifecycle = $this->resolveDyadicConsentLifecycle($invite, $currentConsentPolicyVersion);
         $relationshipSync = $this->relationshipSyncContractService->build(
             $inviter,
             $invitee,
@@ -140,9 +142,16 @@ final class MbtiCompareInviteService
         $accessState = $this->resolvePrivateAccessState(
             $status,
             (bool) ($participantContext['has_invitee'] ?? false),
-            data_get($compare, 'title')
+            data_get($compare, 'title'),
+            $consentLifecycle
         );
         $subjectJoinMode = $this->resolvePrivateJoinMode($status);
+        $relationshipSync = $this->applyPrivateAccessRestrictions(
+            $relationshipSync,
+            $accessState,
+            $locale,
+            (bool) ($consentLifecycle['consent_refresh_required'] ?? false)
+        );
         $participantAttempt = $participantContext['attempt'] ?? null;
         $privateRelationship = $this->privateRelationshipContractService->buildPrivateRelationship(
             $inviter,
@@ -161,7 +170,11 @@ final class MbtiCompareInviteService
             $invite,
             $this->normalizeConsentState($status),
             $accessState,
-            $subjectJoinMode
+            $subjectJoinMode,
+            $currentConsentPolicyVersion,
+            $consentLifecycle + [
+                'private_relationship_access_version' => 'private.relationship.access.v1',
+            ]
         );
 
         return [
@@ -174,6 +187,50 @@ final class MbtiCompareInviteService
             'dyadic_consent_v1' => $dyadicConsent,
             'dyadic_graph_v1' => $this->privateRelationshipContractService->buildProtectedGraph($privateRelationship),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    public function mutatePrivateConsent(string $inviteId, mixed $userId, mixed $anonId, array $payload): array
+    {
+        $invite = MbtiCompareInvite::query()->findOrFail($inviteId);
+        [, $inviterAttempt] = $this->resolveMbtiShareContext((string) $invite->share_id);
+        $participantContext = $this->resolveParticipantContext($invite, $userId, $anonId);
+        if ($participantContext === null) {
+            throw new ApiProblemException(404, 'PRIVATE_RELATIONSHIP_NOT_FOUND', 'private relationship not found.');
+        }
+
+        $action = strtolower(trim((string) ($payload['action'] ?? '')));
+        $currentConsentPolicyVersion = $this->resolvePrivacyPolicyVersion($inviterAttempt);
+        $lifecycle = $this->resolveDyadicConsentLifecycle($invite, $currentConsentPolicyVersion);
+        $participantRole = (string) ($participantContext['participant_role'] ?? 'inviter');
+
+        switch ($action) {
+            case 'revoke_access':
+                $lifecycle['revocation_state'] = 'revoked_by_subject';
+                $lifecycle['revoked_at'] = now()->toISOString();
+                $lifecycle['revoked_by_role'] = $participantRole;
+                break;
+
+            case 'acknowledge_refresh':
+                $lifecycle['consent_policy_version'] = $currentConsentPolicyVersion;
+                $lifecycle['acknowledged_at'] = now()->toISOString();
+                $lifecycle['consent_refresh_required'] = false;
+                if (($lifecycle['expiry_state'] ?? 'active') === 'expired') {
+                    $lifecycle['expiry_state'] = 'active';
+                    $lifecycle['expires_at'] = null;
+                }
+                break;
+
+            default:
+                throw new ApiProblemException(422, 'DYADIC_CONSENT_ACTION_INVALID', 'dyadic consent action invalid.');
+        }
+
+        $this->persistDyadicConsentLifecycle($invite, $lifecycle);
+
+        return $this->showPrivate($inviteId, $userId, $anonId);
     }
 
     public function attachInviteeFromSubmit(
@@ -562,10 +619,21 @@ final class MbtiCompareInviteService
         };
     }
 
-    private function resolvePrivateAccessState(string $status, bool $hasInvitee, mixed $compareTitle): string
+    /**
+     * @param  array<string,mixed>  $consentLifecycle
+     */
+    private function resolvePrivateAccessState(string $status, bool $hasInvitee, mixed $compareTitle, array $consentLifecycle = []): string
     {
         if ($status === 'pending' || ! $hasInvitee) {
             return 'awaiting_second_subject';
+        }
+
+        if (($consentLifecycle['revocation_state'] ?? 'active') === 'revoked_by_subject') {
+            return 'private_access_revoked';
+        }
+
+        if (($consentLifecycle['expiry_state'] ?? 'active') === 'expired') {
+            return 'private_access_expired';
         }
 
         if ($status === 'purchased') {
@@ -707,6 +775,133 @@ final class MbtiCompareInviteService
     private function normalizeMeta(mixed $meta): array
     {
         return is_array($meta) ? $meta : [];
+    }
+
+    private function resolvePrivacyPolicyVersion(Attempt $attempt): string
+    {
+        $region = $this->nullableString($attempt->region ?? null)
+            ?? $this->nullableString(config('regions.default_region', 'CN_MAINLAND'))
+            ?? 'CN_MAINLAND';
+
+        return $this->nullableString(
+            data_get(config('regions.regions'), "{$region}.policy_versions.privacy")
+        ) ?? '2026-01-01';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function resolveDyadicConsentLifecycle(MbtiCompareInvite $invite, string $currentConsentPolicyVersion): array
+    {
+        $meta = $this->normalizeMeta($invite->meta_json ?? null);
+        $overlay = $this->normalizeMeta($meta['dyadic_consent_lifecycle_v1'] ?? null);
+
+        $expiresAt = $this->nullableString($overlay['expires_at'] ?? null);
+        $expiryState = $this->nullableString($overlay['expiry_state'] ?? null) ?? 'active';
+        if ($expiresAt !== null && $expiryState !== 'expired') {
+            try {
+                if (Carbon::parse($expiresAt)->isPast()) {
+                    $expiryState = 'expired';
+                }
+            } catch (\Throwable) {
+                $expiresAt = null;
+            }
+        }
+
+        $storedPolicyVersion = $this->nullableString($overlay['consent_policy_version'] ?? null);
+        $consentRefreshRequired = filter_var(
+            $overlay['consent_refresh_required'] ?? false,
+            FILTER_VALIDATE_BOOLEAN,
+            FILTER_NULL_ON_FAILURE
+        ) ?? false;
+        if ($storedPolicyVersion !== null && $storedPolicyVersion !== $currentConsentPolicyVersion) {
+            $consentRefreshRequired = true;
+        }
+
+        return [
+            'revocation_state' => $this->nullableString($overlay['revocation_state'] ?? null) === 'revoked_by_subject'
+                ? 'revoked_by_subject'
+                : 'active',
+            'revoked_at' => $this->nullableString($overlay['revoked_at'] ?? null),
+            'revoked_by_role' => $this->nullableString($overlay['revoked_by_role'] ?? null),
+            'expiry_state' => $expiryState === 'expired' ? 'expired' : 'active',
+            'expires_at' => $expiresAt,
+            'consent_policy_version' => $storedPolicyVersion,
+            'acknowledged_at' => $this->nullableString($overlay['acknowledged_at'] ?? null),
+            'consent_refresh_required' => $consentRefreshRequired,
+            'private_relationship_access_version' => 'private.relationship.access.v1',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $relationshipSync
+     * @return array<string,mixed>
+     */
+    private function applyPrivateAccessRestrictions(
+        array $relationshipSync,
+        string $accessState,
+        string $locale,
+        bool $consentRefreshRequired
+    ): array {
+        if (! in_array($accessState, ['private_access_revoked', 'private_access_expired'], true)) {
+            return $relationshipSync;
+        }
+
+        $title = $locale === 'zh-CN'
+            ? '私密关系访问已收紧'
+            : 'Private relationship access has tightened';
+        $summary = match ($accessState) {
+            'private_access_expired' => $locale === 'zh-CN'
+                ? '这段私密关系访问已过期。继续查看前，需要先刷新这次双人访问授权。'
+                : 'This private relationship access has expired. Refresh the dyadic consent before viewing private sections again.',
+            default => $locale === 'zh-CN'
+                ? '其中一方已撤回私密访问。当前仅保留最小关系状态，不再继续显示私密同步内容。'
+                : 'One participant revoked private access. Only the minimum relationship status remains visible and private sync sections are withheld.',
+        };
+
+        if ($consentRefreshRequired && $accessState !== 'private_access_revoked') {
+            $summary .= $locale === 'zh-CN'
+                ? ' 当前还需要确认最新隐私与访问条款。'
+                : ' The latest privacy and access terms also need acknowledgment.';
+        }
+
+        return [
+            'shared_count' => $relationshipSync['shared_count'] ?? null,
+            'diverging_count' => $relationshipSync['diverging_count'] ?? null,
+            'overview' => [
+                'title' => $title,
+                'summary' => $summary,
+            ],
+            'friction_keys' => [],
+            'complement_keys' => [],
+            'communication_bridge_keys' => [],
+            'decision_tension_keys' => [],
+            'stress_interplay_keys' => [],
+            'dyadic_action_prompt_keys' => [],
+            'sections' => [],
+            'action_prompt' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $lifecycle
+     */
+    private function persistDyadicConsentLifecycle(MbtiCompareInvite $invite, array $lifecycle): void
+    {
+        $meta = $this->normalizeMeta($invite->meta_json ?? null);
+        $meta['dyadic_consent_lifecycle_v1'] = [
+            'revocation_state' => $this->nullableString($lifecycle['revocation_state'] ?? null) ?? 'active',
+            'revoked_at' => $this->nullableString($lifecycle['revoked_at'] ?? null),
+            'revoked_by_role' => $this->nullableString($lifecycle['revoked_by_role'] ?? null),
+            'expiry_state' => $this->nullableString($lifecycle['expiry_state'] ?? null) ?? 'active',
+            'expires_at' => $this->nullableString($lifecycle['expires_at'] ?? null),
+            'consent_policy_version' => $this->nullableString($lifecycle['consent_policy_version'] ?? null),
+            'acknowledged_at' => $this->nullableString($lifecycle['acknowledged_at'] ?? null),
+            'consent_refresh_required' => (bool) ($lifecycle['consent_refresh_required'] ?? false),
+        ];
+
+        $invite->meta_json = $meta;
+        $invite->save();
     }
 
     private function nullableString(mixed $value): ?string

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -123,6 +123,8 @@ Route::prefix('v0.3')->middleware([
         Route::get('/me/attempts', [MeV03Controller::class, 'attempts']);
         Route::get('/me/relationships/mbti/{inviteId}', [MbtiCompareInviteController::class, 'showPrivate'])
             ->middleware('uuid:inviteId');
+        Route::post('/me/relationships/mbti/{inviteId}/consent', [MbtiCompareInviteController::class, 'mutatePrivateConsent'])
+            ->middleware('uuid:inviteId');
     });
 
     Route::middleware([

--- a/backend/tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php
+++ b/backend/tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php
@@ -50,8 +50,9 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
             ->assertJsonPath('private_relationship_v1.participant_role', 'inviter')
             ->assertJsonPath('dyadic_consent_v1.consent_scope', 'private_relationship_protected')
             ->assertJsonPath('dyadic_consent_v1.consent_state', 'pending')
-            ->assertJsonPath('dyadic_consent_v1.revocation_state', 'not_supported_yet')
-            ->assertJsonPath('dyadic_consent_v1.expiry_state', 'not_enforced_yet')
+            ->assertJsonPath('dyadic_consent_v1.revocation_state', 'active')
+            ->assertJsonPath('dyadic_consent_v1.expiry_state', 'active')
+            ->assertJsonPath('dyadic_consent_v1.private_relationship_access_version', 'private.relationship.access.v1')
             ->assertJsonMissingPath('private_relationship_v1.invitee_summary.invitee_user_id');
 
         [$inviteeAttemptId, $inviteeAnonId, $inviteeToken] = $this->createOwnerContext('anon_private_invitee', 'ENFP-T');
@@ -78,6 +79,8 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
             ->assertJsonPath('private_relationship_v1.participant_role', 'invitee')
             ->assertJsonPath('dyadic_consent_v1.consent_state', 'purchased')
             ->assertJsonPath('dyadic_consent_v1.access_state', 'private_access_ready')
+            ->assertJsonPath('dyadic_consent_v1.revocation_state', 'active')
+            ->assertJsonPath('dyadic_consent_v1.expiry_state', 'active')
             ->assertJsonPath('dyadic_graph_v1.graph_scope', 'private_relationship_protected')
             ->assertJsonMissingPath('invitee_attempt_id')
             ->assertJsonMissingPath('invitee_anon_id')
@@ -92,6 +95,108 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
         ])->getJson("/api/v0.3/me/relationships/mbti/{$inviteId}")
             ->assertNotFound()
             ->assertJsonPath('error_code', 'PRIVATE_RELATIONSHIP_NOT_FOUND');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$outsiderToken,
+            'X-Anon-Id' => $outsiderAnonId,
+        ])->postJson("/api/v0.3/me/relationships/mbti/{$inviteId}/consent", [
+            'action' => 'revoke_access',
+        ])->assertNotFound()
+            ->assertJsonPath('error_code', 'PRIVATE_RELATIONSHIP_NOT_FOUND');
+    }
+
+    public function test_private_relationship_lifecycle_overlay_restricts_access_and_supports_consent_mutation(): void
+    {
+        $this->seedScales();
+
+        [$inviterAttemptId, $inviterAnonId, $inviterToken] = $this->createOwnerContext('anon_private_lifecycle_inviter', 'INTJ-A');
+        $shareId = $this->createShareViaApi($inviterAttemptId, $inviterAnonId, $inviterToken);
+
+        $invite = $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'utm_source' => 'share',
+        ]);
+        $invite->assertOk();
+
+        $inviteId = (string) $invite->json('invite_id');
+
+        [$inviteeAttemptId, $inviteeAnonId, $inviteeToken] = $this->createOwnerContext('anon_private_lifecycle_invitee', 'ENFP-T');
+
+        DB::table('mbti_compare_invites')
+            ->where('id', $inviteId)
+            ->update([
+                'invitee_attempt_id' => $inviteeAttemptId,
+                'invitee_anon_id' => $inviteeAnonId,
+                'status' => 'purchased',
+                'accepted_at' => now()->subMinutes(5),
+                'completed_at' => now()->subMinutes(4),
+                'purchased_at' => now()->subMinutes(3),
+            ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviterToken,
+            'X-Anon-Id' => $inviterAnonId,
+        ])->postJson("/api/v0.3/me/relationships/mbti/{$inviteId}/consent", [
+            'action' => 'revoke_access',
+        ])->assertOk()
+            ->assertJsonPath('dyadic_consent_v1.revocation_state', 'revoked_by_subject')
+            ->assertJsonPath('dyadic_consent_v1.access_state', 'private_access_revoked')
+            ->assertJsonPath('private_relationship_v1.access_state', 'private_access_revoked')
+            ->assertJsonCount(0, 'private_relationship_v1.private_sync_sections')
+            ->assertJsonMissingPath('private_relationship_v1.private_action_prompt.key');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviteeToken,
+            'X-Anon-Id' => $inviteeAnonId,
+        ])->getJson("/api/v0.3/me/relationships/mbti/{$inviteId}")
+            ->assertOk()
+            ->assertJsonPath('dyadic_consent_v1.revocation_state', 'revoked_by_subject')
+            ->assertJsonPath('dyadic_consent_v1.access_state', 'private_access_revoked')
+            ->assertJsonCount(0, 'private_relationship_v1.private_sync_sections');
+
+        DB::table('mbti_compare_invites')
+            ->where('id', $inviteId)
+            ->update([
+                'meta_json' => json_encode([
+                    'dyadic_consent_lifecycle_v1' => [
+                        'revocation_state' => 'active',
+                        'expiry_state' => 'expired',
+                        'expires_at' => now()->subMinute()->toISOString(),
+                        'consent_policy_version' => '2025-01-01',
+                    ],
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviteeToken,
+            'X-Anon-Id' => $inviteeAnonId,
+        ])->getJson("/api/v0.3/me/relationships/mbti/{$inviteId}")
+            ->assertOk()
+            ->assertJsonPath('dyadic_consent_v1.expiry_state', 'expired')
+            ->assertJsonPath('dyadic_consent_v1.access_state', 'private_access_expired')
+            ->assertJsonPath('dyadic_consent_v1.consent_refresh_required', true)
+            ->assertJsonCount(0, 'private_relationship_v1.private_sync_sections');
+
+        $refresh = $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviteeToken,
+            'X-Anon-Id' => $inviteeAnonId,
+        ])->postJson("/api/v0.3/me/relationships/mbti/{$inviteId}/consent", [
+            'action' => 'acknowledge_refresh',
+        ]);
+
+        $refresh->assertOk()
+            ->assertJsonPath('dyadic_consent_v1.expiry_state', 'active')
+            ->assertJsonPath('dyadic_consent_v1.consent_refresh_required', false)
+            ->assertJsonPath('dyadic_consent_v1.access_state', 'private_access_ready')
+            ->assertJsonPath('private_relationship_v1.access_state', 'private_access_ready');
+
+        $row = DB::table('mbti_compare_invites')->where('id', $inviteId)->first();
+        $meta = is_object($row) ? (array) json_decode((string) ($row->meta_json ?? '{}'), true) : [];
+        $overlay = is_array($meta['dyadic_consent_lifecycle_v1'] ?? null) ? $meta['dyadic_consent_lifecycle_v1'] : [];
+        $this->assertSame('active', (string) ($overlay['expiry_state'] ?? ''));
+        $this->assertNotNull($overlay['acknowledged_at'] ?? null);
     }
 
     private function seedScales(): void

--- a/backend/tests/Unit/Services/InsightGraph/PrivateRelationshipContractServiceTest.php
+++ b/backend/tests/Unit/Services/InsightGraph/PrivateRelationshipContractServiceTest.php
@@ -87,14 +87,25 @@ final class PrivateRelationshipContractServiceTest extends TestCase
             $invite,
             'purchased',
             'private_access_ready',
-            'share_compare_invite_purchased'
+            'share_compare_invite_purchased',
+            '2026-01-01',
+            [
+                'revocation_state' => 'active',
+                'expiry_state' => 'active',
+                'consent_refresh_required' => false,
+                'private_relationship_access_version' => 'private.relationship.access.v1',
+                'consent_policy_version' => '2026-01-01',
+            ]
         );
 
         $this->assertSame('private_relationship_protected', $consent['consent_scope']);
         $this->assertSame('purchased', $consent['consent_state']);
-        $this->assertSame('not_supported_yet', $consent['revocation_state']);
-        $this->assertSame('not_enforced_yet', $consent['expiry_state']);
+        $this->assertSame('active', $consent['revocation_state']);
+        $this->assertSame('active', $consent['expiry_state']);
         $this->assertSame('dyadic.consent.v1', $consent['consent_artifact_version']);
+        $this->assertSame('private.relationship.access.v1', $consent['private_relationship_access_version']);
+        $this->assertFalse($consent['consent_refresh_required']);
+        $this->assertNotSame('', (string) ($consent['consent_fingerprint'] ?? ''));
 
         $graph = $service->buildProtectedGraph($relationship);
 


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-11E: dyadic consent lifecycle and access revocation foundation.

It upgrades `dyadic_consent_v1` from a placeholder derived contract into the first operational consent lifecycle for protected/private MBTI relationships, while keeping scope strictly limited to the existing compare-invite authority and protected relationship surface.

## What changed

Backend:
- keeps the public compare path unchanged
- keeps the existing protected/private relationship read path as the only private consent read surface
- adds a minimal protected consent mutation route under the existing auth family
- upgrades `dyadic_consent_v1` with:
  - `consent_fingerprint`
  - `consent_refresh_required`
  - non-placeholder `revocation_state`
  - non-placeholder `expiry_state`
  - `private_relationship_access_version`
- persists lifecycle overlay in `MbtiCompareInvite.meta_json`
- enforces revoked/expired access on the backend by tightening the private relationship payload

## Guardrails

- no migration
- no new dependency
- no new auth system
- no consent ledger table
- no revoke history system
- no expiry scheduler
- no Big Five dyadic
- no social/feed/chat/friend graph expansion
- public-safe compare remains separate and unchanged

## Validation

I ran:

- `php artisan test tests/Unit/Services/InsightGraph/PrivateRelationshipContractServiceTest.php tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`

All passed:
- 6 tests passed
- 266 assertions
