### PR TITLE
[codex] expose offload coverage convergence truth

### DIFF
--- a/backend/app/Console/Commands/StorageBlobOffload.php
+++ b/backend/app/Console/Commands/StorageBlobOffload.php
@@ -177,7 +177,15 @@ final class StorageBlobOffload extends Command
 
         $this->line('status=planned');
         $this->line('disk='.$disk);
+        $this->line('target_disk='.(string) ($summary['target_disk'] ?? $disk));
+        $this->line('copy_only=true');
+        $this->line('surface=coverage_convergence_backfill');
         $this->line('plan='.$planPath);
+        $this->line('reachable_blob_count='.(int) ($summary['reachable_blob_count'] ?? 0));
+        $this->line('verified_remote_copy_counts_by_disk='.$this->formatCountsByDisk($summary['verified_remote_copy_counts_by_disk'] ?? []));
+        $this->line('local_only_count='.(int) ($summary['local_only_count'] ?? 0));
+        $this->line('target_only_count='.(int) ($summary['target_only_count'] ?? 0));
+        $this->line('both_count='.(int) ($summary['both_count'] ?? 0));
         $this->line('candidate_count='.(int) ($summary['candidate_count'] ?? 0));
         $this->line('skipped_count='.(int) ($summary['skipped_count'] ?? 0));
         $this->line('bytes='.(int) ($summary['bytes'] ?? 0));
@@ -193,7 +201,15 @@ final class StorageBlobOffload extends Command
 
         $this->line('status=executed');
         $this->line('disk='.$disk);
+        $this->line('target_disk='.(string) ($summary['target_disk'] ?? $disk));
+        $this->line('copy_only=true');
+        $this->line('surface=coverage_convergence_backfill');
         $this->line('plan='.$planPath);
+        $this->line('reachable_blob_count='.(int) ($summary['reachable_blob_count'] ?? 0));
+        $this->line('verified_remote_copy_counts_by_disk='.$this->formatCountsByDisk($summary['verified_remote_copy_counts_by_disk'] ?? []));
+        $this->line('local_only_count='.(int) ($summary['local_only_count'] ?? 0));
+        $this->line('target_only_count='.(int) ($summary['target_only_count'] ?? 0));
+        $this->line('both_count='.(int) ($summary['both_count'] ?? 0));
         $this->line('candidate_count='.(int) ($summary['candidate_count'] ?? 0));
         $this->line('uploaded_count='.(int) ($result['uploaded_count'] ?? 0));
         $this->line('verified_count='.(int) ($result['verified_count'] ?? 0));
@@ -224,7 +240,15 @@ final class StorageBlobOffload extends Command
                 'schema' => $plan['schema'] ?? null,
                 'mode' => $mode,
                 'disk' => $disk,
+                'target_disk' => $summary['target_disk'] ?? $disk,
                 'plan' => $planPath,
+                'reachable_blob_count' => (int) ($summary['reachable_blob_count'] ?? 0),
+                'verified_remote_copy_counts_by_disk' => is_array($summary['verified_remote_copy_counts_by_disk'] ?? null)
+                    ? $summary['verified_remote_copy_counts_by_disk']
+                    : [],
+                'local_only_count' => (int) ($summary['local_only_count'] ?? 0),
+                'target_only_count' => (int) ($summary['target_only_count'] ?? 0),
+                'both_count' => (int) ($summary['both_count'] ?? 0),
                 'candidate_count' => (int) ($summary['candidate_count'] ?? 0),
                 'skipped_count' => $mode === 'planned'
                     ? (int) ($summary['skipped_count'] ?? 0)
@@ -245,5 +269,32 @@ final class StorageBlobOffload extends Command
             'result' => (int) ($result['failed_count'] ?? 0) > 0 ? 'failed' : 'success',
             'created_at' => now(),
         ]);
+    }
+
+    private function formatCountsByDisk(mixed $value): string
+    {
+        if (! is_array($value) || $value === []) {
+            return 'none';
+        }
+
+        $counts = [];
+        foreach ($value as $disk => $count) {
+            $name = trim((string) $disk);
+            if ($name === '') {
+                continue;
+            }
+
+            $counts[$name] = (int) $count;
+        }
+
+        if ($counts === []) {
+            return 'none';
+        }
+
+        ksort($counts);
+
+        return collect($counts)
+            ->map(static fn (int $count, string $name): string => $name.':'.$count)
+            ->implode(',');
     }
 }

