### PR TITLE
[codex] add cost reclaim posture freshness metadata

### DIFF
--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -438,6 +438,10 @@ final class StorageControlPlaneStatusService
                 'by_category' => [],
                 'no_touch_categories' => [],
                 'reclaim_categories' => [],
+                'last_updated_at' => null,
+                'freshness_age_seconds' => null,
+                'freshness_state' => 'unknown_freshness',
+                'freshness_source_type' => 'disk-derived',
             ];
         }
 
@@ -465,6 +469,10 @@ final class StorageControlPlaneStatusService
             'by_category' => $byCategory,
             'no_touch_categories' => $this->normalizeScalarList((array) ($payload['no_touch_categories'] ?? [])),
             'reclaim_categories' => $reclaimCategories,
+            'last_updated_at' => null,
+            'freshness_age_seconds' => null,
+            'freshness_state' => 'unknown_freshness',
+            'freshness_source_type' => 'disk-derived',
         ];
     }
 

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -100,6 +100,10 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.summary.total_bytes'));
         $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
         $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'cost_reclaim_posture.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
@@ -161,6 +165,10 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
         $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
         $this->assertSame(3, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'cost_reclaim_posture.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertSame([
             'category' => 'v2_materialized_cache',
             'bytes' => $this->totalBytesForFiles($bucket),

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -121,6 +121,10 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
         $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
         $this->assertSame(3, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'cost_reclaim_posture.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertSame([
             'category' => 'v2_materialized_cache',
             'bytes' => $this->totalBytesForFiles($bucket),
@@ -193,6 +197,10 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
         $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
         $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'cost_reclaim_posture.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
         $this->assertSame(['inventory'], data_get($payload, 'attention_digest.not_available_sections'));

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -118,6 +118,10 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertGreaterThan(0, (int) data_get($payload, 'cost_reclaim_posture.summary.total_bytes'));
         $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
         $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'cost_reclaim_posture.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('config-derived', data_get($payload, 'runtime_truth.freshness_source_type'));
@@ -169,6 +173,10 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
         $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
         $this->assertSame(3, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'cost_reclaim_posture.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertSame([
             'category' => 'v2_materialized_cache',
             'bytes' => $this->totalBytesForFiles($bucket),

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -131,6 +131,10 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame($expectedBytes, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
         $this->assertSame(6, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
         $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'cost_reclaim_posture.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertSame([
             'category' => 'v2_materialized_cache',
             'bytes' => $expectedBytes,
@@ -217,6 +221,10 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
         $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.file_count'));
         $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'cost_reclaim_posture.freshness_age_seconds'));
+        $this->assertSame('unknown_freshness', data_get($payload, 'cost_reclaim_posture.freshness_state'));
+        $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));


### PR DESCRIPTION
## Summary
This PR adds additive freshness metadata to `cost_reclaim_posture` in the storage control-plane status payload and lets snapshot inherit the same fields automatically through the existing status payload reuse.

The new fields are intentionally fixed to the scan-approved unknown-freshness contract:
- `last_updated_at: null`
- `freshness_age_seconds: null`
- `freshness_state: "unknown_freshness"`
- `freshness_source_type: "disk-derived"`

## Root cause
`cost_reclaim_posture` had already been integrated into the control-plane status/snapshot read model as a reduced, read-only subset of the storage cost analyzer, but it did not expose the same freshness metadata shape that other control-plane sections expose.

At the same time, the repo still does not have a stable, section-level timestamp truth that can safely classify cost posture as `fresh` or `stale`. The only safe additive contract here is to expose explicit unknown freshness rather than infer recency from analyzer generation time.

## Fix
This PR only adds the four fixed freshness fields under `cost_reclaim_posture` in `StorageControlPlaneStatusService` and locks them in the status/snapshot service and command tests.

This PR does not:
- change `attention_digest`
- wire `cost_reclaim_posture` into `attention_items`
- change `StorageCostAnalyzerService`
- map analyzer `generated_at` into `last_updated_at`
- introduce fresh/stale thresholds or any SLA
- change snapshot service behavior beyond inheriting the additive status fields
- change refresh orchestration, janitor behavior, runtime contracts, scheduler, routes, middleware, migrations, or config

## Validation
- `php -l app/Services/Storage/StorageControlPlaneStatusService.php`
- `php -l tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `php -l tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `php -l tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `php -l tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `./vendor/bin/pint app/Services/Storage/StorageControlPlaneStatusService.php tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `php artisan route:list > /tmp/pr36_route_list.txt`
- `php artisan migrate`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php tests/Feature/Storage/StorageCostAnalyzerServiceTest.php tests/Feature/Storage/StorageCostAnalyzerCommandTest.php tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php tests/Unit/Content/ContentPackV2ResolverMaterializationTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `find storage/app/private/packs_v2_materialized -maxdepth 5 -print 2>/dev/null | sed -n '1,120p'`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
