### PR TITLE
[codex] add reports artifacts lifecycle truth to control-plane

### DIFF
--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -31,11 +31,14 @@ final class StorageControlPlaneStatusService
      */
     public function buildStatus(): array
     {
+        $inventory = $this->inventorySection();
+
         $payload = [
             'schema_version' => self::SCHEMA_VERSION,
             'generated_at' => now()->toIso8601String(),
-            'inventory' => $this->inventorySection(),
+            'inventory' => $inventory,
             'retention' => $this->retentionSection(),
+            'reports_artifacts_lifecycle' => $this->reportsArtifactsLifecycleSection($inventory),
             'blob_coverage' => $this->blobCoverageSection(),
             'exact_authority' => $this->exactAuthoritySection(),
             'rehydrate' => $this->rehydrateSection(),
@@ -158,6 +161,72 @@ final class StorageControlPlaneStatusService
             'configured_scopes' => array_keys($configuredScopes),
             'scopes' => $scopes,
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $inventory
+     * @return array<string,mixed>
+     */
+    private function reportsArtifactsLifecycleSection(array $inventory): array
+    {
+        $canonicalRootPath = storage_path('app/private/artifacts');
+        $legacyRootPath = storage_path('app/private/reports');
+
+        $canonicalReportJson = $this->matchingFilesStats(
+            $canonicalRootPath,
+            static fn (string $relativePath): bool => str_starts_with($relativePath, 'reports/')
+                && str_ends_with($relativePath, '/report.json')
+        );
+        $canonicalPdf = $this->matchingFilesStats(
+            $canonicalRootPath,
+            static fn (string $relativePath): bool => str_starts_with($relativePath, 'pdf/')
+                && (str_ends_with($relativePath, '/report_free.pdf') || str_ends_with($relativePath, '/report_full.pdf'))
+        );
+        $legacyReportJson = $this->matchingFilesStats(
+            $legacyRootPath,
+            static fn (string $relativePath): bool => str_ends_with($relativePath, '/report.json') || $relativePath === 'report.json'
+        );
+        $legacyPdf = $this->matchingFilesStats(
+            $legacyRootPath,
+            static fn (string $relativePath): bool => str_ends_with($relativePath, '/report_free.pdf')
+                || str_ends_with($relativePath, '/report_full.pdf')
+                || in_array($relativePath, ['report_free.pdf', 'report_full.pdf'], true)
+        );
+        $timestampBackups = $this->matchingFilesStats(
+            $legacyRootPath,
+            static fn (string $relativePath): bool => preg_match('#(^|/)report\.\d{8}_\d{6}\.json$#', $relativePath) === 1
+        );
+
+        $latestInventoryGeneratedAt = $this->normalizeTimestamp($inventory['latest_generated_at'] ?? null);
+
+        return array_merge([
+            'status' => $latestInventoryGeneratedAt === null ? 'not_available' : 'ok',
+            'canonical_root_path' => $canonicalRootPath,
+            'legacy_root_path' => $legacyRootPath,
+            'canonical_user_output' => [
+                'report_json_files' => $canonicalReportJson['files'],
+                'pdf_files' => $canonicalPdf['files'],
+                'bytes' => $canonicalReportJson['bytes'] + $canonicalPdf['bytes'],
+            ],
+            'legacy_fallback_live' => [
+                'report_json_files' => $legacyReportJson['files'],
+                'pdf_files' => $legacyPdf['files'],
+                'bytes' => $legacyReportJson['bytes'] + $legacyPdf['bytes'],
+            ],
+            'safe_to_prune_derived' => [
+                'timestamp_backup_json_files' => $timestampBackups['files'],
+                'latest_reports_backups_policy' => [
+                    'keep_days' => (int) config('storage_retention.reports.keep_days', 0),
+                    'keep_timestamp_backups' => (int) config('storage_retention.reports.keep_timestamp_backups', 0),
+                ],
+            ],
+            'archive_candidate_status' => 'none_proven',
+        ], $this->freshnessFromTimestamp(
+            $latestInventoryGeneratedAt,
+            'audit-derived',
+            self::INVENTORY_STALE_AFTER_SECONDS,
+            'not_available'
+        ));
     }
 
     /**
@@ -693,6 +762,7 @@ final class StorageControlPlaneStatusService
             ['path' => 'retention.scopes.reports_backups', 'label' => 'reports backups retention dry-run'],
             ['path' => 'retention.scopes.content_releases_retention', 'label' => 'content releases retention dry-run'],
             ['path' => 'retention.scopes.legacy_private_private_cleanup', 'label' => 'legacy private cleanup dry-run'],
+            ['path' => 'reports_artifacts_lifecycle', 'label' => 'reports artifacts lifecycle'],
             ['path' => 'blob_coverage.blob_gc', 'label' => 'blob gc dry-run'],
             ['path' => 'blob_coverage.blob_offload', 'label' => 'blob offload dry-run'],
             ['path' => 'exact_authority.latest_backfill', 'label' => 'exact authority backfill'],
@@ -899,6 +969,51 @@ final class StorageControlPlaneStatusService
         return [
             'total_files' => $totalFiles,
             'total_bytes' => $totalBytes,
+        ];
+    }
+
+    /**
+     * @param  callable(string):bool  $matcher
+     * @return array{files:int,bytes:int}
+     */
+    private function matchingFilesStats(string $rootPath, callable $matcher): array
+    {
+        if (! is_dir($rootPath)) {
+            return [
+                'files' => 0,
+                'bytes' => 0,
+            ];
+        }
+
+        $files = 0;
+        $bytes = 0;
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($rootPath, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $normalizedRootPath = rtrim(str_replace('\\', '/', $rootPath), '/');
+            $normalizedFilePath = str_replace('\\', '/', $file->getPathname());
+            $relativePath = ltrim((string) preg_replace(
+                '#^'.preg_quote($normalizedRootPath, '#').'/?#',
+                '',
+                $normalizedFilePath
+            ), '/');
+            if ($relativePath === '' || $matcher($relativePath) !== true) {
+                continue;
+            }
+
+            $files++;
+            $bytes += max(0, (int) ($file->getSize() ?: 0));
+        }
+
+        return [
+            'files' => $files,
+            'bytes' => $bytes,
         ];
     }
 

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -75,6 +75,7 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame('storage_control_plane_snapshot.v1', $payload['snapshot_schema']);
         $this->assertSame('snapshotted', $payload['status']);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertArrayHasKey('reports_artifacts_lifecycle', $payload);
         $this->assertArrayHasKey('materialized_cache', $payload);
         $this->assertArrayHasKey('cost_reclaim_posture', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
@@ -82,6 +83,19 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertArrayHasKey('freshness_age_seconds', $payload['inventory']);
         $this->assertArrayHasKey('freshness_state', $payload['inventory']);
         $this->assertArrayHasKey('freshness_source_type', $payload['inventory']);
+        $this->assertSame('ok', data_get($payload, 'reports_artifacts_lifecycle.status'));
+        $this->assertSame(storage_path('app/private/artifacts'), data_get($payload, 'reports_artifacts_lifecycle.canonical_root_path'));
+        $this->assertSame(storage_path('app/private/reports'), data_get($payload, 'reports_artifacts_lifecycle.legacy_root_path'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.report_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.pdf_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.report_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
+        $this->assertSame('none_proven', data_get($payload, 'reports_artifacts_lifecycle.archive_candidate_status'));
+        $this->assertArrayHasKey('last_updated_at', data_get($payload, 'reports_artifacts_lifecycle', []));
+        $this->assertArrayHasKey('freshness_age_seconds', data_get($payload, 'reports_artifacts_lifecycle', []));
+        $this->assertArrayHasKey('freshness_state', data_get($payload, 'reports_artifacts_lifecycle', []));
+        $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'reports_artifacts_lifecycle', []));
         $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
         $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
         $this->assertSame(0, data_get($payload, 'materialized_cache.bucket_count'));
@@ -132,6 +146,7 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
     public function test_command_json_includes_non_zero_materialized_cache_state(): void
     {
         $this->seedMinimalTruth();
+        $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
         $bucket = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -149,6 +164,13 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $payload = json_decode(trim(Artisan::output()), true);
 
         $this->assertIsArray($payload);
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.report_json_files'));
+        $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.pdf_files'));
+        $this->assertSame($lifecycleFiles['canonical_bytes'], data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.bytes'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.report_json_files'));
+        $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
+        $this->assertSame($lifecycleFiles['legacy_bytes'], data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.bytes'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
         $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
         $this->assertSame(3, data_get($payload, 'materialized_cache.total_files'));
         $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'materialized_cache.total_bytes'));
@@ -212,6 +234,12 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         ]);
     }
 
