### PR TITLE
[codex] unblock openapi snapshot drift for mbti relationship index route

### DIFF
--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -778,6 +778,26 @@
                 ]
             }
         },
+        "/api/v0.3/me/relationships/mbti": {
+            "get": {
+                "operationId": "get_api_v0_3_me_relationships_mbti",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\MbtiCompareInviteController@indexPrivate",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth"
+                ]
+            }
+        },
         "/api/v0.3/me/relationships/mbti/{inviteId}": {
             "get": {
                 "operationId": "get_api_v0_3_me_relationships_mbti_inviteid_",


### PR DESCRIPTION
## Summary
- refresh `backend/docs/contracts/openapi.snapshot.json` for the existing private MBTI relationship index route
- keep the fix snapshot-only with no route, controller, middleware, or runtime contract changes
- restore the OpenAPI diff gate on current `main`

## Root cause
- `GET /api/v0.3/me/relationships/mbti` already exists in `backend/routes/api.php`
- `MbtiCompareInviteController@indexPrivate` already exists in runtime code
- `backend/docs/contracts/openapi.snapshot.json` was missing the generated OpenAPI entry for that route

## Validation
- `php artisan route:list > /tmp/pr31a_route_list.txt`
- `php artisan migrate`
- `bash scripts/export_openapi.sh --check`
- `php artisan test --filter OpenApiDiffTest --stop-on-failure`
- `php artisan serve --host=127.0.0.1 --port=18081`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
