### PR TITLE
[codex] add materialized cache janitor

### DIFF
--- a/backend/app/Console/Commands/StorageJanitorMaterializedCache.php
+++ b/backend/app/Console/Commands/StorageJanitorMaterializedCache.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\MaterializedCacheJanitorService;
+use Illuminate\Console\Command;
+
+final class StorageJanitorMaterializedCache extends Command
+{
+    protected $signature = 'storage:janitor-materialized-cache
+        {--dry-run : Preview provably rebuildable materialized cache buckets only}
+        {--execute : Delete provably rebuildable whole materialized cache buckets}
+        {--json : Emit the full janitor payload as JSON}';
+
+    protected $description = 'Manual-only janitor for whole materialized cache buckets that are currently provably rebuildable.';
+
+    public function __construct(
+        private readonly MaterializedCacheJanitorService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $payload = $this->service->run($execute);
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode materialized cache janitor json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return self::SUCCESS;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('mode='.(string) ($payload['mode'] ?? ''));
+        $this->line('schema='.(string) ($payload['schema'] ?? ''));
+        $this->line('generated_at='.(string) ($payload['generated_at'] ?? ''));
+        $this->line('scanned_bucket_count='.(int) ($summary['scanned_bucket_count'] ?? 0));
+        $this->line('candidate_delete_count='.(int) ($summary['candidate_delete_count'] ?? 0));
+        $this->line('deleted_bucket_count='.(int) ($summary['deleted_bucket_count'] ?? 0));
+        $this->line('skipped_bucket_count='.(int) ($summary['skipped_bucket_count'] ?? 0));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Services/Storage/MaterializedCacheJanitorService.php
+++ b/backend/app/Services/Storage/MaterializedCacheJanitorService.php
@@ -1,0 +1,499 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Services\Content\ContentPackV2RemoteRehydrateService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class MaterializedCacheJanitorService
+{
+    private const SCHEMA = 'storage_janitor_materialized_cache.v1';
+
+    private const TARGET_RELATIVE_DIR = 'app/private/packs_v2_materialized';
+
+    public function __construct(
+        private readonly ReleaseStorageLocator $releaseStorageLocator,
+        private readonly ContentPackV2RemoteRehydrateService $remoteRehydrate,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function run(bool $execute): array
+    {
+        $bucketRoots = $this->bucketRoots();
+        $candidates = [];
+        $skipped = [];
+        $deletedPaths = [];
+        $reasonCounts = [];
+
+        foreach ($bucketRoots as $bucketRoot) {
+            $inspection = $this->inspectBucket($bucketRoot);
+            $reason = (string) ($inspection['reason'] ?? '');
+            if ($reason !== '') {
+                $reasonCounts[$reason] = (int) ($reasonCounts[$reason] ?? 0) + 1;
+            }
+
+            if ((bool) ($inspection['candidate'] ?? false)) {
+                $candidate = $inspection;
+                unset($candidate['candidate']);
+
+                if ($execute) {
+                    File::deleteDirectory($bucketRoot);
+                    if (! is_dir($bucketRoot)) {
+                        $deletedPaths[] = $bucketRoot;
+                    }
+                }
+
+                $candidates[] = $candidate;
+
+                continue;
+            }
+
+            $skipped[] = $inspection;
+        }
+
+        usort($candidates, static fn (array $left, array $right): int => strcmp((string) ($left['bucket_root'] ?? ''), (string) ($right['bucket_root'] ?? '')));
+        usort($skipped, static fn (array $left, array $right): int => strcmp((string) ($left['bucket_root'] ?? ''), (string) ($right['bucket_root'] ?? '')));
+        sort($deletedPaths);
+        ksort($reasonCounts);
+
+        $payload = [
+            'schema' => self::SCHEMA,
+            'mode' => $execute ? 'execute' : 'dry_run',
+            'status' => $execute ? 'executed' : 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'summary' => [
+                'scanned_bucket_count' => count($bucketRoots),
+                'candidate_delete_count' => count($candidates),
+                'deleted_bucket_count' => count($deletedPaths),
+                'skipped_bucket_count' => count($skipped),
+            ],
+            'candidates' => array_values($candidates),
+            'skipped' => array_values($skipped),
+            'reasons' => $reasonCounts,
+            'deleted_paths' => $deletedPaths,
+        ];
+
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function bucketRoots(): array
+    {
+        $baseRoot = $this->materializedBaseRoot();
+        if (! is_dir($baseRoot)) {
+            return [];
+        }
+
+        $glob = glob($baseRoot.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR);
+        if (! is_array($glob)) {
+            return [];
+        }
+
+        $roots = array_values(array_filter(
+            array_map(fn (string $path): string => $this->normalizePath($path), $glob),
+            fn (string $path): bool => $path !== '' && is_dir($path)
+        ));
+
+        sort($roots);
+
+        return array_values(array_unique($roots));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function inspectBucket(string $bucketRoot): array
+    {
+        $shape = $this->bucketShape($bucketRoot);
+        if ($shape === null) {
+            return $this->skip($bucketRoot, 'BUCKET_SHAPE_INVALID');
+        }
+
+        $sentinelPath = $bucketRoot.'/.materialization.json';
+        if (! is_file($sentinelPath)) {
+            return $this->skip($bucketRoot, 'MATERIALIZATION_SENTINEL_MISSING', $shape);
+        }
+
+        $sentinel = json_decode((string) File::get($sentinelPath), true);
+        if (! is_array($sentinel)) {
+            return $this->skip($bucketRoot, 'MATERIALIZATION_SENTINEL_INVALID', $shape);
+        }
+
+        $storagePath = trim((string) ($sentinel['storage_path'] ?? ''));
+        if ($storagePath === '') {
+            return $this->skip($bucketRoot, 'MATERIALIZATION_SENTINEL_STORAGE_PATH_MISSING', $shape);
+        }
+
+        $manifestHash = strtolower(trim((string) ($sentinel['manifest_hash'] ?? '')));
+        if ($manifestHash === '') {
+            return $this->skip($bucketRoot, 'MATERIALIZATION_SENTINEL_MANIFEST_HASH_MISSING', $shape, $storagePath);
+        }
+
+        if (! preg_match('/^[a-f0-9]{64}$/', $shape['storage_identity'])) {
+            return $this->skip($bucketRoot, 'BUCKET_STORAGE_IDENTITY_INVALID', $shape, $storagePath, $manifestHash);
+        }
+
+        if (! preg_match('/^[a-f0-9]{64}$/', $shape['manifest_hash'])) {
+            return $this->skip($bucketRoot, 'BUCKET_MANIFEST_HASH_INVALID', $shape, $storagePath, $manifestHash);
+        }
+
+        if ($shape['storage_identity'] !== hash('sha256', $storagePath)) {
+            return $this->skip($bucketRoot, 'BUCKET_STORAGE_IDENTITY_MISMATCH', $shape, $storagePath, $manifestHash);
+        }
+
+        if ($shape['manifest_hash'] !== $manifestHash) {
+            return $this->skip($bucketRoot, 'BUCKET_MANIFEST_HASH_MISMATCH', $shape, $storagePath, $manifestHash);
+        }
+
+        $bucketCompiledManifestPath = $bucketRoot.'/compiled/manifest.json';
+        if (! is_file($bucketCompiledManifestPath)) {
+            return $this->skip($bucketRoot, 'BUCKET_COMPILED_MANIFEST_MISSING', $shape, $storagePath, $manifestHash);
+        }
+
+        $bucketCompiledManifestHash = strtolower((string) hash_file('sha256', $bucketCompiledManifestPath));
+        if ($bucketCompiledManifestHash !== $manifestHash) {
+            return $this->skip($bucketRoot, 'BUCKET_COMPILED_MANIFEST_HASH_MISMATCH', $shape, $storagePath, $manifestHash);
+        }
+
+        $localProof = $this->proveLocal($storagePath, $manifestHash);
+        if ((bool) ($localProof['ok'] ?? false)) {
+            return [
+                'candidate' => true,
+                'bucket_root' => $bucketRoot,
+                'pack_id' => $shape['pack_id'],
+                'pack_version' => $shape['pack_version'],
+                'storage_identity' => $shape['storage_identity'],
+                'manifest_hash' => $manifestHash,
+                'storage_path' => $storagePath,
+                'release_id' => trim((string) ($sentinel['release_id'] ?? '')),
+                'proof_kind' => 'local',
+                'proof_reason' => (string) ($localProof['reason'] ?? 'LOCAL_SOURCE_CONFIRMED'),
+                'proof_context' => $localProof['context'] ?? [],
+                'reason' => 'LOCAL_SOURCE_CONFIRMED',
+            ];
+        }
+
+        $remoteProof = $this->proveRemote(
+            $shape['pack_id'],
+            $shape['pack_version'],
+            $storagePath,
+            $manifestHash,
+            trim((string) ($sentinel['release_id'] ?? ''))
+        );
+
+        if ((bool) ($remoteProof['ok'] ?? false)) {
+            return [
+                'candidate' => true,
+                'bucket_root' => $bucketRoot,
+                'pack_id' => $shape['pack_id'],
+                'pack_version' => $shape['pack_version'],
+                'storage_identity' => $shape['storage_identity'],
+                'manifest_hash' => $manifestHash,
+                'storage_path' => $storagePath,
+                'release_id' => (string) ($remoteProof['release_id'] ?? trim((string) ($sentinel['release_id'] ?? ''))),
+                'proof_kind' => 'remote',
+                'proof_reason' => (string) ($remoteProof['reason'] ?? 'REMOTE_FALLBACK_CONFIRMED'),
+                'proof_context' => $remoteProof['context'] ?? [],
+                'reason' => 'REMOTE_FALLBACK_CONFIRMED',
+            ];
+        }
+
+        return $this->skip(
+            $bucketRoot,
+            (string) ($remoteProof['reason'] ?? $localProof['reason'] ?? 'MATERIALIZED_BUCKET_NOT_PROVABLY_REBUILDABLE'),
+            $shape,
+            $storagePath,
+            $manifestHash,
+            ['local_context' => $localProof['context'] ?? [], 'remote_context' => $remoteProof['context'] ?? []]
+        );
+    }
+
+    /**
+     * @return array<string,string>|null
+     */
+    private function bucketShape(string $bucketRoot): ?array
+    {
+        $baseRoot = $this->materializedBaseRoot();
+        $normalizedBase = $this->normalizePath($baseRoot);
+        $normalizedBucket = $this->normalizePath($bucketRoot);
+        if ($normalizedBase === '' || $normalizedBucket === '' || ! str_starts_with($normalizedBucket, $normalizedBase.'/')) {
+            return null;
+        }
+
+        $relative = substr($normalizedBucket, strlen($normalizedBase) + 1);
+        $segments = explode('/', $relative);
+        if (count($segments) !== 4) {
+            return null;
+        }
+
+        [$packId, $packVersion, $storageIdentity, $manifestHash] = $segments;
+        if ($packId === '' || $packVersion === '' || $storageIdentity === '' || $manifestHash === '') {
+            return null;
+        }
+
+        return [
+            'pack_id' => $packId,
+            'pack_version' => $packVersion,
+            'storage_identity' => strtolower($storageIdentity),
+            'manifest_hash' => strtolower($manifestHash),
+        ];
+    }
+
+    /**
+     * @return array{ok:bool,reason:string,context:array<string,mixed>}
+     */
+    private function proveLocal(string $storagePath, string $manifestHash): array
+    {
+        foreach ($this->releaseStorageLocator->candidateRootsFromStoragePath($storagePath) as $root) {
+            $compiledDir = $this->releaseStorageLocator->compiledDirFromRoot($root);
+            if ($compiledDir === null) {
+                continue;
+            }
+
+            $manifestPath = $compiledDir.'/manifest.json';
+            if (! is_file($manifestPath)) {
+                continue;
+            }
+
+            $currentManifestHash = strtolower((string) hash_file('sha256', $manifestPath));
+            if ($currentManifestHash === $manifestHash) {
+                return [
+                    'ok' => true,
+                    'reason' => 'LOCAL_SOURCE_CONFIRMED',
+                    'context' => [
+                        'source_root' => $root,
+                        'source_compiled_dir' => $compiledDir,
+                    ],
+                ];
+            }
+        }
+
+        return [
+            'ok' => false,
+            'reason' => 'LOCAL_SOURCE_NOT_REBUILDABLE',
+            'context' => [],
+        ];
+    }
+
+    /**
+     * @return array{ok:bool,reason:string,context:array<string,mixed>,release_id?:string}
+     */
+    private function proveRemote(
+        string $packId,
+        string $packVersion,
+        string $storagePath,
+        string $manifestHash,
+        string $sentinelReleaseId,
+    ): array {
+        $disk = trim((string) config('storage_rollout.blob_offload_disk', 's3'));
+        if ($disk === '') {
+            return [
+                'ok' => false,
+                'reason' => 'REMOTE_FALLBACK_DISK_MISSING',
+                'context' => [],
+            ];
+        }
+
+        $candidates = $this->candidateReleases($packId, $packVersion, $storagePath, $manifestHash, $sentinelReleaseId);
+        if ($candidates === []) {
+            return [
+                'ok' => false,
+                'reason' => 'REMOTE_FALLBACK_RELEASE_CONTEXT_MISSING',
+                'context' => [],
+            ];
+        }
+
+        $lastReason = 'REMOTE_FALLBACK_PROBE_FAILED';
+        foreach ($candidates as $release) {
+            try {
+                $probe = $this->remoteRehydrate->probeRemoteFallback($release, $disk);
+                if ((bool) ($probe['available'] ?? false) !== true) {
+                    $lastReason = trim((string) ($probe['reason'] ?? $lastReason));
+
+                    continue;
+                }
+
+                if (strtolower(trim((string) ($probe['manifest_hash'] ?? ''))) !== $manifestHash) {
+                    $lastReason = 'REMOTE_FALLBACK_MANIFEST_HASH_MISMATCH';
+
+                    continue;
+                }
+
+                return [
+                    'ok' => true,
+                    'reason' => 'REMOTE_FALLBACK_CONFIRMED',
+                    'release_id' => trim((string) ($release->id ?? '')),
+                    'context' => [
+                        'disk' => $disk,
+                        'release_id' => trim((string) ($release->id ?? '')),
+                        'exact_manifest_id' => (int) ($probe['exact_manifest_id'] ?? 0),
+                        'exact_identity_hash' => (string) ($probe['exact_identity_hash'] ?? ''),
+                        'source_kind' => (string) ($probe['source_kind'] ?? ''),
+                    ],
+                ];
+            } catch (\Throwable $e) {
+                $message = trim($e->getMessage());
+                $lastReason = $message !== '' ? $message : $lastReason;
+            }
+        }
+
+        return [
+            'ok' => false,
+            'reason' => $lastReason,
+            'context' => [
+                'disk' => $disk,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function candidateReleases(
+        string $packId,
+        string $packVersion,
+        string $storagePath,
+        string $manifestHash,
+        string $sentinelReleaseId,
+    ): array {
+        $rows = [];
+        $seen = [];
+
+        if ($sentinelReleaseId !== '') {
+            $row = DB::table('content_pack_releases')->where('id', $sentinelReleaseId)->first();
+            if ($this->releaseMatchesBucket($row, $packId, $packVersion, $storagePath, $manifestHash)) {
+                $rows[] = $row;
+                $seen[(string) $row->id] = true;
+            }
+        }
+
+        $queryRows = DB::table('content_pack_releases')
+            ->where('to_pack_id', $packId)
+            ->where('storage_path', $storagePath)
+            ->where('manifest_hash', $manifestHash)
+            ->where('status', 'success')
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->get();
+
+        foreach ($queryRows as $row) {
+            if (! $this->releaseMatchesBucket($row, $packId, $packVersion, $storagePath, $manifestHash)) {
+                continue;
+            }
+
+            $releaseId = trim((string) ($row->id ?? ''));
+            if ($releaseId === '' || isset($seen[$releaseId])) {
+                continue;
+            }
+
+            $seen[$releaseId] = true;
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    private function releaseMatchesBucket(
+        ?object $row,
+        string $packId,
+        string $packVersion,
+        string $storagePath,
+        string $manifestHash,
+    ): bool {
+        if ($row === null) {
+            return false;
+        }
+
+        $rowPackVersion = trim((string) ($row->pack_version ?? $row->dir_alias ?? ''));
+
+        return strtoupper(trim((string) ($row->to_pack_id ?? ''))) === strtoupper($packId)
+            && $rowPackVersion === $packVersion
+            && trim((string) ($row->storage_path ?? '')) === $storagePath
+            && strtolower(trim((string) ($row->manifest_hash ?? ''))) === $manifestHash
+            && strtolower(trim((string) ($row->status ?? ''))) === 'success';
+    }
+
+    private function materializedBaseRoot(): string
+    {
+        return storage_path(self::TARGET_RELATIVE_DIR);
+    }
+
+    private function normalizePath(string $path): string
+    {
+        return str_replace('\\', '/', rtrim(trim($path), '/\\'));
+    }
+
+    /**
+     * @param  array<string,string>|null  $shape
+     * @param  array<string,mixed>  $extra
+     * @return array<string,mixed>
+     */
+    private function skip(
+        string $bucketRoot,
+        string $reason,
+        ?array $shape = null,
+        string $storagePath = '',
+        string $manifestHash = '',
+        array $extra = [],
+    ): array {
+        return array_merge([
+            'candidate' => false,
+            'bucket_root' => $bucketRoot,
+            'pack_id' => (string) ($shape['pack_id'] ?? ''),
+            'pack_version' => (string) ($shape['pack_version'] ?? ''),
+            'storage_identity' => (string) ($shape['storage_identity'] ?? ''),
+            'manifest_hash' => $manifestHash !== '' ? $manifestHash : (string) ($shape['manifest_hash'] ?? ''),
+            'storage_path' => $storagePath,
+            'reason' => $reason,
+        ], $extra);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_janitor_materialized_cache',
+            'target_type' => 'storage',
+            'target_id' => 'materialized_cache',
+            'meta_json' => json_encode([
+                'schema' => self::SCHEMA,
+                'mode' => $payload['mode'] ?? null,
+                'generated_at' => $payload['generated_at'] ?? null,
+                'summary' => $payload['summary'] ?? [],
+                'reasons' => $payload['reasons'] ?? [],
+                'candidates' => array_map(static fn (array $entry): array => [
+                    'bucket_root' => (string) ($entry['bucket_root'] ?? ''),
+                    'proof_kind' => (string) ($entry['proof_kind'] ?? ''),
+                    'proof_reason' => (string) ($entry['proof_reason'] ?? ''),
+                    'storage_path' => (string) ($entry['storage_path'] ?? ''),
+                    'manifest_hash' => (string) ($entry['manifest_hash'] ?? ''),
+                ], is_array($payload['candidates'] ?? null) ? $payload['candidates'] : []),
+                'deleted_paths' => $payload['deleted_paths'] ?? [],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_janitor_materialized_cache',
+            'request_id' => null,
+            'reason' => 'materialized_cache_retention',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php
+++ b/backend/tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php
@@ -1,0 +1,530 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Content\ContentPackV2Resolver;
+use App\Services\Storage\ExactReleaseFileSetCatalogService;
+use App\Services\Storage\MaterializedCacheJanitorService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MaterializedCacheJanitorServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-materialized-janitor-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+
+        config()->set('storage_rollout.packs_v2_remote_rehydrate_enabled', true);
+        config()->set('storage_rollout.resolver_materialization_enabled', true);
+        config()->set('storage_rollout.blob_offload_disk', 's3');
+        config()->set('filesystems.disks.s3.bucket', 'packs2-remote-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.packs2-remote.test');
+        Storage::forgetDisk('s3');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_local_source_candidate_is_deleted_as_whole_bucket_and_can_be_rematerialized(): void
+    {
+        $fixture = $this->seedLocalSourceFixture('local-proof');
+        $bucketRoot = $fixture['bucket_root'];
+        $otherRoots = $this->seedNoTouchRoots();
+
+        /** @var MaterializedCacheJanitorService $service */
+        $service = app(MaterializedCacheJanitorService::class);
+
+        $dryRun = $service->run(false);
+        $this->assertSame('planned', $dryRun['status']);
+        $this->assertSame(1, data_get($dryRun, 'summary.scanned_bucket_count'));
+        $this->assertSame(1, data_get($dryRun, 'summary.candidate_delete_count'));
+        $this->assertSame(0, data_get($dryRun, 'summary.deleted_bucket_count'));
+        $this->assertFileExists($bucketRoot.'/.materialization.json');
+        $this->assertFileExists($bucketRoot.'/compiled/questions.compiled.json');
+
+        $result = $service->run(true);
+        $this->assertSame('executed', $result['status']);
+        $this->assertSame(1, data_get($result, 'summary.deleted_bucket_count'));
+        $this->assertDirectoryDoesNotExist($bucketRoot);
+        $this->assertFileExists($fixture['source_compiled_dir'].'/manifest.json');
+        $this->assertFileExists($otherRoots['private_v2_root'].'/compiled/manifest.json');
+        $this->assertFileExists($otherRoots['content_v2_root'].'/compiled/manifest.json');
+        $this->assertFileExists($otherRoots['blobs_file']);
+        $this->assertFileExists($otherRoots['quarantine_file']);
+        $this->assertFileExists($otherRoots['control_plane_file']);
+        $this->assertFileExists($otherRoots['offload_file']);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1');
+        $this->assertSame($fixture['bucket_compiled_dir'], $resolved);
+        $this->assertFileExists($bucketRoot.'/compiled/questions.compiled.json');
+
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_janitor_materialized_cache',
+            'target_id' => 'materialized_cache',
+            'result' => 'success',
+        ]);
+    }
+
+    public function test_remote_proof_candidate_is_deleted_and_resolver_can_regenerate_via_remote_fallback(): void
+    {
+        $fixture = $this->seedRemoteFallbackFixture('remote-proof');
+        $bucketRoot = $fixture['bucket_root'];
+        File::deleteDirectory($fixture['source_root']);
+        File::deleteDirectory($fixture['mirror_root']);
+
+        /** @var MaterializedCacheJanitorService $service */
+        $service = app(MaterializedCacheJanitorService::class);
+        $result = $service->run(true);
+
+        $this->assertSame(1, data_get($result, 'summary.candidate_delete_count'));
+        $this->assertSame(1, data_get($result, 'summary.deleted_bucket_count'));
+        $this->assertDirectoryDoesNotExist($bucketRoot);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1');
+        $this->assertSame($fixture['bucket_compiled_dir'], $resolved);
+        $this->assertSame('{"source":"remote-proof"}', (string) File::get($fixture['bucket_compiled_dir'].'/questions.compiled.json'));
+    }
+
+    public function test_remote_proof_failure_skips_bucket_without_deleting_it(): void
+    {
+        $fixture = $this->seedRemoteFallbackFixture('remote-missing', createRemoteCoverage: false);
+        File::deleteDirectory($fixture['source_root']);
+        File::deleteDirectory($fixture['mirror_root']);
+
+        /** @var MaterializedCacheJanitorService $service */
+        $service = app(MaterializedCacheJanitorService::class);
+        $result = $service->run(true);
+
+        $this->assertSame(0, data_get($result, 'summary.candidate_delete_count'));
+        $this->assertSame(0, data_get($result, 'summary.deleted_bucket_count'));
+        $this->assertSame(1, data_get($result, 'summary.skipped_bucket_count'));
+        $this->assertDirectoryExists($fixture['bucket_root']);
+        $this->assertSame('PACKS2_REMOTE_REHYDRATE_REMOTE_COVERAGE_INCOMPLETE', data_get($result, 'skipped.0.reason'));
+    }
+
+    public function test_invalid_sentinel_and_missing_compiled_manifest_are_skipped_and_partial_paths_are_not_deleted(): void
+    {
+        $invalidSentinel = $this->seedMalformedBucket([
+            'manifest_hash' => str_repeat('1', 64),
+            'with_sentinel' => true,
+            'sentinel' => ['manifest_hash' => str_repeat('1', 64)],
+            'with_compiled_manifest' => true,
+        ]);
+        $missingCompiledManifest = $this->seedMalformedBucket([
+            'manifest_hash' => str_repeat('2', 64),
+            'with_sentinel' => true,
+            'sentinel' => [
+                'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/missing-compiled',
+                'manifest_hash' => str_repeat('2', 64),
+                'release_id' => (string) Str::uuid(),
+            ],
+            'with_compiled_manifest' => false,
+        ]);
+        $partialFile = storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/partial-only.txt');
+        File::ensureDirectoryExists(dirname($partialFile));
+        File::put($partialFile, 'partial');
+
+        /** @var MaterializedCacheJanitorService $service */
+        $service = app(MaterializedCacheJanitorService::class);
+        $result = $service->run(true);
+
+        $this->assertSame(2, data_get($result, 'summary.scanned_bucket_count'));
+        $this->assertSame(0, data_get($result, 'summary.deleted_bucket_count'));
+        $this->assertSame(2, data_get($result, 'summary.skipped_bucket_count'));
+        $this->assertDirectoryExists($invalidSentinel['bucket_root']);
+        $this->assertDirectoryExists($missingCompiledManifest['bucket_root']);
+        $this->assertFileExists($partialFile);
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function seedLocalSourceFixture(string $suffix): array
+    {
+        $releaseId = (string) Str::uuid();
+        $manifestPayload = $this->manifestPayload('BIG5_OCEAN', 'v1', $suffix);
+        $manifestHash = hash('sha256', $manifestPayload);
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $sourceRoot = storage_path('app/'.$storagePath);
+        $sourceCompiledDir = $sourceRoot.'/compiled';
+
+        $this->insertRelease($releaseId, $manifestHash, $storagePath);
+        $this->activateRelease($releaseId);
+        $this->writeCompiledTree($sourceCompiledDir, [
+            'manifest.json' => $manifestPayload,
+            'questions.compiled.json' => '{"source":"'.$suffix.'"}',
+        ]);
+
+        $bucketRoot = $this->materializedBucketRoot('BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+        $this->writeMaterializedBucket($bucketRoot, [
+            'release_id' => $releaseId,
+            'storage_path' => $storagePath,
+            'manifest_hash' => $manifestHash,
+            'source_compiled_dir' => $sourceCompiledDir,
+            'materialized_at' => now()->toIso8601String(),
+        ], [
+            'manifest.json' => $manifestPayload,
+            'questions.compiled.json' => '{"source":"'.$suffix.'"}',
+        ]);
+
+        return [
+            'release_id' => $releaseId,
+            'storage_path' => $storagePath,
+            'manifest_hash' => $manifestHash,
+            'source_root' => $sourceRoot,
+            'source_compiled_dir' => $sourceCompiledDir,
+            'bucket_root' => $bucketRoot,
+            'bucket_compiled_dir' => $bucketRoot.'/compiled',
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function seedRemoteFallbackFixture(string $suffix, bool $createRemoteCoverage = true): array
+    {
+        $releaseId = (string) Str::uuid();
+        ['manifest_hash' => $manifestHash, 'files' => $files] = $this->buildRemoteFiles($suffix);
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $sourceRoot = storage_path('app/'.$storagePath);
+        $mirrorRoot = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId);
+
+        $this->insertRelease($releaseId, $manifestHash, $storagePath);
+        $this->activateRelease($releaseId);
+        $manifest = $this->seedExactManifest(
+            $releaseId,
+            'v2.primary',
+            $sourceRoot,
+            $manifestHash,
+            $files,
+            $createRemoteCoverage
+        );
+
+        $bucketRoot = $this->materializedBucketRoot('BIG5_OCEAN', 'v1', $storagePath, $manifestHash);
+        $this->writeMaterializedBucket($bucketRoot, [
+            'release_id' => $releaseId,
+            'storage_path' => $storagePath,
+            'manifest_hash' => $manifestHash,
+            'source_compiled_dir' => 'remote_rehydrate://exact_manifest/'.(int) $manifest->getKey(),
+            'materialized_at' => now()->toIso8601String(),
+            'remote_fallback' => true,
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'exact_identity_hash' => (string) $manifest->exact_identity_hash,
+            'source_kind' => 'v2.primary',
+        ], [
+            'manifest.json' => $files['compiled/manifest.json'],
+            'questions.compiled.json' => $files['compiled/questions.compiled.json'],
+            'layout.compiled.json' => $files['compiled/layout.compiled.json'],
+        ]);
+
+        return [
+            'release_id' => $releaseId,
+            'storage_path' => $storagePath,
+            'manifest_hash' => $manifestHash,
+            'source_root' => $sourceRoot,
+            'mirror_root' => $mirrorRoot,
+            'bucket_root' => $bucketRoot,
+            'bucket_compiled_dir' => $bucketRoot.'/compiled',
+        ];
+    }
+
+    /**
+     * @param  array{manifest_hash:string,with_sentinel:bool,sentinel:array<string,mixed>,with_compiled_manifest:bool}  $options
+     * @return array<string,string>
+     */
+    private function seedMalformedBucket(array $options): array
+    {
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.Str::uuid();
+        $bucketRoot = $this->materializedBucketRoot('BIG5_OCEAN', 'v1', $storagePath, $options['manifest_hash']);
+        File::ensureDirectoryExists($bucketRoot.'/compiled');
+
+        if ($options['with_sentinel']) {
+            File::put(
+                $bucketRoot.'/.materialization.json',
+                json_encode($options['sentinel'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL
+            );
+        }
+
+        if ($options['with_compiled_manifest']) {
+            File::put($bucketRoot.'/compiled/manifest.json', $this->manifestPayload('BIG5_OCEAN', 'v1', 'malformed-'.$options['manifest_hash']));
+        }
+
+        File::put($bucketRoot.'/compiled/questions.compiled.json', '{"source":"malformed"}');
+
+        return [
+            'bucket_root' => $bucketRoot,
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function seedNoTouchRoots(): array
+    {
+        $privateV2Root = storage_path('app/private/packs_v2/BIG5_OCEAN/v1/no-touch-private');
+        $contentV2Root = storage_path('app/content_packs_v2/BIG5_OCEAN/v1/no-touch-mirror');
+        $blobsFile = storage_path('app/private/blobs/no-touch.bin');
+        $quarantineFile = storage_path('app/private/quarantine/release_roots/run-1/items/item-1/root/.quarantine.json');
+        $controlPlaneFile = storage_path('app/private/control_plane_snapshots/no-touch.json');
+        $offloadFile = storage_path('app/private/offload/blobs/no-touch.bin');
+
+        $this->writeCompiledTree($privateV2Root.'/compiled', ['manifest.json' => $this->manifestPayload('BIG5_OCEAN', 'v1', 'private-no-touch')]);
+        $this->writeCompiledTree($contentV2Root.'/compiled', ['manifest.json' => $this->manifestPayload('BIG5_OCEAN', 'v1', 'mirror-no-touch')]);
+        File::ensureDirectoryExists(dirname($blobsFile));
+        File::put($blobsFile, 'blob');
+        File::ensureDirectoryExists(dirname($quarantineFile));
+        File::put($quarantineFile, '{}');
+        File::ensureDirectoryExists(dirname($controlPlaneFile));
+        File::put($controlPlaneFile, '{}');
+        File::ensureDirectoryExists(dirname($offloadFile));
+        File::put($offloadFile, 'offload');
+
+        return [
+            'private_v2_root' => $privateV2Root,
+            'content_v2_root' => $contentV2Root,
+            'blobs_file' => $blobsFile,
+            'quarantine_file' => $quarantineFile,
+            'control_plane_file' => $controlPlaneFile,
+            'offload_file' => $offloadFile,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $sentinel
+     * @param  array<string,string>  $compiledFiles
+     */
+    private function writeMaterializedBucket(string $bucketRoot, array $sentinel, array $compiledFiles): void
+    {
+        File::ensureDirectoryExists($bucketRoot.'/compiled');
+        File::put(
+            $bucketRoot.'/.materialization.json',
+            json_encode($sentinel, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL
+        );
+
+        foreach ($compiledFiles as $relativePath => $payload) {
+            File::put($bucketRoot.'/compiled/'.ltrim($relativePath, '/'), $payload);
+        }
+    }
+
+    private function materializedBucketRoot(string $packId, string $packVersion, string $storagePath, string $manifestHash): string
+    {
+        return storage_path('app/private/packs_v2_materialized/'.$packId.'/'.$packVersion.'/'.hash('sha256', $storagePath).'/'.$manifestHash);
+    }
+
+    private function manifestPayload(string $packId, string $packVersion, string $suffix): string
+    {
+        $payload = json_encode([
+            'pack_id' => $packId,
+            'pack_version' => $packVersion,
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $this->assertIsString($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return array{manifest_hash:string,files:array<string,string>}
+     */
+    private function buildRemoteFiles(string $suffix): array
+    {
+        $manifestPayload = $this->manifestPayload('BIG5_OCEAN', 'v1', $suffix);
+
+        return [
+            'manifest_hash' => hash('sha256', $manifestPayload),
+            'files' => [
+                'compiled/manifest.json' => $manifestPayload,
+                'compiled/questions.compiled.json' => json_encode(['source' => $suffix], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'compiled/layout.compiled.json' => json_encode(['layout' => $suffix], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function seedExactManifest(
+        string $releaseId,
+        string $sourceKind,
+        string $sourceRoot,
+        string $manifestHash,
+        array $files,
+        bool $createRemoteCoverage,
+    ): object {
+        $manifest = app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => $sourceKind,
+            'source_disk' => 'local',
+            'source_storage_path' => $sourceRoot,
+            'manifest_hash' => $manifestHash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => $manifestHash,
+            'content_hash' => hash('sha256', 'content|'.$manifestHash),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$manifestHash,
+            'payload_json' => ['remote_fallback' => true],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], collect($files)->map(
+            fn (string $payload, string $logicalPath): array => [
+                'logical_path' => $logicalPath,
+                'blob_hash' => hash('sha256', $payload),
+                'size_bytes' => strlen($payload),
+                'role' => $logicalPath === 'compiled/manifest.json' ? 'manifest' : 'compiled',
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'checksum' => 'sha256:'.hash('sha256', $payload),
+            ]
+        )->values()->all());
+
+        foreach ($files as $payload) {
+            $hash = hash('sha256', $payload);
+            DB::table('storage_blobs')->updateOrInsert(
+                ['hash' => $hash],
+                [
+                    'disk' => 'local',
+                    'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                    'size_bytes' => strlen($payload),
+                    'content_type' => 'application/json',
+                    'encoding' => 'identity',
+                    'ref_count' => 1,
+                    'first_seen_at' => now(),
+                    'last_verified_at' => now(),
+                ]
+            );
+
+            if (! $createRemoteCoverage) {
+                continue;
+            }
+
+            $remotePath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+            Storage::disk('s3')->put($remotePath, $payload);
+            DB::table('storage_blob_locations')->updateOrInsert(
+                [
+                    'disk' => 's3',
+                    'storage_path' => $remotePath,
+                ],
+                [
+                    'blob_hash' => $hash,
+                    'location_kind' => 'remote_copy',
+                    'size_bytes' => strlen($payload),
+                    'checksum' => 'sha256:'.$hash,
+                    'etag' => 'etag-'.substr($hash, 0, 8),
+                    'storage_class' => 'STANDARD_IA',
+                    'verified_at' => now(),
+                    'meta_json' => json_encode([
+                        'bucket' => 'packs2-remote-bucket',
+                        'region' => 'ap-guangzhou',
+                        'endpoint' => 'https://cos.packs2-remote.test',
+                        'url' => 'https://cos.packs2-remote.test/'.$remotePath,
+                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]
+            );
+        }
+
+        return $manifest;
+    }
+
+    private function insertRelease(
+        string $releaseId,
+        string $manifestHash,
+        string $storagePath,
+        string $action = 'packs2_publish',
+        mixed $createdAt = null,
+    ): void {
+        $createdAt ??= now();
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => $action,
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v1',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => 'test',
+            'created_by' => 'test',
+            'manifest_hash' => $manifestHash,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => null,
+            'norms_version' => null,
+            'git_sha' => null,
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $storagePath,
+            'source_commit' => null,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ]);
+    }
+
+    private function activateRelease(string $releaseId): void
+    {
+        DB::table('content_pack_activations')->updateOrInsert(
+            [
+                'pack_id' => 'BIG5_OCEAN',
+                'pack_version' => 'v1',
+            ],
+            [
+                'release_id' => $releaseId,
+                'activated_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function writeCompiledTree(string $compiledDir, array $files): void
+    {
+        File::ensureDirectoryExists($compiledDir);
+
+        foreach ($files as $relativePath => $contents) {
+            $absolutePath = $compiledDir.'/'.ltrim($relativePath, '/');
+            File::ensureDirectoryExists(dirname($absolutePath));
+            File::put($absolutePath, $contents);
+        }
+    }
+}

--- a/backend/tests/Feature/Storage/StorageJanitorMaterializedCacheCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageJanitorMaterializedCacheCommandTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageJanitorMaterializedCache;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageJanitorMaterializedCacheCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-materialized-janitor-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageJanitorMaterializedCache::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_dry_run_outputs_summary_contract_without_deleting_files(): void
+    {
+        $fixture = $this->seedLocalCandidateBucket();
+        $filesBefore = $this->storageFilesSnapshot();
+
+        $this->assertSame(0, Artisan::call('storage:janitor-materialized-cache', [
+            '--dry-run' => true,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=planned', $output);
+        $this->assertStringContainsString('mode=dry_run', $output);
+        $this->assertStringContainsString('scanned_bucket_count=1', $output);
+        $this->assertStringContainsString('candidate_delete_count=1', $output);
+        $this->assertStringContainsString('skipped_bucket_count=0', $output);
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+        $this->assertDirectoryExists($fixture['bucket_root']);
+        $this->assertPlanRunReceiptTreesDoNotExist();
+    }
+
+    public function test_command_execute_outputs_summary_contract_and_deletes_whole_bucket(): void
+    {
+        $fixture = $this->seedLocalCandidateBucket();
+
+        $this->assertSame(0, Artisan::call('storage:janitor-materialized-cache', [
+            '--execute' => true,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=executed', $output);
+        $this->assertStringContainsString('mode=execute', $output);
+        $this->assertStringContainsString('deleted_bucket_count=1', $output);
+        $this->assertStringContainsString('skipped_bucket_count=0', $output);
+        $this->assertDirectoryDoesNotExist($fixture['bucket_root']);
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_janitor_materialized_cache',
+            'target_id' => 'materialized_cache',
+            'result' => 'success',
+        ]);
+        $this->assertPlanRunReceiptTreesDoNotExist();
+    }
+
+    public function test_command_json_outputs_full_payload(): void
+    {
+        $fixture = $this->seedLocalCandidateBucket();
+
+        $this->assertSame(0, Artisan::call('storage:janitor-materialized-cache', [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(trim(Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('storage_janitor_materialized_cache.v1', $payload['schema']);
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame(1, data_get($payload, 'summary.scanned_bucket_count'));
+        $this->assertSame($fixture['bucket_root'], data_get($payload, 'candidates.0.bucket_root'));
+        $this->assertSame('local', data_get($payload, 'candidates.0.proof_kind'));
+    }
+
+    public function test_command_fails_when_mode_is_missing(): void
+    {
+        $this->assertSame(1, Artisan::call('storage:janitor-materialized-cache'));
+        $this->assertStringContainsString('exactly one of --dry-run or --execute is required.', Artisan::output());
+    }
+
+    public function test_command_fails_when_both_modes_are_passed(): void
+    {
+        $this->assertSame(1, Artisan::call('storage:janitor-materialized-cache', [
+            '--dry-run' => true,
+            '--execute' => true,
+        ]));
+        $this->assertStringContainsString('exactly one of --dry-run or --execute is required.', Artisan::output());
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function seedLocalCandidateBucket(): array
+    {
+        $releaseId = (string) Str::uuid();
+        $manifestPayload = json_encode([
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|command'),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($manifestPayload);
+
+        $manifestHash = hash('sha256', $manifestPayload);
+        $storagePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => 'packs2_publish',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v1',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => 'test',
+            'created_by' => 'test',
+            'manifest_hash' => $manifestHash,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => null,
+            'norms_version' => null,
+            'git_sha' => null,
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $storagePath,
+            'source_commit' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $sourceCompiledDir = storage_path('app/'.$storagePath.'/compiled');
+        File::ensureDirectoryExists($sourceCompiledDir);
+        File::put($sourceCompiledDir.'/manifest.json', $manifestPayload);
+        File::put($sourceCompiledDir.'/questions.compiled.json', '{"source":"command"}');
+
+        $bucketRoot = storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.hash('sha256', $storagePath).'/'.$manifestHash);
+        File::ensureDirectoryExists($bucketRoot.'/compiled');
+        File::put($bucketRoot.'/.materialization.json', json_encode([
+            'release_id' => $releaseId,
+            'storage_path' => $storagePath,
+            'manifest_hash' => $manifestHash,
+            'source_compiled_dir' => $sourceCompiledDir,
+            'materialized_at' => now()->toIso8601String(),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+        File::put($bucketRoot.'/compiled/manifest.json', $manifestPayload);
+        File::put($bucketRoot.'/compiled/questions.compiled.json', '{"source":"command"}');
+
+        return [
+            'bucket_root' => $bucketRoot,
+        ];
+    }
+
+    private function assertPlanRunReceiptTreesDoNotExist(): void
+    {
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/gc_plans'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/rehydrate_plans'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/quarantine_plans'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/retirement_plans'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/rehydrate_runs'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/quarantine/restore_runs'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/quarantine/purge_runs'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}


### PR DESCRIPTION
## Summary
- add a manual-only `storage:janitor-materialized-cache` command for whole materialized cache buckets
- add `MaterializedCacheJanitorService` with conservative per-bucket local/remote rebuild proofs and whole-bucket delete only
- add focused tests for local proof, remote proof, skip behavior, command mode contract, JSON output, and no plan/run tree side effects

## Validation
- `php -l app/Console/Commands/StorageJanitorMaterializedCache.php`
- `php -l app/Services/Storage/MaterializedCacheJanitorService.php`
- `php -l tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php`
- `php -l tests/Feature/Storage/StorageJanitorMaterializedCacheCommandTest.php`
- `./vendor/bin/pint app/Console/Commands/StorageJanitorMaterializedCache.php app/Services/Storage/MaterializedCacheJanitorService.php tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php tests/Feature/Storage/StorageJanitorMaterializedCacheCommandTest.php`
- `php artisan route:list > /tmp/pr31_route_list.txt`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageJanitorMaterializedCacheCommandTest.php`
- `vendor/bin/phpunit tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php tests/Feature/Storage/ExactRootQuarantineServiceTest.php tests/Feature/Storage/QuarantinedRootPurgeServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageCostAnalyzerServiceTest.php`
- `php artisan storage:janitor-materialized-cache --dry-run --json`
- `php artisan storage:janitor-materialized-cache --execute --json`
- `php artisan serve --host=127.0.0.1 --port=18081`
- `curl -i http://127.0.0.1:18081/api/healthz`

## Known blocker
- `bash backend/scripts/ci_verify_mbti.sh` is red on current `main` for an unrelated OpenAPI snapshot drift:
  - missing `GET /api/v0.3/me/relationships/mbti`
  - action `MbtiCompareInviteController@indexPrivate`
- this PR does not change routes, middleware, or OpenAPI snapshot files, so I kept that unblock out of scope.