+    private function writeRaw(string $path, string $contents): void
+    {
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, $contents);
+    }
+
     /**
      * @param  array<string,string>  $files
      */
@@ -237,6 +265,41 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
     private function totalBytesForFiles(array $files): int
     {
         return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
+    }
+
+    /**
+     * @return array{canonical_bytes:int,legacy_bytes:int}
+     */
+    private function seedReportsArtifactsLifecycleTruth(): array
+    {
+        $canonicalFiles = [
+            'app/private/artifacts/reports/MBTI/attempt-canonical/report.json' => '{"canonical":true}',
+            'app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_free.pdf' => '%PDF-free',
+            'app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_full.pdf' => '%PDF-full',
+        ];
+        $legacyFiles = [
+            'app/private/reports/attempt-legacy/report.json' => '{"legacy":true}',
+            'app/private/reports/attempt-legacy/report_free.pdf' => '%PDF-legacy-free',
+            'app/private/reports/attempt-legacy/report_full.pdf' => '%PDF-legacy-full',
+            'app/private/reports/attempt-legacy/report.20260321_010101.json' => '{"backup":true}',
+        ];
+
+        foreach ($canonicalFiles as $relativePath => $contents) {
+            $this->writeRaw(storage_path($relativePath), $contents);
+        }
+
+        foreach ($legacyFiles as $relativePath => $contents) {
+            $this->writeRaw(storage_path($relativePath), $contents);
+        }
+
+        return [
+            'canonical_bytes' => strlen($canonicalFiles['app/private/artifacts/reports/MBTI/attempt-canonical/report.json'])
+                + strlen($canonicalFiles['app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_free.pdf'])
+                + strlen($canonicalFiles['app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_full.pdf']),
+            'legacy_bytes' => strlen($legacyFiles['app/private/reports/attempt-legacy/report.json'])
+                + strlen($legacyFiles['app/private/reports/attempt-legacy/report_free.pdf'])
+                + strlen($legacyFiles['app/private/reports/attempt-legacy/report_full.pdf']),
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -55,6 +55,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
     public function test_service_creates_snapshot_file_and_audit_without_other_mutation(): void
     {
         $this->seedMinimalTruth();
+        $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
         $bucket = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -83,6 +84,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertArrayHasKey('restore', $payload);
         $this->assertArrayHasKey('purge', $payload);
         $this->assertArrayHasKey('retirement', $payload);
+        $this->assertArrayHasKey('reports_artifacts_lifecycle', $payload);
         $this->assertArrayHasKey('materialized_cache', $payload);
         $this->assertArrayHasKey('cost_reclaim_posture', $payload);
         $this->assertArrayHasKey('runtime_truth', $payload);
@@ -100,6 +102,19 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'restore.status'));
         $this->assertSame('never_run', data_get($payload, 'restore.freshness_state'));
+        $this->assertSame('ok', data_get($payload, 'reports_artifacts_lifecycle.status'));
+        $this->assertSame(storage_path('app/private/artifacts'), data_get($payload, 'reports_artifacts_lifecycle.canonical_root_path'));
+        $this->assertSame(storage_path('app/private/reports'), data_get($payload, 'reports_artifacts_lifecycle.legacy_root_path'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.report_json_files'));
+        $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.pdf_files'));
+        $this->assertSame($lifecycleFiles['canonical_bytes'], data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.bytes'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.report_json_files'));
+        $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
+        $this->assertSame($lifecycleFiles['legacy_bytes'], data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.bytes'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
+        $this->assertSame('none_proven', data_get($payload, 'reports_artifacts_lifecycle.archive_candidate_status'));
+        $this->assertSame('fresh', data_get($payload, 'reports_artifacts_lifecycle.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'reports_artifacts_lifecycle.freshness_source_type'));
         $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
         $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
         $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
@@ -171,6 +186,21 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
 
         $this->assertSame('not_available', data_get($payload, 'inventory.status'));
         $this->assertSame('not_available', data_get($payload, 'inventory.freshness_state'));
+        $this->assertSame('not_available', data_get($payload, 'reports_artifacts_lifecycle.status'));
+        $this->assertSame(storage_path('app/private/artifacts'), data_get($payload, 'reports_artifacts_lifecycle.canonical_root_path'));
+        $this->assertSame(storage_path('app/private/reports'), data_get($payload, 'reports_artifacts_lifecycle.legacy_root_path'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.report_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.pdf_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.bytes'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.report_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.bytes'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
+        $this->assertSame('none_proven', data_get($payload, 'reports_artifacts_lifecycle.archive_candidate_status'));
+        $this->assertNull(data_get($payload, 'reports_artifacts_lifecycle.last_updated_at'));
+        $this->assertNull(data_get($payload, 'reports_artifacts_lifecycle.freshness_age_seconds'));
+        $this->assertSame('not_available', data_get($payload, 'reports_artifacts_lifecycle.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'reports_artifacts_lifecycle.freshness_source_type'));
         $this->assertSame('never_run', data_get($payload, 'retention.status'));
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_gc.status'));
@@ -203,7 +233,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
-        $this->assertSame(['inventory'], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertSame(['inventory', 'reports_artifacts_lifecycle'], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertContains('quarantine', data_get($payload, 'attention_digest.never_run_sections', []));
     }
 
@@ -228,6 +258,12 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
             'result' => 'success',
             'created_at' => now(),
         ]);
+    }
+
+    private function writeRaw(string $path, string $contents): void
+    {
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, $contents);
     }
 
     /**
@@ -255,6 +291,41 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
     private function totalBytesForFiles(array $files): int
     {
         return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
+    }
+
+    /**
+     * @return array{canonical_bytes:int,legacy_bytes:int}
+     */
+    private function seedReportsArtifactsLifecycleTruth(): array
+    {
+        $canonicalFiles = [
+            'app/private/artifacts/reports/MBTI/attempt-canonical/report.json' => '{"canonical":true}',
+            'app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_free.pdf' => '%PDF-free',
+            'app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_full.pdf' => '%PDF-full',
+        ];
+        $legacyFiles = [
+            'app/private/reports/attempt-legacy/report.json' => '{"legacy":true}',
+            'app/private/reports/attempt-legacy/report_free.pdf' => '%PDF-legacy-free',
+            'app/private/reports/attempt-legacy/report_full.pdf' => '%PDF-legacy-full',
+            'app/private/reports/attempt-legacy/report.20260321_010101.json' => '{"backup":true}',
+        ];
+
+        foreach ($canonicalFiles as $relativePath => $contents) {
+            $this->writeRaw(storage_path($relativePath), $contents);
+        }
+
+        foreach ($legacyFiles as $relativePath => $contents) {
+            $this->writeRaw(storage_path($relativePath), $contents);
+        }
+
+        return [
+            'canonical_bytes' => strlen($canonicalFiles['app/private/artifacts/reports/MBTI/attempt-canonical/report.json'])
+                + strlen($canonicalFiles['app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_free.pdf'])
+                + strlen($canonicalFiles['app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_full.pdf']),
+            'legacy_bytes' => strlen($legacyFiles['app/private/reports/attempt-legacy/report.json'])
+                + strlen($legacyFiles['app/private/reports/attempt-legacy/report_free.pdf'])
+                + strlen($legacyFiles['app/private/reports/attempt-legacy/report_full.pdf']),
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -87,6 +87,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('cost_reclaim_posture', $payload);
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
+        $this->assertArrayHasKey('reports_artifacts_lifecycle', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
         $this->assertArrayHasKey('last_updated_at', $payload['inventory']);
@@ -97,6 +98,19 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('freshness_age_seconds', data_get($payload, 'retention.scopes.reports_backups', []));
         $this->assertArrayHasKey('freshness_state', data_get($payload, 'retention.scopes.reports_backups', []));
         $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'retention.scopes.reports_backups', []));
+        $this->assertSame('ok', data_get($payload, 'reports_artifacts_lifecycle.status'));
+        $this->assertSame(storage_path('app/private/artifacts'), data_get($payload, 'reports_artifacts_lifecycle.canonical_root_path'));
+        $this->assertSame(storage_path('app/private/reports'), data_get($payload, 'reports_artifacts_lifecycle.legacy_root_path'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.report_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.pdf_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.report_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
+        $this->assertSame('none_proven', data_get($payload, 'reports_artifacts_lifecycle.archive_candidate_status'));
+        $this->assertArrayHasKey('last_updated_at', data_get($payload, 'reports_artifacts_lifecycle', []));
+        $this->assertArrayHasKey('freshness_age_seconds', data_get($payload, 'reports_artifacts_lifecycle', []));
+        $this->assertArrayHasKey('freshness_state', data_get($payload, 'reports_artifacts_lifecycle', []));
+        $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'reports_artifacts_lifecycle', []));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
         $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
         $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
@@ -140,6 +154,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
     public function test_command_json_reports_non_zero_materialized_cache_state(): void
     {
         $this->seedMinimalTruth();
+        $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
         $bucket = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -157,6 +172,13 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $payload = json_decode(trim(Artisan::output()), true);
 
         $this->assertIsArray($payload);
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.report_json_files'));
+        $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.pdf_files'));
+        $this->assertSame($lifecycleFiles['canonical_bytes'], data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.bytes'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.report_json_files'));
+        $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
+        $this->assertSame($lifecycleFiles['legacy_bytes'], data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.bytes'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
         $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
         $this->assertSame(3, data_get($payload, 'materialized_cache.total_files'));
         $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'materialized_cache.total_bytes'));
@@ -242,6 +264,12 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         File::put($path, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
     }
 
+    private function writeRaw(string $path, string $contents): void
+    {
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, $contents);
+    }
+
     /**
      * @param  array<string,string>  $files
      */
@@ -267,6 +295,41 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
     private function totalBytesForFiles(array $files): int
     {
         return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
+    }
+
+    /**
+     * @return array{canonical_bytes:int,legacy_bytes:int}
+     */
+    private function seedReportsArtifactsLifecycleTruth(): array
+    {
+        $canonicalFiles = [
+            'app/private/artifacts/reports/MBTI/attempt-canonical/report.json' => '{"canonical":true}',
+            'app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_free.pdf' => '%PDF-free',
+            'app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_full.pdf' => '%PDF-full',
+        ];
+        $legacyFiles = [
+            'app/private/reports/attempt-legacy/report.json' => '{"legacy":true}',
+            'app/private/reports/attempt-legacy/report_free.pdf' => '%PDF-legacy-free',
+            'app/private/reports/attempt-legacy/report_full.pdf' => '%PDF-legacy-full',
+            'app/private/reports/attempt-legacy/report.20260321_010101.json' => '{"backup":true}',
+        ];
+
+        foreach ($canonicalFiles as $relativePath => $contents) {
+            $this->writeRaw(storage_path($relativePath), $contents);
+        }
+
+        foreach ($legacyFiles as $relativePath => $contents) {
+            $this->writeRaw(storage_path($relativePath), $contents);
+        }
+
+        return [
+            'canonical_bytes' => strlen($canonicalFiles['app/private/artifacts/reports/MBTI/attempt-canonical/report.json'])
+                + strlen($canonicalFiles['app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_free.pdf'])
+                + strlen($canonicalFiles['app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_full.pdf']),
+            'legacy_bytes' => strlen($legacyFiles['app/private/reports/attempt-legacy/report.json'])
+                + strlen($legacyFiles['app/private/reports/attempt-legacy/report_free.pdf'])
+                + strlen($legacyFiles['app/private/reports/attempt-legacy/report_full.pdf']),
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -55,6 +55,7 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
     public function test_service_aggregates_existing_truth_without_mutation(): void
     {
         $this->seedControlPlaneTruth();
+        $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
         $bucketOne = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -89,6 +90,21 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('fresh', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('mixed-derived', data_get($payload, 'retention.scopes.reports_backups.freshness_source_type'));
         $this->assertSame(['reports', 'artifacts'], data_get($payload, 'inventory.focus_scopes'));
+        $this->assertSame('ok', data_get($payload, 'reports_artifacts_lifecycle.status'));
+        $this->assertSame(storage_path('app/private/artifacts'), data_get($payload, 'reports_artifacts_lifecycle.canonical_root_path'));
+        $this->assertSame(storage_path('app/private/reports'), data_get($payload, 'reports_artifacts_lifecycle.legacy_root_path'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.report_json_files'));
+        $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.pdf_files'));
+        $this->assertSame($lifecycleFiles['canonical_bytes'], data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.bytes'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.report_json_files'));
+        $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
+        $this->assertSame($lifecycleFiles['legacy_bytes'], data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.bytes'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.latest_reports_backups_policy.keep_days'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.latest_reports_backups_policy.keep_timestamp_backups'));
+        $this->assertSame('none_proven', data_get($payload, 'reports_artifacts_lifecycle.archive_candidate_status'));
+        $this->assertSame('fresh', data_get($payload, 'reports_artifacts_lifecycle.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'reports_artifacts_lifecycle.freshness_source_type'));
         $this->assertSame(1, data_get($payload, 'blob_coverage.counts.storage_blobs'));
         $this->assertSame(1, data_get($payload, 'blob_coverage.counts.verified_storage_blob_locations_by_disk.s3'));
         $this->assertSame('fresh', data_get($payload, 'blob_coverage.blob_gc.freshness_state'));
@@ -178,6 +194,23 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
 
         $this->assertSame('not_available', data_get($payload, 'inventory.status'));
         $this->assertSame('not_available', data_get($payload, 'inventory.freshness_state'));
+        $this->assertSame('not_available', data_get($payload, 'reports_artifacts_lifecycle.status'));
+        $this->assertSame(storage_path('app/private/artifacts'), data_get($payload, 'reports_artifacts_lifecycle.canonical_root_path'));
+        $this->assertSame(storage_path('app/private/reports'), data_get($payload, 'reports_artifacts_lifecycle.legacy_root_path'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.report_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.pdf_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.bytes'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.report_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.bytes'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.latest_reports_backups_policy.keep_days'));
+        $this->assertSame(0, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.latest_reports_backups_policy.keep_timestamp_backups'));
+        $this->assertSame('none_proven', data_get($payload, 'reports_artifacts_lifecycle.archive_candidate_status'));
+        $this->assertNull(data_get($payload, 'reports_artifacts_lifecycle.last_updated_at'));
+        $this->assertNull(data_get($payload, 'reports_artifacts_lifecycle.freshness_age_seconds'));
+        $this->assertSame('not_available', data_get($payload, 'reports_artifacts_lifecycle.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'reports_artifacts_lifecycle.freshness_source_type'));
         $this->assertSame('never_run', data_get($payload, 'retention.status'));
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.content_releases_retention.freshness_state'));
@@ -229,13 +262,18 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
-        $this->assertSame(['inventory'], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertSame(['inventory', 'reports_artifacts_lifecycle'], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertContains('rehydrate', data_get($payload, 'attention_digest.never_run_sections', []));
         $this->assertContains('retention.scopes.reports_backups', data_get($payload, 'attention_digest.never_run_sections', []));
         $this->assertSame([], data_get($payload, 'attention_digest.stale_sections'));
-        $this->assertSame(1, data_get($payload, 'attention_digest.counts.not_available'));
+        $this->assertSame(2, data_get($payload, 'attention_digest.counts.not_available'));
         $this->assertGreaterThan(0, (int) data_get($payload, 'attention_digest.counts.never_run'));
-        $this->assertSame('inventory is not available', data_get($payload, 'attention_digest.attention_items.0.message'));
+        $attentionMessages = array_values(array_filter(array_map(
+            static fn ($item): ?string => is_array($item) ? ($item['message'] ?? null) : null,
+            (array) data_get($payload, 'attention_digest.attention_items', [])
+        )));
+        $this->assertContains('inventory is not available', $attentionMessages);
+        $this->assertContains('reports artifacts lifecycle is not available', $attentionMessages);
     }
 
     private function seedControlPlaneTruth(): void
@@ -522,6 +560,12 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         File::put($path, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
     }
 
+    private function writeRaw(string $path, string $contents): void
+    {
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, $contents);
+    }
+
     /**
      * @param  array<string,string>  $files
      */
@@ -547,6 +591,41 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
     private function totalBytesForFiles(array $files): int
     {
         return array_sum(array_map(static fn (string $contents): int => strlen($contents), $files));
+    }
+
+    /**
+     * @return array{canonical_bytes:int,legacy_bytes:int}
+     */
+    private function seedReportsArtifactsLifecycleTruth(): array
+    {
+        $canonicalFiles = [
+            'app/private/artifacts/reports/MBTI/attempt-canonical/report.json' => '{"canonical":true}',
+            'app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_free.pdf' => '%PDF-free',
+            'app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_full.pdf' => '%PDF-full',
+        ];
+        $legacyFiles = [
+            'app/private/reports/attempt-legacy/report.json' => '{"legacy":true}',
+            'app/private/reports/attempt-legacy/report_free.pdf' => '%PDF-legacy-free',
+            'app/private/reports/attempt-legacy/report_full.pdf' => '%PDF-legacy-full',
+            'app/private/reports/attempt-legacy/report.20260321_010101.json' => '{"backup":true}',
+        ];
+
+        foreach ($canonicalFiles as $relativePath => $contents) {
+            $this->writeRaw(storage_path($relativePath), $contents);
+        }
+
+        foreach ($legacyFiles as $relativePath => $contents) {
+            $this->writeRaw(storage_path($relativePath), $contents);
+        }
+
+        return [
+            'canonical_bytes' => strlen($canonicalFiles['app/private/artifacts/reports/MBTI/attempt-canonical/report.json'])
+                + strlen($canonicalFiles['app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_free.pdf'])
+                + strlen($canonicalFiles['app/private/artifacts/pdf/MBTI/attempt-canonical/nohash/report_full.pdf']),
+            'legacy_bytes' => strlen($legacyFiles['app/private/reports/attempt-legacy/report.json'])
+                + strlen($legacyFiles['app/private/reports/attempt-legacy/report_free.pdf'])
+                + strlen($legacyFiles['app/private/reports/attempt-legacy/report_full.pdf']),
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR adds a new `reports_artifacts_lifecycle` read-model section to `storage:control-plane-status --json` and lets `storage:control-plane-snapshot --json` inherit it automatically.

The section makes the reports/artifacts lifecycle truth operator-visible without changing any write path, read fallback path, retention execution, cleanup behavior, or archive behavior.

It exposes:
- canonical root path
- legacy fallback root path
- canonical user output counts and bytes
- legacy fallback live-file counts and bytes
- strict timestamp-backup-json safe-to-prune counts
- current reports_backups retention policy
- fixed `archive_candidate_status=none_proven`
- standard freshness metadata derived from inventory truth

## Root cause
The repository already had stable contracts for this storage line:
- canonical report writes live under `storage/app/private/artifacts/**`
- legacy read compatibility still falls back to `storage/app/private/reports/**`
- the only proven safe-to-prune reports objects are strict legacy timestamp backup json files

But control-plane status and snapshot did not have a first-class section that unified those truths. Operators had to piece them together from code, inventory, prune dry-runs, and cost analysis.

## What changed
This PR only updates the control-plane read model:
- adds `reports_artifacts_lifecycle` to `StorageControlPlaneStatusService`
- uses inventory-generated time as the only freshness source for this section
- wires the section into standard attention digest handling as a normal freshness-bearing node
- extends status/snapshot service and command tests to lock:
  - canonical vs legacy roots
  - canonical user output counts
  - legacy fallback live-file counts
  - strict timestamp backup json matching
  - fixed archive candidate status
  - `not_available` behavior when inventory truth is missing
  - snapshot inheritance of the new section

## Explicit non-goals
This PR does not:
- modify `ArtifactStore`
- modify `GenerateReportJob`
- modify `ReportPersistence`
- modify `ReportPdfArtifactStore`
- modify `StorageMigrateLegacyArtifacts`
- modify `StoragePrune`
- add a command, service, config, route, migration, middleware, or scheduler change
- perform cleanup, archive, retention execute, or export logic
- change any runtime, write-chain, or legacy fallback contract

## Validation
### Focused
- `vendor/bin/phpunit tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`
- Result: `OK (10 tests, 512 assertions)`

### Regression
- `vendor/bin/phpunit tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php tests/Feature/Storage/StorageCostAnalyzerServiceTest.php tests/Feature/Storage/StorageCostAnalyzerCommandTest.php tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php`
- Result: `OK (23 tests, 731 assertions)`

### Live
- `php artisan storage:prune --dry-run --scope=reports_backups`
- `php artisan storage:analyze-cost --json`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan storage:refresh-control-plane --dry-run --json`
- `php artisan storage:inventory --json`
- `find storage/app/private/artifacts -maxdepth 5 -print 2>/dev/null | sed -n '1,260p'`
- `find storage/app/private/reports -maxdepth 5 -print 2>/dev/null | sed -n '1,260p'`
- `du -sh storage/app/private/artifacts storage/app/private/reports 2>/dev/null`

Observed live truth:
- `reports_artifacts_lifecycle` is now present in status and snapshot
- snapshot inherits the section automatically
- refresh's final snapshot payload carries the section without adding steps
- canonical root resolves to `storage/app/private/artifacts`
- legacy root resolves to `storage/app/private/reports`
- live status currently reports:
  - `canonical_user_output.report_json_files=2781`
  - `canonical_user_output.pdf_files=139`
  - `legacy_fallback_live.report_json_files=0`
  - `legacy_fallback_live.pdf_files=0`
  - `safe_to_prune_derived.timestamp_backup_json_files=0`
  - `archive_candidate_status=none_proven`

### CI master chain
- `bash backend/scripts/ci_verify_mbti.sh`
- Result: passed end-to-end