--- a/backend/app/Services/Storage/BlobOffloadService.php
+++ b/backend/app/Services/Storage/BlobOffloadService.php
@@ -27,13 +27,14 @@ final class BlobOffloadService
     {
         $disk = $this->normalizeDisk($disk);
         $sourceMap = $this->collectSourceMap();
+        $reachableHashes = $this->reachableBlobHashes();
+        $coverage = $this->buildCoverageSummary($reachableHashes, $disk);
 
         $candidates = [];
         $skipped = [];
         $candidateBytes = 0;
         $skippedBytes = 0;
 
-        $reachableHashes = $this->reachableBlobHashes();
         $catalogedBlobs = DB::table('storage_blobs')
             ->when(
                 $reachableHashes !== [],
@@ -56,6 +57,8 @@ final class BlobOffloadService
                 ->where('blob_hash', $hash)
                 ->where('disk', $disk)
                 ->where('storage_path', $remotePath)
+                ->where('location_kind', self::LOCATION_KIND_REMOTE_COPY)
+                ->whereNotNull('verified_at')
                 ->first();
 
             if ($existingLocation !== null) {
@@ -123,6 +126,12 @@ final class BlobOffloadService
             'generated_at' => now()->toAtomString(),
             'disk' => $disk,
             'summary' => [
+                'target_disk' => $disk,
+                'reachable_blob_count' => $coverage['reachable_blob_count'],
+                'verified_remote_copy_counts_by_disk' => $coverage['verified_remote_copy_counts_by_disk'],
+                'local_only_count' => $coverage['local_only_count'],
+                'target_only_count' => $coverage['target_only_count'],
+                'both_count' => $coverage['both_count'],
                 'candidate_count' => count($candidates),
                 'skipped_count' => count($skipped),
                 'bytes' => $candidateBytes,
@@ -238,6 +247,92 @@ final class BlobOffloadService
         }
 
         return $summary;
+    }
+
+    /**
+     * @param  list<string>  $reachableHashes
+     * @return array{
+     *   reachable_blob_count:int,
+     *   verified_remote_copy_counts_by_disk:array<string,int>,
+     *   local_only_count:int,
+     *   target_only_count:int,
+     *   both_count:int
+     * }
+     */
+    private function buildCoverageSummary(array $reachableHashes, string $targetDisk): array
+    {
+        $targetDisk = $this->normalizeDisk($targetDisk);
+
+        if ($reachableHashes === []) {
+            return [
+                'reachable_blob_count' => 0,
+                'verified_remote_copy_counts_by_disk' => [],
+                'local_only_count' => 0,
+                'target_only_count' => 0,
+                'both_count' => 0,
+            ];
+        }
+
+        $verifiedHashesByDisk = [];
+        $rows = StorageBlobLocation::query()
+            ->select(['disk', 'blob_hash'])
+            ->where('location_kind', self::LOCATION_KIND_REMOTE_COPY)
+            ->whereNotNull('verified_at')
+            ->whereIn('blob_hash', $reachableHashes)
+            ->orderBy('disk')
+            ->orderBy('blob_hash')
+            ->get();
+
+        foreach ($rows as $row) {
+            $disk = trim((string) ($row->disk ?? ''));
+            $hash = strtolower(trim((string) ($row->blob_hash ?? '')));
+            if ($disk === '' || ! $this->isValidHash($hash)) {
+                continue;
+            }
+
+            $verifiedHashesByDisk[$disk][$hash] = true;
+        }
+
+        $verifiedCountsByDisk = [];
+        foreach ($verifiedHashesByDisk as $disk => $hashes) {
+            $verifiedCountsByDisk[$disk] = count($hashes);
+        }
+        ksort($verifiedCountsByDisk);
+
+        $localHashes = $verifiedHashesByDisk['local'] ?? [];
+        $targetHashes = $verifiedHashesByDisk[$targetDisk] ?? [];
+        $localOnlyCount = 0;
+        $targetOnlyCount = 0;
+        $bothCount = 0;
+
+        foreach ($reachableHashes as $hash) {
+            $hasLocal = isset($localHashes[$hash]);
+            $hasTarget = isset($targetHashes[$hash]);
+
+            if ($hasLocal && $hasTarget) {
+                $bothCount++;
+
+                continue;
+            }
+
+            if ($hasLocal) {
+                $localOnlyCount++;
+
+                continue;
+            }
+
+            if ($hasTarget) {
+                $targetOnlyCount++;
+            }
+        }
+
+        return [
+            'reachable_blob_count' => count($reachableHashes),
+            'verified_remote_copy_counts_by_disk' => $verifiedCountsByDisk,
+            'local_only_count' => $localOnlyCount,
+            'target_only_count' => $targetOnlyCount,
+            'both_count' => $bothCount,
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageBlobOffloadCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageBlobOffloadCommandTest.php
@@ -192,6 +192,7 @@ final class StorageBlobOffloadCommandTest extends TestCase
         $dryRunOutput = Artisan::output();
         $this->assertStringContainsString('status=planned', $dryRunOutput);
         $this->assertStringContainsString('disk=s3', $dryRunOutput);
+        $this->assertStringContainsString('surface=coverage_convergence_backfill', $dryRunOutput);
         $this->assertStringContainsString('candidate_count=7', $dryRunOutput);
         $this->assertStringContainsString('skipped_count=2', $dryRunOutput);
 
@@ -281,6 +282,122 @@ final class StorageBlobOffloadCommandTest extends TestCase
         $this->assertIsArray($auditMeta);
         $this->assertSame('executed', (string) ($auditMeta['mode'] ?? ''));
         $this->assertSame('s3', (string) ($auditMeta['disk'] ?? ''));
+        $this->assertSame('s3', (string) ($auditMeta['target_disk'] ?? ''));
+        $this->assertTrue((bool) ($auditMeta['copy_only'] ?? false));
+    }
+
+    public function test_blob_offload_exposes_overlap_summary_and_keeps_local_verified_copy_after_backfill(): void
+    {
+        $blobCatalog = app(BlobCatalogService::class);
+
+        $localOnly = $this->createArtifactBlob($blobCatalog, 'attempt-local-only', '{"kind":"local_only"}');
+        $both = $this->createArtifactBlob($blobCatalog, 'attempt-both', '{"kind":"both"}');
+        $targetOnly = $this->createArtifactBlob($blobCatalog, 'attempt-target-only', '{"kind":"target_only"}');
+
+        $localOnlyOffloadPath = $this->localOffloadPathForHash($localOnly['hash']);
+        Storage::disk('local')->put($localOnlyOffloadPath, $localOnly['bytes']);
+        $this->seedVerifiedRemoteCopyLocation($localOnly['hash'], 'local', $localOnlyOffloadPath, $localOnly['bytes'], 'local');
+
+        $bothLocalOffloadPath = $this->localOffloadPathForHash($both['hash']);
+        Storage::disk('local')->put($bothLocalOffloadPath, $both['bytes']);
+        $this->seedVerifiedRemoteCopyLocation($both['hash'], 'local', $bothLocalOffloadPath, $both['bytes'], 'local');
+
+        $bothRemotePath = $this->remotePathForHash($both['hash']);
+        Storage::disk('s3')->put($bothRemotePath, $both['bytes']);
+        $this->seedVerifiedRemoteCopyLocation($both['hash'], 's3', $bothRemotePath, $both['bytes'], 's3');
+
+        $targetOnlyRemotePath = $this->remotePathForHash($targetOnly['hash']);
+        Storage::disk('s3')->put($targetOnlyRemotePath, $targetOnly['bytes']);
+        $this->seedVerifiedRemoteCopyLocation($targetOnly['hash'], 's3', $targetOnlyRemotePath, $targetOnly['bytes'], 's3');
+
+        $this->assertSame(0, Artisan::call('storage:blob-offload', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('surface=coverage_convergence_backfill', $dryRunOutput);
+        $this->assertStringContainsString('target_disk=s3', $dryRunOutput);
+        $this->assertStringContainsString('reachable_blob_count=3', $dryRunOutput);
+        $this->assertStringContainsString('verified_remote_copy_counts_by_disk=local:2,s3:2', $dryRunOutput);
+        $this->assertStringContainsString('local_only_count=1', $dryRunOutput);
+        $this->assertStringContainsString('target_only_count=1', $dryRunOutput);
+        $this->assertStringContainsString('both_count=1', $dryRunOutput);
+        $this->assertStringContainsString('candidate_count=1', $dryRunOutput);
+        $this->assertStringContainsString('skipped_count=2', $dryRunOutput);
+
+        $plan = json_decode((string) file_get_contents($this->extractPlanPath($dryRunOutput)), true);
+        $this->assertIsArray($plan);
+        $summary = (array) ($plan['summary'] ?? []);
+        $this->assertSame('s3', (string) ($summary['target_disk'] ?? ''));
+        $this->assertSame(3, (int) ($summary['reachable_blob_count'] ?? -1));
+        $this->assertSame(['local' => 2, 's3' => 2], $summary['verified_remote_copy_counts_by_disk'] ?? null);
+        $this->assertSame(1, (int) ($summary['local_only_count'] ?? -1));
+        $this->assertSame(1, (int) ($summary['target_only_count'] ?? -1));
+        $this->assertSame(1, (int) ($summary['both_count'] ?? -1));
+        $this->assertSame([$localOnly['hash']], array_column((array) ($plan['candidates'] ?? []), 'blob_hash'));
+
+        $this->assertSame(0, Artisan::call('storage:blob-offload', [
+            '--execute' => true,
+            '--disk' => 's3',
+        ]));
+
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('surface=coverage_convergence_backfill', $executeOutput);
+        $this->assertStringContainsString('candidate_count=1', $executeOutput);
+        $this->assertStringContainsString('uploaded_count=1', $executeOutput);
+        $this->assertStringContainsString('verified_count=1', $executeOutput);
+        $this->assertStringContainsString('failed_count=0', $executeOutput);
+
+        Storage::disk('s3')->assertExists($this->remotePathForHash($localOnly['hash']));
+        $this->assertTrue(Storage::disk('local')->exists($localOnlyOffloadPath));
+        $this->assertTrue(Storage::disk('local')->exists($bothLocalOffloadPath));
+
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $localOnly['hash'],
+            'disk' => 'local',
+            'storage_path' => $localOnlyOffloadPath,
+            'location_kind' => 'remote_copy',
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $localOnly['hash'],
+            'disk' => 's3',
+            'storage_path' => $this->remotePathForHash($localOnly['hash']),
+            'location_kind' => 'remote_copy',
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $both['hash'],
+            'disk' => 'local',
+            'storage_path' => $bothLocalOffloadPath,
+            'location_kind' => 'remote_copy',
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $both['hash'],
+            'disk' => 's3',
+            'storage_path' => $bothRemotePath,
+            'location_kind' => 'remote_copy',
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $targetOnly['hash'],
+            'disk' => 's3',
+            'storage_path' => $targetOnlyRemotePath,
+            'location_kind' => 'remote_copy',
+        ]);
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_blob_offload')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($audit);
+        $auditMeta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($auditMeta);
+        $this->assertSame(3, (int) ($auditMeta['reachable_blob_count'] ?? -1));
+        $this->assertSame(1, (int) ($auditMeta['local_only_count'] ?? -1));
+        $this->assertSame(1, (int) ($auditMeta['target_only_count'] ?? -1));
+        $this->assertSame(1, (int) ($auditMeta['both_count'] ?? -1));
+        $this->assertSame(['local' => 2, 's3' => 2], $auditMeta['verified_remote_copy_counts_by_disk'] ?? null);
         $this->assertTrue((bool) ($auditMeta['copy_only'] ?? false));
     }
 
@@ -368,6 +485,58 @@ final class StorageBlobOffloadCommandTest extends TestCase
                 'last_verified_at' => now(),
             ]);
         }
