### PR TITLE
[codex] add report artifacts archive pipeline

### DIFF
--- a/backend/app/Console/Commands/StorageArchiveReportArtifacts.php
+++ b/backend/app/Console/Commands/StorageArchiveReportArtifacts.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\ReportArtifactsArchiveService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class StorageArchiveReportArtifacts extends Command
+{
+    protected $signature = 'storage:archive-report-artifacts
+        {--dry-run : Build an archive plan for canonical report artifacts only}
+        {--execute : Execute archive from an existing plan}
+        {--disk=s3 : Remote object storage disk that receives archived canonical artifacts}
+        {--plan= : Absolute or storage-relative plan path required for execute mode}
+        {--json : Emit the full payload as JSON}';
+
+    protected $description = 'Manual-only copy pipeline that archives canonical report artifacts to remote object storage without deleting or cutting over local reads.';
+
+    public function __construct(
+        private readonly ReportArtifactsArchiveService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $disk = trim((string) ($this->option('disk') ?? 's3'));
+
+        try {
+            $this->ensureTargetDiskIsRemote($disk);
+
+            if ($dryRun) {
+                $plan = $this->service->buildPlan($disk);
+                $planPath = $this->persistPlan($plan);
+                $payload = $plan + ['plan' => $planPath];
+
+                return $this->emitPayload($payload);
+            }
+
+            $planOption = trim((string) ($this->option('plan') ?? ''));
+            if ($planOption === '') {
+                $this->error('--execute requires --plan.');
+
+                return self::FAILURE;
+            }
+
+            $resolvedPlanPath = $this->resolvePlanPath($planOption);
+            $plan = $this->readPlan($resolvedPlanPath);
+            $planDisk = trim((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+            if ($planDisk !== $disk) {
+                $this->error('plan disk mismatch: '.$planDisk.' != '.$disk);
+
+                return self::FAILURE;
+            }
+
+            $plan['_meta'] = [
+                'plan_path' => $resolvedPlanPath,
+            ];
+            $payload = $this->service->executePlan($plan);
+
+            return $this->emitPayload($payload);
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function ensureTargetDiskIsRemote(string $disk): void
+    {
+        $driver = trim((string) config('filesystems.disks.'.$disk.'.driver', ''));
+        if ($driver === '') {
+            throw new \RuntimeException('archive target disk is not configured: filesystems.disks.'.$disk.' is missing.');
+        }
+
+        if ($driver === 'local') {
+            throw new \RuntimeException('archive target disk must be remote: local disks are not allowed.');
+        }
+
+        if ($driver === 's3' && trim((string) config('filesystems.disks.'.$disk.'.bucket', '')) === '') {
+            throw new \RuntimeException('archive target disk is not configured: filesystems.disks.'.$disk.'.bucket is empty.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function emitPayload(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode report artifact archive json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return (($payload['status'] ?? 'executed') === 'partial_failure') ? self::FAILURE : self::SUCCESS;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('disk='.(string) ($payload['disk'] ?? ''));
+        $this->line('target_disk='.(string) ($payload['target_disk'] ?? ''));
+        $this->line('schema='.(string) ($payload['schema'] ?? ''));
+        $this->line('plan='.(string) ($payload['plan'] ?? ''));
+        $this->line('candidate_count='.(int) ($summary['candidate_count'] ?? 0));
+        $this->line('copied_count='.(int) ($summary['copied_count'] ?? 0));
+        $this->line('verified_count='.(int) ($summary['verified_count'] ?? 0));
+        $this->line('already_archived_count='.(int) ($summary['already_archived_count'] ?? 0));
+        $this->line('failed_count='.(int) ($summary['failed_count'] ?? 0));
+
+        if (isset($payload['run_path'])) {
+            $this->line('run_path='.(string) $payload['run_path']);
+        }
+
+        return (($payload['status'] ?? 'executed') === 'partial_failure') ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function persistPlan(array $plan): string
+    {
+        $planDir = storage_path('app/private/report_artifact_archive_plans');
+        File::ensureDirectoryExists($planDir);
+
+        $planPath = $planDir.DIRECTORY_SEPARATOR.now()->format('Ymd_His').'_report_artifact_archive_'.substr(bin2hex(random_bytes(4)), 0, 8).'.json';
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode report artifact archive plan json.');
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        return $planPath;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readPlan(string $planPath): array
+    {
+        if (! is_file($planPath)) {
+            throw new \RuntimeException('plan not found: '.$planPath);
+        }
+
+        $decoded = json_decode((string) File::get($planPath), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('invalid report artifact archive plan json: '.$planPath);
+        }
+
+        if ((string) ($decoded['schema'] ?? '') !== 'storage_archive_report_artifacts_plan.v1') {
+            throw new \RuntimeException('plan schema mismatch.');
+        }
+
+        return $decoded;
+    }
+
+    private function resolvePlanPath(string $planOption): string
+    {
+        if (str_starts_with($planOption, DIRECTORY_SEPARATOR)) {
+            return $planOption;
+        }
+
+        $basePathCandidate = base_path($planOption);
+        if (is_file($basePathCandidate)) {
+            return $basePathCandidate;
+        }
+
+        return storage_path('app/private/'.ltrim($planOption, '/\\'));
+    }
+}

--- a/backend/app/Services/Storage/ReportArtifactsArchiveService.php
+++ b/backend/app/Services/Storage/ReportArtifactsArchiveService.php
@@ -1,0 +1,456 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Finder\SplFileInfo;
+
+final class ReportArtifactsArchiveService
+{
+    private const PLAN_SCHEMA = 'storage_archive_report_artifacts_plan.v1';
+
+    private const RUN_SCHEMA = 'storage_archive_report_artifacts_run.v1';
+
+    private const AUDIT_ACTION = 'storage_archive_report_artifacts';
+
+    private const TARGET_PREFIX = 'report_artifacts_archive';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildPlan(string $targetDisk): array
+    {
+        $targetDisk = $this->normalizeDisk($targetDisk);
+        $candidates = $this->collectCandidates($targetDisk);
+        $summary = $this->buildSummary($candidates);
+
+        return [
+            'schema' => self::PLAN_SCHEMA,
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'disk' => $targetDisk,
+            'target_disk' => $targetDisk,
+            'summary' => $summary + [
+                'copied_count' => 0,
+                'verified_count' => 0,
+                'already_archived_count' => 0,
+                'failed_count' => 0,
+            ],
+            'candidates' => $candidates,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    public function executePlan(array $plan): array
+    {
+        $this->assertPlanSchema($plan);
+
+        $targetDisk = $this->normalizeDisk((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+        $candidates = is_array($plan['candidates'] ?? null) ? array_values($plan['candidates']) : [];
+        $results = [];
+        $summary = [
+            'candidate_count' => count($candidates),
+            'candidate_bytes' => (int) data_get($plan, 'summary.candidate_bytes', 0),
+            'kind_counts' => is_array(data_get($plan, 'summary.kind_counts')) ? data_get($plan, 'summary.kind_counts') : [],
+            'copied_count' => 0,
+            'verified_count' => 0,
+            'already_archived_count' => 0,
+            'failed_count' => 0,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $result = $this->executeCandidate($candidate, $targetDisk);
+            $results[] = $result;
+
+            $status = (string) ($result['status'] ?? '');
+            if ($status === 'copied') {
+                $summary['copied_count']++;
+                $summary['verified_count']++;
+
+                continue;
+            }
+
+            if ($status === 'already_archived') {
+                $summary['already_archived_count']++;
+                $summary['verified_count']++;
+
+                continue;
+            }
+
+            $summary['failed_count']++;
+        }
+
+        $status = $summary['failed_count'] > 0 ? 'partial_failure' : 'executed';
+        $runDir = $this->runDirectory();
+        $runPath = $runDir.DIRECTORY_SEPARATOR.'run.json';
+
+        $payload = [
+            'schema' => self::RUN_SCHEMA,
+            'mode' => 'execute',
+            'status' => $status,
+            'generated_at' => now()->toIso8601String(),
+            'disk' => $targetDisk,
+            'target_disk' => $targetDisk,
+            'plan' => trim((string) data_get($plan, '_meta.plan_path', '')),
+            'summary' => $summary,
+            'results' => $results,
+        ];
+
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode report artifact archive run receipt.');
+        }
+
+        File::put($runPath, $encoded.PHP_EOL);
+        $payload['run_path'] = $runPath;
+
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function collectCandidates(string $targetDisk): array
+    {
+        $artifactsRoot = storage_path('app/private/artifacts');
+        if (! is_dir($artifactsRoot)) {
+            return [];
+        }
+
+        $candidates = [];
+
+        foreach (['reports', 'pdf'] as $subdir) {
+            $root = $artifactsRoot.DIRECTORY_SEPARATOR.$subdir;
+            if (! is_dir($root)) {
+                continue;
+            }
+
+            foreach (File::allFiles($root) as $file) {
+                $candidate = $this->candidateFromFile($file, $artifactsRoot, $targetDisk);
+                if ($candidate === null) {
+                    continue;
+                }
+
+                $candidates[] = $candidate;
+            }
+        }
+
+        usort($candidates, static fn (array $left, array $right): int => strcmp((string) ($left['relative_path'] ?? ''), (string) ($right['relative_path'] ?? '')));
+
+        return $candidates;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function candidateFromFile(SplFileInfo $file, string $artifactsRoot, string $targetDisk): ?array
+    {
+        if (! $file->isFile()) {
+            return null;
+        }
+
+        $absolutePath = $file->getPathname();
+        $relativePath = $this->relativePathWithinArtifacts($absolutePath, $artifactsRoot);
+        if ($relativePath === '') {
+            return null;
+        }
+
+        $context = $this->canonicalContextForRelativePath($relativePath);
+        if ($context === null) {
+            return null;
+        }
+
+        $bytes = max(0, (int) ($file->getSize() ?: 0));
+        $sha256 = hash_file('sha256', $absolutePath);
+        if (! is_string($sha256) || $sha256 === '') {
+            throw new \RuntimeException('failed to hash canonical artifact source: '.$absolutePath);
+        }
+
+        return [
+            'kind' => $context['kind'],
+            'source_path' => 'artifacts/'.$relativePath,
+            'relative_path' => $relativePath,
+            'target_disk' => $targetDisk,
+            'target_object_key' => self::TARGET_PREFIX.'/'.$relativePath,
+            'bytes' => $bytes,
+            'sha256' => $sha256,
+            'scale_code' => $context['scale_code'],
+            'attempt_id' => $context['attempt_id'],
+        ];
+    }
+
+    /**
+     * @return array{kind:string,scale_code:?string,attempt_id:?string}|null
+     */
+    private function canonicalContextForRelativePath(string $relativePath): ?array
+    {
+        if (preg_match('#^reports/([^/]+)/([^/]+)/report\.json$#', $relativePath, $matches) === 1) {
+            return [
+                'kind' => 'report_json',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+            ];
+        }
+
+        if (preg_match('#^pdf/([^/]+)/([^/]+)/[^/]+/report_(free|full)\.pdf$#', $relativePath, $matches) === 1) {
+            return [
+                'kind' => 'report_'.$matches[3].'_pdf',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+            ];
+        }
+
+        return null;
+    }
+
+    private function relativePathWithinArtifacts(string $absolutePath, string $artifactsRoot): string
+    {
+        $root = rtrim(str_replace('\\', '/', $artifactsRoot), '/');
+        $path = str_replace('\\', '/', $absolutePath);
+        $prefix = $root.'/';
+
+        if (! str_starts_with($path, $prefix)) {
+            return '';
+        }
+
+        return ltrim(substr($path, strlen($prefix)), '/');
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $candidates
+     * @return array<string,mixed>
+     */
+    private function buildSummary(array $candidates): array
+    {
+        $candidateBytes = 0;
+        $kindCounts = [];
+
+        foreach ($candidates as $candidate) {
+            $candidateBytes += (int) ($candidate['bytes'] ?? 0);
+            $kind = (string) ($candidate['kind'] ?? 'unknown');
+            $kindCounts[$kind] = (int) ($kindCounts[$kind] ?? 0) + 1;
+        }
+
+        ksort($kindCounts);
+
+        return [
+            'candidate_count' => count($candidates),
+            'candidate_bytes' => $candidateBytes,
+            'kind_counts' => $kindCounts,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     * @return array<string,mixed>
+     */
+    private function executeCandidate(array $candidate, string $targetDisk): array
+    {
+        $sourcePath = trim((string) ($candidate['source_path'] ?? ''));
+        $relativePath = trim((string) ($candidate['relative_path'] ?? ''));
+        $targetObjectKey = trim((string) ($candidate['target_object_key'] ?? ''));
+        $kind = trim((string) ($candidate['kind'] ?? ''));
+        $absoluteSourcePath = storage_path('app/private/'.$sourcePath);
+
+        $baseResult = [
+            'kind' => $kind,
+            'source_path' => $sourcePath,
+            'relative_path' => $relativePath,
+            'target_disk' => $targetDisk,
+            'target_object_key' => $targetObjectKey,
+            'scale_code' => $candidate['scale_code'] ?? null,
+            'attempt_id' => $candidate['attempt_id'] ?? null,
+            'planned_sha256' => $candidate['sha256'] ?? null,
+            'planned_bytes' => (int) ($candidate['bytes'] ?? 0),
+        ];
+
+        if ($sourcePath === '' || $relativePath === '' || $targetObjectKey === '') {
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'CANDIDATE_METADATA_INVALID',
+            ];
+        }
+
+        if (! is_file($absoluteSourcePath)) {
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'SOURCE_MISSING_AT_EXECUTE',
+            ];
+        }
+
+        $sourceBytes = max(0, (int) (filesize($absoluteSourcePath) ?: 0));
+        $sourceSha256 = hash_file('sha256', $absoluteSourcePath);
+        if (! is_string($sourceSha256) || $sourceSha256 === '') {
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'SOURCE_HASH_FAILED_AT_EXECUTE',
+            ];
+        }
+
+        $baseResult['source_bytes'] = $sourceBytes;
+        $baseResult['source_sha256'] = $sourceSha256;
+
+        $targetExists = Storage::disk($targetDisk)->exists($targetObjectKey);
+        if ($targetExists) {
+            $targetBytes = $this->sizeForDiskPath($targetDisk, $targetObjectKey);
+            $targetSha256 = $this->hashForDiskPath($targetDisk, $targetObjectKey);
+
+            if ($targetBytes === $sourceBytes && $targetSha256 === $sourceSha256) {
+                return $baseResult + [
+                    'status' => 'already_archived',
+                    'reason' => 'TARGET_ALREADY_MATCHED',
+                    'verified_at' => now()->toIso8601String(),
+                    'target_bytes' => $targetBytes,
+                    'target_sha256' => $targetSha256,
+                ];
+            }
+        }
+
+        $stream = @fopen($absoluteSourcePath, 'rb');
+        if ($stream === false) {
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'SOURCE_OPEN_FAILED',
+            ];
+        }
+
+        try {
+            $stored = Storage::disk($targetDisk)->put($targetObjectKey, $stream);
+        } finally {
+            fclose($stream);
+        }
+
+        if (! $stored) {
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'TARGET_UPLOAD_FAILED',
+            ];
+        }
+
+        $targetExistsAfterUpload = Storage::disk($targetDisk)->exists($targetObjectKey);
+        $targetBytesAfterUpload = $this->sizeForDiskPath($targetDisk, $targetObjectKey);
+
+        if (! $targetExistsAfterUpload || $targetBytesAfterUpload !== $sourceBytes) {
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'TARGET_VERIFY_FAILED',
+                'target_bytes' => $targetBytesAfterUpload,
+            ];
+        }
+
+        return $baseResult + [
+            'status' => 'copied',
+            'reason' => 'TARGET_UPLOADED_AND_VERIFIED',
+            'copied_at' => now()->toIso8601String(),
+            'verified_at' => now()->toIso8601String(),
+            'target_bytes' => $targetBytesAfterUpload,
+        ];
+    }
+
+    private function sizeForDiskPath(string $disk, string $path): ?int
+    {
+        try {
+            return max(0, (int) Storage::disk($disk)->size($path));
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function hashForDiskPath(string $disk, string $path): ?string
+    {
+        try {
+            $stream = Storage::disk($disk)->readStream($path);
+        } catch (\Throwable) {
+            $stream = false;
+        }
+
+        if (! is_resource($stream)) {
+            return null;
+        }
+
+        try {
+            $context = hash_init('sha256');
+            hash_update_stream($context, $stream);
+
+            return hash_final($context);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => self::AUDIT_ACTION,
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_archive',
+            'meta_json' => json_encode([
+                'schema' => $payload['schema'] ?? null,
+                'mode' => $payload['mode'] ?? null,
+                'target_disk' => $payload['target_disk'] ?? null,
+                'plan' => $payload['plan'] ?? null,
+                'run_path' => $payload['run_path'] ?? null,
+                'summary' => $payload['summary'] ?? [],
+                'results' => $payload['results'] ?? [],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'artisan/storage:archive-report-artifacts',
+            'request_id' => null,
+            'reason' => 'manual_archive_copy',
+            'result' => ($payload['status'] ?? 'executed') === 'executed' ? 'success' : 'partial_failure',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function assertPlanSchema(array $plan): void
+    {
+        if ((string) ($plan['schema'] ?? '') !== self::PLAN_SCHEMA) {
+            throw new \RuntimeException('report artifact archive plan schema mismatch.');
+        }
+    }
+
+    private function normalizeDisk(string $disk): string
+    {
+        $normalized = trim($disk);
+        if ($normalized === '') {
+            throw new \RuntimeException('target disk is required.');
+        }
+
+        return $normalized;
+    }
+
+    private function runDirectory(): string
+    {
+        $dir = storage_path('app/private/report_artifact_archive_runs/'.now()->format('Ymd_His').'_'.substr(bin2hex(random_bytes(4)), 0, 8));
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+}

--- a/backend/tests/Feature/Storage/ReportArtifactsArchiveServiceTest.php
+++ b/backend/tests/Feature/Storage/ReportArtifactsArchiveServiceTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ReportArtifactsArchiveService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ReportArtifactsArchiveServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-report-artifacts-archive-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('filesystems.disks.s3.bucket', 'report-artifacts-archive-service-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.report-archive.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_archives_canonical_report_and_pdf_without_local_delete(): void
+    {
+        $report = $this->seedCanonicalReportJson('MBTI', 'attempt-report', ['ok' => true]);
+        $pdf = $this->seedCanonicalPdf('BIG5', 'attempt-pdf', 'manifest-hash', 'free', '%PDF-1.4 free');
+        $legacyPdfPath = 'reports/legacy-attempt/report_free.pdf';
+        Storage::disk('local')->put($legacyPdfPath, '%PDF-1.4 legacy');
+
+        /** @var ReportArtifactsArchiveService $service */
+        $service = app(ReportArtifactsArchiveService::class);
+
+        $plan = $service->buildPlan('s3');
+        $this->assertSame('storage_archive_report_artifacts_plan.v1', $plan['schema']);
+        $this->assertSame(2, data_get($plan, 'summary.candidate_count'));
+        $this->assertSame(1, data_get($plan, 'summary.kind_counts.report_json'));
+        $this->assertSame(1, data_get($plan, 'summary.kind_counts.report_free_pdf'));
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_archive_plans/test-plan.json')];
+        $result = $service->executePlan($plan);
+
+        $this->assertSame('executed', $result['status']);
+        $this->assertSame(2, data_get($result, 'summary.copied_count'));
+        $this->assertSame(2, data_get($result, 'summary.verified_count'));
+        $this->assertSame(0, data_get($result, 'summary.failed_count'));
+        $this->assertFileExists((string) ($result['run_path'] ?? ''));
+
+        Storage::disk('s3')->assertExists('report_artifacts_archive/reports/MBTI/attempt-report/report.json');
+        Storage::disk('s3')->assertExists('report_artifacts_archive/pdf/BIG5/attempt-pdf/manifest-hash/report_free.pdf');
+        $this->assertTrue(Storage::disk('local')->exists($report['source_path']));
+        $this->assertTrue(Storage::disk('local')->exists($pdf['source_path']));
+        $this->assertTrue(Storage::disk('local')->exists($legacyPdfPath));
+
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'storage_archive_report_artifacts',
+            'target_id' => 'report_artifacts_archive',
+            'result' => 'success',
+        ]);
+    }
+
+    public function test_service_excludes_non_canonical_files_and_marks_already_archived_when_target_matches(): void
+    {
+        $report = $this->seedCanonicalReportJson('MBTI', 'attempt-already', ['ok' => true]);
+        Storage::disk('local')->put('reports/MBTI/attempt-already/report.json', json_encode(['legacy' => true], JSON_UNESCAPED_UNICODE));
+        Storage::disk('local')->put('reports/MBTI/attempt-already/report.20260322_120000.json', json_encode(['backup' => true], JSON_UNESCAPED_UNICODE));
+        Storage::disk('local')->put('artifacts/reports/.DS_Store', 'finder');
+        Storage::disk('local')->put('artifacts/reports/.gitkeep', '');
+        Storage::disk('s3')->put('report_artifacts_archive/reports/MBTI/attempt-already/report.json', $report['bytes']);
+
+        /** @var ReportArtifactsArchiveService $service */
+        $service = app(ReportArtifactsArchiveService::class);
+
+        $plan = $service->buildPlan('s3');
+        $this->assertSame(1, data_get($plan, 'summary.candidate_count'));
+        $this->assertSame(['reports/MBTI/attempt-already/report.json'], array_column((array) ($plan['candidates'] ?? []), 'relative_path'));
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_archive_plans/already.json')];
+        $result = $service->executePlan($plan);
+
+        $this->assertSame('executed', $result['status']);
+        $this->assertSame(0, data_get($result, 'summary.copied_count'));
+        $this->assertSame(1, data_get($result, 'summary.already_archived_count'));
+        $this->assertSame(1, data_get($result, 'summary.verified_count'));
+        $this->assertSame('already_archived', data_get($result, 'results.0.status'));
+        $this->assertTrue(Storage::disk('local')->exists($report['source_path']));
+    }
+
+    public function test_service_records_partial_failure_when_source_disappears_after_plan_generation(): void
+    {
+        $report = $this->seedCanonicalReportJson('MBTI', 'attempt-fail', ['ok' => false]);
+
+        /** @var ReportArtifactsArchiveService $service */
+        $service = app(ReportArtifactsArchiveService::class);
+
+        $plan = $service->buildPlan('s3');
+        Storage::disk('local')->delete($report['source_path']);
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_archive_plans/failure.json')];
+        $result = $service->executePlan($plan);
+
+        $this->assertSame('partial_failure', $result['status']);
+        $this->assertSame(1, data_get($result, 'summary.failed_count'));
+        $this->assertSame('failed', data_get($result, 'results.0.status'));
+        $this->assertSame('SOURCE_MISSING_AT_EXECUTE', data_get($result, 'results.0.reason'));
+        $this->assertFileExists((string) ($result['run_path'] ?? ''));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_archive_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $this->assertSame('partial_failure', $audit->result);
+        $meta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($meta);
+        $this->assertSame(1, data_get($meta, 'summary.failed_count'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array{source_path:string,bytes:string}
+     */
+    private function seedCanonicalReportJson(string $scaleCode, string $attemptId, array $payload): array
+    {
+        $bytes = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($bytes);
+
+        $sourcePath = 'artifacts/reports/'.$scaleCode.'/'.$attemptId.'/report.json';
+        Storage::disk('local')->put($sourcePath, $bytes);
+
+        return [
+            'source_path' => $sourcePath,
+            'bytes' => $bytes,
+        ];
+    }
+
+    /**
+     * @return array{source_path:string,bytes:string}
+     */
+    private function seedCanonicalPdf(string $scaleCode, string $attemptId, string $manifestHash, string $variant, string $bytes): array
+    {
+        $sourcePath = 'artifacts/pdf/'.$scaleCode.'/'.$attemptId.'/'.$manifestHash.'/report_'.$variant.'.pdf';
+        Storage::disk('local')->put($sourcePath, $bytes);
+
+        return [
+            'source_path' => $sourcePath,
+            'bytes' => $bytes,
+        ];
+    }
+}

--- a/backend/tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageArchiveReportArtifacts;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageArchiveReportArtifactsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-report-artifacts-archive-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('filesystems.disks.s3.bucket', 'report-artifacts-archive-command-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.report-archive-command.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageArchiveReportArtifacts::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_requires_exactly_one_mode_and_plan_for_execute(): void
+    {
+        $this->artisan('storage:archive-report-artifacts')
+            ->expectsOutputToContain('exactly one of --dry-run or --execute is required.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:archive-report-artifacts --dry-run --execute')
+            ->expectsOutputToContain('exactly one of --dry-run or --execute is required.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:archive-report-artifacts --execute --disk=s3')
+            ->expectsOutputToContain('--execute requires --plan.')
+            ->assertExitCode(1);
+    }
+
+    public function test_command_dry_run_execute_json_and_partial_failure_are_visible(): void
+    {
+        $reportBytes = json_encode(['attempt' => 'command-report'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($reportBytes);
+
+        $reportSourcePath = 'artifacts/reports/MBTI/command-report/report.json';
+        $pdfSourcePath = 'artifacts/pdf/BIG5/command-pdf/manifest-123/report_full.pdf';
+        $legacySourcePath = 'reports/MBTI/command-report/report.json';
+
+        Storage::disk('local')->put($reportSourcePath, $reportBytes);
+        Storage::disk('local')->put($pdfSourcePath, '%PDF-1.4 full');
+        Storage::disk('local')->put($legacySourcePath, json_encode(['legacy' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('candidate_count=2', $dryRunOutput);
+        $this->assertStringContainsString('copied_count=0', $dryRunOutput);
+        $this->assertStringContainsString('already_archived_count=0', $dryRunOutput);
+
+        preg_match('/^plan=(.+)$/m', $dryRunOutput, $matches);
+        $planPath = trim((string) ($matches[1] ?? ''));
+        $this->assertFileExists($planPath);
+
+        $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('candidate_count=2', $executeOutput);
+        $this->assertStringContainsString('copied_count=2', $executeOutput);
+        $this->assertStringContainsString('verified_count=2', $executeOutput);
+        $this->assertStringContainsString('run_path=', $executeOutput);
+
+        Storage::disk('s3')->assertExists('report_artifacts_archive/reports/MBTI/command-report/report.json');
+        Storage::disk('s3')->assertExists('report_artifacts_archive/pdf/BIG5/command-pdf/manifest-123/report_full.pdf');
+        $this->assertTrue(Storage::disk('local')->exists($reportSourcePath));
+        $this->assertTrue(Storage::disk('local')->exists($pdfSourcePath));
+        $this->assertTrue(Storage::disk('local')->exists($legacySourcePath));
+
+        $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--json' => true,
+        ]));
+        $jsonPayload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($jsonPayload);
+        $this->assertSame('storage_archive_report_artifacts_plan.v1', $jsonPayload['schema'] ?? null);
+        $this->assertSame(2, data_get($jsonPayload, 'summary.candidate_count'));
+
+        $secondPlanPath = storage_path('app/private/report_artifact_archive_plans/failure.json');
+        File::ensureDirectoryExists(dirname($secondPlanPath));
+        File::copy($planPath, $secondPlanPath);
+        Storage::disk('local')->delete($reportSourcePath);
+
+        $this->assertSame(1, Artisan::call('storage:archive-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $secondPlanPath,
+        ]));
+        $failureOutput = Artisan::output();
+        $this->assertStringContainsString('status=partial_failure', $failureOutput);
+        $this->assertStringContainsString('failed_count=1', $failureOutput);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a manual-only archive/export pipeline for canonical report artifacts under `storage/app/private/artifacts/**`.

The new surface is intentionally narrow:

- plan-first
- execute-from-plan
- copy-only
- no local delete
- no read cutover
- no write-path changes
- no fallback changes

It only archives exact canonical user outputs to the existing `s3` disk:

- `artifacts/reports/**/report.json`
- `artifacts/pdf/**/report_free.pdf`
- `artifacts/pdf/**/report_full.pdf`

The execution unit is a single file, not a bundle.

## Why

The repository already has stable canonical report/pdf outputs in `storage/app/private/artifacts/**`, and these files are now one of the larger storage surfaces in the system.

What was missing was not retention or cleanup logic. The missing piece was a safe archive/export readiness surface that can:

- enumerate the exact canonical files eligible for archive
- copy them to remote object storage
- verify the copy at execution time
- persist plan/run/audit truth for later review

Without this surface, a future retention/shrink PR would have no durable archive receipt to rely on.

## Root cause

Before this PR, the codebase had:

- canonical artifact write paths
- legacy fallback read compatibility
- reports/artifacts lifecycle truth in control-plane status
- storage inventory and cost visibility

But it did not have a dedicated archive pipeline for canonical report artifacts. That left a gap between “we know what the canonical outputs are” and “we can safely prove they have been archived remotely.”

## What changed

### New command

`storage:archive-report-artifacts`

Options:

- `--dry-run`
- `--execute`
- `--disk=s3`
- `--plan=`
- `--json`

Rules:

- exactly one of `--dry-run` or `--execute`
- `--execute` requires `--plan`
- target disk must be a configured remote disk

### New service

`ReportArtifactsArchiveService`

Responsibilities:

- build a plan from exact canonical files only
- execute copy to the target disk
- verify archive success after copy
- treat matching existing target objects as `already_archived`
- write run receipt and audit truth

### Archive truth surfaces

This PR stores archive truth only in:

- plan files under `storage/app/private/report_artifact_archive_plans/*.json`
- run receipts under `storage/app/private/report_artifact_archive_runs/{run_id}/run.json`
- `audit_logs` with action `storage_archive_report_artifacts`

It does **not** mix archive truth into `storage_blob_locations` or any runtime storage authority tables.

## Behavioral guarantees

This PR does **not**:

- delete local canonical files
- modify legacy fallback paths
- modify write-chain behavior
- modify consumer read behavior
- change storage retention semantics
- introduce scheduler automation
- introduce cutover logic

The archive target key uses a stable reversible mapping:

- `report_artifacts_archive/<relative-path-from-artifacts-root>`

Examples:

- `artifacts/reports/MBTI/<attempt>/report.json`
  -> `report_artifacts_archive/reports/MBTI/<attempt>/report.json`
- `artifacts/pdf/BIG5/<attempt>/<hash>/report_free.pdf`
  -> `report_artifacts_archive/pdf/BIG5/<attempt>/<hash>/report_free.pdf`

## Validation

Focused tests:

- `tests/Feature/Storage/ReportArtifactsArchiveServiceTest.php`
- `tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php`

Regression tests:

- `tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php`
- `tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php`
- `tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php`
- `tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php`
- `tests/Feature/Storage/StorageCostAnalyzerServiceTest.php`
- `tests/Feature/Storage/StorageCostAnalyzerCommandTest.php`
- `tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php`
- `tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php`

Live validation performed in an isolated worktree:

- `php artisan storage:archive-report-artifacts --dry-run --disk=s3`
- `php artisan storage:archive-report-artifacts --execute --disk=s3 --plan=...`
- `php artisan storage:prune --dry-run --scope=reports_backups`
- `php artisan storage:analyze-cost --json`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan storage:refresh-control-plane --dry-run --json`
- `php artisan storage:inventory --json`
- `bash backend/scripts/ci_verify_mbti.sh`

Key live results:

- `candidate_count=2926`
- `copied_count=2298`
- `already_archived_count=628`
- `verified_count=2926`
- `failed_count=0`
- local canonical files remained in place
- legacy paths were untouched
- run receipt was written successfully

## Effect

This PR gives operators a safe, manual archive/export surface for canonical report artifacts and creates the durable archive truth needed before any future retention/shrink work can be considered.
