### PR TITLE
[codex] polish control-plane attention digest summary output

### DIFF
--- a/backend/app/Console/Commands/StorageControlPlaneStatus.php
+++ b/backend/app/Console/Commands/StorageControlPlaneStatus.php
@@ -53,6 +53,10 @@ final class StorageControlPlaneStatus extends Command
         $this->line('automation_readiness.auto_dry_run_ok='.(int) count((array) data_get($payload, 'automation_readiness.auto_dry_run_ok', [])));
         $this->line('automation_readiness.manual_execute_only='.(int) count((array) data_get($payload, 'automation_readiness.manual_execute_only', [])));
         $this->line('automation_readiness.not_in_scope_for_pr25='.(int) count((array) data_get($payload, 'automation_readiness.not_in_scope_for_pr25', [])));
+        $this->line('attention_digest.overall_state='.(string) data_get($payload, 'attention_digest.overall_state', 'healthy'));
+        $this->line('attention_digest.counts.stale='.(int) data_get($payload, 'attention_digest.counts.stale', 0));
+        $this->line('attention_digest.counts.never_run='.(int) data_get($payload, 'attention_digest.counts.never_run', 0));
+        $this->line('attention_digest.counts.not_available='.(int) data_get($payload, 'attention_digest.counts.not_available', 0));
 
         return self::SUCCESS;
     }

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -169,6 +169,10 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertStringContainsString('inventory.status=ok', $output);
         $this->assertStringContainsString('runtime_truth.v2_readiness=remote_rehydrate_enabled', $output);
         $this->assertStringContainsString('automation_readiness.auto_dry_run_ok=', $output);
+        $this->assertStringContainsString('attention_digest.overall_state=attention_required', $output);
+        $this->assertStringContainsString('attention_digest.counts.stale=0', $output);
+        $this->assertStringContainsString('attention_digest.counts.never_run=', $output);
+        $this->assertStringContainsString('attention_digest.counts.not_available=0', $output);
     }
 
     private function seedMinimalTruth(): void


### PR DESCRIPTION
## Summary
This PR polishes the operator readability of the default `storage:control-plane-status` command output.

The underlying `attention_digest` contract was already present and correct in the JSON payload, but the default human-readable CLI summary did not expose the top-level digest result. That meant an operator had to switch to `--json` just to answer a basic question such as whether the storage control-plane was currently `healthy`, `attention_required`, or `degraded`.

This change keeps the existing command shape and simply appends four digest summary lines to the default output:
- `attention_digest.overall_state`
- `attention_digest.counts.stale`
- `attention_digest.counts.never_run`
- `attention_digest.counts.not_available`

## Scope guardrails
This PR does not:
- change `storage:control-plane-status --json`
- change `attention_digest` structure or calculation rules
- change `attention_items.message`
- change `storage:control-plane-snapshot`
- change any storage service, scheduler, refresh orchestration, janitor, analyzer, runtime, lifecycle, route, middleware, migration, or config behavior

## Root cause
The control-plane already had a grounded digest model, but the non-JSON operator surface omitted that digest entirely. The gap was readability, not truth.

## Validation
- `php -l app/Console/Commands/StorageControlPlaneStatus.php`
- `php -l tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `./vendor/bin/pint app/Console/Commands/StorageControlPlaneStatus.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `php artisan route:list > /tmp/pr34_route_list.txt`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `php artisan storage:control-plane-status`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan serve --host=127.0.0.1 --port=18081`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
