### PR TITLE
[codex] tighten reports_backups retention

### DIFF
--- a/backend/app/Console/Commands/StoragePrune.php
+++ b/backend/app/Console/Commands/StoragePrune.php
@@ -323,10 +323,48 @@ final class StoragePrune extends Command
             $items[] = [
                 'path' => $relPath,
                 'bytes' => max(0, (int) ($file->getSize() ?: 0)),
+                'mtime' => max(0, (int) ($file->getMTime() ?: 0)),
+                'group' => dirname($relPath),
             ];
         }
 
+        $keepTimestampBackups = max(0, (int) config('storage_retention.reports.keep_timestamp_backups', 0));
+        $keepDays = max(0, (int) config('storage_retention.reports.keep_days', 0));
+        $threshold = now()->subDays($keepDays)->getTimestamp();
+
+        $protectedPaths = [];
+        if ($keepTimestampBackups > 0) {
+            $grouped = [];
+            foreach ($items as $item) {
+                $grouped[$item['group']][] = $item;
+            }
+
+            foreach ($grouped as $groupItems) {
+                usort($groupItems, static fn (array $a, array $b): int => ($b['mtime'] <=> $a['mtime']) ?: strcmp($a['path'], $b['path']));
+                foreach (array_slice($groupItems, 0, $keepTimestampBackups) as $protectedItem) {
+                    $protectedPaths[$protectedItem['path']] = true;
+                }
+            }
+        }
+
+        $items = array_values(array_filter($items, static function (array $item) use ($keepDays, $protectedPaths, $threshold): bool {
+            if (isset($protectedPaths[$item['path']])) {
+                return false;
+            }
+
+            if ($keepDays > 0 && $item['mtime'] >= $threshold) {
+                return false;
+            }
+
+            return true;
+        }));
+
         usort($items, static fn (array $a, array $b): int => strcmp($a['path'], $b['path']));
+
+        $items = array_map(static fn (array $item): array => [
+            'path' => $item['path'],
+            'bytes' => $item['bytes'],
+        ], $items);
 
         return $items;
     }

--- a/backend/config/storage_retention.php
+++ b/backend/config/storage_retention.php
@@ -2,7 +2,7 @@
 
 return [
     'reports' => [
-        'keep_days' => (int) env('STORAGE_RETENTION_REPORTS_DAYS', 365),
+        'keep_days' => (int) env('STORAGE_RETENTION_REPORTS_DAYS', 0),
         'keep_timestamp_backups' => (int) env('STORAGE_RETENTION_REPORT_TS_KEEP', 0),
     ],
     'content_releases' => [

--- a/backend/tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php
+++ b/backend/tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php
@@ -96,4 +96,62 @@ final class StoragePruneDoesNotDeleteCanonicalTest extends TestCase
         $this->assertFileDoesNotExist($this->attemptDir.'/report.20260222_123456.json');
         $this->assertFileExists($this->attemptDir.'/report.20260222.json');
     }
+
+    public function test_prune_respects_reports_backup_retention_window_without_touching_canonical_files(): void
+    {
+        config()->set('storage_retention.reports.keep_days', 7);
+        config()->set('storage_retention.reports.keep_timestamp_backups', 1);
+
+        $oldBackup = $this->attemptDir.'/report.20260101_010101.json';
+        $recentBackup = $this->attemptDir.'/report.20260321_010101.json';
+        $newestBackup = $this->attemptDir.'/report.20260321_020202.json';
+
+        File::put($oldBackup, json_encode(['ok' => true, 'kind' => 'old'], JSON_UNESCAPED_UNICODE));
+        File::put($recentBackup, json_encode(['ok' => true, 'kind' => 'recent'], JSON_UNESCAPED_UNICODE));
+        File::put($newestBackup, json_encode(['ok' => true, 'kind' => 'newest'], JSON_UNESCAPED_UNICODE));
+
+        touch($oldBackup, now()->subDays(30)->getTimestamp());
+        touch($recentBackup, now()->subDays(2)->getTimestamp());
+        touch($newestBackup, now()->subDay()->getTimestamp());
+
+        $this->artisan('storage:prune --dry-run --scope=reports_backups')
+            ->assertExitCode(0);
+
+        $latestPlan = $this->latestGeneratedPlanPath();
+        $this->assertIsString($latestPlan);
+        $this->assertTrue(is_file($latestPlan));
+
+        $plan = json_decode((string) file_get_contents($latestPlan), true);
+        $this->assertIsArray($plan);
+        $this->assertSame([
+            [
+                'path' => 'reports/'.$this->attemptId.'/report.20260101_010101.json',
+                'bytes' => filesize($oldBackup),
+            ],
+        ], $plan['files'] ?? []);
+
+        $this->artisan('storage:prune --execute --scope=reports_backups --plan='.$latestPlan)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->attemptDir.'/report.json');
+        $this->assertFileDoesNotExist($oldBackup);
+        $this->assertFileExists($recentBackup);
+        $this->assertFileExists($newestBackup);
+        $this->assertFileExists($this->attemptDir.'/report.20260222.json');
+    }
+
+    private function latestGeneratedPlanPath(): ?string
+    {
+        $currentPlans = glob(storage_path('app/private/prune_plans/*.json')) ?: [];
+        $newPlans = array_values(array_diff($currentPlans, $this->preExistingPlans));
+        if ($newPlans === []) {
+            return null;
+        }
+
+        usort($newPlans, static fn (string $a, string $b): int => filemtime($a) <=> filemtime($b));
+
+        $latestPlan = end($newPlans);
+
+        return is_string($latestPlan) ? $latestPlan : null;
+    }
 }


