### PR TITLE
[codex] add materialized cache freshness metadata

### DIFF
--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -410,6 +410,10 @@ final class StorageControlPlaneStatusService
             'runtime_role' => 'derived_cache_return_surface',
             'source_of_truth' => false,
             'zero_state' => count($bucketRoots) === 0,
+            'last_updated_at' => null,
+            'freshness_age_seconds' => null,
+            'freshness_state' => 'unknown_freshness',
+            'freshness_source_type' => 'disk-derived',
         ];
     }
 

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -89,6 +89,10 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame([], data_get($payload, 'materialized_cache.sample_bucket_paths'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
         $this->assertTrue((bool) data_get($payload, 'materialized_cache.zero_state'));
+        $this->assertNull(data_get($payload, 'materialized_cache.last_updated_at'));
+        $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
@@ -140,6 +144,10 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
             str_replace('\\', '/', storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.str_repeat('a', 64).'/'.str_repeat('b', 64))),
         ], data_get($payload, 'materialized_cache.sample_bucket_paths'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.zero_state'));
+        $this->assertNull(data_get($payload, 'materialized_cache.last_updated_at'));
+        $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
     }
 
     public function test_command_outputs_human_readable_summary(): void

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -111,6 +111,10 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('derived_cache_return_surface', data_get($payload, 'materialized_cache.runtime_role'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.zero_state'));
+        $this->assertNull(data_get($payload, 'materialized_cache.last_updated_at'));
+        $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('attention_required', data_get($payload, 'attention_digest.overall_state'));
@@ -167,6 +171,10 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame([], data_get($payload, 'materialized_cache.sample_bucket_paths'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
         $this->assertTrue((bool) data_get($payload, 'materialized_cache.zero_state'));
+        $this->assertNull(data_get($payload, 'materialized_cache.last_updated_at'));
+        $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
         $this->assertSame(['inventory'], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertContains('quarantine', data_get($payload, 'attention_digest.never_run_sections', []));

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -107,6 +107,10 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertSame('derived_cache_return_surface', data_get($payload, 'materialized_cache.runtime_role'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
         $this->assertTrue((bool) data_get($payload, 'materialized_cache.zero_state'));
+        $this->assertNull(data_get($payload, 'materialized_cache.last_updated_at'));
+        $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('config-derived', data_get($payload, 'runtime_truth.freshness_source_type'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
@@ -148,6 +152,10 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
             str_replace('\\', '/', storage_path('app/private/packs_v2_materialized/BIG5_OCEAN/v1/'.str_repeat('a', 64).'/'.str_repeat('b', 64))),
         ], data_get($payload, 'materialized_cache.sample_bucket_paths'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.zero_state'));
+        $this->assertNull(data_get($payload, 'materialized_cache.last_updated_at'));
+        $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
     }
 
     public function test_command_outputs_human_readable_summary(): void

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -121,6 +121,10 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('derived_cache_return_surface', data_get($payload, 'materialized_cache.runtime_role'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.zero_state'));
+        $this->assertNull(data_get($payload, 'materialized_cache.last_updated_at'));
+        $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
         $this->assertTrue((bool) data_get($payload, 'runtime_truth.resolver_materialization_enabled'));
         $this->assertFalse((bool) data_get($payload, 'runtime_truth.packs_v2_remote_rehydrate_enabled'));
         $this->assertSame('materialization_enabled_only', data_get($payload, 'runtime_truth.v2_readiness'));
@@ -191,6 +195,10 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('derived_cache_return_surface', data_get($payload, 'materialized_cache.runtime_role'));
         $this->assertFalse((bool) data_get($payload, 'materialized_cache.source_of_truth'));
         $this->assertTrue((bool) data_get($payload, 'materialized_cache.zero_state'));
+        $this->assertNull(data_get($payload, 'materialized_cache.last_updated_at'));
+        $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));


### PR DESCRIPTION
## Summary
- add additive freshness metadata to `materialized_cache` in `storage:control-plane-status --json`
- let `storage:control-plane-snapshot --json` inherit the same fields automatically through the existing status payload
- keep the values fixed to the scan-approved unknown-freshness contract and leave `attention_digest` unchanged

## Root cause
`materialized_cache` had already been integrated into the control-plane status/snapshot read model as an occupancy and cache-contract section, but it did not expose the same freshness metadata shape that other status sections expose.

At the same time, the repo still does not have a stable, section-level timestamp truth that can safely classify materialized cache as `fresh` or `stale`. The only safe additive contract here is to report explicit unknown freshness rather than inferring runtime recency from sentinel timestamps, mtimes, or janitor/analyzer views.

## Fix
This PR adds four additive fields under `materialized_cache`:
- `last_updated_at: null`
- `freshness_age_seconds: null`
- `freshness_state: "unknown_freshness"`
- `freshness_source_type: "disk-derived"`

The existing section fields remain unchanged:
- `status`
- `root_path`
- `bucket_count`
- `total_files`
- `total_bytes`
- `sample_bucket_paths`
- `cache_key_contract`
- `runtime_role`
- `source_of_truth`
- `zero_state`

This PR does not:
- change `attention_digest`
- change refresh orchestration
- change janitor behavior
- change cost analyzer behavior
- change resolver/materializer/remote fallback/runtime truth contracts
- change routes, middleware, migrations, scheduler, or config semantics

## Validation
- `php -l app/Services/Storage/StorageControlPlaneStatusService.php`
- `php -l tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `php -l tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `php -l tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `php -l tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `./vendor/bin/pint app/Services/Storage/StorageControlPlaneStatusService.php tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `php artisan route:list > /tmp/pr33_route_list.txt`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `find storage/app/private/packs_v2_materialized -maxdepth 5 -print 2>/dev/null | sed -n '1,120p'`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
