### PR TITLE
[codex] Ship PR-11G relationship index and revisit surface (backend)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
@@ -40,6 +40,16 @@ final class MbtiCompareInviteController extends Controller
         return response()->json(array_merge(['ok' => true], $result));
     }
 
+    public function indexPrivate(Request $request): JsonResponse
+    {
+        $result = $this->service->listPrivate(
+            $request->attributes->get('user_id'),
+            $request->attributes->get('anon_id')
+        );
+
+        return response()->json(array_merge(['ok' => true], $result));
+    }
+
     public function mutatePrivateConsent(Request $request, string $inviteId): JsonResponse
     {
         $validated = $request->validate([

--- a/backend/app/Services/InsightGraph/RelationshipIndexContractService.php
+++ b/backend/app/Services/InsightGraph/RelationshipIndexContractService.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InsightGraph;
+
+final class RelationshipIndexContractService
+{
+    private const INDEX_VERSION = 'relationship.index.v1';
+    private const INDEX_SCOPE = 'private_relationship_index';
+    private const RESUME_VERSION = 'relationship.resume.v1';
+
+    /**
+     * @param  array<string,mixed>  $privateRelationship
+     * @param  array<string,mixed>  $dyadicConsent
+     * @param  array<string,mixed>  $privateJourney
+     * @return array<string,mixed>
+     */
+    public function buildItem(
+        string $inviteId,
+        array $privateRelationship,
+        array $dyadicConsent,
+        array $privateJourney,
+        string $resumeTarget,
+        string $updatedAt,
+        string $locale
+    ): array {
+        $accessState = $this->normalizeText($privateRelationship['access_state'] ?? null, $dyadicConsent['access_state'] ?? null) ?? 'awaiting_second_subject';
+        $consentState = $this->normalizeText($dyadicConsent['consent_state'] ?? null) ?? 'pending';
+        $journeyState = $this->normalizeText($privateJourney['journey_state'] ?? null) ?? 'awaiting_partner';
+        $progressState = $this->normalizeText($privateJourney['progress_state'] ?? null) ?? 'not_started';
+        $participantRole = $this->normalizeText($privateRelationship['participant_role'] ?? null) ?? 'inviter';
+        $entryKey = $this->resolveEntryKey($accessState, $consentState, $journeyState, $progressState);
+        $resumeReason = $this->resolveResumeReason($entryKey, $journeyState, $privateJourney);
+        $continueLabel = $this->resolveContinueLabel($entryKey, $locale);
+        $revisitReorderReason = $this->normalizeText($privateJourney['revisit_reorder_reason'] ?? null) ?? $resumeReason;
+
+        return [
+            'invite_id' => $inviteId,
+            'relationship_scope' => $this->normalizeText($privateRelationship['relationship_scope'] ?? null) ?? 'private_relationship_protected',
+            'access_state' => $accessState,
+            'consent_state' => $consentState,
+            'journey_state' => $journeyState,
+            'progress_state' => $progressState,
+            'participant_role' => $participantRole,
+            'entry_summary' => [
+                'title' => $this->normalizeText(data_get($privateRelationship, 'overview.title'))
+                    ?? ($locale === 'zh-CN' ? '私密关系洞察' : 'Private relationship sync'),
+                'summary' => $this->normalizeText(data_get($privateRelationship, 'overview.summary'))
+                    ?? ($locale === 'zh-CN' ? '回到这段关系，继续你们当前最适合的一步。' : 'Return to this relationship and continue the most relevant shared step.'),
+                'badge_label' => $this->resolveEntryLabel($entryKey, $locale),
+                'badge_key' => $entryKey,
+            ],
+            'resume_target' => $resumeTarget,
+            'revisit_priority_keys' => array_values(array_filter(array_unique([
+                $entryKey,
+                $journeyState,
+                $consentState,
+                $accessState,
+            ]))),
+            'last_dyadic_pulse_signal' => $this->normalizeText($privateJourney['last_dyadic_pulse_signal'] ?? null) ?? '',
+            'updated_at' => $updatedAt,
+            'relationship_resume_v1' => [
+                'resume_version' => self::RESUME_VERSION,
+                'resume_target' => $resumeTarget,
+                'continue_label' => $continueLabel,
+                'resume_reason' => $resumeReason,
+                'revisit_reorder_reason' => $revisitReorderReason,
+                'relationship_entry_keys' => [$entryKey],
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return array<string,mixed>
+     */
+    public function buildIndex(array $items): array
+    {
+        usort($items, fn (array $left, array $right): int => $this->compareItems($left, $right));
+
+        $fingerprintSeed = array_map(
+            fn (array $item): array => [
+                'invite_id' => $this->normalizeText($item['invite_id'] ?? null) ?? '',
+                'relationship_scope' => $this->normalizeText($item['relationship_scope'] ?? null) ?? '',
+                'access_state' => $this->normalizeText($item['access_state'] ?? null) ?? '',
+                'consent_state' => $this->normalizeText($item['consent_state'] ?? null) ?? '',
+                'journey_state' => $this->normalizeText($item['journey_state'] ?? null) ?? '',
+                'progress_state' => $this->normalizeText($item['progress_state'] ?? null) ?? '',
+                'participant_role' => $this->normalizeText($item['participant_role'] ?? null) ?? '',
+                'resume_target' => $this->normalizeText($item['resume_target'] ?? null) ?? '',
+                'updated_at' => $this->normalizeText($item['updated_at'] ?? null) ?? '',
+            ],
+            $items
+        );
+
+        return [
+            'relationship_index_version' => self::INDEX_VERSION,
+            'relationship_index_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'index_scope' => self::INDEX_SCOPE,
+            'items' => array_values($items),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $left
+     * @param  array<string,mixed>  $right
+     */
+    private function compareItems(array $left, array $right): int
+    {
+        $leftEntryKey = $this->firstString(data_get($left, 'relationship_resume_v1.relationship_entry_keys', []))
+            ?? $this->firstString($left['revisit_priority_keys'] ?? [])
+            ?? 'recently_active';
+        $rightEntryKey = $this->firstString(data_get($right, 'relationship_resume_v1.relationship_entry_keys', []))
+            ?? $this->firstString($right['revisit_priority_keys'] ?? [])
+            ?? 'recently_active';
+
+        $leftRank = $this->entryRank($leftEntryKey);
+        $rightRank = $this->entryRank($rightEntryKey);
+        if ($leftRank !== $rightRank) {
+            return $leftRank <=> $rightRank;
+        }
+
+        $leftUpdatedAt = strtotime((string) ($left['updated_at'] ?? '')) ?: 0;
+        $rightUpdatedAt = strtotime((string) ($right['updated_at'] ?? '')) ?: 0;
+        if ($leftUpdatedAt !== $rightUpdatedAt) {
+            return $rightUpdatedAt <=> $leftUpdatedAt;
+        }
+
+        return strcmp(
+            (string) data_get($left, 'entry_summary.title', ''),
+            (string) data_get($right, 'entry_summary.title', '')
+        );
+    }
+
+    private function resolveEntryKey(string $accessState, string $consentState, string $journeyState, string $progressState): string
+    {
+        return match (true) {
+            $accessState === 'private_access_expired' || $journeyState === 'revisit_after_consent_refresh' => 'needs_consent_refresh',
+            $accessState === 'private_access_revoked' || $progressState === 'restricted' => 'restricted_access',
+            $accessState === 'awaiting_second_subject' || $consentState === 'pending' => 'awaiting_partner',
+            in_array($journeyState, ['ready_for_first_step', 'practice_started', 'practice_revisit'], true) => 'ready_to_continue',
+            default => 'recently_active',
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $privateJourney
+     */
+    private function resolveResumeReason(string $entryKey, string $journeyState, array $privateJourney): string
+    {
+        $revisitReason = $this->normalizeText($privateJourney['revisit_reorder_reason'] ?? null);
+        if ($revisitReason !== null) {
+            return $revisitReason;
+        }
+
+        return match ($entryKey) {
+            'ready_to_continue' => $journeyState === 'practice_revisit' ? 'resume_dyadic_practice' : 'activate_first_dyadic_step',
+            'needs_consent_refresh' => 'refresh_private_access',
+            'restricted_access' => 'private_access_restricted',
+            'awaiting_partner' => 'await_partner_completion',
+            default => 'review_recent_relationship',
+        };
+    }
+
+    private function resolveContinueLabel(string $entryKey, string $locale): string
+    {
+        if ($locale === 'zh-CN') {
+            return match ($entryKey) {
+                'ready_to_continue' => '继续关系行动',
+                'needs_consent_refresh' => '刷新并继续',
+                'restricted_access' => '查看访问状态',
+                'awaiting_partner' => '查看等待状态',
+                default => '回到关系洞察',
+            };
+        }
+
+        return match ($entryKey) {
+            'ready_to_continue' => 'Continue relationship',
+            'needs_consent_refresh' => 'Refresh and continue',
+            'restricted_access' => 'Review access state',
+            'awaiting_partner' => 'Review waiting state',
+            default => 'Open relationship',
+        };
+    }
+
+    private function resolveEntryLabel(string $entryKey, string $locale): string
+    {
+        if ($locale === 'zh-CN') {
+            return match ($entryKey) {
+                'ready_to_continue' => '可继续',
+                'needs_consent_refresh' => '需刷新授权',
+                'restricted_access' => '访问受限',
+                'awaiting_partner' => '等待对方',
+                default => '最近活跃',
+            };
+        }
+
+        return match ($entryKey) {
+            'ready_to_continue' => 'Ready to continue',
+            'needs_consent_refresh' => 'Refresh required',
+            'restricted_access' => 'Restricted access',
+            'awaiting_partner' => 'Awaiting partner',
+            default => 'Recently active',
+        };
+    }
+
+    private function entryRank(string $entryKey): int
+    {
+        return match ($entryKey) {
+            'ready_to_continue' => 0,
+            'needs_consent_refresh' => 1,
+            'restricted_access' => 2,
+            'awaiting_partner' => 3,
+            default => 4,
+        };
+    }
+
+    /**
+     * @param  iterable<mixed>  $values
+     */
+    private function firstString(iterable $values): ?string
+    {
+        foreach ($values as $value) {
+            $text = $this->normalizeText($value);
+            if ($text !== null) {
+                return $text;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeText(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/V0_3/MbtiCompareInviteService.php
+++ b/backend/app/Services/V0_3/MbtiCompareInviteService.php
@@ -12,6 +12,7 @@ use App\Models\Share;
 use App\Services\InsightGraph\PrivateRelationshipContractService;
 use App\Services\InsightGraph\PrivateRelationshipJourneyContractService;
 use App\Services\InsightGraph\RelationshipSyncContractService;
+use App\Services\InsightGraph\RelationshipIndexContractService;
 use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -27,6 +28,7 @@ final class MbtiCompareInviteService
         private readonly RelationshipSyncContractService $relationshipSyncContractService,
         private readonly PrivateRelationshipContractService $privateRelationshipContractService,
         private readonly PrivateRelationshipJourneyContractService $privateRelationshipJourneyContractService,
+        private readonly RelationshipIndexContractService $relationshipIndexContractService,
     ) {}
 
     /**
@@ -202,6 +204,99 @@ final class MbtiCompareInviteService
             'private_relationship_journey_v1' => $privateRelationshipJourney,
             'dyadic_pulse_check_v1' => $dyadicPulseCheck,
             'dyadic_graph_v1' => $this->privateRelationshipContractService->buildProtectedGraph($privateRelationship),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function listPrivate(mixed $userId, mixed $anonId): array
+    {
+        $normalizedUserId = $this->nullableString($userId);
+        $normalizedAnonId = $this->nullableString($anonId);
+        $normalizedNumericUserId = $this->normalizeUserId($normalizedUserId);
+
+        $attemptIds = Attempt::query()
+            ->where(static function ($query) use ($normalizedNumericUserId, $normalizedAnonId): void {
+                $hasCondition = false;
+                if ($normalizedNumericUserId !== null) {
+                    $query->where('user_id', $normalizedNumericUserId);
+                    $hasCondition = true;
+                }
+                if ($normalizedAnonId !== null) {
+                    if ($hasCondition) {
+                        $query->orWhere('anon_id', $normalizedAnonId);
+                    } else {
+                        $query->where('anon_id', $normalizedAnonId);
+                    }
+                }
+            })
+            ->pluck('id')
+            ->map(static fn (mixed $value): string => (string) $value)
+            ->all();
+
+        if ($attemptIds === [] && $normalizedNumericUserId === null && $normalizedAnonId === null) {
+            return [
+                'scale_code' => 'MBTI',
+                'relationship_index_v1' => $this->relationshipIndexContractService->buildIndex([]),
+            ];
+        }
+
+        $invites = MbtiCompareInvite::query()
+            ->where(static function ($query) use ($attemptIds, $normalizedNumericUserId, $normalizedAnonId): void {
+                $hasCondition = false;
+                if ($attemptIds !== []) {
+                    $query->whereIn('inviter_attempt_id', $attemptIds)
+                        ->orWhereIn('invitee_attempt_id', $attemptIds);
+                    $hasCondition = true;
+                }
+                if ($normalizedNumericUserId !== null) {
+                    if ($hasCondition) {
+                        $query->orWhere('invitee_user_id', $normalizedNumericUserId);
+                    } else {
+                        $query->where('invitee_user_id', $normalizedNumericUserId);
+                        $hasCondition = true;
+                    }
+                }
+                if ($normalizedAnonId !== null) {
+                    if ($hasCondition) {
+                        $query->orWhere('invitee_anon_id', $normalizedAnonId);
+                    } else {
+                        $query->where('invitee_anon_id', $normalizedAnonId);
+                    }
+                }
+            })
+            ->orderByDesc('updated_at')
+            ->get();
+
+        $items = [];
+
+        foreach ($invites as $invite) {
+            try {
+                $detail = $this->showPrivate((string) $invite->id, $userId, $anonId);
+            } catch (ApiProblemException $exception) {
+                if ($exception->getStatusCode() === 404) {
+                    continue;
+                }
+
+                throw $exception;
+            }
+
+            $locale = $this->normalizeLocale((string) ($detail['locale'] ?? 'zh-CN'));
+            $items[] = $this->relationshipIndexContractService->buildItem(
+                (string) $invite->id,
+                is_array($detail['private_relationship_v1'] ?? null) ? $detail['private_relationship_v1'] : [],
+                is_array($detail['dyadic_consent_v1'] ?? null) ? $detail['dyadic_consent_v1'] : [],
+                is_array($detail['private_relationship_journey_v1'] ?? null) ? $detail['private_relationship_journey_v1'] : [],
+                $this->buildProtectedRelationshipPath($locale, (string) $invite->id),
+                $this->resolveRelationshipUpdatedAt($invite),
+                $locale
+            );
+        }
+
+        return [
+            'scale_code' => 'MBTI',
+            'relationship_index_v1' => $this->relationshipIndexContractService->buildIndex($items),
         ];
     }
 
@@ -711,6 +806,13 @@ final class MbtiCompareInviteService
         return '/'.$segment.'/history/mbti';
     }
 
+    private function buildProtectedRelationshipPath(string $locale, string $inviteId): string
+    {
+        $segment = $locale === 'zh-CN' ? 'zh' : 'en';
+
+        return '/'.$segment.'/relationships/mbti/'.rawurlencode($inviteId);
+    }
+
     private function normalizeStatus(string $status): string
     {
         $normalized = strtolower(trim($status));
@@ -1048,6 +1150,15 @@ final class MbtiCompareInviteService
 
         $invite->meta_json = $meta;
         $invite->save();
+    }
+
+    private function resolveRelationshipUpdatedAt(MbtiCompareInvite $invite): string
+    {
+        return $invite->updated_at?->toISOString()
+            ?? $invite->purchased_at?->toISOString()
+            ?? $invite->completed_at?->toISOString()
+            ?? $invite->accepted_at?->toISOString()
+            ?? '';
     }
 
     private function nullableString(mixed $value): ?string

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -121,6 +121,7 @@ Route::prefix('v0.3')->middleware([
 
     Route::middleware(\App\Http\Middleware\FmTokenAuth::class)->group(function () {
         Route::get('/me/attempts', [MeV03Controller::class, 'attempts']);
+        Route::get('/me/relationships/mbti', [MbtiCompareInviteController::class, 'indexPrivate']);
         Route::get('/me/relationships/mbti/{inviteId}', [MbtiCompareInviteController::class, 'showPrivate'])
             ->middleware('uuid:inviteId');
         Route::post('/me/relationships/mbti/{inviteId}/consent', [MbtiCompareInviteController::class, 'mutatePrivateConsent'])

--- a/backend/tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php
+++ b/backend/tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php
@@ -252,6 +252,117 @@ final class MbtiPrivateRelationshipAccessTest extends TestCase
         $this->assertSame('continue_dyadic_action', (string) ($journeyOverlay['last_dyadic_pulse_signal'] ?? ''));
     }
 
+    public function test_private_relationship_index_lists_accessible_relationships_and_orders_resume_priority(): void
+    {
+        $this->seedScales();
+
+        [$inviterAttemptId, $inviterAnonId, $inviterToken] = $this->createOwnerContext('anon_private_index_inviter', 'INTJ-A');
+        $shareId = $this->createShareViaApi($inviterAttemptId, $inviterAnonId, $inviterToken);
+        [$inviteeAttemptId, $inviteeAnonId] = $this->createOwnerContext('anon_private_index_invitee', 'ENFP-T');
+        [$outsiderAttemptId, $outsiderAnonId, $outsiderToken] = $this->createOwnerContext('anon_private_index_outsider', 'INFJ-A');
+        $outsiderShareId = $this->createShareViaApi($outsiderAttemptId, $outsiderAnonId, $outsiderToken);
+
+        $readyInviteId = (string) $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'utm_source' => 'share',
+        ])->assertOk()->json('invite_id');
+
+        $refreshInviteId = (string) $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe_2',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'utm_source' => 'share',
+        ])->assertOk()->json('invite_id');
+
+        $awaitingInviteId = (string) $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe_3',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'utm_source' => 'share',
+        ])->assertOk()->json('invite_id');
+
+        $outsiderInviteId = (string) $this->postJson("/api/v0.3/shares/{$outsiderShareId}/compare-invites", [
+            'anon_id' => 'scan_probe_4',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'utm_source' => 'share',
+        ])->assertOk()->json('invite_id');
+
+        DB::table('mbti_compare_invites')
+            ->where('id', $readyInviteId)
+            ->update([
+                'invitee_attempt_id' => $inviteeAttemptId,
+                'invitee_anon_id' => $inviteeAnonId,
+                'status' => 'purchased',
+                'accepted_at' => now()->subMinutes(12),
+                'completed_at' => now()->subMinutes(11),
+                'purchased_at' => now()->subMinutes(10),
+                'updated_at' => now()->subMinutes(2),
+            ]);
+
+        DB::table('mbti_compare_invites')
+            ->where('id', $refreshInviteId)
+            ->update([
+                'invitee_attempt_id' => $inviteeAttemptId,
+                'invitee_anon_id' => $inviteeAnonId,
+                'status' => 'purchased',
+                'accepted_at' => now()->subMinutes(9),
+                'completed_at' => now()->subMinutes(8),
+                'purchased_at' => now()->subMinutes(7),
+                'meta_json' => json_encode([
+                    'dyadic_consent_lifecycle_v1' => [
+                        'revocation_state' => 'active',
+                        'expiry_state' => 'expired',
+                        'expires_at' => now()->subMinute()->toISOString(),
+                        'consent_policy_version' => '2025-01-01',
+                    ],
+                    'private_relationship_journey_v1' => [
+                        'journey_state' => 'practice_started',
+                        'progress_state' => 'warming_up',
+                        'revisit_reorder_reason' => 'refresh_private_access',
+                        'updated_at' => now()->subMinute()->toISOString(),
+                    ],
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'updated_at' => now()->subMinute(),
+            ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviterToken,
+            'X-Anon-Id' => $inviterAnonId,
+        ])->getJson('/api/v0.3/me/relationships/mbti');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('scale_code', 'MBTI')
+            ->assertJsonPath('relationship_index_v1.relationship_index_version', 'relationship.index.v1')
+            ->assertJsonPath('relationship_index_v1.index_scope', 'private_relationship_index')
+            ->assertJsonCount(3, 'relationship_index_v1.items')
+            ->assertJsonPath('relationship_index_v1.items.0.invite_id', $readyInviteId)
+            ->assertJsonPath('relationship_index_v1.items.0.relationship_scope', 'private_relationship_protected')
+            ->assertJsonPath('relationship_index_v1.items.0.access_state', 'private_access_ready')
+            ->assertJsonPath('relationship_index_v1.items.0.consent_state', 'purchased')
+            ->assertJsonPath('relationship_index_v1.items.0.journey_state', 'ready_for_first_step')
+            ->assertJsonPath('relationship_index_v1.items.0.resume_target', '/zh/relationships/mbti/'.$readyInviteId)
+            ->assertJsonPath('relationship_index_v1.items.0.relationship_resume_v1.relationship_entry_keys.0', 'ready_to_continue')
+            ->assertJsonPath('relationship_index_v1.items.1.invite_id', $refreshInviteId)
+            ->assertJsonPath('relationship_index_v1.items.1.relationship_resume_v1.relationship_entry_keys.0', 'needs_consent_refresh')
+            ->assertJsonPath('relationship_index_v1.items.2.invite_id', $awaitingInviteId)
+            ->assertJsonPath('relationship_index_v1.items.2.relationship_resume_v1.relationship_entry_keys.0', 'awaiting_partner')
+            ->assertJsonMissingPath('relationship_index_v1.items.0.invitee_attempt_id')
+            ->assertJsonMissingPath('relationship_index_v1.items.0.invitee_anon_id')
+            ->assertJsonMissingPath('relationship_index_v1.items.0.invitee_user_id')
+            ->assertJsonMissingPath('relationship_index_v1.items.0.invitee_order_no');
+
+        $itemIds = array_map(
+            static fn (array $item): string => (string) ($item['invite_id'] ?? ''),
+            (array) $response->json('relationship_index_v1.items', [])
+        );
+
+        $this->assertNotContains($outsiderInviteId, $itemIds);
+    }
+
     private function seedScales(): void
     {
         (new ScaleRegistrySeeder)->run();

--- a/backend/tests/Unit/Services/InsightGraph/RelationshipIndexContractServiceTest.php
+++ b/backend/tests/Unit/Services/InsightGraph/RelationshipIndexContractServiceTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\InsightGraph;
+
+use App\Services\InsightGraph\RelationshipIndexContractService;
+use Tests\TestCase;
+
+final class RelationshipIndexContractServiceTest extends TestCase
+{
+    public function test_it_builds_relationship_index_items_and_orders_them_by_resume_priority(): void
+    {
+        $service = app(RelationshipIndexContractService::class);
+
+        $ready = $service->buildItem(
+            'invite-ready',
+            [
+                'relationship_scope' => 'private_relationship_protected',
+                'access_state' => 'private_access_ready',
+                'participant_role' => 'inviter',
+                'overview' => [
+                    'title' => 'Ready relationship',
+                    'summary' => 'Continue the next shared step.',
+                ],
+            ],
+            [
+                'consent_state' => 'purchased',
+                'access_state' => 'private_access_ready',
+            ],
+            [
+                'journey_state' => 'practice_started',
+                'progress_state' => 'warming_up',
+                'revisit_reorder_reason' => 'activate_first_dyadic_step',
+                'last_dyadic_pulse_signal' => 'continue_dyadic_action',
+            ],
+            '/en/relationships/mbti/invite-ready',
+            '2026-03-21T09:00:00+08:00',
+            'en'
+        );
+
+        $refresh = $service->buildItem(
+            'invite-refresh',
+            [
+                'relationship_scope' => 'private_relationship_protected',
+                'access_state' => 'private_access_expired',
+                'participant_role' => 'inviter',
+                'overview' => [
+                    'title' => 'Refresh relationship',
+                    'summary' => 'Refresh private access before continuing.',
+                ],
+            ],
+            [
+                'consent_state' => 'purchased',
+                'access_state' => 'private_access_expired',
+            ],
+            [
+                'journey_state' => 'revisit_after_consent_refresh',
+                'progress_state' => 'restricted',
+                'revisit_reorder_reason' => 'refresh_private_access',
+                'last_dyadic_pulse_signal' => 'refresh_private_access',
+            ],
+            '/en/relationships/mbti/invite-refresh',
+            '2026-03-21T08:00:00+08:00',
+            'en'
+        );
+
+        $awaiting = $service->buildItem(
+            'invite-awaiting',
+            [
+                'relationship_scope' => 'private_relationship_protected',
+                'access_state' => 'awaiting_second_subject',
+                'participant_role' => 'inviter',
+                'overview' => [
+                    'title' => 'Awaiting relationship',
+                    'summary' => 'Wait for the second participant.',
+                ],
+            ],
+            [
+                'consent_state' => 'pending',
+                'access_state' => 'awaiting_second_subject',
+            ],
+            [
+                'journey_state' => 'awaiting_partner',
+                'progress_state' => 'not_started',
+                'last_dyadic_pulse_signal' => '',
+            ],
+            '/en/relationships/mbti/invite-awaiting',
+            '2026-03-21T07:00:00+08:00',
+            'en'
+        );
+
+        $index = $service->buildIndex([$awaiting, $refresh, $ready]);
+
+        $this->assertSame('relationship.index.v1', $index['relationship_index_version']);
+        $this->assertSame('private_relationship_index', $index['index_scope']);
+        $this->assertNotSame('', (string) ($index['relationship_index_fingerprint'] ?? ''));
+        $this->assertSame('invite-ready', data_get($index, 'items.0.invite_id'));
+        $this->assertSame('invite-refresh', data_get($index, 'items.1.invite_id'));
+        $this->assertSame('invite-awaiting', data_get($index, 'items.2.invite_id'));
+        $this->assertSame('ready_to_continue', data_get($index, 'items.0.revisit_priority_keys.0'));
+        $this->assertSame('needs_consent_refresh', data_get($index, 'items.1.revisit_priority_keys.0'));
+        $this->assertSame('awaiting_partner', data_get($index, 'items.2.relationship_resume_v1.relationship_entry_keys.0'));
+        $this->assertSame('Continue relationship', data_get($index, 'items.0.relationship_resume_v1.continue_label'));
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships the backend half of PR-11G: relationship index and revisit surface.

It upgrades the existing private relationship and compare-invite foundation into the first backend-owned relationship index, so authenticated users no longer need a single invite deep link to revisit protected MBTI relationship insights.

## Problem

By PR-11F, the platform already had:

- compare-invite lifecycle
- protected/private relationship detail
- `private_relationship_v1`
- `dyadic_consent_v1`
- `private_relationship_journey_v1`
- `dyadic_pulse_check_v1`

But users still lacked a stable authenticated relationship entry surface.

In practice, private relationship revisit still depended on:

- a single `inviteId` deep link
- a post-purchase entry shortcut
- manual re-entry into a known relationship URL

That meant the relationship system had detail authority, but no index authority.

## Root cause

The repo already had a strong single authority object in `MbtiCompareInvite`, and the protected detail route already built complete private relationship, consent, and journey contracts.

What was missing was a backend-owned list/read model that:

- aggregates only accessible relationship items for the current actor
- exposes relationship-scoped summary and resume metadata
- orders revisit priority on the backend
- keeps public compare and private relationship index fully separate

Without that layer, the system still behaved like a collection of private detail pages rather than a revisit surface.

## Fix

This PR adds `relationship_index_v1` and a protected list route under the existing auth family:

- `GET /api/v0.3/me/relationships/mbti`

The implementation stays intentionally constrained:

- reuses `MbtiCompareInvite` as the single authority
- derives index items from existing private relationship, consent, and journey contracts
- uses existing lifecycle timestamps and `meta_json`
- does not add a new data model, CRM table, or second authority

Each relationship index item includes:

- `invite_id`
- `relationship_scope`
- `access_state`
- `consent_state`
- `journey_state`
- `progress_state`
- `participant_role`
- `entry_summary`
- `resume_target`
- `revisit_priority_keys`
- `last_dyadic_pulse_signal`
- `updated_at`
- additive `relationship_resume_v1`

The service also applies backend-owned ordering so the list can distinguish first-wave revisit buckets such as:

- ready to continue
- needs consent refresh
- restricted access
- awaiting partner
- recently active

## User impact

Authenticated users now have the first stable relationship revisit foundation.

They no longer need to rely on a single `inviteId` deep link to get back into private relationship insights. Instead, the backend can expose a scoped relationship list with resume targets and revisit priority already resolved.

## Validation

I ran:

- `php artisan test tests/Unit/Services/InsightGraph/RelationshipIndexContractServiceTest.php tests/Unit/Services/InsightGraph/PrivateRelationshipContractServiceTest.php tests/Unit/Services/InsightGraph/PrivateRelationshipJourneyContractServiceTest.php tests/Feature/V0_3/MbtiPrivateRelationshipAccessTest.php --compact`

All passed:

- 7 tests passed
- 162 assertions

## Scope note

This PR is intentionally limited to the first relationship index layer.

It does not add:

- CRM notes, labels, or reminders
- public relationship feeds
- friend graph or social graph features
- Big Five dyadic support
- multi-party relationship graph support
- migration or new dependencies

It also does not include unrelated backend worktree changes already present outside the 11G task scope.