+    }
+
+    /**
+     * @return array{hash:string,bytes:string}
+     */
+    private function createArtifactBlob(BlobCatalogService $blobCatalog, string $attemptId, string $payload): array
+    {
+        $relativePath = 'artifacts/reports/MBTI/'.$attemptId.'/report.json';
+        Storage::disk('local')->put($relativePath, $payload);
+
+        $bytes = (string) Storage::disk('local')->get($relativePath);
+        $hash = hash('sha256', $bytes);
+        $blobCatalog->upsertBlob([
+            'hash' => $hash,
+            'disk' => 'local',
+            'storage_path' => $blobCatalog->storagePathForHash($hash),
+            'size_bytes' => strlen($bytes),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+            'last_verified_at' => now(),
+        ]);
+
+        return [
+            'hash' => $hash,
+            'bytes' => $bytes,
+        ];
+    }
+
+    private function localOffloadPathForHash(string $hash): string
+    {
+        return 'offload/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+    }
+
+    private function seedVerifiedRemoteCopyLocation(string $hash, string $disk, string $storagePath, string $bytes, string $driver): void
+    {
+        StorageBlobLocation::query()->create([
+            'blob_hash' => $hash,
+            'disk' => $disk,
+            'storage_path' => $storagePath,
+            'location_kind' => 'remote_copy',
+            'size_bytes' => strlen($bytes),
+            'checksum' => 'sha256:'.hash('sha256', $bytes),
+            'etag' => null,
+            'storage_class' => $disk === 's3' ? 'STANDARD_IA' : null,
+            'verified_at' => now(),
+            'meta_json' => [
+                'driver' => $driver,
+                'source_kind' => 'seeded_test_fixture',
+                'verified_checksum_sha256' => hash('sha256', $bytes),
+            ],
+        ]);
     }
 
     private function remotePathForHash(string $hash): string


### PR DESCRIPTION
## Summary
This PR keeps the existing `storage:blob-offload` surface and makes its intended role explicit: it is a coverage convergence/backfill command for verified non-local `remote_copy` rows, not a cleanup command.

The change is additive. It exposes overlap truth for reachable blob hashes on the target disk so operators can see whether a dry-run is backfilling `local_only` coverage, observing `both` overlap, or encountering `target_only` coverage that already exists.

## Root cause
The repository already proved that local offload copies cannot be cleaned up yet because most reachable blobs still have only `disk=local, location_kind=remote_copy, verified_at not null` coverage.

That made the next safe step a convergence/backfill step rather than a shrink step. However, the existing `storage:blob-offload` plan and command output did not surface enough overlap truth to make that role obvious during dry-runs and audits.

## Fix
This PR only strengthens the existing offload surface.

It adds blob-hash based convergence summary fields to the plan, command output, and audit metadata:
- `target_disk`
- `reachable_blob_count`
- `verified_remote_copy_counts_by_disk`
- `local_only_count`
- `target_only_count`
- `both_count`
- existing `candidate_count` remains unchanged in meaning

The candidate contract is preserved:
- candidates are still reachable blobs that have a usable source and are missing a verified target-disk `remote_copy`

The execute contract is also preserved:
- copy to target disk
- verify remote object
- upsert target-disk verified `remote_copy`
- do not delete local files
- do not delete local rows

## Scope guardrails
This PR does not:
- add a new command
- add a new service
- add scheduler wiring
- change `storage_blob_locations` schema
- change `location_kind=remote_copy` semantics
- change exact rehydrate / V2 remote fallback / runtime reader contracts
- delete local offload files
- delete local location rows
- perform any cleanup or shrink behavior

## Validation
- `php -l backend/app/Services/Storage/BlobOffloadService.php`
- `php -l backend/app/Console/Commands/StorageBlobOffload.php`
- `php -l backend/tests/Feature/Storage/StorageBlobOffloadCommandTest.php`
- `cd backend && ./vendor/bin/pint app/Services/Storage/BlobOffloadService.php app/Console/Commands/StorageBlobOffload.php tests/Feature/Storage/StorageBlobOffloadCommandTest.php`
- `cd backend && vendor/bin/phpunit tests/Feature/Storage/StorageBlobOffloadCommandTest.php`
- `cd backend && php artisan route:list > /tmp/pr39a_impl_route_list.txt`
- `cd backend && php artisan migrate`
- `cd backend && vendor/bin/phpunit tests/Feature/Storage/StorageBlobOffloadCommandTest.php tests/Feature/Storage/StorageBlobGcCommandTest.php tests/Feature/Storage/ExactReleaseRehydrateServiceTest.php tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `cd backend && php artisan storage:blob-gc --dry-run`
- `cd backend && php artisan storage:blob-offload --dry-run --disk=s3`
- `cd backend && php artisan storage:analyze-cost --json`
- `cd backend && php artisan storage:control-plane-status --json`
- `cd backend && php artisan storage:control-plane-snapshot --json`
- `cd backend && php artisan storage:refresh-control-plane --dry-run --json`
- `cd backend && php artisan serve --host=127.0.0.1 --port=18081`
- `cd backend && curl -i http://127.0.0.1:18081/api/healthz`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