### PR DESCRIPTION
## Summary
This PR tightens the `reports_backups` retention policy without expanding the delete surface.

The change stays strictly inside the existing `storage:prune --scope=reports_backups` flow and only affects legacy timestamp backup JSON files under `storage/app/private/reports/**/report.YYYYMMDD_HHMMSS.json`.

It does not touch:
- canonical artifacts under `storage/app/private/artifacts/**`
- `report.json`
- any PDF files
- any report bundle directory
- any new command, service, scheduler, or migration

## Root cause
The repository had already proven that legacy timestamp backup JSON files are the only reports-related objects that are safely prunable by contract.

At the same time, the active retention policy was still effectively in legacy-compat mode:
- `StoragePrune` strict matching was already constrained to timestamp backup JSON files
- but the default `storage_retention.reports.keep_days` window still remained wide
- and the prune collector was not actually consuming the reports keep window / keep-count policy in a meaningful way

That left a gap between the proven-safe delete unit and the configured retention behavior.

## Fix
This PR:
- tightens `storage_retention.reports.keep_days` from `365` to `0`
- keeps `keep_timestamp_backups=0`
- updates `StoragePrune` so `reports_backups` actually applies the configured keep window and keep-count while still matching only timestamp backup JSON files
- adds a focused test that locks the intended behavior:
  - old timestamp backup JSON is pruned
  - recent/newest timestamp backup JSON can be protected by policy override in-test
  - `report.json` remains untouched
  - non-matching files remain untouched

## Scope guardrails
This PR does not:
- change `ArtifactStore`
- change report write paths
- change PDF artifact paths
- change legacy fallback read behavior
- change canonical artifact retention
- add a new janitor command
- add a new service
- modify scheduler wiring

## Validation
- `php -l backend/config/storage_retention.php`
- `php -l backend/app/Console/Commands/StoragePrune.php`
- `php -l backend/tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php`
- `cd backend && ./vendor/bin/pint config/storage_retention.php app/Console/Commands/StoragePrune.php tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php`
- `cd backend && php artisan route:list > /tmp/pr38a_impl_route_list.txt`
- `cd backend && php artisan migrate`
- `cd backend && vendor/bin/phpunit tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php`
- `cd backend && vendor/bin/phpunit tests/Feature/Storage/StorageCostAnalyzerServiceTest.php tests/Feature/Storage/StorageCostAnalyzerCommandTest.php tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `cd backend && php artisan storage:prune --dry-run --scope=reports_backups`
- `cd backend && php artisan storage:analyze-cost --json`
- `cd backend && php artisan storage:control-plane-status --json`
- `cd backend && php artisan storage:control-plane-snapshot --json`
- `cd backend && php artisan storage:refresh-control-plane --dry-run --json`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
