### PR TITLE
[codex] add materialized cache status reporting

### DIFF
--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -39,6 +39,7 @@ final class StorageControlPlaneStatusService
             'restore' => $this->restoreSection(),
             'purge' => $this->purgeSection(),
             'retirement' => $this->retirementSection(),
+            'materialized_cache' => $this->materializedCacheSection(),
             'runtime_truth' => $this->runtimeTruthSection(),
             'automation_readiness' => $this->automationReadinessSection(),
         ];
@@ -387,6 +388,29 @@ final class StorageControlPlaneStatusService
             'packs_v2_remote_rehydrate_enabled' => $packsV2RemoteRehydrateEnabled,
             'v2_readiness' => $readiness,
         ] + $this->unknownFreshness('config-derived');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function materializedCacheSection(): array
+    {
+        $rootPath = storage_path('app/private/packs_v2_materialized');
+        $bucketRoots = $this->materializedBucketRoots($rootPath);
+        $stats = $this->directoryTreeStats($rootPath);
+
+        return [
+            'status' => 'ok',
+            'root_path' => $rootPath,
+            'bucket_count' => count($bucketRoots),
+            'total_files' => $stats['total_files'],
+            'total_bytes' => $stats['total_bytes'],
+            'sample_bucket_paths' => array_slice($bucketRoots, 0, 5),
+            'cache_key_contract' => 'storage_path + manifest_hash',
+            'runtime_role' => 'derived_cache_return_surface',
+            'source_of_truth' => false,
+            'zero_state' => count($bucketRoots) === 0,
+        ];
     }
 
     /**
@@ -756,6 +780,63 @@ final class StorageControlPlaneStatusService
         }
 
         return count(array_filter($matches, 'is_file'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function materializedBucketRoots(string $rootPath): array
+    {
+        if (! is_dir($rootPath)) {
+            return [];
+        }
+
+        $matches = glob($rootPath.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'*'.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR);
+        if (! is_array($matches)) {
+            return [];
+        }
+
+        $roots = array_values(array_filter(
+            array_map(static fn (string $path): string => str_replace('\\', '/', $path), $matches),
+            static fn (string $path): bool => $path !== '' && is_dir($path)
+        ));
+
+        sort($roots);
+
+        return array_values(array_unique($roots));
+    }
+
+    /**
+     * @return array{total_files:int,total_bytes:int}
+     */
+    private function directoryTreeStats(string $rootPath): array
+    {
+        if (! is_dir($rootPath)) {
+            return [
+                'total_files' => 0,
+                'total_bytes' => 0,
+            ];
+        }
+
+        $totalFiles = 0;
+        $totalBytes = 0;
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($rootPath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $totalFiles++;
+            $totalBytes += (int) $file->getSize();
+        }
+
+        return [
+            'total_files' => $totalFiles,
+            'total_bytes' => $totalBytes,
+        ];
     }
 
     private function tableCount(string $table): int

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -75,11 +75,20 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame('storage_control_plane_snapshot.v1', $payload['snapshot_schema']);
         $this->assertSame('snapshotted', $payload['status']);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertArrayHasKey('materialized_cache', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
         $this->assertArrayHasKey('last_updated_at', $payload['inventory']);
         $this->assertArrayHasKey('freshness_age_seconds', $payload['inventory']);
         $this->assertArrayHasKey('freshness_state', $payload['inventory']);
         $this->assertArrayHasKey('freshness_source_type', $payload['inventory']);
+        $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
+        $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.bucket_count'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.total_files'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.total_bytes'));
+        $this->assertSame([], data_get($payload, 'materialized_cache.sample_bucket_paths'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
+        $this->assertTrue((bool) data_get($payload, 'materialized_cache.zero_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
@@ -102,6 +111,35 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame([], $this->existingFilesUnder('app/private/prune_plans'));
         $this->assertSame([], $this->existingFilesUnder('app/private/retirement_runs'));
         $this->assertSame([], $this->existingFilesUnder('app/private/blobs'));
+    }
+
+    public function test_command_json_includes_non_zero_materialized_cache_state(): void
+    {
+        $this->seedMinimalTruth();
+        $bucket = [
+            '.materialization.json' => json_encode([
+                'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
+                'manifest_hash' => str_repeat('b', 64),
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'compiled/manifest.json' => str_repeat('m', 10),
+            'compiled/questions.compiled.json' => str_repeat('q', 7),
+        ];
+        $this->seedMaterializedBucket('BIG5_OCEAN', 'v1', str_repeat('a', 64), str_repeat('b', 64), $bucket);
+
+        $this->assertSame(0, Artisan::call('storage:control-plane-snapshot', [
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(trim(Artisan::output()), true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
+        $this->assertSame(3, data_get($payload, 'materialized_cache.total_files'));
+        $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'materialized_cache.total_bytes'));
+        $this->assertSame([
+            str_replace('\\', '/', storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.str_repeat('a', 64).'/'.str_repeat('b', 64))),
+        ], data_get($payload, 'materialized_cache.sample_bucket_paths'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.zero_state'));
     }
 
     public function test_command_outputs_human_readable_summary(): void
@@ -138,6 +176,33 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
             'result' => 'success',
             'created_at' => now(),
         ]);
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function seedMaterializedBucket(
+        string $packId,
+        string $packVersion,
+        string $storageIdentity,
+        string $manifestHash,
+        array $files,
+    ): void {
+        $root = storage_path('app/private/packs_v2_materialized/'.$packId.'/'.$packVersion.'/'.$storageIdentity.'/'.$manifestHash);
+
+        foreach ($files as $relativePath => $contents) {
+            $absolutePath = $root.'/'.ltrim($relativePath, '/');
+            File::ensureDirectoryExists(dirname($absolutePath));
+            File::put($absolutePath, $contents);
+        }
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function totalBytesForFiles(array $files): int
+    {
+        return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -55,6 +55,15 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
     public function test_service_creates_snapshot_file_and_audit_without_other_mutation(): void
     {
         $this->seedMinimalTruth();
+        $bucket = [
+            '.materialization.json' => json_encode([
+                'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
+                'manifest_hash' => str_repeat('b', 64),
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'compiled/manifest.json' => str_repeat('m', 16),
+            'compiled/questions.compiled.json' => str_repeat('q', 6),
+        ];
+        $this->seedMaterializedBucket('BIG5_OCEAN', 'v1', str_repeat('a', 64), str_repeat('b', 64), $bucket);
 
         $auditCountBefore = DB::table('audit_logs')->count();
         $filesBefore = $this->storageFilesSnapshot();
@@ -74,6 +83,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertArrayHasKey('restore', $payload);
         $this->assertArrayHasKey('purge', $payload);
         $this->assertArrayHasKey('retirement', $payload);
+        $this->assertArrayHasKey('materialized_cache', $payload);
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
@@ -89,6 +99,18 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'restore.status'));
         $this->assertSame('never_run', data_get($payload, 'restore.freshness_state'));
+        $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
+        $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
+        $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
+        $this->assertSame(3, data_get($payload, 'materialized_cache.total_files'));
+        $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'materialized_cache.total_bytes'));
+        $this->assertSame([
+            str_replace('\\', '/', storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.str_repeat('a', 64).'/'.str_repeat('b', 64))),
+        ], data_get($payload, 'materialized_cache.sample_bucket_paths'));
+        $this->assertSame('storage_path + manifest_hash', data_get($payload, 'materialized_cache.cache_key_contract'));
+        $this->assertSame('derived_cache_return_surface', data_get($payload, 'materialized_cache.runtime_role'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.zero_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('attention_required', data_get($payload, 'attention_digest.overall_state'));
@@ -138,6 +160,13 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('never_run', data_get($payload, 'quarantine.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.status'));
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.freshness_state'));
+        $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.bucket_count'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.total_files'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.total_bytes'));
+        $this->assertSame([], data_get($payload, 'materialized_cache.sample_bucket_paths'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
+        $this->assertTrue((bool) data_get($payload, 'materialized_cache.zero_state'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
         $this->assertSame(['inventory'], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertContains('quarantine', data_get($payload, 'attention_digest.never_run_sections', []));
@@ -164,6 +193,33 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
             'result' => 'success',
             'created_at' => now(),
         ]);
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function seedMaterializedBucket(
+        string $packId,
+        string $packVersion,
+        string $storageIdentity,
+        string $manifestHash,
+        array $files,
+    ): void {
+        $root = storage_path('app/private/packs_v2_materialized/'.$packId.'/'.$packVersion.'/'.$storageIdentity.'/'.$manifestHash);
+
+        foreach ($files as $relativePath => $contents) {
+            $absolutePath = $root.'/'.ltrim($relativePath, '/');
+            File::ensureDirectoryExists(dirname($absolutePath));
+            File::put($absolutePath, $contents);
+        }
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function totalBytesForFiles(array $files): int
+    {
+        return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -83,6 +83,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('restore', $payload);
         $this->assertArrayHasKey('purge', $payload);
         $this->assertArrayHasKey('retirement', $payload);
+        $this->assertArrayHasKey('materialized_cache', $payload);
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
@@ -96,6 +97,16 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('freshness_state', data_get($payload, 'retention.scopes.reports_backups', []));
         $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'retention.scopes.reports_backups', []));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
+        $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
+        $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.bucket_count'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.total_files'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.total_bytes'));
+        $this->assertSame([], data_get($payload, 'materialized_cache.sample_bucket_paths'));
+        $this->assertSame('storage_path + manifest_hash', data_get($payload, 'materialized_cache.cache_key_contract'));
+        $this->assertSame('derived_cache_return_surface', data_get($payload, 'materialized_cache.runtime_role'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
+        $this->assertTrue((bool) data_get($payload, 'materialized_cache.zero_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('config-derived', data_get($payload, 'runtime_truth.freshness_source_type'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
@@ -108,6 +119,35 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
 
         $this->assertSame($auditCountBefore, DB::table('audit_logs')->count());
         $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+    }
+
+    public function test_command_json_reports_non_zero_materialized_cache_state(): void
+    {
+        $this->seedMinimalTruth();
+        $bucket = [
+            '.materialization.json' => json_encode([
+                'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
+                'manifest_hash' => str_repeat('b', 64),
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'compiled/manifest.json' => str_repeat('m', 12),
+            'compiled/questions.compiled.json' => str_repeat('q', 8),
+        ];
+        $this->seedMaterializedBucket('BIG5_OCEAN', 'v1', str_repeat('a', 64), str_repeat('b', 64), $bucket);
+
+        $this->assertSame(0, Artisan::call('storage:control-plane-status', [
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(trim(Artisan::output()), true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
+        $this->assertSame(3, data_get($payload, 'materialized_cache.total_files'));
+        $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'materialized_cache.total_bytes'));
+        $this->assertSame([
+            str_replace('\\', '/', storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.str_repeat('a', 64).'/'.str_repeat('b', 64))),
+        ], data_get($payload, 'materialized_cache.sample_bucket_paths'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.zero_state'));
     }
 
     public function test_command_outputs_human_readable_summary(): void
@@ -162,6 +202,33 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
     {
         File::ensureDirectoryExists(dirname($path));
         File::put($path, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function seedMaterializedBucket(
+        string $packId,
+        string $packVersion,
+        string $storageIdentity,
+        string $manifestHash,
+        array $files,
+    ): void {
+        $root = storage_path('app/private/packs_v2_materialized/'.$packId.'/'.$packVersion.'/'.$storageIdentity.'/'.$manifestHash);
+
+        foreach ($files as $relativePath => $contents) {
+            $absolutePath = $root.'/'.ltrim($relativePath, '/');
+            File::ensureDirectoryExists(dirname($absolutePath));
+            File::put($absolutePath, $contents);
+        }
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function totalBytesForFiles(array $files): int
+    {
+        return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -55,6 +55,25 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
     public function test_service_aggregates_existing_truth_without_mutation(): void
     {
         $this->seedControlPlaneTruth();
+        $bucketOne = [
+            '.materialization.json' => json_encode([
+                'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
+                'manifest_hash' => str_repeat('b', 64),
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'compiled/manifest.json' => str_repeat('m', 40),
+            'compiled/questions.compiled.json' => str_repeat('q', 20),
+        ];
+        $bucketTwo = [
+            '.materialization.json' => json_encode([
+                'storage_path' => 'private/packs_v2/EQ60/v2/release-b',
+                'manifest_hash' => str_repeat('d', 64),
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'compiled/manifest.json' => str_repeat('n', 30),
+            'compiled/layout.compiled.json' => str_repeat('l', 10),
+        ];
+        $this->seedMaterializedBucket('BIG5_OCEAN', 'v1', str_repeat('a', 64), str_repeat('b', 64), $bucketOne);
+        $this->seedMaterializedBucket('EQ60', 'v2', str_repeat('c', 64), str_repeat('d', 64), $bucketTwo);
+        $expectedBytes = $this->totalBytesForFiles($bucketOne) + $this->totalBytesForFiles($bucketTwo);
 
         $auditCountBefore = DB::table('audit_logs')->count();
         $filesBefore = $this->storageFilesSnapshot();
@@ -89,6 +108,19 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('ok', data_get($payload, 'retirement.actions.purge.status'));
         $this->assertSame('fresh', data_get($payload, 'retirement.actions.quarantine.freshness_state'));
         $this->assertSame('fresh', data_get($payload, 'retirement.actions.purge.freshness_state'));
+        $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
+        $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
+        $this->assertSame(2, data_get($payload, 'materialized_cache.bucket_count'));
+        $this->assertSame(6, data_get($payload, 'materialized_cache.total_files'));
+        $this->assertSame($expectedBytes, data_get($payload, 'materialized_cache.total_bytes'));
+        $this->assertSame([
+            str_replace('\\', '/', storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.str_repeat('a', 64).'/'.str_repeat('b', 64))),
+            str_replace('\\', '/', storage_path('app/private/packs_v2_materialized/EQ60/v2/'.str_repeat('c', 64).'/'.str_repeat('d', 64))),
+        ], data_get($payload, 'materialized_cache.sample_bucket_paths'));
+        $this->assertSame('storage_path + manifest_hash', data_get($payload, 'materialized_cache.cache_key_contract'));
+        $this->assertSame('derived_cache_return_surface', data_get($payload, 'materialized_cache.runtime_role'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.zero_state'));
         $this->assertTrue((bool) data_get($payload, 'runtime_truth.resolver_materialization_enabled'));
         $this->assertFalse((bool) data_get($payload, 'runtime_truth.packs_v2_remote_rehydrate_enabled'));
         $this->assertSame('materialization_enabled_only', data_get($payload, 'runtime_truth.v2_readiness'));
@@ -149,6 +181,16 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.quarantine.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.purge.status'));
         $this->assertSame('never_run', data_get($payload, 'retirement.actions.purge.freshness_state'));
+        $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
+        $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.bucket_count'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.total_files'));
+        $this->assertSame(0, data_get($payload, 'materialized_cache.total_bytes'));
+        $this->assertSame([], data_get($payload, 'materialized_cache.sample_bucket_paths'));
+        $this->assertSame('storage_path + manifest_hash', data_get($payload, 'materialized_cache.cache_key_contract'));
+        $this->assertSame('derived_cache_return_surface', data_get($payload, 'materialized_cache.runtime_role'));
+        $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
+        $this->assertTrue((bool) data_get($payload, 'materialized_cache.zero_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
@@ -443,6 +485,33 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
     {
         File::ensureDirectoryExists(dirname($path));
         File::put($path, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function seedMaterializedBucket(
+        string $packId,
+        string $packVersion,
+        string $storageIdentity,
+        string $manifestHash,
+        array $files,
+    ): void {
+        $root = storage_path('app/private/packs_v2_materialized/'.$packId.'/'.$packVersion.'/'.$storageIdentity.'/'.$manifestHash);
+
+        foreach ($files as $relativePath => $contents) {
+            $absolutePath = $root.'/'.ltrim($relativePath, '/');
+            File::ensureDirectoryExists(dirname($absolutePath));
+            File::put($absolutePath, $contents);
+        }
+    }
+
+    /**
+     * @param  array<string,string>  $files
+     */
+    private function totalBytesForFiles(array $files): int
+    {
+        return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a read-only `materialized_cache` section to `storage:control-plane-status --json`
- let `storage:control-plane-snapshot --json` inherit the same section automatically through the existing status payload
- lock zero-state and non-zero materialized cache reporting in status/snapshot service and command tests

## Why
`packs_v2_materialized/**` already has a real runtime contract and a janitor/cost-analyzer view, but the control-plane read model had no first-class status section for it.

That left a gap between:
- runtime truth: materialized is a derived cache return surface, not source-of-truth
- cost truth: `storage:analyze-cost` can classify it as `v2_materialized_cache`
- execute truth: `storage:janitor-materialized-cache --dry-run` can inspect it for deletion candidates

This PR only closes the status/reporting gap. It does not change runtime reads, cache keys, remote fallback, janitor behavior, or scheduler wiring.

## Behavior
The new `materialized_cache` section exposes:
- `status`
- `root_path`
- `bucket_count`
- `total_files`
- `total_bytes`
- `sample_bucket_paths`
- `cache_key_contract`
- `runtime_role`
- `source_of_truth`
- `zero_state`

Zero-state is explicit and non-error:
- if `storage/app/private/packs_v2_materialized` is absent or has zero buckets, status still returns `ok`
- `zero_state=true`
- no freshness metadata is added
- `attention_digest` is unchanged

## Scope guardrails
This PR does not:
- add a new command
- add a new service
- change `StorageControlPlaneSnapshotService` behavior beyond inheriting the additive status section
- change `StorageControlPlaneRefreshService`
- change `StorageCostAnalyzerService`
- change `MaterializedCacheJanitorService`
- change resolver/materializer/remote fallback/runtime-truth contracts
- change routes, middleware, migrations, scheduler, or delete policy

## Validation
- `php artisan route:list > /tmp/pr32_impl_route_list.txt`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `find storage/app/private/packs_v2_materialized -maxdepth 5 -print 2>/dev/null | sed -n '1,120p'`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
