### PR TITLE
[codex] unblock openapi snapshot drift for journey route

### DIFF
--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -820,6 +820,27 @@
                 ]
             }
         },
+        "/api/v0.3/me/relationships/mbti/{inviteId}/journey": {
+            "post": {
+                "operationId": "post_api_v0_3_me_relationships_mbti_inviteid_journey",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\MbtiCompareInviteController@mutatePrivateJourney",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:inviteId"
+                ]
+            }
+        },
         "/api/v0.3/orders": {
             "post": {
                 "operationId": "post_api_v0_3_orders",


### PR DESCRIPTION
## Summary
- refresh `backend/docs/contracts/openapi.snapshot.json` for the existing private journey route
- keep the fix snapshot-only; no route, controller, middleware, or runtime contract changes
- restore the OpenAPI diff gate on current `main`

## Root cause
- `POST /api/v0.3/me/relationships/mbti/{inviteId}/journey` already exists in `backend/routes/api.php`
- `MbtiCompareInviteController@mutatePrivateJourney` already exists in runtime code
- `backend/docs/contracts/openapi.snapshot.json` was missing the generated OpenAPI entry for that route

## Validation
- `php artisan route:list > /tmp/pr30a_route_list.txt`
- `php artisan migrate`
- `bash scripts/export_openapi.sh --check`
- `php artisan test --filter OpenApiDiffTest --stop-on-failure`
- `php artisan serve --host=127.0.0.1 --port=18082`
- `curl -i http://127.0.0.1:18082/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
