### PR TITLE
[codex] add runtime temp janitor

### DIFF
--- a/backend/app/Console/Commands/StorageJanitorRuntimeTemps.php
+++ b/backend/app/Console/Commands/StorageJanitorRuntimeTemps.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\RuntimeTempJanitorService;
+use Illuminate\Console\Command;
+
+final class StorageJanitorRuntimeTemps extends Command
+{
+    protected $signature = 'storage:janitor-runtime-temps
+        {--dry-run : Preview allowlisted runtime temp file deletions only}
+        {--execute : Delete allowlisted runtime temp files}
+        {--json : Emit the full janitor payload as JSON}';
+
+    protected $description = 'Manual-only janitor for allowlisted runtime temp files under storage/logs and storage/framework cache/views.';
+
+    public function __construct(
+        private readonly RuntimeTempJanitorService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $payload = $this->service->run($execute);
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode runtime temp janitor json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return self::SUCCESS;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('mode='.(string) ($payload['mode'] ?? ''));
+        $this->line('schema='.(string) ($payload['schema'] ?? ''));
+        $this->line('generated_at='.(string) ($payload['generated_at'] ?? ''));
+        $this->line('scanned_file_count='.(int) ($summary['scanned_file_count'] ?? 0));
+        $this->line('candidate_delete_count='.(int) ($summary['candidate_delete_count'] ?? 0));
+        $this->line('deleted_file_count='.(int) ($summary['deleted_file_count'] ?? 0));
+        $this->line('skipped_file_count='.(int) ($summary['skipped_file_count'] ?? 0));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Services/Storage/RuntimeTempJanitorService.php
+++ b/backend/app/Services/Storage/RuntimeTempJanitorService.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class RuntimeTempJanitorService
+{
+    private const SCHEMA = 'storage_janitor_runtime_temps.v1';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function run(bool $execute): array
+    {
+        $candidates = [];
+        $skipped = [];
+        $deletedPaths = [];
+        $noTouchPaths = $this->existingRootPaths();
+
+        foreach ($this->scannedFiles() as $path) {
+            $entry = $this->classifyFile($path);
+            if ((bool) ($entry['candidate'] ?? false) === true) {
+                $candidates[] = $entry;
+
+                continue;
+            }
+
+            $skipped[] = $entry;
+            $noTouchPaths[] = $path;
+        }
+
+        if ($execute) {
+            foreach ($candidates as $entry) {
+                $path = (string) ($entry['path'] ?? '');
+                if ($path === '' || ! is_file($path)) {
+                    continue;
+                }
+
+                File::delete($path);
+                if (! is_file($path)) {
+                    $deletedPaths[] = $path;
+                }
+            }
+        }
+
+        sort($deletedPaths);
+        $noTouchPaths = $this->uniqueSorted($noTouchPaths);
+        $payload = [
+            'schema' => self::SCHEMA,
+            'mode' => $execute ? 'execute' : 'dry_run',
+            'status' => $execute ? 'executed' : 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'summary' => [
+                'scanned_file_count' => count($candidates) + count($skipped),
+                'candidate_delete_count' => count($candidates),
+                'deleted_file_count' => count($deletedPaths),
+                'skipped_file_count' => count($skipped),
+            ],
+            'candidates' => $candidates,
+            'skipped' => $skipped,
+            'deleted_paths' => $deletedPaths,
+            'no_touch_paths' => $noTouchPaths,
+            'skipped_reasons' => $this->countByReason($skipped),
+        ];
+
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function existingRootPaths(): array
+    {
+        $roots = [];
+
+        foreach ($this->rootDefinitions() as $definition) {
+            $path = $this->normalizePath(storage_path($definition['relative_dir']));
+            if ($path !== '' && is_dir($path)) {
+                $roots[] = $path;
+            }
+        }
+
+        $cacheDataRoot = $this->normalizePath(storage_path('framework/cache/data'));
+        if ($cacheDataRoot !== '' && is_dir($cacheDataRoot)) {
+            $roots[] = $cacheDataRoot;
+        }
+
+        return $this->uniqueSorted($roots);
+    }
+
+    /**
+     * @return array<string,array{relative_dir:string,surface:string}>
+     */
+    private function rootDefinitions(): array
+    {
+        return [
+            'logs' => [
+                'relative_dir' => 'logs',
+                'surface' => 'logs',
+            ],
+            'framework_cache' => [
+                'relative_dir' => 'framework/cache',
+                'surface' => 'framework_cache',
+            ],
+            'framework_sessions' => [
+                'relative_dir' => 'framework/sessions',
+                'surface' => 'framework_sessions',
+            ],
+            'framework_views' => [
+                'relative_dir' => 'framework/views',
+                'surface' => 'framework_views',
+            ],
+            'framework_testing' => [
+                'relative_dir' => 'framework/testing',
+                'surface' => 'framework_testing',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scannedFiles(): array
+    {
+        $files = [];
+
+        foreach ($this->rootDefinitions() as $definition) {
+            $root = storage_path($definition['relative_dir']);
+            if (! is_dir($root)) {
+                continue;
+            }
+
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $file) {
+                if (! $file->isFile()) {
+                    continue;
+                }
+
+                $files[] = $this->normalizePath($file->getPathname());
+            }
+        }
+
+        return $this->uniqueSorted($files);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function classifyFile(string $path): array
+    {
+        $normalizedPath = $this->normalizePath($path);
+        $basename = basename($normalizedPath);
+
+        if ($basename === '.gitkeep') {
+            return $this->skip($normalizedPath, 'GITKEEP_PRESERVED', $this->surfaceForPath($normalizedPath));
+        }
+
+        $surface = $this->surfaceForPath($normalizedPath);
+        if (in_array($surface, ['framework_sessions', 'framework_testing'], true)) {
+            return $this->skip($normalizedPath, 'RUNTIME_NO_TOUCH_SURFACE', $surface);
+        }
+
+        if ($this->isAllowedDeletePath($normalizedPath)) {
+            return [
+                'candidate' => true,
+                'path' => $normalizedPath,
+                'relative_path' => $this->relativeStoragePath($normalizedPath),
+                'surface' => $surface,
+                'reason' => 'ALLOWLIST_TEMP_FILE',
+            ];
+        }
+
+        return $this->skip($normalizedPath, 'NON_ALLOWLIST_FILE', $surface);
+    }
+
+    private function isAllowedDeletePath(string $path): bool
+    {
+        return $this->isLogFile($path)
+            || $this->isFacadeCacheFile($path)
+            || $this->isCacheDataLeafFile($path)
+            || $this->isViewLeafFile($path);
+    }
+
+    private function isLogFile(string $path): bool
+    {
+        $logsRoot = $this->normalizePath(storage_path('logs'));
+
+        return dirname($path) === $logsRoot && str_ends_with(basename($path), '.log');
+    }
+
+    private function isFacadeCacheFile(string $path): bool
+    {
+        $cacheRoot = $this->normalizePath(storage_path('framework/cache'));
+        $basename = basename($path);
+
+        return dirname($path) === $cacheRoot
+            && preg_match('/^facade\-.*\.php$/', $basename) === 1;
+    }
+
+    private function isCacheDataLeafFile(string $path): bool
+    {
+        $dataRoot = $this->normalizePath(storage_path('framework/cache/data'));
+
+        return $dataRoot !== ''
+            && str_starts_with($path, $dataRoot.'/')
+            && is_file($path);
+    }
+
+    private function isViewLeafFile(string $path): bool
+    {
+        $viewsRoot = $this->normalizePath(storage_path('framework/views'));
+
+        return $viewsRoot !== ''
+            && str_starts_with($path, $viewsRoot.'/')
+            && is_file($path);
+    }
+
+    private function surfaceForPath(string $path): string
+    {
+        foreach ($this->rootDefinitions() as $definition) {
+            $root = $this->normalizePath(storage_path($definition['relative_dir']));
+            if ($root !== '' && ($path === $root || str_starts_with($path, $root.'/'))) {
+                return $definition['surface'];
+            }
+        }
+
+        return 'unknown';
+    }
+
+    private function relativeStoragePath(string $path): string
+    {
+        $storageRoot = $this->normalizePath(storage_path());
+
+        if ($storageRoot === '' || ! str_starts_with($path, $storageRoot.'/')) {
+            return $path;
+        }
+
+        return substr($path, strlen($storageRoot) + 1);
+    }
+
+    private function normalizePath(string $path): string
+    {
+        return str_replace('\\', '/', rtrim(trim($path), '/\\'));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $entries
+     * @return array<string,int>
+     */
+    private function countByReason(array $entries): array
+    {
+        $counts = [];
+
+        foreach ($entries as $entry) {
+            $reason = (string) ($entry['reason'] ?? 'UNKNOWN');
+            $counts[$reason] = (int) ($counts[$reason] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return list<string>
+     */
+    private function uniqueSorted(array $paths): array
+    {
+        $paths = array_values(array_unique(array_filter($paths, static fn (string $path): bool => $path !== '')));
+        sort($paths);
+
+        return $paths;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function skip(string $path, string $reason, string $surface): array
+    {
+        return [
+            'candidate' => false,
+            'path' => $path,
+            'relative_path' => $this->relativeStoragePath($path),
+            'surface' => $surface,
+            'reason' => $reason,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $deletedPaths = is_array($payload['deleted_paths'] ?? null) ? $payload['deleted_paths'] : [];
+        $skippedReasons = is_array($payload['skipped_reasons'] ?? null) ? $payload['skipped_reasons'] : [];
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_janitor_runtime_temps',
+            'target_type' => 'storage',
+            'target_id' => 'runtime_temps',
+            'meta_json' => json_encode([
+                'schema' => self::SCHEMA,
+                'mode' => $payload['mode'] ?? null,
+                'generated_at' => $payload['generated_at'] ?? null,
+                'summary' => $payload['summary'] ?? [],
+                'deleted_paths' => $deletedPaths,
+                'skipped_reasons' => $skippedReasons,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_janitor_runtime_temps',
+            'request_id' => null,
+            'reason' => 'runtime_temp_retention',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Feature/Storage/RuntimeTempJanitorCommandTest.php
+++ b/backend/tests/Feature/Storage/RuntimeTempJanitorCommandTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageJanitorRuntimeTemps;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class RuntimeTempJanitorCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-runtime-temp-janitor-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath);
+        $this->app->useStoragePath($this->isolatedStoragePath);
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageJanitorRuntimeTemps::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->app->useStoragePath($this->originalStoragePath);
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_dry_run_outputs_summary_without_deleting_files(): void
+    {
+        $fixture = $this->seedRuntimeTempFixture();
+
+        $this->assertSame(0, Artisan::call('storage:janitor-runtime-temps', [
+            '--dry-run' => true,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=planned', $output);
+        $this->assertStringContainsString('mode=dry_run', $output);
+        $this->assertStringContainsString('schema=storage_janitor_runtime_temps.v1', $output);
+        $this->assertStringContainsString('scanned_file_count=7', $output);
+        $this->assertStringContainsString('candidate_delete_count=4', $output);
+        $this->assertStringContainsString('deleted_file_count=0', $output);
+        $this->assertStringContainsString('skipped_file_count=3', $output);
+
+        $this->assertFileExists($fixture['logs_candidate']);
+        $this->assertFileExists($fixture['session_file']);
+        $this->assertFileExists($fixture['gitkeep']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/runs'));
+    }
+
+    public function test_command_execute_deletes_only_allowlisted_files(): void
+    {
+        $fixture = $this->seedRuntimeTempFixture();
+
+        $this->assertSame(0, Artisan::call('storage:janitor-runtime-temps', [
+            '--execute' => true,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=executed', $output);
+        $this->assertStringContainsString('mode=execute', $output);
+        $this->assertStringContainsString('deleted_file_count=4', $output);
+
+        $this->assertFileDoesNotExist($fixture['logs_candidate']);
+        $this->assertFileDoesNotExist($fixture['cache_candidate']);
+        $this->assertFileDoesNotExist($fixture['cache_data_candidate']);
+        $this->assertFileDoesNotExist($fixture['views_candidate']);
+        $this->assertFileExists($fixture['session_file']);
+        $this->assertFileExists($fixture['gitkeep']);
+        $this->assertDirectoryExists(storage_path('logs'));
+        $this->assertDirectoryExists(storage_path('framework/sessions'));
+    }
+
+    public function test_command_requires_exactly_one_mode(): void
+    {
+        $this->assertSame(1, Artisan::call('storage:janitor-runtime-temps'));
+        $this->assertStringContainsString('exactly one of --dry-run or --execute is required.', Artisan::output());
+
+        $this->assertSame(1, Artisan::call('storage:janitor-runtime-temps', [
+            '--dry-run' => true,
+            '--execute' => true,
+        ]));
+        $this->assertStringContainsString('exactly one of --dry-run or --execute is required.', Artisan::output());
+    }
+
+    public function test_command_json_outputs_full_payload_without_extra_artifacts(): void
+    {
+        $fixture = $this->seedRuntimeTempFixture();
+
+        $this->assertSame(0, Artisan::call('storage:janitor-runtime-temps', [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(trim(Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('storage_janitor_runtime_temps.v1', $payload['schema']);
+        $this->assertSame('planned', $payload['status']);
+        $this->assertSame(4, data_get($payload, 'summary.candidate_delete_count'));
+        $this->assertSame(4, count((array) ($payload['candidates'] ?? [])));
+        $this->assertContains($fixture['session_file'], array_column((array) ($payload['skipped'] ?? []), 'path'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/plans'));
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function seedRuntimeTempFixture(): array
+    {
+        return [
+            'logs_candidate' => $this->writeFile('logs/laravel.log', 'laravel'),
+            'cache_candidate' => $this->writeFile('framework/cache/facade-runtime.php', '<?php return [];'),
+            'cache_data_candidate' => $this->writeFile('framework/cache/data/ab/cd/cache.bin', 'cache'),
+            'views_candidate' => $this->writeFile('framework/views/compiled.php', '<?php echo "view";'),
+            'session_file' => $this->writeFile('framework/sessions/session-live', 'session'),
+            'gitkeep' => $this->writeFile('framework/views/.gitkeep', ''),
+            'non_allow' => $this->writeFile('logs/readme.txt', 'readme'),
+        ];
+    }
+
+    private function writeFile(string $relativePath, string $contents): string
+    {
+        $path = storage_path($relativePath);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, $contents);
+
+        return $path;
+    }
+}

--- a/backend/tests/Feature/Storage/RuntimeTempJanitorServiceTest.php
+++ b/backend/tests/Feature/Storage/RuntimeTempJanitorServiceTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\RuntimeTempJanitorService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class RuntimeTempJanitorServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-runtime-temp-janitor-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath);
+        $this->app->useStoragePath($this->isolatedStoragePath);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->app->useStoragePath($this->originalStoragePath);
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_dry_run_enumerates_only_allowlisted_temp_files_and_preserves_no_touch_surfaces(): void
+    {
+        $fixture = $this->seedRuntimeTempFixture();
+        $filesBefore = $this->storageFilesSnapshot();
+
+        /** @var RuntimeTempJanitorService $service */
+        $service = app(RuntimeTempJanitorService::class);
+        $result = $service->run(false);
+
+        $this->assertSame('planned', $result['status']);
+        $this->assertSame(15, data_get($result, 'summary.scanned_file_count'));
+        $this->assertSame(7, data_get($result, 'summary.candidate_delete_count'));
+        $this->assertSame(0, data_get($result, 'summary.deleted_file_count'));
+        $this->assertSame(8, data_get($result, 'summary.skipped_file_count'));
+
+        $candidatePaths = array_column((array) $result['candidates'], 'path');
+        sort($candidatePaths);
+        $this->assertSame($fixture['candidate_paths'], $candidatePaths);
+
+        $skippedPaths = array_column((array) $result['skipped'], 'path');
+        sort($skippedPaths);
+        $this->assertContains($fixture['session_file'], $skippedPaths);
+        $this->assertContains($fixture['logs_gitkeep'], $skippedPaths);
+        $this->assertContains($fixture['cache_non_allow'], $skippedPaths);
+        $this->assertContains($fixture['testing_file'], $skippedPaths);
+        $this->assertSame(4, data_get($result, 'skipped_reasons.GITKEEP_PRESERVED'));
+        $this->assertSame(2, data_get($result, 'skipped_reasons.NON_ALLOWLIST_FILE'));
+        $this->assertSame(2, data_get($result, 'skipped_reasons.RUNTIME_NO_TOUCH_SURFACE'));
+
+        $noTouchPaths = (array) ($result['no_touch_paths'] ?? []);
+        $this->assertContains(storage_path('logs'), $noTouchPaths);
+        $this->assertContains(storage_path('framework/cache'), $noTouchPaths);
+        $this->assertContains(storage_path('framework/cache/data'), $noTouchPaths);
+        $this->assertContains(storage_path('framework/views'), $noTouchPaths);
+        $this->assertContains(storage_path('framework/sessions'), $noTouchPaths);
+
+        $this->assertSame($filesBefore, $this->storageFilesSnapshot());
+        $this->assertDirectoryExists(storage_path('logs'));
+        $this->assertDirectoryExists(storage_path('framework/cache'));
+        $this->assertDirectoryExists(storage_path('framework/cache/data'));
+        $this->assertDirectoryExists(storage_path('framework/views'));
+        $this->assertDirectoryExists(storage_path('framework/sessions'));
+        $this->assertFileExists($fixture['logs_gitkeep']);
+        $this->assertFileExists($fixture['session_file']);
+        $this->assertFileExists($fixture['testing_file']);
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/runs'));
+
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_janitor_runtime_temps',
+            'target_id' => 'runtime_temps',
+            'result' => 'success',
+        ]);
+    }
+
+    public function test_execute_deletes_only_allowlisted_files_and_preserves_roots_gitkeep_and_sessions(): void
+    {
+        $fixture = $this->seedRuntimeTempFixture();
+
+        /** @var RuntimeTempJanitorService $service */
+        $service = app(RuntimeTempJanitorService::class);
+        $result = $service->run(true);
+
+        $this->assertSame('executed', $result['status']);
+        $this->assertSame(7, data_get($result, 'summary.candidate_delete_count'));
+        $this->assertSame(7, data_get($result, 'summary.deleted_file_count'));
+        $this->assertSame(8, data_get($result, 'summary.skipped_file_count'));
+
+        foreach ($fixture['candidate_paths'] as $path) {
+            $this->assertFileDoesNotExist($path);
+        }
+
+        $this->assertFileExists($fixture['logs_gitkeep']);
+        $this->assertFileExists($fixture['cache_gitkeep']);
+        $this->assertFileExists($fixture['views_gitkeep']);
+        $this->assertFileExists($fixture['session_file']);
+        $this->assertFileExists($fixture['sessions_gitkeep']);
+        $this->assertFileExists($fixture['testing_file']);
+        $this->assertFileExists($fixture['logs_non_allow']);
+        $this->assertFileExists($fixture['cache_non_allow']);
+        $this->assertDirectoryExists(storage_path('logs'));
+        $this->assertDirectoryExists(storage_path('framework/cache'));
+        $this->assertDirectoryExists(storage_path('framework/cache/data'));
+        $this->assertDirectoryExists(storage_path('framework/views'));
+        $this->assertDirectoryExists(storage_path('framework/sessions'));
+        $this->assertDirectoryDoesNotExist(storage_path('app/private/plans'));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_janitor_runtime_temps')
+            ->orderByDesc('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $meta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($meta);
+        $this->assertSame('execute', $meta['mode']);
+        $this->assertSame(7, data_get($meta, 'summary.deleted_file_count'));
+        $this->assertCount(7, (array) ($meta['deleted_paths'] ?? []));
+        $this->assertSame(4, data_get($meta, 'skipped_reasons.GITKEEP_PRESERVED'));
+        $this->assertSame(2, data_get($meta, 'skipped_reasons.NON_ALLOWLIST_FILE'));
+        $this->assertSame(2, data_get($meta, 'skipped_reasons.RUNTIME_NO_TOUCH_SURFACE'));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function seedRuntimeTempFixture(): array
+    {
+        $paths = [
+            'logs_candidate_a' => $this->writeFile('logs/laravel.log', 'laravel'),
+            'logs_candidate_b' => $this->writeFile('logs/worker.log', 'worker'),
+            'logs_non_allow' => $this->writeFile('logs/readme.txt', 'readme'),
+            'logs_gitkeep' => $this->writeFile('logs/.gitkeep', ''),
+            'cache_facade' => $this->writeFile('framework/cache/facade-abc123.php', '<?php return [];'),
+            'cache_non_allow' => $this->writeFile('framework/cache/not-allowed.php', '<?php return false;'),
+            'cache_gitkeep' => $this->writeFile('framework/cache/.gitkeep', ''),
+            'cache_data_a' => $this->writeFile('framework/cache/data/aa/bb/cache-one.bin', 'cache-one'),
+            'cache_data_b' => $this->writeFile('framework/cache/data/root-cache.bin', 'cache-root'),
+            'views_compiled' => $this->writeFile('framework/views/compiled.php', '<?php echo "compiled";'),
+            'views_nested' => $this->writeFile('framework/views/nested/item.blade.php', 'blade'),
+            'views_gitkeep' => $this->writeFile('framework/views/.gitkeep', ''),
+            'session_file' => $this->writeFile('framework/sessions/session-active', 'session'),
+            'sessions_gitkeep' => $this->writeFile('framework/sessions/.gitkeep', ''),
+            'testing_file' => $this->writeFile('framework/testing/testing.tmp', 'testing'),
+        ];
+
+        $paths['candidate_paths'] = [
+            $paths['cache_data_a'],
+            $paths['cache_data_b'],
+            $paths['cache_facade'],
+            $paths['logs_candidate_a'],
+            $paths['logs_candidate_b'],
+            $paths['views_compiled'],
+            $paths['views_nested'],
+        ];
+        sort($paths['candidate_paths']);
+
+        return $paths;
+    }
+
+    private function writeFile(string $relativePath, string $contents): string
+    {
+        $path = storage_path($relativePath);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, $contents);
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageFilesSnapshot(): array
+    {
+        if (! is_dir($this->isolatedStoragePath)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->isolatedStoragePath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $files[] = str_replace($this->isolatedStoragePath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a manual-only runtime temp janitor for low-risk derived files under `backend/storage/logs` and `backend/storage/framework`.

The new command is intentionally narrow:
- it only deletes allowlisted temp files
- it only deletes at file granularity
- it never deletes directory roots
- it never deletes `.gitkeep`
- it never deletes `framework/sessions/**`
- it does not touch any `storage/app/**`, reports, artifacts, materialized cache, quarantine, offload, or lifecycle paths

Added surfaces:
- `storage:janitor-runtime-temps {--dry-run} {--execute} {--json}`
- `RuntimeTempJanitorService`
- focused service and command tests

## Root cause
The repository already had manual janitors for control-plane artifacts and materialized cache, but it still lacked a dedicated janitor for the most common local runtime temp surfaces:
- `storage/logs/*.log`
- `storage/framework/cache/facade-*.php`
- `storage/framework/cache/data/**` leaf files
- `storage/framework/views/**` leaf files

That gap left routine temp buildup in place without a repo-grounded cleanup surface, even though these files are derived and safe to prune when handled conservatively.

This was not a runtime-reader, lifecycle, scheduler, or schema problem. The missing piece was a small manual-only janitor with a strict allowlist and strict no-touch rules.

## Fix
This PR adds a new `RuntimeTempJanitorService` and a matching `storage:janitor-runtime-temps` command.

The janitor supports:
- `--dry-run` to preview candidates and skipped paths
- `--execute` to delete only allowlisted temp files
- `--json` to emit the full payload
- an `audit_logs` record with action `storage_janitor_runtime_temps`

Allowed delete patterns:
- `storage/logs/*.log`
- `storage/framework/cache/facade-*.php`
- `storage/framework/cache/data/**` leaf files
- `storage/framework/views/**` leaf files

Explicit no-touch rules:
- `storage/framework/sessions/**`
- `storage/framework/testing/**`
- any directory root
- any `.gitkeep`
- any non-allowlisted file
- any `storage/app/**`

The execution unit is always a single file. This PR does not do whole-directory deletes, does not create plan/run/receipt artifacts, and does not alter any existing storage control-plane, analyzer, materialized-cache, or runtime contracts.

## Validation
Focused:
- `vendor/bin/phpunit tests/Feature/Storage/RuntimeTempJanitorServiceTest.php tests/Feature/Storage/RuntimeTempJanitorCommandTest.php`

Regression:
- `vendor/bin/phpunit tests/Feature/Storage/StorageCostAnalyzerServiceTest.php tests/Feature/Storage/StorageCostAnalyzerCommandTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorServiceTest.php tests/Feature/Storage/StorageControlPlaneArtifactsJanitorCommandTest.php tests/Feature/Storage/MaterializedCacheJanitorServiceTest.php`

Live:
- `php artisan route:list > /tmp/pr37_route_list.txt`
- `php artisan migrate`
- `php artisan storage:janitor-runtime-temps --dry-run`
- `php artisan storage:janitor-runtime-temps --execute`
- `php artisan storage:analyze-cost --json`
- `find storage/logs -maxdepth 3 -print 2>/dev/null | sed -n '1,120p'`
- `find storage/framework/cache -maxdepth 4 -print 2>/dev/null | sed -n '1,160p'`
- `find storage/framework/views -maxdepth 2 -print 2>/dev/null | sed -n '1,120p'`
- `find storage/framework/sessions -maxdepth 2 -print 2>/dev/null | sed -n '1,120p'`
- `php artisan serve --host=127.0.0.1 --port=18081`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`

## Result
After live execution in the isolated worktree:
- allowlisted log/cache/view temp files were removed
- `framework/sessions/**` remained untouched
- directory roots remained intact
- `.gitkeep` files remained intact
- no extra artifact trees were created
