### PR TITLE
[codex] add offload local-copy shrink cleanup

### DIFF
--- a/backend/app/Console/Commands/StorageShrinkOffloadLocalCopies.php
+++ b/backend/app/Console/Commands/StorageShrinkOffloadLocalCopies.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\OffloadLocalCopyShrinkService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class StorageShrinkOffloadLocalCopies extends Command
+{
+    protected $signature = 'storage:shrink-offload-local-copies
+        {--dry-run : Build a shrink plan for local offload copies only}
+        {--execute : Execute shrink from an existing plan}
+        {--disk=s3 : Target non-local disk that already holds verified remote_copy coverage}
+        {--plan= : Absolute or storage-relative plan path required for execute mode}
+        {--json : Emit the full payload as JSON}';
+
+    protected $description = 'Manual-only cleanup for local offload copies that are already fully covered by a non-local verified remote_copy.';
+
+    public function __construct(
+        private readonly OffloadLocalCopyShrinkService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $disk = trim((string) ($this->option('disk') ?? 's3'));
+
+        try {
+            $this->ensureTargetDiskIsRemote($disk);
+
+            if ($dryRun) {
+                $plan = $this->service->buildPlan($disk);
+                $planPath = $this->persistPlan($plan);
+                $payload = $plan + ['plan' => $planPath];
+
+                return $this->emitPayload($payload);
+            }
+
+            $planPath = trim((string) ($this->option('plan') ?? ''));
+            if ($planPath === '') {
+                $this->error('--execute requires --plan.');
+
+                return self::FAILURE;
+            }
+
+            $resolvedPlanPath = $this->resolvePlanPath($planPath);
+            $plan = $this->readPlan($resolvedPlanPath);
+            $planDisk = trim((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+            if ($planDisk !== $disk) {
+                $this->error('plan disk mismatch: '.$planDisk.' != '.$disk);
+
+                return self::FAILURE;
+            }
+
+            $plan['_meta'] = [
+                'plan_path' => $resolvedPlanPath,
+            ];
+            $payload = $this->service->executePlan($plan);
+
+            return $this->emitPayload($payload);
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function ensureTargetDiskIsRemote(string $disk): void
+    {
+        $driver = trim((string) config('filesystems.disks.'.$disk.'.driver', ''));
+        if ($driver === '') {
+            throw new \RuntimeException('shrink target disk is not configured: filesystems.disks.'.$disk.' is missing.');
+        }
+
+        if ($driver === 'local') {
+            throw new \RuntimeException('shrink target disk must be remote: local disks are not allowed.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function emitPayload(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode offload local copy shrink json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return self::SUCCESS;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('disk='.(string) ($payload['disk'] ?? ''));
+        $this->line('target_disk='.(string) ($payload['target_disk'] ?? ''));
+        $this->line('schema='.(string) ($payload['schema'] ?? ''));
+        $this->line('plan='.(string) ($payload['plan'] ?? ''));
+        $this->line('both_candidate_count='.(int) ($summary['both_candidate_count'] ?? 0));
+        $this->line('blocked_count='.(int) ($summary['blocked_count'] ?? 0));
+        $this->line('local_only_count='.(int) ($summary['local_only_count'] ?? 0));
+        $this->line('target_only_count='.(int) ($summary['target_only_count'] ?? 0));
+        $this->line('deleted_local_files_count='.(int) ($summary['deleted_local_files_count'] ?? 0));
+        $this->line('deleted_local_rows_count='.(int) ($summary['deleted_local_rows_count'] ?? 0));
+
+        if (isset($payload['run_path'])) {
+            $this->line('run_path='.(string) $payload['run_path']);
+        }
+
+        return (($payload['status'] ?? 'executed') === 'partial_failure') ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function persistPlan(array $plan): string
+    {
+        $planDir = storage_path('app/private/offload_local_copy_shrink_plans');
+        File::ensureDirectoryExists($planDir);
+
+        $planPath = $planDir.DIRECTORY_SEPARATOR.now()->format('Ymd_His').'_offload_local_copy_shrink_'.substr(bin2hex(random_bytes(4)), 0, 8).'.json';
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode offload local copy shrink plan json.');
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        return $planPath;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readPlan(string $planPath): array
+    {
+        if (! is_file($planPath)) {
+            throw new \RuntimeException('plan not found: '.$planPath);
+        }
+
+        $decoded = json_decode((string) File::get($planPath), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('invalid offload local copy shrink plan json: '.$planPath);
+        }
+
+        if ((string) ($decoded['schema'] ?? '') !== 'storage_shrink_offload_local_copies_plan.v1') {
+            throw new \RuntimeException('plan schema mismatch.');
+        }
+
+        return $decoded;
+    }
+
+    private function resolvePlanPath(string $planOption): string
+    {
+        if (str_starts_with($planOption, DIRECTORY_SEPARATOR)) {
+            return $planOption;
+        }
+
+        $basePathCandidate = base_path($planOption);
+        if (is_file($basePathCandidate)) {
+            return $basePathCandidate;
+        }
+
+        return storage_path('app/private/'.ltrim($planOption, '/\\'));
+    }
+}

--- a/backend/app/Services/Storage/OffloadLocalCopyShrinkService.php
+++ b/backend/app/Services/Storage/OffloadLocalCopyShrinkService.php
@@ -1,0 +1,524 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\StorageBlobLocation;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+final class OffloadLocalCopyShrinkService
+{
+    private const PLAN_SCHEMA = 'storage_shrink_offload_local_copies_plan.v1';
+
+    private const RUN_SCHEMA = 'storage_shrink_offload_local_copies_run.v1';
+
+    private const LOCATION_KIND_REMOTE_COPY = 'remote_copy';
+
+    private const AUDIT_ACTION = 'storage_shrink_offload_local_copies';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildPlan(string $targetDisk): array
+    {
+        $targetDisk = $this->normalizeDisk($targetDisk);
+        $localRowsByHash = $this->verifiedRowsByHash('local');
+        $targetRowsByHash = $this->verifiedRowsByHash($targetDisk);
+        $distribution = $this->buildDistributionSummary($localRowsByHash, $targetRowsByHash, $targetDisk);
+
+        $candidates = [];
+        $blocked = [];
+        $blockedReasonCounts = [];
+
+        foreach ($localRowsByHash as $blobHash => $localRows) {
+            $targetRows = $targetRowsByHash[$blobHash] ?? [];
+
+            if ($targetRows === []) {
+                $blocked[] = $this->blockedEntry($blobHash, 'LOCAL_ONLY_TARGET_VERIFIED_ROW_MISSING');
+                $blockedReasonCounts['LOCAL_ONLY_TARGET_VERIFIED_ROW_MISSING'] = (int) ($blockedReasonCounts['LOCAL_ONLY_TARGET_VERIFIED_ROW_MISSING'] ?? 0) + 1;
+
+                continue;
+            }
+
+            if (count($localRows) !== 1) {
+                $blocked[] = $this->blockedEntry($blobHash, 'LOCAL_VERIFIED_ROW_CARDINALITY_INVALID', [
+                    'local_row_ids' => array_map(static fn (StorageBlobLocation $row): int => (int) $row->getKey(), $localRows),
+                    'target_row_ids' => array_map(static fn (StorageBlobLocation $row): int => (int) $row->getKey(), $targetRows),
+                ]);
+                $blockedReasonCounts['LOCAL_VERIFIED_ROW_CARDINALITY_INVALID'] = (int) ($blockedReasonCounts['LOCAL_VERIFIED_ROW_CARDINALITY_INVALID'] ?? 0) + 1;
+
+                continue;
+            }
+
+            if (count($targetRows) !== 1) {
+                $blocked[] = $this->blockedEntry($blobHash, 'TARGET_VERIFIED_ROW_CARDINALITY_INVALID', [
+                    'local_row_ids' => array_map(static fn (StorageBlobLocation $row): int => (int) $row->getKey(), $localRows),
+                    'target_row_ids' => array_map(static fn (StorageBlobLocation $row): int => (int) $row->getKey(), $targetRows),
+                ]);
+                $blockedReasonCounts['TARGET_VERIFIED_ROW_CARDINALITY_INVALID'] = (int) ($blockedReasonCounts['TARGET_VERIFIED_ROW_CARDINALITY_INVALID'] ?? 0) + 1;
+
+                continue;
+            }
+
+            $localRow = $localRows[0];
+            $targetRow = $targetRows[0];
+            $localStoragePath = trim((string) $localRow->storage_path);
+            $expectedLocalStoragePath = $this->localOffloadPathForHash($blobHash);
+
+            if ($localStoragePath === '' || $localStoragePath !== $expectedLocalStoragePath) {
+                $blocked[] = $this->blockedEntry($blobHash, 'LOCAL_STORAGE_PATH_OUT_OF_SCOPE', [
+                    'local_location_row_id' => (int) $localRow->getKey(),
+                    'local_storage_path' => $localStoragePath,
+                    'expected_local_storage_path' => $expectedLocalStoragePath,
+                    'target_location_row_id' => (int) $targetRow->getKey(),
+                ]);
+                $blockedReasonCounts['LOCAL_STORAGE_PATH_OUT_OF_SCOPE'] = (int) ($blockedReasonCounts['LOCAL_STORAGE_PATH_OUT_OF_SCOPE'] ?? 0) + 1;
+
+                continue;
+            }
+
+            $targetStoragePath = trim((string) $targetRow->storage_path);
+            $expectedTargetStoragePath = $this->targetOffloadPathForHash($blobHash);
+            if ($targetStoragePath === '' || $targetStoragePath !== $expectedTargetStoragePath) {
+                $blocked[] = $this->blockedEntry($blobHash, 'TARGET_STORAGE_PATH_OUT_OF_SCOPE', [
+                    'local_location_row_id' => (int) $localRow->getKey(),
+                    'target_location_row_id' => (int) $targetRow->getKey(),
+                    'target_storage_path' => $targetStoragePath,
+                    'expected_target_storage_path' => $expectedTargetStoragePath,
+                ]);
+                $blockedReasonCounts['TARGET_STORAGE_PATH_OUT_OF_SCOPE'] = (int) ($blockedReasonCounts['TARGET_STORAGE_PATH_OUT_OF_SCOPE'] ?? 0) + 1;
+
+                continue;
+            }
+
+            if (! Storage::disk('local')->exists($localStoragePath)) {
+                $blocked[] = $this->blockedEntry($blobHash, 'LOCAL_FILE_MISSING', [
+                    'local_location_row_id' => (int) $localRow->getKey(),
+                    'local_storage_path' => $localStoragePath,
+                    'target_location_row_id' => (int) $targetRow->getKey(),
+                ]);
+                $blockedReasonCounts['LOCAL_FILE_MISSING'] = (int) ($blockedReasonCounts['LOCAL_FILE_MISSING'] ?? 0) + 1;
+
+                continue;
+            }
+
+            $candidates[] = [
+                'blob_hash' => $blobHash,
+                'local_file_path' => $localStoragePath,
+                'local_location_row_id' => (int) $localRow->getKey(),
+                'target_location_row_id' => (int) $targetRow->getKey(),
+                'local_storage_path' => $localStoragePath,
+                'target_storage_path' => $targetStoragePath,
+                'target_disk' => $targetDisk,
+            ];
+        }
+
+        usort($candidates, static fn (array $left, array $right): int => strcmp((string) ($left['blob_hash'] ?? ''), (string) ($right['blob_hash'] ?? '')));
+        usort($blocked, static fn (array $left, array $right): int => strcmp((string) ($left['blob_hash'] ?? ''), (string) ($right['blob_hash'] ?? '')));
+        ksort($blockedReasonCounts);
+
+        return [
+            'schema' => self::PLAN_SCHEMA,
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'disk' => $targetDisk,
+            'target_disk' => $targetDisk,
+            'summary' => [
+                'verified_remote_copy_counts_by_disk' => $distribution['verified_remote_copy_counts_by_disk'],
+                'local_only_count' => $distribution['local_only_count'],
+                'target_only_count' => $distribution['target_only_count'],
+                'both_count' => $distribution['both_count'],
+                'both_candidate_count' => count($candidates),
+                'blocked_count' => count($blocked),
+                'deleted_local_files_count' => 0,
+                'deleted_local_rows_count' => 0,
+            ],
+            'candidates' => array_values($candidates),
+            'blocked' => array_values($blocked),
+            'reasons' => $blockedReasonCounts,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    public function executePlan(array $plan): array
+    {
+        $this->assertPlanSchema($plan);
+
+        $targetDisk = $this->normalizeDisk((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+        $planPath = trim((string) ($plan['_meta']['plan_path'] ?? ''));
+        $runDir = $this->runDirectory();
+        File::ensureDirectoryExists($runDir);
+
+        $results = [];
+        $summary = [
+            'both_candidate_count' => count(is_array($plan['candidates'] ?? null) ? $plan['candidates'] : []),
+            'blocked_count' => 0,
+            'deleted_local_files_count' => 0,
+            'deleted_local_rows_count' => 0,
+            'partial_failure_count' => 0,
+            'failed_count' => 0,
+            'local_only_count' => (int) data_get($plan, 'summary.local_only_count', 0),
+            'target_only_count' => (int) data_get($plan, 'summary.target_only_count', 0),
+        ];
+
+        $candidates = is_array($plan['candidates'] ?? null) ? $plan['candidates'] : [];
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $result = $this->executeCandidate($candidate, $targetDisk);
+            $results[] = $result;
+
+            $status = (string) ($result['status'] ?? '');
+            if ($status === 'deleted') {
+                $summary['deleted_local_files_count']++;
+                $summary['deleted_local_rows_count']++;
+
+                continue;
+            }
+
+            if ($status === 'blocked') {
+                $summary['blocked_count']++;
+
+                continue;
+            }
+
+            if ($status === 'partial_failure') {
+                if ((bool) ($result['local_row_deleted'] ?? false)) {
+                    $summary['deleted_local_rows_count']++;
+                }
+                if ((bool) ($result['local_file_deleted'] ?? false)) {
+                    $summary['deleted_local_files_count']++;
+                }
+                $summary['partial_failure_count']++;
+
+                continue;
+            }
+
+            $summary['failed_count']++;
+        }
+
+        $status = 'executed';
+        if ($summary['partial_failure_count'] > 0 || $summary['failed_count'] > 0) {
+            $status = 'partial_failure';
+        }
+
+        $payload = [
+            'schema' => self::RUN_SCHEMA,
+            'mode' => 'execute',
+            'status' => $status,
+            'generated_at' => now()->toIso8601String(),
+            'disk' => $targetDisk,
+            'target_disk' => $targetDisk,
+            'plan' => $planPath,
+            'summary' => $summary,
+            'results' => $results,
+        ];
+
+        $runPath = $runDir.DIRECTORY_SEPARATOR.'run.json';
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode offload local copy shrink run receipt.');
+        }
+        File::put($runPath, $encoded.PHP_EOL);
+
+        $payload['run_path'] = $runPath;
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     * @return array<string,mixed>
+     */
+    private function executeCandidate(array $candidate, string $targetDisk): array
+    {
+        $blobHash = strtolower(trim((string) ($candidate['blob_hash'] ?? '')));
+        $localStoragePath = trim((string) ($candidate['local_storage_path'] ?? $candidate['local_file_path'] ?? ''));
+        $localRowId = (int) ($candidate['local_location_row_id'] ?? 0);
+        $targetRowId = (int) ($candidate['target_location_row_id'] ?? 0);
+
+        $baseResult = [
+            'blob_hash' => $blobHash,
+            'local_file_path' => $localStoragePath,
+            'local_location_row_id' => $localRowId,
+            'target_location_row_id' => $targetRowId,
+            'target_disk' => $targetDisk,
+            'local_row_deleted' => false,
+            'local_file_deleted' => false,
+        ];
+
+        $localRow = $this->resolveVerifiedRow($localRowId, $blobHash, 'local');
+        if ($localRow === null) {
+            return $baseResult + [
+                'status' => 'blocked',
+                'reason' => 'LOCAL_VERIFIED_ROW_MISSING_AT_EXECUTE',
+            ];
+        }
+
+        $targetRow = $this->resolveVerifiedRow($targetRowId, $blobHash, $targetDisk);
+        if ($targetRow === null) {
+            return $baseResult + [
+                'status' => 'blocked',
+                'reason' => 'TARGET_VERIFIED_ROW_MISSING_AT_EXECUTE',
+            ];
+        }
+
+        if (trim((string) $localRow->storage_path) !== $localStoragePath) {
+            return $baseResult + [
+                'status' => 'blocked',
+                'reason' => 'LOCAL_STORAGE_PATH_CHANGED_AT_EXECUTE',
+            ];
+        }
+
+        if (! Storage::disk('local')->exists($localStoragePath)) {
+            return $baseResult + [
+                'status' => 'blocked',
+                'reason' => 'LOCAL_FILE_MISSING_AT_EXECUTE',
+            ];
+        }
+
+        if (! $this->hasVerifiedRowForHash($blobHash, 'local') || ! $this->hasVerifiedRowForHash($blobHash, $targetDisk)) {
+            return $baseResult + [
+                'status' => 'blocked',
+                'reason' => 'BOTH_OVERLAP_LOST_AT_EXECUTE',
+            ];
+        }
+
+        $deletedLocalRows = DB::transaction(function () use ($localRowId, $blobHash): int {
+            return StorageBlobLocation::query()
+                ->whereKey($localRowId)
+                ->where('blob_hash', $blobHash)
+                ->where('disk', 'local')
+                ->where('location_kind', self::LOCATION_KIND_REMOTE_COPY)
+                ->whereNotNull('verified_at')
+                ->delete();
+        });
+
+        if ($deletedLocalRows !== 1) {
+            return $baseResult + [
+                'status' => 'blocked',
+                'reason' => 'LOCAL_VERIFIED_ROW_DELETE_BLOCKED',
+            ];
+        }
+
+        $fileDeleteResult = Storage::disk('local')->delete($localStoragePath);
+        $localFileStillExists = Storage::disk('local')->exists($localStoragePath);
+        if (! $fileDeleteResult && $localFileStillExists) {
+            return $baseResult + [
+                'status' => 'partial_failure',
+                'reason' => 'LOCAL_FILE_DELETE_FAILED_AFTER_ROW_DELETE',
+                'local_row_deleted' => true,
+                'local_file_deleted' => false,
+            ];
+        }
+
+        return $baseResult + [
+            'status' => 'deleted',
+            'reason' => 'LOCAL_SIDE_REMOVED',
+            'local_row_deleted' => true,
+            'local_file_deleted' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => self::AUDIT_ACTION,
+            'target_type' => 'storage',
+            'target_id' => 'offload_local_copies',
+            'meta_json' => json_encode([
+                'schema' => $payload['schema'] ?? null,
+                'mode' => $payload['mode'] ?? null,
+                'target_disk' => $payload['target_disk'] ?? null,
+                'plan' => $payload['plan'] ?? null,
+                'run_path' => $payload['run_path'] ?? null,
+                'summary' => $payload['summary'] ?? [],
+                'results' => $payload['results'] ?? [],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'artisan/storage:shrink-offload-local-copies',
+            'request_id' => null,
+            'reason' => 'manual_cleanup',
+            'result' => ($payload['status'] ?? 'executed') === 'executed' ? 'success' : 'partial_failure',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function assertPlanSchema(array $plan): void
+    {
+        if ((string) ($plan['schema'] ?? '') !== self::PLAN_SCHEMA) {
+            throw new \RuntimeException('offload local copy shrink plan schema mismatch.');
+        }
+    }
+
+    /**
+     * @param  array<string,array<int,StorageBlobLocation>>  $localRowsByHash
+     * @param  array<string,array<int,StorageBlobLocation>>  $targetRowsByHash
+     * @return array{
+     *   verified_remote_copy_counts_by_disk:array<string,int>,
+     *   local_only_count:int,
+     *   target_only_count:int,
+     *   both_count:int
+     * }
+     */
+    private function buildDistributionSummary(array $localRowsByHash, array $targetRowsByHash, string $targetDisk): array
+    {
+        $allHashes = array_values(array_unique(array_merge(array_keys($localRowsByHash), array_keys($targetRowsByHash))));
+        sort($allHashes);
+
+        $localOnlyCount = 0;
+        $targetOnlyCount = 0;
+        $bothCount = 0;
+
+        foreach ($allHashes as $blobHash) {
+            $hasLocal = isset($localRowsByHash[$blobHash]) && $localRowsByHash[$blobHash] !== [];
+            $hasTarget = isset($targetRowsByHash[$blobHash]) && $targetRowsByHash[$blobHash] !== [];
+
+            if ($hasLocal && $hasTarget) {
+                $bothCount++;
+
+                continue;
+            }
+
+            if ($hasLocal) {
+                $localOnlyCount++;
+
+                continue;
+            }
+
+            if ($hasTarget) {
+                $targetOnlyCount++;
+            }
+        }
+
+        return [
+            'verified_remote_copy_counts_by_disk' => [
+                'local' => count($localRowsByHash),
+                $targetDisk => count($targetRowsByHash),
+            ],
+            'local_only_count' => $localOnlyCount,
+            'target_only_count' => $targetOnlyCount,
+            'both_count' => $bothCount,
+        ];
+    }
+
+    /**
+     * @return array<string,array<int,StorageBlobLocation>>
+     */
+    private function verifiedRowsByHash(string $disk): array
+    {
+        $rows = StorageBlobLocation::query()
+            ->where('disk', $disk)
+            ->where('location_kind', self::LOCATION_KIND_REMOTE_COPY)
+            ->whereNotNull('verified_at')
+            ->orderBy('blob_hash')
+            ->orderByDesc('verified_at')
+            ->orderByDesc('id')
+            ->get();
+
+        $grouped = [];
+        foreach ($rows as $row) {
+            $blobHash = strtolower(trim((string) $row->blob_hash));
+            if (! preg_match('/^[a-f0-9]{64}$/', $blobHash)) {
+                continue;
+            }
+
+            $grouped[$blobHash] ??= [];
+            $grouped[$blobHash][] = $row;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function blockedEntry(string $blobHash, string $reason, array $context = []): array
+    {
+        return [
+            'blob_hash' => $blobHash,
+            'reason' => $reason,
+            'context' => $context,
+        ];
+    }
+
+    private function hasVerifiedRowForHash(string $blobHash, string $disk): bool
+    {
+        return StorageBlobLocation::query()
+            ->where('blob_hash', $blobHash)
+            ->where('disk', $disk)
+            ->where('location_kind', self::LOCATION_KIND_REMOTE_COPY)
+            ->whereNotNull('verified_at')
+            ->exists();
+    }
+
+    private function resolveVerifiedRow(int $rowId, string $blobHash, string $disk): ?StorageBlobLocation
+    {
+        if ($rowId <= 0) {
+            return null;
+        }
+
+        return StorageBlobLocation::query()
+            ->whereKey($rowId)
+            ->where('blob_hash', $blobHash)
+            ->where('disk', $disk)
+            ->where('location_kind', self::LOCATION_KIND_REMOTE_COPY)
+            ->whereNotNull('verified_at')
+            ->first();
+    }
+
+    private function normalizeDisk(string $disk): string
+    {
+        $normalized = trim($disk);
+        if ($normalized === '') {
+            throw new \RuntimeException('target disk is required.');
+        }
+
+        return $normalized;
+    }
+
+    private function targetOffloadPathForHash(string $blobHash): string
+    {
+        $prefix = trim((string) config('storage_rollout.blob_offload_prefix', 'rollout/blobs'), '/');
+
+        return $prefix.'/sha256/'.substr($blobHash, 0, 2).'/'.$blobHash;
+    }
+
+    private function localOffloadPathForHash(string $blobHash): string
+    {
+        return 'offload/blobs/sha256/'.substr($blobHash, 0, 2).'/'.$blobHash;
+    }
+
+    private function runDirectory(): string
+    {
+        $dir = storage_path('app/private/offload_local_copy_shrink_runs/'.now()->format('Ymd_His').'_'.substr(bin2hex(random_bytes(4)), 0, 8));
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+}

--- a/backend/tests/Feature/Storage/OffloadLocalCopyShrinkServiceTest.php
+++ b/backend/tests/Feature/Storage/OffloadLocalCopyShrinkServiceTest.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ExactReleaseFileSetCatalogService;
+use App\Services\Storage\ExactReleaseRehydrateService;
+use App\Services\Storage\OffloadLocalCopyShrinkService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class OffloadLocalCopyShrinkServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-offload-local-copy-shrink-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_rollout.blob_offload_prefix', 'rollout/blobs');
+        config()->set('storage_rollout.blob_offload_disk', 's3');
+        config()->set('filesystems.disks.s3.bucket', 'offload-shrink-test-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.offload-shrink.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_dry_run_and_execute_only_delete_both_local_side(): void
+    {
+        $localOnly = $this->seedBlob('local-only', withLocal: true, withTarget: false);
+        $both = $this->seedBlob('both', withLocal: true, withTarget: true);
+        $targetOnly = $this->seedBlob('target-only', withLocal: false, withTarget: true);
+
+        /** @var OffloadLocalCopyShrinkService $service */
+        $service = app(OffloadLocalCopyShrinkService::class);
+
+        $plan = $service->buildPlan('s3');
+        $this->assertSame('storage_shrink_offload_local_copies_plan.v1', (string) ($plan['schema'] ?? ''));
+        $this->assertSame(1, data_get($plan, 'summary.both_candidate_count'));
+        $this->assertSame(1, data_get($plan, 'summary.blocked_count'));
+        $this->assertSame(1, data_get($plan, 'summary.local_only_count'));
+        $this->assertSame(1, data_get($plan, 'summary.target_only_count'));
+        $this->assertSame(1, data_get($plan, 'summary.both_count'));
+        $this->assertSame([$both['hash']], array_column((array) ($plan['candidates'] ?? []), 'blob_hash'));
+        $this->assertSame('LOCAL_ONLY_TARGET_VERIFIED_ROW_MISSING', data_get($plan, 'blocked.0.reason'));
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/offload_local_copy_shrink_plans/test-plan.json')];
+        $result = $service->executePlan($plan);
+
+        $this->assertSame('executed', $result['status']);
+        $this->assertSame(1, data_get($result, 'summary.deleted_local_files_count'));
+        $this->assertSame(1, data_get($result, 'summary.deleted_local_rows_count'));
+        $this->assertSame(0, data_get($result, 'summary.blocked_count'));
+        $this->assertFileExists((string) ($result['run_path'] ?? ''));
+
+        Storage::disk('s3')->assertExists($both['target_path']);
+        $this->assertFalse(Storage::disk('local')->exists($both['local_path']));
+        $this->assertTrue(Storage::disk('local')->exists($localOnly['local_path']));
+
+        $this->assertDatabaseMissing('storage_blob_locations', [
+            'blob_hash' => $both['hash'],
+            'disk' => 'local',
+            'storage_path' => $both['local_path'],
+            'location_kind' => 'remote_copy',
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $both['hash'],
+            'disk' => 's3',
+            'storage_path' => $both['target_path'],
+            'location_kind' => 'remote_copy',
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $localOnly['hash'],
+            'disk' => 'local',
+            'storage_path' => $localOnly['local_path'],
+            'location_kind' => 'remote_copy',
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $targetOnly['hash'],
+            'disk' => 's3',
+            'storage_path' => $targetOnly['target_path'],
+            'location_kind' => 'remote_copy',
+        ]);
+
+        $this->assertDirectoryExists(storage_path('app/private/offload'));
+        $this->assertDirectoryExists(storage_path('app/private/offload/blobs'));
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_shrink_offload_local_copies',
+            'target_id' => 'offload_local_copies',
+            'result' => 'success',
+        ]);
+    }
+
+    public function test_service_blocks_missing_local_file_and_target_only_rows(): void
+    {
+        $missingLocalFile = $this->seedBlob('missing-local-file', withLocal: true, withTarget: true, createLocalFile: false);
+        $this->seedBlob('target-only', withLocal: false, withTarget: true);
+
+        /** @var OffloadLocalCopyShrinkService $service */
+        $service = app(OffloadLocalCopyShrinkService::class);
+
+        $plan = $service->buildPlan('s3');
+        $this->assertSame(0, data_get($plan, 'summary.both_candidate_count'));
+        $this->assertSame(1, data_get($plan, 'summary.blocked_count'));
+        $this->assertSame(1, data_get($plan, 'summary.target_only_count'));
+        $this->assertSame(1, data_get($plan, 'summary.both_count'));
+        $this->assertSame([], array_column((array) ($plan['candidates'] ?? []), 'blob_hash'));
+        $this->assertSame($missingLocalFile['hash'], data_get($plan, 'blocked.0.blob_hash'));
+        $this->assertSame('LOCAL_FILE_MISSING', data_get($plan, 'blocked.0.reason'));
+    }
+
+    public function test_service_cleanup_keeps_exact_rehydrate_working_via_target_verified_row(): void
+    {
+        $fixture = $this->seedExactRehydrateFixture('rehydrate-after-shrink');
+
+        /** @var OffloadLocalCopyShrinkService $service */
+        $service = app(OffloadLocalCopyShrinkService::class);
+        $plan = $service->buildPlan('s3');
+        $this->assertSame(1, data_get($plan, 'summary.both_candidate_count'));
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/offload_local_copy_shrink_plans/rehydrate-plan.json')];
+        $result = $service->executePlan($plan);
+        $this->assertSame('executed', $result['status']);
+
+        /** @var ExactReleaseRehydrateService $rehydrate */
+        $rehydrate = app(ExactReleaseRehydrateService::class);
+        $rehydratePlan = $rehydrate->buildPlan($fixture['exact_manifest_id'], null, 's3', storage_path('app/private/rehydrate_runs'));
+        $this->assertSame(0, (int) data_get($rehydratePlan, 'summary.missing_locations'));
+        $rehydrateResult = $rehydrate->executePlan($rehydratePlan);
+
+        $this->assertSame(1, (int) ($rehydrateResult['verified_files'] ?? 0));
+        $this->assertFalse(Storage::disk('local')->exists($fixture['local_path']));
+        $this->assertDatabaseMissing('storage_blob_locations', [
+            'blob_hash' => $fixture['hash'],
+            'disk' => 'local',
+            'storage_path' => $fixture['local_path'],
+            'location_kind' => 'remote_copy',
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $fixture['hash'],
+            'disk' => 's3',
+            'storage_path' => $fixture['target_path'],
+            'location_kind' => 'remote_copy',
+        ]);
+    }
+
+    /**
+     * @return array{hash:string,bytes:string,local_path:string,target_path:string}
+     */
+    private function seedBlob(string $suffix, bool $withLocal, bool $withTarget, bool $createLocalFile = true): array
+    {
+        $payload = json_encode(['suffix' => $suffix], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $bytes = is_string($payload) ? $payload : '{}';
+        $hash = hash('sha256', $bytes);
+
+        DB::table('storage_blobs')->updateOrInsert(
+            ['hash' => $hash],
+            [
+                'disk' => 'local',
+                'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+                'size_bytes' => strlen($bytes),
+                'content_type' => 'application/json',
+                'encoding' => 'identity',
+                'ref_count' => 1,
+                'first_seen_at' => now(),
+                'last_verified_at' => now(),
+            ]
+        );
+
+        $localPath = 'offload/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+        $targetPath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+
+        if ($withLocal) {
+            if ($createLocalFile) {
+                Storage::disk('local')->put($localPath, $bytes);
+            }
+            $this->seedVerifiedRemoteCopyLocation($hash, 'local', $localPath, $bytes, 'local');
+        }
+
+        if ($withTarget) {
+            Storage::disk('s3')->put($targetPath, $bytes);
+            $this->seedVerifiedRemoteCopyLocation($hash, 's3', $targetPath, $bytes, 's3');
+        }
+
+        return [
+            'hash' => $hash,
+            'bytes' => $bytes,
+            'local_path' => $localPath,
+            'target_path' => $targetPath,
+        ];
+    }
+
+    /**
+     * @return array{exact_manifest_id:int,hash:string,local_path:string,target_path:string}
+     */
+    private function seedExactRehydrateFixture(string $suffix): array
+    {
+        $releaseId = (string) Str::uuid();
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => 'OFFLOAD-SHRINK',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => '',
+            'created_by' => 'test',
+            'probe_ok' => false,
+            'probe_json' => null,
+            'probe_run_at' => null,
+            'manifest_hash' => str_repeat('a', 64),
+            'compiled_hash' => str_repeat('b', 64),
+            'content_hash' => str_repeat('c', 64),
+            'norms_version' => '2026Q1',
+            'git_sha' => 'git-'.$suffix,
+            'pack_version' => 'v1',
+            'manifest_json' => null,
+            'storage_path' => null,
+            'source_commit' => 'git-'.$suffix,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $payload = json_encode(['suffix' => $suffix, 'kind' => 'manifest'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $bytes = is_string($payload) ? $payload : '{}';
+        $hash = hash('sha256', $bytes);
+        $localPath = 'offload/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+        $targetPath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+
+        DB::table('storage_blobs')->insert([
+            'hash' => $hash,
+            'disk' => 'local',
+            'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+            'size_bytes' => strlen($bytes),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 1,
+            'first_seen_at' => now(),
+            'last_verified_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $catalogService = app(ExactReleaseFileSetCatalogService::class);
+        $manifest = $catalogService->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'schema_version' => (string) config('storage_rollout.exact_manifest_schema_version', 'storage_exact_manifest.v1'),
+            'source_kind' => 'legacy.source_pack',
+            'source_disk' => 'local',
+            'source_storage_path' => storage_path('app/private/content_releases/'.$suffix.'/source_pack'),
+            'manifest_hash' => $hash,
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'compiled_hash' => hash('sha256', 'compiled|'.$suffix),
+            'content_hash' => hash('sha256', 'content|'.$suffix),
+            'norms_version' => '2026Q1',
+            'source_commit' => 'git-'.$suffix,
+            'payload_json' => ['suffix' => $suffix],
+            'sealed_at' => now(),
+            'last_verified_at' => now(),
+        ], [[
+            'logical_path' => 'compiled/manifest.json',
+            'blob_hash' => $hash,
+            'size_bytes' => strlen($bytes),
+            'role' => 'manifest',
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'checksum' => 'sha256:'.$hash,
+        ]]);
+
+        Storage::disk('local')->put($localPath, $bytes);
+        $this->seedVerifiedRemoteCopyLocation($hash, 'local', $localPath, $bytes, 'local');
+        Storage::disk('s3')->put($targetPath, $bytes);
+        $this->seedVerifiedRemoteCopyLocation($hash, 's3', $targetPath, $bytes, 's3');
+
+        return [
+            'exact_manifest_id' => (int) $manifest->getKey(),
+            'hash' => $hash,
+            'local_path' => $localPath,
+            'target_path' => $targetPath,
+        ];
+    }
+
+    private function seedVerifiedRemoteCopyLocation(string $hash, string $disk, string $storagePath, string $bytes, string $driver): void
+    {
+        DB::table('storage_blob_locations')->insert([
+            'blob_hash' => $hash,
+            'disk' => $disk,
+            'storage_path' => $storagePath,
+            'location_kind' => 'remote_copy',
+            'size_bytes' => strlen($bytes),
+            'checksum' => 'sha256:'.hash('sha256', $bytes),
+            'etag' => null,
+            'storage_class' => $disk === 's3' ? 'STANDARD_IA' : null,
+            'verified_at' => now(),
+            'meta_json' => json_encode([
+                'driver' => $driver,
+                'source_kind' => 'seeded_test_fixture',
+                'verified_checksum_sha256' => hash('sha256', $bytes),
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Feature/Storage/StorageShrinkOffloadLocalCopiesCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageShrinkOffloadLocalCopiesCommandTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageShrinkOffloadLocalCopies;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageShrinkOffloadLocalCopiesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-offload-local-copy-shrink-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('storage_rollout.blob_offload_prefix', 'rollout/blobs');
+        config()->set('filesystems.disks.s3.bucket', 'offload-shrink-command-bucket');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageShrinkOffloadLocalCopies::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_requires_exactly_one_mode_and_plan_for_execute(): void
+    {
+        $this->artisan('storage:shrink-offload-local-copies')
+            ->expectsOutputToContain('exactly one of --dry-run or --execute is required.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:shrink-offload-local-copies --dry-run --execute')
+            ->expectsOutputToContain('exactly one of --dry-run or --execute is required.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:shrink-offload-local-copies --execute --disk=s3')
+            ->expectsOutputToContain('--execute requires --plan.')
+            ->assertExitCode(1);
+    }
+
+    public function test_command_dry_run_and_execute_emit_summary_and_json_payload(): void
+    {
+        $hash = hash('sha256', '{"suffix":"command-both"}');
+        $localPath = 'offload/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+        $targetPath = 'rollout/blobs/sha256/'.substr($hash, 0, 2).'/'.$hash;
+        $bytes = '{"suffix":"command-both"}';
+
+        \DB::table('storage_blobs')->insert([
+            'hash' => $hash,
+            'disk' => 'local',
+            'storage_path' => 'blobs/sha256/'.substr($hash, 0, 2).'/'.$hash,
+            'size_bytes' => strlen($bytes),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 1,
+            'first_seen_at' => now(),
+            'last_verified_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        Storage::disk('local')->put($localPath, $bytes);
+        Storage::disk('s3')->put($targetPath, $bytes);
+        $this->seedVerifiedRemoteCopyLocation($hash, 'local', $localPath, $bytes);
+        $this->seedVerifiedRemoteCopyLocation($hash, 's3', $targetPath, $bytes);
+
+        $this->assertSame(0, Artisan::call('storage:shrink-offload-local-copies', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('disk=s3', $dryRunOutput);
+        $this->assertStringContainsString('both_candidate_count=1', $dryRunOutput);
+        $this->assertStringContainsString('blocked_count=0', $dryRunOutput);
+        $this->assertStringContainsString('deleted_local_files_count=0', $dryRunOutput);
+        $this->assertStringContainsString('deleted_local_rows_count=0', $dryRunOutput);
+
+        preg_match('/^plan=(.+)$/m', $dryRunOutput, $matches);
+        $planPath = trim((string) ($matches[1] ?? ''));
+        $this->assertFileExists($planPath);
+
+        $this->assertSame(0, Artisan::call('storage:shrink-offload-local-copies', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('both_candidate_count=1', $executeOutput);
+        $this->assertStringContainsString('deleted_local_files_count=1', $executeOutput);
+        $this->assertStringContainsString('deleted_local_rows_count=1', $executeOutput);
+        $this->assertStringContainsString('run_path=', $executeOutput);
+
+        $this->assertFalse(Storage::disk('local')->exists($localPath));
+        Storage::disk('s3')->assertExists($targetPath);
+        $this->assertDatabaseMissing('storage_blob_locations', [
+            'blob_hash' => $hash,
+            'disk' => 'local',
+            'storage_path' => $localPath,
+            'location_kind' => 'remote_copy',
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'blob_hash' => $hash,
+            'disk' => 's3',
+            'storage_path' => $targetPath,
+            'location_kind' => 'remote_copy',
+        ]);
+
+        $this->assertSame(0, Artisan::call('storage:shrink-offload-local-copies', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--json' => true,
+        ]));
+        $jsonPayload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($jsonPayload);
+        $this->assertSame('storage_shrink_offload_local_copies_plan.v1', $jsonPayload['schema'] ?? null);
+        $this->assertSame('planned', $jsonPayload['status'] ?? null);
+    }
+
+    private function seedVerifiedRemoteCopyLocation(string $hash, string $disk, string $storagePath, string $bytes): void
+    {
+        \DB::table('storage_blob_locations')->insert([
+            'blob_hash' => $hash,
+            'disk' => $disk,
+            'storage_path' => $storagePath,
+            'location_kind' => 'remote_copy',
+            'size_bytes' => strlen($bytes),
+            'checksum' => 'sha256:'.hash('sha256', $bytes),
+            'etag' => null,
+            'storage_class' => $disk === 's3' ? 'STANDARD_IA' : null,
+            'verified_at' => now(),
+            'meta_json' => json_encode([
+                'driver' => $disk,
+                'source_kind' => 'seeded_test_fixture',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a manual-only cleanup surface for local offload copies that are already covered by non-local verified `remote_copy` rows.

It introduces a dedicated plan-first command:
- `php artisan storage:shrink-offload-local-copies --dry-run --disk=s3`
- `php artisan storage:shrink-offload-local-copies --execute --disk=s3 --plan=/absolute/path/to/plan.json`

The cleanup scope is intentionally narrow:
- only the `local` side of blobs that are currently `both`
- never the target-disk row
- never the target object
- never any directory/prefix root

## Root cause
PR-39A established non-local verified coverage convergence.

At that point, reachable blobs were no longer `local_only`; they had become `both`, meaning the `local` side was now redundant for a bounded set of hashes.

What was still missing was a dedicated cleanup surface that could:
- operate only on `both` overlap
- treat one `blob_hash` as the cleanup unit
- remove the local file and the local verified row together
- leave exact rehydrate / runtime / V2 remote fallback contracts unchanged

## What changed
This PR adds:
- `OffloadLocalCopyShrinkService`
- `storage:shrink-offload-local-copies`
- focused service and command tests

Behavior:
- dry-run builds a plan from verified `remote_copy` overlap
- execute revalidates each candidate at execution time
- only blobs with:
  - local verified row
  - target verified row
  - local file present
  become cleanup candidates
- execute deletes:
  - local offload file
  - matching local verified `storage_blob_locations` row
- execute does not delete:
  - target verified row
  - target object
  - any root/prefix directory

## Guardrails
This PR does not modify:
- `BlobOffloadService`
- `StorageBlobOffload`
- `BlobReachabilityService`
- `StorageBlobGc`
- `ExactReleaseRehydrateService`
- `ContentPackV2RemoteRehydrateService`
- `ContentPackV2RuntimeTruthService`
- `StorageCostAnalyzerService`
- `StorageControlPlaneStatusService`
- `StorageControlPlaneSnapshotService`
- routes / middleware / migrations / scheduler / config
- `storage_blob_locations` schema or `location_kind=remote_copy` semantics

## Validation
- `php -l backend/app/Console/Commands/StorageShrinkOffloadLocalCopies.php`
- `php -l backend/app/Services/Storage/OffloadLocalCopyShrinkService.php`
- `php -l backend/tests/Feature/Storage/OffloadLocalCopyShrinkServiceTest.php`
- `php -l backend/tests/Feature/Storage/StorageShrinkOffloadLocalCopiesCommandTest.php`
- `cd backend && ./vendor/bin/pint app/Console/Commands/StorageShrinkOffloadLocalCopies.php app/Services/Storage/OffloadLocalCopyShrinkService.php tests/Feature/Storage/OffloadLocalCopyShrinkServiceTest.php tests/Feature/Storage/StorageShrinkOffloadLocalCopiesCommandTest.php`
- `cd backend && vendor/bin/phpunit tests/Feature/Storage/OffloadLocalCopyShrinkServiceTest.php`
- `cd backend && vendor/bin/phpunit tests/Feature/Storage/StorageShrinkOffloadLocalCopiesCommandTest.php`
- `cd backend && php artisan route:list > /tmp/pr39b_impl_route_list.txt`
- `cd backend && php artisan migrate`
- `cd backend && vendor/bin/phpunit tests/Feature/Storage/OffloadLocalCopyShrinkServiceTest.php tests/Feature/Storage/StorageShrinkOffloadLocalCopiesCommandTest.php`
- `cd backend && vendor/bin/phpunit tests/Feature/Storage/StorageBlobOffloadCommandTest.php tests/Feature/Storage/StorageBlobGcCommandTest.php tests/Feature/Storage/ExactReleaseRehydrateServiceTest.php tests/Unit/Content/ContentPackV2RuntimeTruthServiceTest.php tests/Unit/Content/ContentPackV2ResolverRemoteRehydrateFallbackTest.php tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `cd backend && php artisan storage:shrink-offload-local-copies --dry-run --disk=s3`
- `cd backend && php artisan storage:shrink-offload-local-copies --execute --disk=s3 --plan=/private/tmp/fap-api-pr39b-offload-local-copy-shrink/backend/storage/app/private/offload_local_copy_shrink_plans/20260321_184916_offload_local_copy_shrink_4070cc2b.json`
- `cd backend && php artisan storage:blob-offload --dry-run --disk=s3`
- `cd backend && php artisan storage:blob-gc --dry-run`
- `cd backend && php artisan storage:analyze-cost --json`
- `cd backend && php artisan storage:control-plane-status --json`
- `cd backend && php artisan storage:control-plane-snapshot --json`
- `cd backend && php artisan storage:refresh-control-plane --dry-run --json`
- `cd backend && php artisan serve --host=127.0.0.1 --port=18081`
- `curl -i http://127.0.0.1:18081/api/healthz`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
