### PR TITLE
feat(storage): add read-only storage cost analyzer

### DIFF
--- a/backend/app/Console/Commands/StorageCostAnalyzer.php
+++ b/backend/app/Console/Commands/StorageCostAnalyzer.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\StorageCostAnalyzerService;
+use Illuminate\Console\Command;
+
+final class StorageCostAnalyzer extends Command
+{
+    protected $signature = 'storage:analyze-cost
+        {--json : Emit the full storage cost analysis payload as JSON}';
+
+    protected $description = 'Read-only storage cost analyzer for the backend storage tree.';
+
+    public function __construct(
+        private readonly StorageCostAnalyzerService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $payload = $this->service->analyze();
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode storage cost analysis json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return self::SUCCESS;
+        }
+
+        $topDirectory = is_array($payload['top_directories'][0] ?? null) ? $payload['top_directories'][0] : [];
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+        $this->line('status='.(string) ($payload['status'] ?? 'ok'));
+        $this->line('root='.(string) ($payload['root_path'] ?? ''));
+        $this->line('total_bytes='.(int) ($summary['total_bytes'] ?? 0));
+        $this->line('total_files='.(int) ($summary['total_files'] ?? 0));
+        $this->line('total_directories='.(int) ($summary['total_directories'] ?? 0));
+        $this->line('largest_category='.(string) ($summary['largest_category'] ?? ''));
+        $this->line('largest_category_bytes='.(int) ($summary['largest_category_bytes'] ?? 0));
+        $this->line('top_directory='.(string) ($topDirectory['path'] ?? ''));
+        $this->line('top_directory_bytes='.(int) ($topDirectory['bytes'] ?? 0));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Services/Storage/StorageCostAnalyzerService.php
+++ b/backend/app/Services/Storage/StorageCostAnalyzerService.php
@@ -1,0 +1,528 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+final class StorageCostAnalyzerService
+{
+    private const SCHEMA_VERSION = 'storage_cost_analyzer.v1';
+
+    private const TOP_DIRECTORY_LIMIT = 20;
+
+    /**
+     * @var list<string>
+     */
+    private const CATEGORY_ORDER = [
+        'control_plane_snapshots',
+        'control_plane_plans',
+        'control_plane_receipts',
+        'quarantine_live_roots',
+        'v2_materialized_cache',
+        'offload_blob_copies',
+        'framework_cache_or_sessions',
+        'logs',
+        'runtime_or_data_truth',
+        'unknown',
+    ];
+
+    /**
+     * @var array<string,array{risk_level:string,rationale:string,safe_next_action:string}>
+     */
+    private const CATEGORY_POLICY = [
+        'control_plane_snapshots' => [
+            'risk_level' => 'low',
+            'rationale' => 'control-plane snapshots are read-only reporting artifacts and can be regenerated from the current storage state',
+            'safe_next_action' => 'janitor snapshots',
+        ],
+        'control_plane_plans' => [
+            'risk_level' => 'low',
+            'rationale' => 'derived control-plane plan artifacts are rebuildable and do not represent runtime truth',
+            'safe_next_action' => 'janitor plans',
+        ],
+        'control_plane_receipts' => [
+            'risk_level' => 'manual_only',
+            'rationale' => 'run receipts record operator-visible lifecycle history and should be retained unless a separate retention policy is approved',
+            'safe_next_action' => 'retain',
+        ],
+        'quarantine_live_roots' => [
+            'risk_level' => 'no_touch',
+            'rationale' => 'quarantined release roots are live lifecycle inputs for restore or purge and must not be modified by analysis-only work',
+            'safe_next_action' => 'retain; restore/purge inputs',
+        ],
+        'v2_materialized_cache' => [
+            'risk_level' => 'medium',
+            'rationale' => 'materialized v2 cache is rebuildable but impacts runtime warmness and needs a dedicated cache janitor contract',
+            'safe_next_action' => 'future materialized-cache janitor PR',
+        ],
+        'offload_blob_copies' => [
+            'risk_level' => 'manual_only',
+            'rationale' => 'offloaded blob copies may mirror remote rollout state and should be evaluated separately before any deletion decision',
+            'safe_next_action' => 'analyze separately before deletion',
+        ],
+        'framework_cache_or_sessions' => [
+            'risk_level' => 'manual_review',
+            'rationale' => 'framework cache and session trees can be regenerated or expired, but active runtime usage must be understood first',
+            'safe_next_action' => 'analyze framework cache/session retention separately',
+        ],
+        'logs' => [
+            'risk_level' => 'low',
+            'rationale' => 'log files are operational artifacts and are typically the safest storage surface for a separate retention or rotation PR',
+            'safe_next_action' => 'future log retention/rotation PR',
+        ],
+        'runtime_or_data_truth' => [
+            'risk_level' => 'no_touch',
+            'rationale' => 'runtime or data-truth trees hold canonical data and should not be targeted by storage cost reduction without a separate contract change',
+            'safe_next_action' => 'retain',
+        ],
+        'unknown' => [
+            'risk_level' => 'manual_review',
+            'rationale' => 'unknown storage trees are not covered by the current classifier and require manual inspection before any action',
+            'safe_next_action' => 'inspect before action',
+        ],
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const NO_TOUCH_CATEGORIES = [
+        'quarantine_live_roots',
+        'runtime_or_data_truth',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ANCHOR_PREFIXES = [
+        'app/private/control_plane_snapshots',
+        'app/private/gc_plans',
+        'app/private/offload_plans',
+        'app/private/rehydrate_plans',
+        'app/private/quarantine_plans',
+        'app/private/quarantine_restore_plans',
+        'app/private/quarantine_purge_plans',
+        'app/private/retirement_plans',
+        'app/private/prune_plans',
+        'app/private/quarantine/restore_runs',
+        'app/private/quarantine/purge_runs',
+        'app/private/retirement_runs',
+        'app/private/rehydrate_runs',
+        'app/private/quarantine/release_roots',
+        'app/private/packs_v2_materialized',
+        'app/private/offload/blobs',
+        'app/private/blobs',
+        'app/private/content_releases',
+        'app/private/reports',
+        'app/private/artifacts',
+        'app/private/packs_v2',
+        'app/content_packs_v2',
+        'app/public',
+        'framework/cache',
+        'framework/sessions',
+        'framework/views',
+        'framework/testing',
+        'logs',
+    ];
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function analyze(?string $rootPath = null): array
+    {
+        $rootPath = $this->normalizePath($rootPath ?? storage_path());
+
+        $summary = [
+            'total_bytes' => 0,
+            'total_files' => 0,
+            'total_directories' => 0,
+            'largest_category' => null,
+            'largest_category_bytes' => 0,
+        ];
+
+        /** @var array<string,array{bytes:int,file_count:int,directory_count:int}> $byCategory */
+        $byCategory = [];
+        foreach (self::CATEGORY_ORDER as $category) {
+            $byCategory[$category] = [
+                'bytes' => 0,
+                'file_count' => 0,
+                'directory_count' => 0,
+            ];
+        }
+
+        /** @var array<string,array{path:string,bytes:int,file_count:int,directory_count:int,category:string,risk_level:string}> $topDirectoryIndex */
+        $topDirectoryIndex = [];
+
+        if (is_dir($rootPath)) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($rootPath, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::SELF_FIRST
+            );
+
+            foreach ($iterator as $item) {
+                if (! $item instanceof \SplFileInfo || $item->isLink()) {
+                    continue;
+                }
+
+                $relativePath = $this->relativePath($rootPath, $item->getPathname());
+                if ($relativePath === '') {
+                    continue;
+                }
+
+                if ($item->isDir()) {
+                    $summary['total_directories']++;
+
+                    $category = $this->classifyRelativePath($relativePath);
+                    $byCategory[$category]['directory_count']++;
+
+                    $anchor = $this->anchorPathForRelativePath($relativePath, true);
+                    $anchorStats = &$this->topDirectoryEntry($topDirectoryIndex, $anchor);
+                    if ($relativePath !== $anchor) {
+                        $anchorStats['directory_count']++;
+                    }
+                    unset($anchorStats);
+
+                    continue;
+                }
+
+                if (! $item->isFile()) {
+                    continue;
+                }
+
+                $size = max(0, (int) ($item->getSize() ?: 0));
+                $summary['total_bytes'] += $size;
+                $summary['total_files']++;
+
+                $category = $this->classifyRelativePath($relativePath);
+                $byCategory[$category]['bytes'] += $size;
+                $byCategory[$category]['file_count']++;
+
+                $anchor = $this->anchorPathForRelativePath($relativePath, false);
+                $anchorStats = &$this->topDirectoryEntry($topDirectoryIndex, $anchor);
+                $anchorStats['bytes'] += $size;
+                $anchorStats['file_count']++;
+                unset($anchorStats);
+            }
+        }
+
+        $summary['largest_category'] = $this->largestCategory($byCategory);
+        $summary['largest_category_bytes'] = $summary['largest_category'] === null
+            ? 0
+            : (int) $byCategory[$summary['largest_category']]['bytes'];
+
+        $topDirectories = array_values(array_filter(
+            $topDirectoryIndex,
+            static fn (array $row): bool => (int) ($row['bytes'] ?? 0) > 0
+        ));
+        usort($topDirectories, fn (array $left, array $right): int => $this->compareDirectoryRows($left, $right));
+        $topDirectories = array_slice($topDirectories, 0, self::TOP_DIRECTORY_LIMIT);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => 'ok',
+            'generated_at' => now()->toIso8601String(),
+            'root_path' => $rootPath,
+            'summary' => $summary,
+            'top_directories' => $topDirectories,
+            'by_category' => $byCategory,
+            'reclaim_candidates' => $this->buildReclaimCandidates($byCategory),
+            'no_touch_categories' => self::NO_TOUCH_CATEGORIES,
+            'suggested_next_actions' => $this->buildSuggestedNextActions($byCategory),
+        ];
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $normalized = str_replace('\\', '/', $path);
+
+        return rtrim($normalized, '/');
+    }
+
+    private function relativePath(string $rootPath, string $fullPath): string
+    {
+        $rootPath = $this->normalizePath($rootPath);
+        $fullPath = $this->normalizePath($fullPath);
+
+        if ($fullPath === $rootPath) {
+            return '';
+        }
+
+        if (! str_starts_with($fullPath, $rootPath.'/')) {
+            return ltrim($fullPath, '/');
+        }
+
+        return ltrim(substr($fullPath, strlen($rootPath)), '/');
+    }
+
+    private function classifyRelativePath(string $relativePath): string
+    {
+        $relativePath = trim(str_replace('\\', '/', $relativePath), '/');
+
+        return match (true) {
+            $this->matchesPrefix($relativePath, 'app/private/control_plane_snapshots') => 'control_plane_snapshots',
+            $this->matchesAnyPrefix($relativePath, [
+                'app/private/gc_plans',
+                'app/private/offload_plans',
+                'app/private/rehydrate_plans',
+                'app/private/quarantine_plans',
+                'app/private/quarantine_restore_plans',
+                'app/private/quarantine_purge_plans',
+                'app/private/retirement_plans',
+                'app/private/prune_plans',
+            ]) => 'control_plane_plans',
+            $this->matchesAnyPrefix($relativePath, [
+                'app/private/quarantine/restore_runs',
+                'app/private/quarantine/purge_runs',
+                'app/private/retirement_runs',
+                'app/private/rehydrate_runs',
+            ]) => 'control_plane_receipts',
+            $this->matchesPrefix($relativePath, 'app/private/quarantine/release_roots') => 'quarantine_live_roots',
+            $this->matchesPrefix($relativePath, 'app/private/packs_v2_materialized') => 'v2_materialized_cache',
+            $this->matchesPrefix($relativePath, 'app/private/offload/blobs') => 'offload_blob_copies',
+            $this->matchesPrefix($relativePath, 'framework') => 'framework_cache_or_sessions',
+            $this->matchesPrefix($relativePath, 'logs') => 'logs',
+            $this->matchesAnyPrefix($relativePath, [
+                'app/private/blobs',
+                'app/private/content_releases',
+                'app/private/reports',
+                'app/private/artifacts',
+                'app/private/packs_v2',
+                'app/content_packs_v2',
+                'app/public',
+            ]) => 'runtime_or_data_truth',
+            default => 'unknown',
+        };
+    }
+
+    private function anchorPathForRelativePath(string $relativePath, bool $isDirectory): string
+    {
+        $relativePath = trim(str_replace('\\', '/', $relativePath), '/');
+        $pathForAnchor = $isDirectory ? $relativePath : $this->parentDirectoryForFile($relativePath);
+
+        foreach (self::ANCHOR_PREFIXES as $prefix) {
+            if ($this->matchesPrefix($pathForAnchor, $prefix)) {
+                return $prefix;
+            }
+        }
+
+        if ($this->matchesPrefix($pathForAnchor, 'app/private/quarantine')) {
+            return $this->slicePath($pathForAnchor, 4);
+        }
+
+        if ($this->matchesPrefix($pathForAnchor, 'app/private')) {
+            return $this->slicePath($pathForAnchor, 3);
+        }
+
+        if ($this->matchesPrefix($pathForAnchor, 'app')) {
+            return $this->slicePath($pathForAnchor, 2);
+        }
+
+        if ($this->matchesPrefix($pathForAnchor, 'framework')) {
+            return $this->slicePath($pathForAnchor, 2);
+        }
+
+        if ($this->matchesPrefix($pathForAnchor, 'logs')) {
+            return 'logs';
+        }
+
+        return $this->slicePath($pathForAnchor, 1);
+    }
+
+    private function parentDirectoryForFile(string $relativePath): string
+    {
+        $directory = trim(str_replace('\\', '/', dirname($relativePath)), '/.');
+
+        if ($directory !== '') {
+            return $directory;
+        }
+
+        return trim(basename($relativePath), '/');
+    }
+
+    private function matchesAnyPrefix(string $path, array $prefixes): bool
+    {
+        foreach ($prefixes as $prefix) {
+            if ($this->matchesPrefix($path, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function matchesPrefix(string $path, string $prefix): bool
+    {
+        $path = trim($path, '/');
+        $prefix = trim($prefix, '/');
+
+        return $path === $prefix || str_starts_with($path, $prefix.'/');
+    }
+
+    private function slicePath(string $path, int $segments): string
+    {
+        $parts = array_values(array_filter(explode('/', trim($path, '/')), static fn (string $part): bool => $part !== ''));
+
+        return implode('/', array_slice($parts, 0, max(1, $segments)));
+    }
+
+    /**
+     * @param  array<string,array{path:string,bytes:int,file_count:int,directory_count:int,category:string,risk_level:string}>  $index
+     * @return array{path:string,bytes:int,file_count:int,directory_count:int,category:string,risk_level:string}
+     */
+    private function &topDirectoryEntry(array &$index, string $anchor): array
+    {
+        if (! isset($index[$anchor])) {
+            $category = $this->classifyRelativePath($anchor);
+            $index[$anchor] = [
+                'path' => $anchor,
+                'bytes' => 0,
+                'file_count' => 0,
+                'directory_count' => 0,
+                'category' => $category,
+                'risk_level' => self::CATEGORY_POLICY[$category]['risk_level'],
+            ];
+        }
+
+        return $index[$anchor];
+    }
+
+    /**
+     * @param  array{path:string,bytes:int,file_count:int,directory_count:int,category:string,risk_level:string}  $left
+     * @param  array{path:string,bytes:int,file_count:int,directory_count:int,category:string,risk_level:string}  $right
+     */
+    private function compareDirectoryRows(array $left, array $right): int
+    {
+        $bytes = $right['bytes'] <=> $left['bytes'];
+        if ($bytes !== 0) {
+            return $bytes;
+        }
+
+        return strcmp($left['path'], $right['path']);
+    }
+
+    /**
+     * @param  array<string,array{bytes:int,file_count:int,directory_count:int}>  $byCategory
+     */
+    private function largestCategory(array $byCategory): ?string
+    {
+        $largest = null;
+
+        foreach (self::CATEGORY_ORDER as $category) {
+            if (! isset($byCategory[$category])) {
+                continue;
+            }
+
+            if ($largest === null) {
+                $largest = $category;
+
+                continue;
+            }
+
+            $currentBytes = (int) $byCategory[$category]['bytes'];
+            $largestBytes = (int) $byCategory[$largest]['bytes'];
+            if ($currentBytes > $largestBytes) {
+                $largest = $category;
+            }
+        }
+
+        if ($largest === null || (int) $byCategory[$largest]['bytes'] === 0) {
+            return null;
+        }
+
+        return $largest;
+    }
+
+    /**
+     * @param  array<string,array{bytes:int,file_count:int,directory_count:int}>  $byCategory
+     * @return list<array{category:string,bytes:int,rationale:string,safe_next_action:string,risk_level:string}>
+     */
+    private function buildReclaimCandidates(array $byCategory): array
+    {
+        $candidates = [];
+
+        foreach (self::CATEGORY_ORDER as $category) {
+            if (in_array($category, self::NO_TOUCH_CATEGORIES, true)) {
+                continue;
+            }
+
+            $bytes = (int) ($byCategory[$category]['bytes'] ?? 0);
+            if ($bytes <= 0) {
+                continue;
+            }
+
+            $policy = self::CATEGORY_POLICY[$category];
+            $candidates[] = [
+                'category' => $category,
+                'bytes' => $bytes,
+                'rationale' => $policy['rationale'],
+                'safe_next_action' => $policy['safe_next_action'],
+                'risk_level' => $policy['risk_level'],
+            ];
+        }
+
+        usort($candidates, static function (array $left, array $right): int {
+            $bytes = $right['bytes'] <=> $left['bytes'];
+            if ($bytes !== 0) {
+                return $bytes;
+            }
+
+            return strcmp($left['category'], $right['category']);
+        });
+
+        return $candidates;
+    }
+
+    /**
+     * @param  array<string,array{bytes:int,file_count:int,directory_count:int}>  $byCategory
+     * @return list<array{priority:int,category:string,bytes:int,rationale:string,safe_next_action:string,risk_level:string}>
+     */
+    private function buildSuggestedNextActions(array $byCategory): array
+    {
+        $priorityOrder = [
+            'low' => 0,
+            'medium' => 1,
+            'manual_review' => 2,
+            'manual_only' => 3,
+        ];
+
+        $actions = [];
+
+        foreach ($this->buildReclaimCandidates($byCategory) as $candidate) {
+            if ($candidate['safe_next_action'] === 'retain') {
+                continue;
+            }
+
+            $actions[] = $candidate;
+        }
+
+        usort($actions, static function (array $left, array $right) use ($priorityOrder): int {
+            $leftPriority = $priorityOrder[$left['risk_level']] ?? 99;
+            $rightPriority = $priorityOrder[$right['risk_level']] ?? 99;
+
+            $priority = $leftPriority <=> $rightPriority;
+            if ($priority !== 0) {
+                return $priority;
+            }
+
+            $bytes = $right['bytes'] <=> $left['bytes'];
+            if ($bytes !== 0) {
+                return $bytes;
+            }
+
+            return strcmp($left['category'], $right['category']);
+        });
+
+        $prioritized = [];
+        foreach (array_values($actions) as $index => $action) {
+            $prioritized[] = [
+                'priority' => $index + 1,
+                'category' => $action['category'],
+                'bytes' => $action['bytes'],
+                'rationale' => $action['rationale'],
+                'safe_next_action' => $action['safe_next_action'],
+                'risk_level' => $action['risk_level'],
+            ];
+        }
+
+        return $prioritized;
+    }
+}

--- a/backend/tests/Feature/Storage/StorageCostAnalyzerCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageCostAnalyzerCommandTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageCostAnalyzer;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageCostAnalyzerCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-cost-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageCostAnalyzer::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_emits_json_payload_without_side_effects(): void
+    {
+        $this->writeSizedFile('app/private/control_plane_snapshots/snapshot.json', 12);
+        $this->writeSizedFile('logs/laravel.log', 5);
+        $this->writeSizedFile('app/private/blobs/runtime.bin', 18);
+
+        $auditCountBefore = DB::table('audit_logs')->count();
+        $filesBefore = $this->storageFilesSnapshot();
+
+        $this->assertSame(0, Artisan::call('storage:analyze-cost', [
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(trim(Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('storage_cost_analyzer.v1', $payload['schema_version']);
+        $this->assertSame('ok', $payload['status']);
+        $this->assertSame($this->isolatedStoragePath, $payload['root_path']);
+        $this->assertSame(35, data_get($payload, 'summary.total_bytes'));
+        $this->assertSame('runtime_or_data_truth', data_get($payload, 'summary.largest_category'));
+        $this->assertSame('app/private/blobs', data_get($payload, 'top_directories.0.path'));
+
+        $this->assertSame($auditCountBefore, DB::table('audit_logs')->count());
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+    }
+
+    public function test_command_emits_summary_output(): void
+    {
+        $this->writeSizedFile('app/private/packs_v2_materialized/cache/item.bin', 22);
+        $this->writeSizedFile('logs/laravel.log', 9);
+
+        $this->assertSame(0, Artisan::call('storage:analyze-cost'));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=ok', $output);
+        $this->assertStringContainsString('root='.$this->isolatedStoragePath, $output);
+        $this->assertStringContainsString('total_bytes=31', $output);
+        $this->assertStringContainsString('largest_category=v2_materialized_cache', $output);
+        $this->assertStringContainsString('largest_category_bytes=22', $output);
+        $this->assertStringContainsString('top_directory=app/private/packs_v2_materialized', $output);
+        $this->assertStringContainsString('top_directory_bytes=22', $output);
+    }
+
+    private function writeSizedFile(string $relativePath, int $bytes): void
+    {
+        $path = storage_path($relativePath);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, str_repeat('x', $bytes));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}

--- a/backend/tests/Feature/Storage/StorageCostAnalyzerServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageCostAnalyzerServiceTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\StorageCostAnalyzerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageCostAnalyzerServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-storage-cost-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_builds_stable_category_and_directory_analysis_without_side_effects(): void
+    {
+        $this->seedStorageTreeForAnalysis();
+
+        $auditCountBefore = DB::table('audit_logs')->count();
+        $filesBefore = $this->storageFilesSnapshot();
+
+        /** @var StorageCostAnalyzerService $service */
+        $service = app(StorageCostAnalyzerService::class);
+        $payload = $service->analyze($this->isolatedStoragePath);
+
+        $this->assertSame('storage_cost_analyzer.v1', $payload['schema_version']);
+        $this->assertSame('ok', $payload['status']);
+        $this->assertSame($this->isolatedStoragePath, $payload['root_path']);
+        $this->assertSame(360, data_get($payload, 'summary.total_bytes'));
+        $this->assertSame(11, data_get($payload, 'summary.total_files'));
+        $this->assertSame(24, data_get($payload, 'summary.total_directories'));
+        $this->assertSame('runtime_or_data_truth', data_get($payload, 'summary.largest_category'));
+        $this->assertSame(120, data_get($payload, 'summary.largest_category_bytes'));
+
+        $this->assertSame([
+            'path' => 'app/private/reports',
+            'bytes' => 90,
+            'file_count' => 1,
+            'directory_count' => 0,
+            'category' => 'runtime_or_data_truth',
+            'risk_level' => 'no_touch',
+        ], $payload['top_directories'][0]);
+        $topPaths = array_values(array_map(
+            static fn (array $row): string => (string) ($row['path'] ?? ''),
+            $payload['top_directories']
+        ));
+        $this->assertSame(
+            [
+                'app/private/reports',
+                'app/private/quarantine/release_roots',
+                'app/private/packs_v2_materialized',
+                'app/private/blobs',
+                'app/private/control_plane_snapshots',
+                'app/private/offload/blobs',
+                'app/private/prune_plans',
+                'app/private/custom_unknown',
+                'app/private/quarantine/restore_runs',
+                'framework/cache',
+                'logs',
+            ],
+            $topPaths
+        );
+
+        $this->assertSame([
+            'bytes' => 30,
+            'file_count' => 1,
+            'directory_count' => 1,
+        ], data_get($payload, 'by_category.control_plane_snapshots'));
+        $this->assertSame([
+            'bytes' => 20,
+            'file_count' => 1,
+            'directory_count' => 2,
+        ], data_get($payload, 'by_category.control_plane_plans'));
+        $this->assertSame([
+            'bytes' => 10,
+            'file_count' => 1,
+            'directory_count' => 2,
+        ], data_get($payload, 'by_category.control_plane_receipts'));
+        $this->assertSame([
+            'bytes' => 80,
+            'file_count' => 1,
+            'directory_count' => 5,
+        ], data_get($payload, 'by_category.quarantine_live_roots'));
+        $this->assertSame([
+            'bytes' => 40,
+            'file_count' => 1,
+            'directory_count' => 2,
+        ], data_get($payload, 'by_category.v2_materialized_cache'));
+        $this->assertSame([
+            'bytes' => 25,
+            'file_count' => 1,
+            'directory_count' => 2,
+        ], data_get($payload, 'by_category.offload_blob_copies'));
+        $this->assertSame([
+            'bytes' => 10,
+            'file_count' => 1,
+            'directory_count' => 2,
+        ], data_get($payload, 'by_category.framework_cache_or_sessions'));
+        $this->assertSame([
+            'bytes' => 10,
+            'file_count' => 1,
+            'directory_count' => 1,
+        ], data_get($payload, 'by_category.logs'));
+        $this->assertSame([
+            'bytes' => 120,
+            'file_count' => 2,
+            'directory_count' => 2,
+        ], data_get($payload, 'by_category.runtime_or_data_truth'));
+        $this->assertSame([
+            'bytes' => 15,
+            'file_count' => 1,
+            'directory_count' => 5,
+        ], data_get($payload, 'by_category.unknown'));
+
+        $this->assertSame([
+            'quarantine_live_roots',
+            'runtime_or_data_truth',
+        ], $payload['no_touch_categories']);
+
+        $this->assertSame('runtime_or_data_truth', data_get($payload, 'top_directories.0.category'));
+        $this->assertSame('control_plane_snapshots', data_get($payload, 'reclaim_candidates.1.category'));
+        $this->assertSame('low', data_get($payload, 'reclaim_candidates.1.risk_level'));
+        $this->assertSame('janitor snapshots', data_get($payload, 'reclaim_candidates.1.safe_next_action'));
+        $this->assertSame('unknown', data_get($payload, 'reclaim_candidates.4.category'));
+        $this->assertSame('inspect before action', data_get($payload, 'reclaim_candidates.4.safe_next_action'));
+        $this->assertSame('control_plane_snapshots', data_get($payload, 'suggested_next_actions.0.category'));
+        $this->assertSame('control_plane_plans', data_get($payload, 'suggested_next_actions.1.category'));
+        $this->assertSame('logs', data_get($payload, 'suggested_next_actions.2.category'));
+        $this->assertSame('v2_materialized_cache', data_get($payload, 'suggested_next_actions.3.category'));
+
+        $this->assertSame($auditCountBefore, DB::table('audit_logs')->count());
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+    }
+
+    private function seedStorageTreeForAnalysis(): void
+    {
+        $this->writeSizedFile('app/private/control_plane_snapshots/snapshot-1.json', 30);
+        $this->writeSizedFile('app/private/prune_plans/reports/plan-1.json', 20);
+        $this->writeSizedFile('app/private/quarantine/restore_runs/run-1/receipt.json', 10);
+        $this->writeSizedFile('app/private/quarantine/release_roots/run-1/items/item-1/root/live.bin', 80);
+        $this->writeSizedFile('app/private/packs_v2_materialized/cache-a/payload.bin', 40);
+        $this->writeSizedFile('app/private/offload/blobs/aa/blob-copy.bin', 25);
+        $this->writeSizedFile('framework/cache/data.bin', 10);
+        $this->writeSizedFile('logs/laravel.log', 10);
+        $this->writeSizedFile('app/private/reports/report-a.json', 90);
+        $this->writeSizedFile('app/private/custom_unknown/data.bin', 15);
+        $this->writeSizedFile('app/private/blobs/runtime.bin', 30);
+    }
+
+    private function writeSizedFile(string $relativePath, int $bytes): void
+    {
+        $path = storage_path($relativePath);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, str_repeat('x', $bytes));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}


### PR DESCRIPTION
## Summary
- add a new read-only `storage:analyze-cost` command for storage cost analysis
- add `StorageCostAnalyzerService` with stable category classification, top-directory ranking, reclaim candidates, and no-touch categories
- add focused tests for service classification/sorting/no-side-effects and command `--json`/summary output

## Validation
- `php artisan route:list > /tmp/pr30_route_list.txt`
- `php artisan migrate`
- `vendor/bin/pint --test app/Console/Commands/StorageCostAnalyzer.php app/Services/Storage/StorageCostAnalyzerService.php tests/Feature/Storage/StorageCostAnalyzerServiceTest.php tests/Feature/Storage/StorageCostAnalyzerCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageCostAnalyzerServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageCostAnalyzerCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php`
- `php artisan storage:analyze-cost --json`
- `php artisan storage:analyze-cost`
- `php artisan serve --host=127.0.0.1 --port=18081`
- `curl -i http://127.0.0.1:18081/api/healthz`

## Known blocker
- `bash backend/scripts/ci_verify_mbti.sh` is currently red on clean main for an unrelated OpenAPI snapshot drift:
  - missing `/api/v0.3/me/relationships/mbti/{inviteId}/journey`
  - action `MbtiCompareInviteController@mutatePrivateJourney`
- this PR does not change routes, middleware, migrations, lifecycle execution, or existing storage command contracts, so I kept that unblock out of scope.
