### PR TITLE
[codex] add storage cost reclaim posture to control-plane status

### DIFF
--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -22,6 +22,10 @@ final class StorageControlPlaneStatusService
     // Manual dry-run and operator-driven control-plane surfaces age out more slowly.
     private const MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS = 30 * 24 * 60 * 60;
 
+    public function __construct(
+        private readonly StorageCostAnalyzerService $costAnalyzer,
+    ) {}
+
     /**
      * @return array<string,mixed>
      */
@@ -40,6 +44,7 @@ final class StorageControlPlaneStatusService
             'purge' => $this->purgeSection(),
             'retirement' => $this->retirementSection(),
             'materialized_cache' => $this->materializedCacheSection(),
+            'cost_reclaim_posture' => $this->costReclaimPostureSection(),
             'runtime_truth' => $this->runtimeTruthSection(),
             'automation_readiness' => $this->automationReadinessSection(),
         ];
@@ -414,6 +419,52 @@ final class StorageControlPlaneStatusService
             'freshness_age_seconds' => null,
             'freshness_state' => 'unknown_freshness',
             'freshness_source_type' => 'disk-derived',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function costReclaimPostureSection(): array
+    {
+        try {
+            $payload = $this->costAnalyzer->analyze();
+        } catch (\Throwable) {
+            return [
+                'status' => 'not_available',
+                'source_schema_version' => null,
+                'root_path' => storage_path(),
+                'summary' => null,
+                'by_category' => [],
+                'no_touch_categories' => [],
+                'reclaim_categories' => [],
+            ];
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : null;
+        $byCategory = is_array($payload['by_category'] ?? null) ? $payload['by_category'] : [];
+        $reclaimCategories = [];
+
+        foreach ((array) ($payload['reclaim_candidates'] ?? []) as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $reclaimCategories[] = [
+                'category' => (string) ($candidate['category'] ?? ''),
+                'bytes' => (int) ($candidate['bytes'] ?? 0),
+                'risk_level' => (string) ($candidate['risk_level'] ?? ''),
+            ];
+        }
+
+        return [
+            'status' => (string) ($payload['status'] ?? 'ok'),
+            'source_schema_version' => (string) ($payload['schema_version'] ?? ''),
+            'root_path' => (string) ($payload['root_path'] ?? storage_path()),
+            'summary' => $summary,
+            'by_category' => $byCategory,
+            'no_touch_categories' => $this->normalizeScalarList((array) ($payload['no_touch_categories'] ?? [])),
+            'reclaim_categories' => $reclaimCategories,
         ];
     }
 

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -76,6 +76,7 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame('snapshotted', $payload['status']);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
         $this->assertArrayHasKey('materialized_cache', $payload);
+        $this->assertArrayHasKey('cost_reclaim_posture', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
         $this->assertArrayHasKey('last_updated_at', $payload['inventory']);
         $this->assertArrayHasKey('freshness_age_seconds', $payload['inventory']);
@@ -93,6 +94,13 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
         $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
         $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'cost_reclaim_posture.status'));
+        $this->assertSame('storage_cost_analyzer.v1', data_get($payload, 'cost_reclaim_posture.source_schema_version'));
+        $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
+        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.summary.total_bytes'));
+        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
+        $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
@@ -148,6 +156,16 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
         $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
         $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'cost_reclaim_posture.status'));
+        $this->assertSame('storage_cost_analyzer.v1', data_get($payload, 'cost_reclaim_posture.source_schema_version'));
+        $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
+        $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
+        $this->assertSame(3, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
+        $this->assertSame([
+            'category' => 'v2_materialized_cache',
+            'bytes' => $this->totalBytesForFiles($bucket),
+            'risk_level' => 'medium',
+        ], $this->reclaimCategory($payload, 'v2_materialized_cache'));
     }
 
     public function test_command_outputs_human_readable_summary(): void
