### PR TITLE
[codex] Ship PR-11F private relationship journey and dyadic action loop (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
@@ -55,4 +55,20 @@ final class MbtiCompareInviteController extends Controller
 
         return response()->json(array_merge(['ok' => true], $result));
     }
+
+    public function mutatePrivateJourney(Request $request, string $inviteId): JsonResponse
+    {
+        $validated = $request->validate([
+            'action' => ['required', 'string', Rule::in(['continue_dyadic_action', 'acknowledge_dyadic_pulse'])],
+        ]);
+
+        $result = $this->service->mutatePrivateJourney(
+            $inviteId,
+            $request->attributes->get('user_id'),
+            $request->attributes->get('anon_id'),
+            $validated
+        );
+
+        return response()->json(array_merge(['ok' => true], $result));
+    }
 }

--- a/backend/app/Services/InsightGraph/PrivateRelationshipJourneyContractService.php
+++ b/backend/app/Services/InsightGraph/PrivateRelationshipJourneyContractService.php
@@ -1,0 +1,491 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InsightGraph;
+
+final class PrivateRelationshipJourneyContractService
+{
+    private const JOURNEY_VERSION = 'private_relationship_journey.v1';
+    private const JOURNEY_FINGERPRINT_VERSION = 'private_relationship_journey.fp.v1';
+    private const PULSE_VERSION = 'dyadic_pulse_check.v1';
+    private const JOURNEY_SCOPE = 'private_relationship_revisit';
+
+    /**
+     * @param  array<string,mixed>  $privateRelationship
+     * @param  array<string,mixed>  $dyadicConsent
+     * @param  array<string,mixed>  $overlay
+     * @return array<string,mixed>
+     */
+    public function buildJourney(array $privateRelationship, array $dyadicConsent, array $overlay): array
+    {
+        if ($privateRelationship === []) {
+            return [];
+        }
+
+        $accessState = $this->normalizeText($dyadicConsent['access_state'] ?? null, $privateRelationship['access_state'] ?? null);
+        $consentRefreshRequired = (bool) ($dyadicConsent['consent_refresh_required'] ?? false);
+        $completedDyadicActionKeys = $this->normalizeStringList($overlay['completed_dyadic_action_keys'] ?? []);
+        if (in_array($accessState, ['awaiting_second_subject', 'private_access_revoked', 'private_access_expired'], true)) {
+            $completedDyadicActionKeys = [];
+        }
+
+        $dyadicActionFocusKey = $this->resolveActionFocusKey($privateRelationship, $accessState);
+        $journeyState = $this->resolveJourneyState($accessState, $consentRefreshRequired, $completedDyadicActionKeys, $overlay);
+        $progressState = $this->resolveProgressState($accessState, $completedDyadicActionKeys, $overlay);
+        $recommendedNextDyadicPulseKeys = $this->resolveRecommendedNextPulseKeys(
+            $privateRelationship,
+            $dyadicActionFocusKey,
+            $journeyState,
+            $accessState,
+            $consentRefreshRequired,
+            $completedDyadicActionKeys,
+            $overlay
+        );
+        $revisitReorderReason = $this->resolveRevisitReorderReason(
+            $journeyState,
+            $accessState,
+            $consentRefreshRequired,
+            $completedDyadicActionKeys,
+            $privateRelationship,
+            $overlay
+        );
+        $lastDyadicPulseSignal = $this->normalizeText($overlay['last_dyadic_pulse_signal'] ?? null)
+            ?? $this->deriveLastPulseSignal($journeyState, $consentRefreshRequired);
+
+        $fingerprintSeed = [
+            'journey_scope' => self::JOURNEY_SCOPE,
+            'journey_state' => $journeyState,
+            'progress_state' => $progressState,
+            'dyadic_action_focus_key' => $dyadicActionFocusKey,
+            'completed_dyadic_action_keys' => $completedDyadicActionKeys,
+            'recommended_next_dyadic_pulse_keys' => $recommendedNextDyadicPulseKeys,
+            'revisit_reorder_reason' => $revisitReorderReason,
+            'last_dyadic_pulse_signal' => $lastDyadicPulseSignal,
+            'relationship_fingerprint' => $this->normalizeText($privateRelationship['relationship_fingerprint'] ?? null),
+            'consent_fingerprint' => $this->normalizeText($dyadicConsent['consent_fingerprint'] ?? null),
+            'private_relationship_access_version' => $this->normalizeText($dyadicConsent['private_relationship_access_version'] ?? null),
+        ];
+
+        return [
+            'journey_contract_version' => self::JOURNEY_VERSION,
+            'journey_fingerprint_version' => self::JOURNEY_FINGERPRINT_VERSION,
+            'journey_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'journey_scope' => self::JOURNEY_SCOPE,
+            'journey_state' => $journeyState,
+            'progress_state' => $progressState,
+            'dyadic_action_focus_key' => $dyadicActionFocusKey,
+            'completed_dyadic_action_keys' => $completedDyadicActionKeys,
+            'recommended_next_dyadic_pulse_keys' => $recommendedNextDyadicPulseKeys,
+            'revisit_reorder_reason' => $revisitReorderReason,
+            'last_dyadic_pulse_signal' => $lastDyadicPulseSignal,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $privateRelationship
+     * @param  array<string,mixed>  $dyadicConsent
+     * @param  array<string,mixed>  $journey
+     * @param  array<string,mixed>  $overlay
+     * @return array<string,mixed>
+     */
+    public function buildPulseCheck(array $privateRelationship, array $dyadicConsent, array $journey, array $overlay): array
+    {
+        if ($journey === []) {
+            return [];
+        }
+
+        $pulseState = $this->resolvePulseState(
+            $this->normalizeText($journey['journey_state'] ?? null),
+            $this->normalizeText($journey['progress_state'] ?? null),
+            $this->normalizeText($dyadicConsent['access_state'] ?? null),
+            (bool) ($dyadicConsent['consent_refresh_required'] ?? false)
+        );
+        if ($pulseState === '') {
+            return [];
+        }
+
+        $nextPulseTarget = $this->resolveNextPulseTarget(
+            $pulseState,
+            $journey,
+            $privateRelationship,
+            $dyadicConsent
+        );
+
+        return [
+            'pulse_contract_version' => self::PULSE_VERSION,
+            'pulse_state' => $pulseState,
+            'pulse_prompt_keys' => $this->resolvePulsePromptKeys(
+                $pulseState,
+                $this->normalizeText($journey['dyadic_action_focus_key'] ?? null) ?? '',
+                $overlay
+            ),
+            'pulse_feedback_mode' => $this->normalizeText($overlay['pulse_feedback_mode'] ?? null)
+                ?? 'dyadic_event_feedback',
+            'next_pulse_target' => $nextPulseTarget,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $overlay
+     * @return array<string,mixed>
+     */
+    public function applyJourneyMutation(
+        array $overlay,
+        string $action,
+        string $accessState,
+        string $dyadicActionFocusKey,
+        array $completedDyadicActionKeys
+    ): array {
+        $normalizedAction = $this->normalizeText($action) ?? '';
+        $overlay['updated_at'] = now()->toISOString();
+
+        switch ($normalizedAction) {
+            case 'continue_dyadic_action':
+                if (! in_array($accessState, ['private_access_ready', 'private_access_partial', 'joined_public_only'], true)) {
+                    return $overlay;
+                }
+
+                $completed = $this->normalizeStringList($overlay['completed_dyadic_action_keys'] ?? []);
+                foreach ($completedDyadicActionKeys as $key) {
+                    $completed[] = $key;
+                }
+                if ($dyadicActionFocusKey !== '') {
+                    $completed[] = $dyadicActionFocusKey;
+                }
+                $completed = array_values(array_unique(array_filter($completed)));
+
+                $overlay['completed_dyadic_action_keys'] = $completed;
+                $overlay['journey_state'] = count($completed) > 1 ? 'practice_revisit' : 'practice_started';
+                $overlay['progress_state'] = count($completed) > 1 ? 'repeatable' : 'warming_up';
+                $overlay['last_dyadic_pulse_signal'] = 'continue_dyadic_action';
+                $overlay['pulse_feedback_mode'] = 'protected_dyadic_ack';
+                $overlay['revisit_reorder_reason'] = count($completed) > 1
+                    ? 'resume_dyadic_practice'
+                    : 'activate_first_dyadic_step';
+                break;
+
+            case 'acknowledge_dyadic_pulse':
+                if (! in_array($accessState, ['private_access_ready', 'private_access_partial', 'joined_public_only'], true)) {
+                    return $overlay;
+                }
+
+                $completed = $this->normalizeStringList($overlay['completed_dyadic_action_keys'] ?? []);
+                $overlay['journey_state'] = $completed === [] ? 'practice_started' : 'practice_revisit';
+                $overlay['progress_state'] = $completed === [] ? 'warming_up' : 'repeatable';
+                $overlay['last_dyadic_pulse_signal'] = 'acknowledge_dyadic_pulse';
+                $overlay['pulse_feedback_mode'] = 'protected_dyadic_ack';
+                $overlay['revisit_reorder_reason'] = $completed === []
+                    ? 'activate_first_dyadic_step'
+                    : 'resume_dyadic_practice';
+                break;
+        }
+
+        return $overlay;
+    }
+
+    /**
+     * @param  array<string,mixed>  $privateRelationship
+     */
+    private function resolveActionFocusKey(array $privateRelationship, string $accessState): string
+    {
+        if (in_array($accessState, ['private_access_revoked', 'private_access_expired', 'awaiting_second_subject'], true)) {
+            return '';
+        }
+
+        $actionPromptKey = $this->normalizeText(data_get($privateRelationship, 'private_action_prompt.key'));
+        if ($actionPromptKey !== null) {
+            return $actionPromptKey;
+        }
+
+        foreach ([
+            $privateRelationship['communication_bridge_keys'] ?? [],
+            $privateRelationship['decision_tension_keys'] ?? [],
+            $privateRelationship['stress_interplay_keys'] ?? [],
+            $privateRelationship['friction_keys'] ?? [],
+            $privateRelationship['complement_keys'] ?? [],
+        ] as $candidateKeys) {
+            $keys = $this->normalizeStringList($candidateKeys);
+            if ($keys !== []) {
+                return $keys[0];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  list<string>  $completedDyadicActionKeys
+     * @param  array<string,mixed>  $overlay
+     */
+    private function resolveJourneyState(
+        string $accessState,
+        bool $consentRefreshRequired,
+        array $completedDyadicActionKeys,
+        array $overlay
+    ): string {
+        $overlayState = $this->normalizeText($overlay['journey_state'] ?? null);
+        if ($overlayState !== null && in_array($accessState, ['private_access_ready', 'private_access_partial', 'joined_public_only'], true)) {
+            return $overlayState;
+        }
+
+        return match (true) {
+            $accessState === 'awaiting_second_subject' => 'awaiting_partner',
+            $accessState === 'private_access_revoked' => 'access_revoked',
+            $accessState === 'private_access_expired' || $consentRefreshRequired => 'revisit_after_consent_refresh',
+            $completedDyadicActionKeys !== [] => 'practice_revisit',
+            default => 'ready_for_first_step',
+        };
+    }
+
+    /**
+     * @param  list<string>  $completedDyadicActionKeys
+     * @param  array<string,mixed>  $overlay
+     */
+    private function resolveProgressState(string $accessState, array $completedDyadicActionKeys, array $overlay): string
+    {
+        $overlayState = $this->normalizeText($overlay['progress_state'] ?? null);
+        if ($overlayState !== null && in_array($accessState, ['private_access_ready', 'private_access_partial', 'joined_public_only'], true)) {
+            return $overlayState;
+        }
+
+        return match (true) {
+            in_array($accessState, ['private_access_revoked', 'private_access_expired'], true) => 'restricted',
+            count($completedDyadicActionKeys) >= 2 => 'repeatable',
+            count($completedDyadicActionKeys) === 1 => 'warming_up',
+            default => 'not_started',
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $privateRelationship
+     * @param  list<string>  $completedDyadicActionKeys
+     * @param  array<string,mixed>  $overlay
+     * @return list<string>
+     */
+    private function resolveRecommendedNextPulseKeys(
+        array $privateRelationship,
+        string $dyadicActionFocusKey,
+        string $journeyState,
+        string $accessState,
+        bool $consentRefreshRequired,
+        array $completedDyadicActionKeys,
+        array $overlay
+    ): array {
+        $overlayKeys = $this->normalizeStringList($overlay['recommended_next_dyadic_pulse_keys'] ?? []);
+        if ($overlayKeys !== [] && in_array($accessState, ['private_access_ready', 'private_access_partial', 'joined_public_only'], true)) {
+            return $overlayKeys;
+        }
+
+        if ($accessState === 'awaiting_second_subject') {
+            return ['dyadic_pulse.wait_for_partner'];
+        }
+
+        if ($accessState === 'private_access_revoked') {
+            return [];
+        }
+
+        if ($accessState === 'private_access_expired' || $consentRefreshRequired) {
+            return ['dyadic_pulse.refresh_private_access'];
+        }
+
+        if ($completedDyadicActionKeys === []) {
+            return $this->uniqueStringList([
+                $dyadicActionFocusKey,
+                'dyadic_pulse.start_private_practice',
+            ]);
+        }
+
+        if (($privateRelationship['friction_keys'] ?? []) !== []) {
+            return $this->uniqueStringList([
+                $dyadicActionFocusKey,
+                $this->firstString($privateRelationship['friction_keys'] ?? []),
+                'dyadic_pulse.review_tension_signal',
+            ]);
+        }
+
+        return $this->uniqueStringList([
+            $dyadicActionFocusKey,
+            'dyadic_pulse.repeat_shared_action',
+            'dyadic_pulse.name_next_step_together',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $completedDyadicActionKeys
+     * @param  array<string,mixed>  $privateRelationship
+     * @param  array<string,mixed>  $overlay
+     */
+    private function resolveRevisitReorderReason(
+        string $journeyState,
+        string $accessState,
+        bool $consentRefreshRequired,
+        array $completedDyadicActionKeys,
+        array $privateRelationship,
+        array $overlay
+    ): string {
+        $overlayReason = $this->normalizeText($overlay['revisit_reorder_reason'] ?? null);
+        if ($overlayReason !== null && in_array($accessState, ['private_access_ready', 'private_access_partial', 'joined_public_only'], true)) {
+            return $overlayReason;
+        }
+
+        return match (true) {
+            $accessState === 'awaiting_second_subject' => 'await_partner_completion',
+            $accessState === 'private_access_revoked' => 'respect_revoked_private_access',
+            $accessState === 'private_access_expired' || $consentRefreshRequired => 'refresh_private_access',
+            $completedDyadicActionKeys !== [] => 'resume_dyadic_practice',
+            ($privateRelationship['friction_keys'] ?? []) !== [] => 'review_tension_signal',
+            $journeyState === 'ready_for_first_step' => 'activate_first_dyadic_step',
+            default => 'resume_private_relationship_focus',
+        };
+    }
+
+    private function deriveLastPulseSignal(string $journeyState, bool $consentRefreshRequired): string
+    {
+        if ($consentRefreshRequired) {
+            return 'consent_refresh_required';
+        }
+
+        return match ($journeyState) {
+            'awaiting_partner' => 'awaiting_partner',
+            'access_revoked' => 'private_access_revoked',
+            'revisit_after_consent_refresh' => 'refresh_private_access',
+            'practice_revisit' => 'resume_dyadic_practice',
+            default => 'ready_for_first_step',
+        };
+    }
+
+    private function resolvePulseState(
+        string $journeyState,
+        string $progressState,
+        string $accessState,
+        bool $consentRefreshRequired
+    ): string {
+        if ($accessState === 'private_access_revoked') {
+            return '';
+        }
+
+        if ($accessState === 'awaiting_second_subject') {
+            return 'wait_for_partner';
+        }
+
+        if ($accessState === 'private_access_expired' || $consentRefreshRequired) {
+            return 'refresh_private_access';
+        }
+
+        return match ($journeyState) {
+            'practice_revisit' => $progressState === 'repeatable'
+                ? 'review_tension_signal'
+                : 'repeat_shared_practice',
+            'ready_for_first_step' => 'start_shared_practice',
+            default => 'repeat_shared_practice',
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $journey
+     * @param  array<string,mixed>  $privateRelationship
+     * @param  array<string,mixed>  $dyadicConsent
+     */
+    private function resolveNextPulseTarget(
+        string $pulseState,
+        array $journey,
+        array $privateRelationship,
+        array $dyadicConsent
+    ): string {
+        return match ($pulseState) {
+            'refresh_private_access' => 'acknowledge_refresh',
+            'wait_for_partner' => 'private_relationship_wait',
+            'review_tension_signal' => $this->normalizeText(
+                $this->firstString($privateRelationship['friction_keys'] ?? []),
+                $journey['dyadic_action_focus_key'] ?? null
+            ) ?? '',
+            default => $this->normalizeText(
+                $journey['dyadic_action_focus_key'] ?? null,
+                data_get($privateRelationship, 'private_action_prompt.key'),
+                data_get($dyadicConsent, 'consent_state')
+            ) ?? '',
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $overlay
+     * @return list<string>
+     */
+    private function resolvePulsePromptKeys(string $pulseState, string $dyadicActionFocusKey, array $overlay): array
+    {
+        $overlayKeys = $this->normalizeStringList($overlay['pulse_prompt_keys'] ?? []);
+        if ($overlayKeys !== []) {
+            return $overlayKeys;
+        }
+
+        return match ($pulseState) {
+            'wait_for_partner' => ['dyadic_pulse.wait_for_partner'],
+            'refresh_private_access' => ['dyadic_pulse.refresh_private_access'],
+            'review_tension_signal' => $this->uniqueStringList([
+                'dyadic_pulse.review_tension_signal',
+                $dyadicActionFocusKey,
+            ]),
+            'repeat_shared_practice' => $this->uniqueStringList([
+                'dyadic_pulse.repeat_shared_action',
+                $dyadicActionFocusKey,
+            ]),
+            default => $this->uniqueStringList([
+                'dyadic_pulse.start_private_practice',
+                $dyadicActionFocusKey,
+            ]),
+        };
+    }
+
+    private function normalizeText(mixed ...$values): ?string
+    {
+        foreach ($values as $value) {
+            if (! is_string($value) && ! is_numeric($value)) {
+                continue;
+            }
+
+            $normalized = trim((string) $value);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeStringList(mixed $values): array
+    {
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($values as $value) {
+            $candidate = $this->normalizeText($value);
+            if ($candidate !== null) {
+                $normalized[] = $candidate;
+            }
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private function uniqueStringList(array $values): array
+    {
+        return $this->normalizeStringList($values);
+    }
+
+    private function firstString(mixed $values): ?string
+    {
+        $normalized = $this->normalizeStringList($values);
+
+        return $normalized[0] ?? null;
+    }
+}

--- a/backend/app/Services/V0_3/MbtiCompareInviteService.php
+++ b/backend/app/Services/V0_3/MbtiCompareInviteService.php
@@ -10,6 +10,7 @@ use App\Models\MbtiCompareInvite;
 use App\Models\Result;
 use App\Models\Share;
 use App\Services\InsightGraph\PrivateRelationshipContractService;
+use App\Services\InsightGraph\PrivateRelationshipJourneyContractService;
 use App\Services\InsightGraph\RelationshipSyncContractService;
 use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
@@ -25,6 +26,7 @@ final class MbtiCompareInviteService
         private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private readonly RelationshipSyncContractService $relationshipSyncContractService,
         private readonly PrivateRelationshipContractService $privateRelationshipContractService,
+        private readonly PrivateRelationshipJourneyContractService $privateRelationshipJourneyContractService,
     ) {}
 
     /**
@@ -176,6 +178,18 @@ final class MbtiCompareInviteService
                 'private_relationship_access_version' => 'private.relationship.access.v1',
             ]
         );
+        $journeyOverlay = $this->resolvePrivateJourneyOverlay($invite);
+        $privateRelationshipJourney = $this->privateRelationshipJourneyContractService->buildJourney(
+            $privateRelationship,
+            $dyadicConsent,
+            $journeyOverlay
+        );
+        $dyadicPulseCheck = $this->privateRelationshipJourneyContractService->buildPulseCheck(
+            $privateRelationship,
+            $dyadicConsent,
+            $privateRelationshipJourney,
+            $journeyOverlay
+        );
 
         return [
             'invite_id' => (string) $invite->id,
@@ -185,6 +199,8 @@ final class MbtiCompareInviteService
             'status' => $status,
             'private_relationship_v1' => $privateRelationship,
             'dyadic_consent_v1' => $dyadicConsent,
+            'private_relationship_journey_v1' => $privateRelationshipJourney,
+            'dyadic_pulse_check_v1' => $dyadicPulseCheck,
             'dyadic_graph_v1' => $this->privateRelationshipContractService->buildProtectedGraph($privateRelationship),
         ];
     }
@@ -229,6 +245,98 @@ final class MbtiCompareInviteService
         }
 
         $this->persistDyadicConsentLifecycle($invite, $lifecycle);
+
+        return $this->showPrivate($inviteId, $userId, $anonId);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    public function mutatePrivateJourney(string $inviteId, mixed $userId, mixed $anonId, array $payload): array
+    {
+        $invite = MbtiCompareInvite::query()->findOrFail($inviteId);
+        [, $inviterAttempt, $inviterResult] = $this->resolveMbtiShareContext((string) $invite->share_id);
+        $participantContext = $this->resolveParticipantContext($invite, $userId, $anonId);
+        if ($participantContext === null) {
+            throw new ApiProblemException(404, 'PRIVATE_RELATIONSHIP_NOT_FOUND', 'private relationship not found.');
+        }
+
+        $inviterPayload = $this->shareService->buildPublicSummaryPayload($inviterAttempt, $inviterResult, (string) $invite->share_id);
+        $locale = $this->normalizeLocale(
+            $this->nullableString($invite->locale)
+                ?? $this->nullableString($inviterPayload['locale'] ?? null)
+                ?? 'zh-CN'
+        );
+        $status = $this->normalizeStatus((string) ($invite->status ?? 'pending'));
+        [$inviter, $invitee, $compare] = $this->buildInviteReadContext($invite, $inviterAttempt, $inviterResult, $locale, false);
+        $currentConsentPolicyVersion = $this->resolvePrivacyPolicyVersion($inviterAttempt);
+        $consentLifecycle = $this->resolveDyadicConsentLifecycle($invite, $currentConsentPolicyVersion);
+        $relationshipSync = $this->relationshipSyncContractService->build(
+            $inviter,
+            $invitee,
+            $compare,
+            $status === 'purchased' ? 'ready' : $status,
+            $locale,
+            null
+        );
+
+        $accessState = $this->resolvePrivateAccessState(
+            $status,
+            (bool) ($participantContext['has_invitee'] ?? false),
+            data_get($compare, 'title'),
+            $consentLifecycle
+        );
+        $subjectJoinMode = $this->resolvePrivateJoinMode($status);
+        $relationshipSync = $this->applyPrivateAccessRestrictions(
+            $relationshipSync,
+            $accessState,
+            $locale,
+            (bool) ($consentLifecycle['consent_refresh_required'] ?? false)
+        );
+        $participantAttempt = $participantContext['attempt'] ?? null;
+        $privateRelationship = $this->privateRelationshipContractService->buildPrivateRelationship(
+            $inviter,
+            $invitee,
+            $relationshipSync,
+            (string) ($participantContext['participant_role'] ?? 'inviter'),
+            $accessState,
+            $subjectJoinMode,
+            $locale,
+            $participantAttempt instanceof Attempt
+                ? $this->buildProtectedResultPath($locale, (string) $participantAttempt->id)
+                : $this->buildProtectedHistoryPath($locale),
+            $locale === 'zh-CN' ? '进入我的 MBTI 报告' : 'Open my MBTI reports'
+        );
+        $dyadicConsent = $this->privateRelationshipContractService->buildDyadicConsent(
+            $invite,
+            $this->normalizeConsentState($status),
+            $accessState,
+            $subjectJoinMode,
+            $currentConsentPolicyVersion,
+            $consentLifecycle + [
+                'private_relationship_access_version' => 'private.relationship.access.v1',
+            ]
+        );
+
+        $action = strtolower(trim((string) ($payload['action'] ?? '')));
+        $journeyOverlay = $this->resolvePrivateJourneyOverlay($invite);
+        $journey = $this->privateRelationshipJourneyContractService->buildJourney(
+            $privateRelationship,
+            $dyadicConsent,
+            $journeyOverlay
+        );
+        $updatedOverlay = $this->privateRelationshipJourneyContractService->applyJourneyMutation(
+            $journeyOverlay,
+            $action,
+            (string) ($dyadicConsent['access_state'] ?? ''),
+            (string) ($journey['dyadic_action_focus_key'] ?? ''),
+            is_array($journey['completed_dyadic_action_keys'] ?? null)
+                ? $journey['completed_dyadic_action_keys']
+                : []
+        );
+
+        $this->persistPrivateJourneyOverlay($invite, $updatedOverlay);
 
         return $this->showPrivate($inviteId, $userId, $anonId);
     }
@@ -777,6 +885,16 @@ final class MbtiCompareInviteService
         return is_array($meta) ? $meta : [];
     }
 
+    /**
+     * @return array<string,mixed>
+     */
+    private function resolvePrivateJourneyOverlay(MbtiCompareInvite $invite): array
+    {
+        $meta = $this->normalizeMeta($invite->meta_json ?? null);
+
+        return $this->normalizeMeta($meta['private_relationship_journey_v1'] ?? null);
+    }
+
     private function resolvePrivacyPolicyVersion(Attempt $attempt): string
     {
         $region = $this->nullableString($attempt->region ?? null)
@@ -898,6 +1016,34 @@ final class MbtiCompareInviteService
             'consent_policy_version' => $this->nullableString($lifecycle['consent_policy_version'] ?? null),
             'acknowledged_at' => $this->nullableString($lifecycle['acknowledged_at'] ?? null),
             'consent_refresh_required' => (bool) ($lifecycle['consent_refresh_required'] ?? false),
+        ];
+
+        $invite->meta_json = $meta;
+        $invite->save();
+    }
+
+    /**
+     * @param  array<string,mixed>  $overlay
+     */
+    private function persistPrivateJourneyOverlay(MbtiCompareInvite $invite, array $overlay): void
+    {
+        $meta = $this->normalizeMeta($invite->meta_json ?? null);
+        $meta['private_relationship_journey_v1'] = [
+            'journey_state' => $this->nullableString($overlay['journey_state'] ?? null),
+            'progress_state' => $this->nullableString($overlay['progress_state'] ?? null),
+            'completed_dyadic_action_keys' => array_values(array_filter(
+                array_map(fn (mixed $value): ?string => $this->nullableString($value), (array) ($overlay['completed_dyadic_action_keys'] ?? []))
+            )),
+            'recommended_next_dyadic_pulse_keys' => array_values(array_filter(
+                array_map(fn (mixed $value): ?string => $this->nullableString($value), (array) ($overlay['recommended_next_dyadic_pulse_keys'] ?? []))
+            )),
+            'last_dyadic_pulse_signal' => $this->nullableString($overlay['last_dyadic_pulse_signal'] ?? null),
+            'pulse_feedback_mode' => $this->nullableString($overlay['pulse_feedback_mode'] ?? null),
+            'revisit_reorder_reason' => $this->nullableString($overlay['revisit_reorder_reason'] ?? null),
+            'pulse_prompt_keys' => array_values(array_filter(
+                array_map(fn (mixed $value): ?string => $this->nullableString($value), (array) ($overlay['pulse_prompt_keys'] ?? []))
+            )),
+            'updated_at' => $this->nullableString($overlay['updated_at'] ?? null),
         ];
 
         $invite->meta_json = $meta;

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -125,6 +125,8 @@ Route::prefix('v0.3')->middleware([
             ->middleware('uuid:inviteId');
         Route::post('/me/relationships/mbti/{inviteId}/consent', [MbtiCompareInviteController::class, 'mutatePrivateConsent'])
             ->middleware('uuid:inviteId');
+        Route::post('/me/relationships/mbti/{inviteId}/journey', [MbtiCompareInviteController::class, 'mutatePrivateJourney'])
+            ->middleware('uuid:inviteId');
     });
 
     Route::middleware([

--- a/backend/tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php
+++ b/backend/tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php
@@ -76,6 +76,12 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
             ->assertJsonPath('ok', true)
             ->assertJsonPath('status', 'purchased')
             ->assertJsonPath('private_relationship_v1.access_state', 'private_access_ready')
+            ->assertJsonPath('private_relationship_journey_v1.journey_contract_version', 'private_relationship_journey.v1')
+            ->assertJsonPath('private_relationship_journey_v1.journey_scope', 'private_relationship_revisit')
+            ->assertJsonPath('private_relationship_journey_v1.journey_state', 'ready_for_first_step')
+            ->assertJsonPath('private_relationship_journey_v1.progress_state', 'not_started')
+            ->assertJsonPath('dyadic_pulse_check_v1.pulse_contract_version', 'dyadic_pulse_check.v1')
+            ->assertJsonPath('dyadic_pulse_check_v1.pulse_state', 'start_shared_practice')
             ->assertJsonPath('private_relationship_v1.participant_role', 'invitee')
             ->assertJsonPath('dyadic_consent_v1.consent_state', 'purchased')
             ->assertJsonPath('dyadic_consent_v1.access_state', 'private_access_ready')
@@ -101,6 +107,14 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
             'X-Anon-Id' => $outsiderAnonId,
         ])->postJson("/api/v0.3/me/relationships/mbti/{$inviteId}/consent", [
             'action' => 'revoke_access',
+        ])->assertNotFound()
+            ->assertJsonPath('error_code', 'PRIVATE_RELATIONSHIP_NOT_FOUND');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$outsiderToken,
+            'X-Anon-Id' => $outsiderAnonId,
+        ])->postJson("/api/v0.3/me/relationships/mbti/{$inviteId}/journey", [
+            'action' => 'continue_dyadic_action',
         ])->assertNotFound()
             ->assertJsonPath('error_code', 'PRIVATE_RELATIONSHIP_NOT_FOUND');
     }
@@ -136,6 +150,17 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
             ]);
 
         $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviteeToken,
+            'X-Anon-Id' => $inviteeAnonId,
+        ])->postJson("/api/v0.3/me/relationships/mbti/{$inviteId}/journey", [
+            'action' => 'continue_dyadic_action',
+        ])->assertOk()
+            ->assertJsonPath('private_relationship_journey_v1.journey_state', 'practice_started')
+            ->assertJsonPath('private_relationship_journey_v1.progress_state', 'warming_up')
+            ->assertJsonPath('private_relationship_journey_v1.last_dyadic_pulse_signal', 'continue_dyadic_action')
+            ->assertJsonPath('dyadic_pulse_check_v1.pulse_state', 'repeat_shared_practice');
+
+        $this->withHeaders([
             'Authorization' => 'Bearer '.$inviterToken,
             'X-Anon-Id' => $inviterAnonId,
         ])->postJson("/api/v0.3/me/relationships/mbti/{$inviteId}/consent", [
@@ -144,8 +169,21 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
             ->assertJsonPath('dyadic_consent_v1.revocation_state', 'revoked_by_subject')
             ->assertJsonPath('dyadic_consent_v1.access_state', 'private_access_revoked')
             ->assertJsonPath('private_relationship_v1.access_state', 'private_access_revoked')
+            ->assertJsonPath('private_relationship_journey_v1.journey_state', 'access_revoked')
+            ->assertJsonPath('private_relationship_journey_v1.progress_state', 'restricted')
             ->assertJsonCount(0, 'private_relationship_v1.private_sync_sections')
-            ->assertJsonMissingPath('private_relationship_v1.private_action_prompt.key');
+            ->assertJsonMissingPath('private_relationship_v1.private_action_prompt.key')
+            ->assertJsonMissingPath('dyadic_pulse_check_v1.pulse_state');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviteeToken,
+            'X-Anon-Id' => $inviteeAnonId,
+        ])->postJson("/api/v0.3/me/relationships/mbti/{$inviteId}/journey", [
+            'action' => 'continue_dyadic_action',
+        ])->assertOk()
+            ->assertJsonPath('private_relationship_journey_v1.journey_state', 'access_revoked')
+            ->assertJsonPath('private_relationship_journey_v1.progress_state', 'restricted')
+            ->assertJsonMissingPath('dyadic_pulse_check_v1.pulse_state');
 
         $this->withHeaders([
             'Authorization' => 'Bearer '.$inviteeToken,
@@ -166,6 +204,14 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
                         'expires_at' => now()->subMinute()->toISOString(),
                         'consent_policy_version' => '2025-01-01',
                     ],
+                    'private_relationship_journey_v1' => [
+                        'journey_state' => 'practice_started',
+                        'progress_state' => 'warming_up',
+                        'completed_dyadic_action_keys' => ['dyadic_action.name_decision_rule'],
+                        'last_dyadic_pulse_signal' => 'continue_dyadic_action',
+                        'pulse_feedback_mode' => 'protected_dyadic_ack',
+                        'revisit_reorder_reason' => 'activate_first_dyadic_step',
+                    ],
                 ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             ]);
 
@@ -177,7 +223,10 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
             ->assertJsonPath('dyadic_consent_v1.expiry_state', 'expired')
             ->assertJsonPath('dyadic_consent_v1.access_state', 'private_access_expired')
             ->assertJsonPath('dyadic_consent_v1.consent_refresh_required', true)
-            ->assertJsonCount(0, 'private_relationship_v1.private_sync_sections');
+            ->assertJsonCount(0, 'private_relationship_v1.private_sync_sections')
+            ->assertJsonPath('private_relationship_journey_v1.journey_state', 'revisit_after_consent_refresh')
+            ->assertJsonPath('private_relationship_journey_v1.progress_state', 'restricted')
+            ->assertJsonPath('dyadic_pulse_check_v1.pulse_state', 'refresh_private_access');
 
         $refresh = $this->withHeaders([
             'Authorization' => 'Bearer '.$inviteeToken,
@@ -195,8 +244,12 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
         $row = DB::table('mbti_compare_invites')->where('id', $inviteId)->first();
         $meta = is_object($row) ? (array) json_decode((string) ($row->meta_json ?? '{}'), true) : [];
         $overlay = is_array($meta['dyadic_consent_lifecycle_v1'] ?? null) ? $meta['dyadic_consent_lifecycle_v1'] : [];
+        $journeyOverlay = is_array($meta['private_relationship_journey_v1'] ?? null) ? $meta['private_relationship_journey_v1'] : [];
         $this->assertSame('active', (string) ($overlay['expiry_state'] ?? ''));
         $this->assertNotNull($overlay['acknowledged_at'] ?? null);
+        $this->assertSame('practice_started', (string) ($journeyOverlay['journey_state'] ?? ''));
+        $this->assertSame('warming_up', (string) ($journeyOverlay['progress_state'] ?? ''));
+        $this->assertSame('continue_dyadic_action', (string) ($journeyOverlay['last_dyadic_pulse_signal'] ?? ''));
     }
 
     private function seedScales(): void

--- a/backend/tests/Unit/Services/InsightGraph/PrivateRelationshipJourneyContractServiceTest.php
+++ b/backend/tests/Unit/Services/InsightGraph/PrivateRelationshipJourneyContractServiceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\InsightGraph;
+
+use App\Services\InsightGraph\PrivateRelationshipJourneyContractService;
+use Tests\TestCase;
+
+final class PrivateRelationshipJourneyContractServiceTest extends TestCase
+{
+    public function test_it_builds_private_relationship_journey_and_pulse_contracts(): void
+    {
+        $service = app(PrivateRelationshipJourneyContractService::class);
+
+        $journey = $service->buildJourney(
+            [
+                'relationship_fingerprint' => 'private-relationship-fingerprint',
+                'private_action_prompt' => [
+                    'key' => 'dyadic_action.name_decision_rule',
+                ],
+                'friction_keys' => ['friction.energy_mismatch'],
+                'communication_bridge_keys' => ['communication_bridge.energy_pacing'],
+            ],
+            [
+                'access_state' => 'private_access_ready',
+                'consent_fingerprint' => 'consent-fingerprint-001',
+                'consent_refresh_required' => false,
+                'private_relationship_access_version' => 'private.relationship.access.v1',
+            ],
+            [
+                'completed_dyadic_action_keys' => ['dyadic_action.name_decision_rule'],
+            ]
+        );
+
+        $this->assertSame('private_relationship_journey.v1', $journey['journey_contract_version']);
+        $this->assertSame('private_relationship_journey.fp.v1', $journey['journey_fingerprint_version']);
+        $this->assertSame('private_relationship_revisit', $journey['journey_scope']);
+        $this->assertSame('practice_revisit', $journey['journey_state']);
+        $this->assertSame('warming_up', $journey['progress_state']);
+        $this->assertSame('dyadic_action.name_decision_rule', $journey['dyadic_action_focus_key']);
+        $this->assertContains('dyadic_action.name_decision_rule', $journey['completed_dyadic_action_keys']);
+        $this->assertContains('dyadic_pulse.review_tension_signal', $journey['recommended_next_dyadic_pulse_keys']);
+        $this->assertSame('resume_dyadic_practice', $journey['revisit_reorder_reason']);
+        $this->assertNotSame('', (string) ($journey['journey_fingerprint'] ?? ''));
+
+        $pulse = $service->buildPulseCheck(
+            [
+                'private_action_prompt' => [
+                    'key' => 'dyadic_action.name_decision_rule',
+                ],
+                'friction_keys' => ['friction.energy_mismatch'],
+            ],
+            [
+                'access_state' => 'private_access_ready',
+                'consent_state' => 'purchased',
+                'consent_refresh_required' => false,
+            ],
+            $journey,
+            []
+        );
+
+        $this->assertSame('dyadic_pulse_check.v1', $pulse['pulse_contract_version']);
+        $this->assertSame('repeat_shared_practice', $pulse['pulse_state']);
+        $this->assertContains('dyadic_pulse.repeat_shared_action', $pulse['pulse_prompt_keys']);
+        $this->assertSame('dyadic_action.name_decision_rule', $pulse['next_pulse_target']);
+    }
+
+    public function test_it_restricts_journey_and_removes_pulse_when_access_is_revoked(): void
+    {
+        $service = app(PrivateRelationshipJourneyContractService::class);
+
+        $journey = $service->buildJourney(
+            [
+                'relationship_fingerprint' => 'private-relationship-fingerprint',
+                'private_action_prompt' => [
+                    'key' => 'dyadic_action.name_decision_rule',
+                ],
+            ],
+            [
+                'access_state' => 'private_access_revoked',
+                'consent_fingerprint' => 'consent-fingerprint-001',
+                'consent_refresh_required' => false,
+                'private_relationship_access_version' => 'private.relationship.access.v1',
+            ],
+            [
+                'completed_dyadic_action_keys' => ['dyadic_action.name_decision_rule'],
+            ]
+        );
+
+        $this->assertSame('access_revoked', $journey['journey_state']);
+        $this->assertSame('restricted', $journey['progress_state']);
+        $this->assertSame([], $journey['completed_dyadic_action_keys']);
+        $this->assertSame([], $journey['recommended_next_dyadic_pulse_keys']);
+
+        $pulse = $service->buildPulseCheck(
+            [],
+            [
+                'access_state' => 'private_access_revoked',
+                'consent_refresh_required' => false,
+            ],
+            $journey,
+            []
+        );
+
+        $this->assertSame([], $pulse);
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-11F: private relationship journey and dyadic action loop.

It upgrades the existing protected/private MBTI relationship surface into the first backend-owned dyadic journey layer, while keeping scope strictly limited to the existing private relationship path and compare-invite authority.

## What changed

Backend:
- adds `private_relationship_journey_v1`
- adds additive `dyadic_pulse_check_v1`
- wires both into the existing protected read path
- adds a minimal protected journey mutation route
- persists first-wave journey overlay in `MbtiCompareInvite.meta_json`
- keeps revoked and expired states tightening the private journey surface on the backend

## Guardrails

- no migration
- no new dependency
- no new auth system
- no task DB or progress ledger
- no checklist, streak, challenge, or reminder system
- no share, workspace, or history expansion into a new dyadic shell
- no Big Five dyadic
- public compare remains separate and unchanged

## Validation

I ran:

- `php artisan test tests/Unit/Services/InsightGraph/PrivateRelationshipJourneyContractServiceTest.php tests/Unit/Services/InsightGraph/PrivateRelationshipContractServiceTest.php tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`

All passed:
- 8 tests passed
- 311 assertions

## Scope note

This PR is intentionally limited to the first protected dyadic journey layer.

It does not add:
- a task product shell
- task/checklist/streak storage
- notifications or reminders
- Big Five dyadic
- public compare journey behavior
- any change to unrelated dirty files already present in the backend worktree
