### PR TITLE
[codex] unblock openapi snapshot drift for consent route

### DIFF
--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -799,6 +799,27 @@
                 ]
             }
         },
+        "/api/v0.3/me/relationships/mbti/{inviteId}/consent": {
+            "post": {
+                "operationId": "post_api_v0_3_me_relationships_mbti_inviteid_consent",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\MbtiCompareInviteController@mutatePrivateConsent",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:inviteId"
+                ]
+            }
+        },
         "/api/v0.3/orders": {
             "post": {
                 "operationId": "post_api_v0_3_orders",


### PR DESCRIPTION
## Summary
- refresh the OpenAPI snapshot for the private relationship consent route
- keep the runtime contract unchanged
- restore the OpenAPI diff gate on main

## Validation
- php artisan route:list > /tmp/pr29d_route_list.txt
- php artisan migrate
- bash scripts/export_openapi.sh --check
- php artisan test --filter OpenApiDiffTest --stop-on-failure
- php artisan serve --host=127.0.0.1 --port=18081
- curl -i http://127.0.0.1:18081/api/healthz
- bash backend/scripts/ci_verify_mbti.sh