@@ -211,6 +229,24 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
     private function totalBytesForFiles(array $files): int
     {
         return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function reclaimCategory(array $payload, string $category): ?array
+    {
+        foreach ((array) data_get($payload, 'cost_reclaim_posture.reclaim_categories', []) as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            if ((string) ($candidate['category'] ?? '') === $category) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -84,6 +84,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertArrayHasKey('purge', $payload);
         $this->assertArrayHasKey('retirement', $payload);
         $this->assertArrayHasKey('materialized_cache', $payload);
+        $this->assertArrayHasKey('cost_reclaim_posture', $payload);
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
@@ -115,6 +116,16 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
         $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
         $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'cost_reclaim_posture.status'));
+        $this->assertSame('storage_cost_analyzer.v1', data_get($payload, 'cost_reclaim_posture.source_schema_version'));
+        $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
+        $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
+        $this->assertSame(3, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
+        $this->assertSame([
+            'category' => 'v2_materialized_cache',
+            'bytes' => $this->totalBytesForFiles($bucket),
+            'risk_level' => 'medium',
+        ], $this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('attention_required', data_get($payload, 'attention_digest.overall_state'));
@@ -175,6 +186,14 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
         $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
         $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'cost_reclaim_posture.status'));
+        $this->assertSame('storage_cost_analyzer.v1', data_get($payload, 'cost_reclaim_posture.source_schema_version'));
+        $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
+        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.summary.total_bytes'));
+        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
+        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
+        $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
         $this->assertSame(['inventory'], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertContains('quarantine', data_get($payload, 'attention_digest.never_run_sections', []));
@@ -228,6 +247,24 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
     private function totalBytesForFiles(array $files): int
     {
         return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function reclaimCategory(array $payload, string $category): ?array
+    {
+        foreach ((array) data_get($payload, 'cost_reclaim_posture.reclaim_categories', []) as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            if ((string) ($candidate['category'] ?? '') === $category) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -84,6 +84,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('purge', $payload);
         $this->assertArrayHasKey('retirement', $payload);
         $this->assertArrayHasKey('materialized_cache', $payload);
+        $this->assertArrayHasKey('cost_reclaim_posture', $payload);
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
@@ -111,6 +112,13 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
         $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
         $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'cost_reclaim_posture.status'));
+        $this->assertSame('storage_cost_analyzer.v1', data_get($payload, 'cost_reclaim_posture.source_schema_version'));
+        $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
+        $this->assertGreaterThan(0, (int) data_get($payload, 'cost_reclaim_posture.summary.total_bytes'));
+        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
+        $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('config-derived', data_get($payload, 'runtime_truth.freshness_source_type'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
@@ -156,6 +164,16 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
         $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
         $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'cost_reclaim_posture.status'));
+        $this->assertSame('storage_cost_analyzer.v1', data_get($payload, 'cost_reclaim_posture.source_schema_version'));
+        $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
+        $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
+        $this->assertSame(3, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
+        $this->assertSame([
+            'category' => 'v2_materialized_cache',
+            'bytes' => $this->totalBytesForFiles($bucket),
+            'risk_level' => 'medium',
+        ], $this->reclaimCategory($payload, 'v2_materialized_cache'));
     }
 
     public function test_command_outputs_human_readable_summary(): void
@@ -241,6 +259,24 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
     private function totalBytesForFiles(array $files): int
     {
         return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function reclaimCategory(array $payload, string $category): ?array
+    {
+        foreach ((array) data_get($payload, 'cost_reclaim_posture.reclaim_categories', []) as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            if ((string) ($candidate['category'] ?? '') === $category) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -125,6 +125,17 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
         $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
         $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'cost_reclaim_posture.status'));
+        $this->assertSame('storage_cost_analyzer.v1', data_get($payload, 'cost_reclaim_posture.source_schema_version'));
+        $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
+        $this->assertSame($expectedBytes, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
+        $this->assertSame(6, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
+        $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertSame([
+            'category' => 'v2_materialized_cache',
+            'bytes' => $expectedBytes,
+            'risk_level' => 'medium',
+        ], $this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertTrue((bool) data_get($payload, 'runtime_truth.resolver_materialization_enabled'));
         $this->assertFalse((bool) data_get($payload, 'runtime_truth.packs_v2_remote_rehydrate_enabled'));
         $this->assertSame('materialization_enabled_only', data_get($payload, 'runtime_truth.v2_readiness'));
@@ -199,6 +210,14 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertNull(data_get($payload, 'materialized_cache.freshness_age_seconds'));
         $this->assertSame('unknown_freshness', data_get($payload, 'materialized_cache.freshness_state'));
         $this->assertSame('disk-derived', data_get($payload, 'materialized_cache.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'cost_reclaim_posture.status'));
+        $this->assertSame('storage_cost_analyzer.v1', data_get($payload, 'cost_reclaim_posture.source_schema_version'));
+        $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
+        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.summary.total_bytes'));
+        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
+        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
+        $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
@@ -520,6 +539,24 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
     private function totalBytesForFiles(array $files): int
     {
         return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function reclaimCategory(array $payload, string $category): ?array
+    {
+        foreach ((array) data_get($payload, 'cost_reclaim_posture.reclaim_categories', []) as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            if ((string) ($candidate['category'] ?? '') === $category) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR adds a new read-only `cost_reclaim_posture` section to the storage control-plane status payload and lets the control-plane snapshot inherit it automatically through the existing status payload reuse.

The new section promotes the stable subset of the existing storage cost analyzer into the control-plane read model:
- `status`
- `source_schema_version`
- `root_path`
- `summary`
- `by_category`
- `no_touch_categories`
- `reclaim_categories`

`reclaim_categories` is intentionally reduced to `category`, `bytes`, and `risk_level` only.

## Root cause
The repository already had a grounded cost-analysis surface in `storage:analyze-cost`, but that truth only existed behind the analyzer command. The control-plane status/snapshot surfaces still lacked a first-class storage cost and reclaim posture section.

That left an operator-facing gap:
- cost analyzer had the numbers
- control-plane status had the operational truth
- snapshot mirrored status
- but status/snapshot did not expose cost or reclaim posture directly

This PR closes only that read-model gap.

## Scope guardrails
This PR does not:
- add a new command
- add a new service
- add a new config key
- change `storage:analyze-cost`
- change refresh orchestration order
- change snapshot service behavior beyond inheriting the additive status section
- change attention digest logic
- add freshness for cost posture
- change runtime reader, lifecycle, janitor, scheduler, routes, middleware, or migrations

## Design notes
The integrated section is intentionally narrower than the full analyzer output.

It does not promote:
- `top_directories`
- raw `reclaim_candidates.rationale`
- raw `reclaim_candidates.safe_next_action`
- `suggested_next_actions`

That keeps the control-plane read model focused on stable posture truth rather than action wording that can drift independently from execute surfaces.

## Validation
- `php -l app/Services/Storage/StorageControlPlaneStatusService.php`
- `php -l tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `php -l tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `php -l tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `php -l tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `./vendor/bin/pint app/Services/Storage/StorageControlPlaneStatusService.php tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `php artisan route:list > /tmp/pr35_impl_route_list.txt`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php tests/Feature/Storage/StorageCostAnalyzerServiceTest.php tests/Feature/Storage/StorageCostAnalyzerCommandTest.php tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php`
- `php artisan storage:analyze-cost --json`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan storage:refresh-control-plane --dry-run --json`
- `php artisan serve --host=127.0.0.1 --port=18081`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
