### PR TITLE
[codex] Ship PR-13A content control plane expansion

### DIFF
--- a/backend/app/Filament/Ops/Resources/ContentPackVersionResource.php
+++ b/backend/app/Filament/Ops/Resources/ContentPackVersionResource.php
@@ -116,6 +116,10 @@ class ContentPackVersionResource extends Resource
                         ->label('First-wave managed objects')
                         ->content(fn (?ContentPackVersion $record): HtmlString => self::renderObjectInventory($record))
                         ->columnSpanFull(),
+                    Forms\Components\Placeholder::make('cp.content_objects_v1')
+                        ->label('Object-level contracts')
+                        ->content(fn (?ContentPackVersion $record): HtmlString => self::renderObjectContracts($record))
+                        ->columnSpanFull(),
                 ])
                 ->columns(1),
             Forms\Components\Grid::make(2)
@@ -221,6 +225,7 @@ class ContentPackVersionResource extends Resource
                 ],
                 'runtime_artifact_ref' => null,
                 'content_object_inventory' => [],
+                'content_objects_v1' => [],
             ];
         }
 
@@ -306,6 +311,42 @@ class ContentPackVersionResource extends Resource
 
             return e($type).': '.($enabled ? 'enabled' : 'not_in_scope');
         }, $inventory);
+        $items = array_values(array_filter($items, static fn (string $item): bool => $item !== ''));
+
+        return new HtmlString('<ul><li>'.implode('</li><li>', $items).'</li></ul>');
+    }
+
+    private static function renderObjectContracts(?ContentPackVersion $record): HtmlString
+    {
+        $contracts = self::controlPlaneValue($record, 'content_objects_v1', []);
+        if (! is_array($contracts) || $contracts === []) {
+            return new HtmlString('<span>No object-level control-plane contracts available yet.</span>');
+        }
+
+        $items = array_map(static function (mixed $item): string {
+            if (! is_array($item)) {
+                return '';
+            }
+
+            $artifact = $item['runtime_artifact_ref'] ?? null;
+            $artifactRef = 'runtime_artifact_ref=none';
+            if (is_array($artifact) && $artifact !== []) {
+                $artifactRef = 'runtime_artifact_ref='.(string) ($artifact['storage_path'] ?? ($artifact['dir_alias'] ?? 'published'));
+            }
+
+            $parts = [
+                (string) ($item['content_object_type'] ?? 'unknown'),
+                'draft='.(string) ($item['draft_state'] ?? 'unknown'),
+                'review='.(string) ($item['review_state'] ?? 'unknown'),
+                'compile='.(string) ($item['compile_status'] ?? 'unknown'),
+                'governance='.(string) ($item['governance_status'] ?? 'unknown'),
+                'release_candidate='.(string) ($item['release_candidate_status'] ?? 'unknown'),
+                'locale='.(string) ($item['locale_scope'] ?? 'unknown'),
+                $artifactRef,
+            ];
+
+            return e(implode(' | ', $parts));
+        }, $contracts);
         $items = array_values(array_filter($items, static fn (string $item): bool => $item !== ''));
 
         return new HtmlString('<ul><li>'.implode('</li><li>', $items).'</li></ul>');

--- a/backend/app/Services/Content/ContentControlPlaneService.php
+++ b/backend/app/Services/Content/ContentControlPlaneService.php
@@ -28,6 +28,25 @@ final class ContentControlPlaneService
 
         $draftState = $this->resolveDraftState($compile['status'], $governance['status'], $release);
         $reviewState = $this->resolveReviewState($compile['status'], $governance['status'], $release);
+        $localeScope = $this->resolveLocaleScope($versionData);
+        $publishTarget = $this->resolvePublishTarget($versionData);
+        $previewTarget = $this->resolvePreviewTarget($versionData);
+        $releaseCandidateStatus = $this->resolveReleaseCandidateStatus($release, $compile['status'], $governance['status']);
+        $contentObjects = $this->buildContentObjects(
+            $versionData,
+            $governance['content_object_inventory'],
+            $draftState,
+            $reviewState,
+            $compile['status'],
+            $governance['status'],
+            $releaseCandidateStatus,
+            $previewTarget,
+            $publishTarget,
+            $localeScope,
+            $governance['experiment_scope'],
+            $release['runtime_artifact_ref'],
+            $release['rollback_target'],
+        );
 
         return [
             'content_control_plane_v1' => [
@@ -36,17 +55,18 @@ final class ContentControlPlaneService
                 'draft_state' => $draftState,
                 'revision_no' => $this->resolveRevisionNo($versionData),
                 'review_state' => $reviewState,
-                'preview_target' => $this->resolvePreviewTarget($versionData),
+                'preview_target' => $previewTarget,
                 'compile_status' => $compile['status'],
                 'governance_status' => $governance['status'],
-                'release_candidate_status' => $this->resolveReleaseCandidateStatus($release, $compile['status'], $governance['status']),
-                'publish_target' => $this->resolvePublishTarget($versionData),
+                'release_candidate_status' => $releaseCandidateStatus,
+                'publish_target' => $publishTarget,
                 'rollback_target' => $release['rollback_target'],
-                'locale_scope' => $this->resolveLocaleScope($versionData),
+                'locale_scope' => $localeScope,
                 'experiment_scope' => $governance['experiment_scope'],
                 'runtime_artifact_ref' => $release['runtime_artifact_ref'],
                 'cultural_context' => $governance['cultural_context'],
-                'content_object_inventory' => $governance['content_object_inventory'],
+                'content_object_inventory' => $this->summarizeContentObjects($contentObjects),
+                'content_objects_v1' => $contentObjects,
             ],
         ];
     }
@@ -424,28 +444,275 @@ final class ContentControlPlaneService
             [
                 'type' => 'narrative_fragment',
                 'enabled' => $hasNarrative,
+                'governance_profile' => 'growth_content.narrative_fragment.v1',
+                'layer_scope' => ['scene', 'explainability', 'action'],
             ],
             [
                 'type' => 'calibration_copy',
                 'enabled' => $hasLocaleVariant,
+                'governance_profile' => 'growth_content.calibration_copy.v1',
+                'layer_scope' => ['boundary', 'explainability'],
             ],
             [
                 'type' => 'cta_overlay',
                 'enabled' => $hasCtaOverlay,
+                'governance_profile' => 'growth_content.cta_overlay.v1',
+                'layer_scope' => ['action'],
             ],
             [
-                'type' => 'experiment_overlay',
-                'enabled' => $hasExperimentOverlay,
+                'type' => 'faq_explainability_copy',
+                'enabled' => $hasNarrative,
+                'governance_profile' => 'growth_content.faq_explainability_copy.v1',
+                'layer_scope' => ['explainability'],
+            ],
+            [
+                'type' => 'scene_fragment',
+                'enabled' => $hasNarrative,
+                'governance_profile' => 'growth_content.scene_fragment.v1',
+                'layer_scope' => ['scene'],
+            ],
+            [
+                'type' => 'action_fragment',
+                'enabled' => $hasNarrative,
+                'governance_profile' => 'growth_content.action_fragment.v1',
+                'layer_scope' => ['action'],
             ],
             [
                 'type' => 'locale_variant_draft',
                 'enabled' => $hasLocaleVariant,
+                'governance_profile' => 'growth_content.locale_variant_draft.v1',
+                'layer_scope' => ['skeleton', 'boundary', 'scene', 'explainability', 'action'],
+            ],
+            [
+                'type' => 'experiment_overlay',
+                'enabled' => $hasExperimentOverlay,
+                'governance_profile' => 'growth_content.experiment_overlay.v1',
+                'layer_scope' => ['scene', 'action', 'explainability'],
             ],
             [
                 'type' => 'release_candidate_metadata',
                 'enabled' => $hasReleaseCandidate,
+                'governance_profile' => 'growth_content.release_candidate_metadata.v1',
+                'layer_scope' => [],
             ],
         ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $inventory
+     * @param  array<string,mixed>  $experimentScope
+     * @param  array<string,mixed>|null  $runtimeArtifactRef
+     * @param  array<string,mixed>|null  $rollbackTarget
+     * @return list<array<string,mixed>>
+     */
+    private function buildContentObjects(
+        array $versionData,
+        array $inventory,
+        string $draftState,
+        string $reviewState,
+        string $compileStatus,
+        string $governanceStatus,
+        string $releaseCandidateStatus,
+        string $previewTarget,
+        string $publishTarget,
+        string $localeScope,
+        array $experimentScope,
+        ?array $runtimeArtifactRef,
+        ?array $rollbackTarget,
+    ): array {
+        $versionId = trim((string) ($versionData['id'] ?? ''));
+        $packId = trim((string) ($versionData['pack_id'] ?? ''));
+        $objects = [];
+
+        foreach ($inventory as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $type = trim((string) ($item['type'] ?? ''));
+            if ($type === '') {
+                continue;
+            }
+
+            $enabled = (bool) ($item['enabled'] ?? false);
+            $runtimeBindable = $enabled && $this->isRuntimeBindableObject($type);
+            $objectId = implode(':', array_filter([$packId, $versionId, $type], static fn (string $value): bool => $value !== ''));
+            $objectPreviewTarget = $enabled && $previewTarget !== ''
+                ? $previewTarget.'?object='.rawurlencode($type)
+                : null;
+            $objectPublishTarget = $runtimeBindable && $publishTarget !== 'default/pending/pending/pending'
+                ? $publishTarget.'#object='.rawurlencode($type)
+                : null;
+            $objectDraftState = $this->resolveObjectDraftState($type, $enabled, $draftState, $compileStatus, $governanceStatus);
+            $objectReviewState = $this->resolveObjectReviewState($type, $enabled, $reviewState, $compileStatus, $governanceStatus);
+            $objectReleaseCandidateStatus = $this->resolveObjectReleaseCandidateStatus($type, $enabled, $releaseCandidateStatus, $compileStatus, $governanceStatus);
+
+            $objects[] = [
+                'content_object_v1' => 'content_object.v1',
+                'content_object_id' => $objectId,
+                'content_object_type' => $type,
+                'authoring_scope' => 'backend_filament_ops',
+                'draft_state' => $objectDraftState,
+                'revision_no' => $this->resolveRevisionNo($versionData),
+                'review_state' => $objectReviewState,
+                'preview_target' => $objectPreviewTarget,
+                'compile_status' => $enabled ? $compileStatus : 'not_in_scope',
+                'governance_status' => $enabled ? $governanceStatus : 'not_in_scope',
+                'release_candidate_status' => $objectReleaseCandidateStatus,
+                'publish_target' => $objectPublishTarget,
+                'rollback_target' => $runtimeBindable ? $this->decorateArtifactRef($rollbackTarget, $type, $objectId) : null,
+                'locale_scope' => $localeScope,
+                'experiment_scope' => $this->buildObjectExperimentScope($type, $experimentScope, $enabled),
+                'runtime_artifact_ref' => $runtimeBindable ? $this->decorateArtifactRef($runtimeArtifactRef, $type, $objectId) : null,
+                'source_pack_version_id' => $versionId !== '' ? $versionId : null,
+                'source_release_id' => $runtimeBindable && is_array($runtimeArtifactRef)
+                    ? trim((string) ($runtimeArtifactRef['release_id'] ?? '')) ?: null
+                    : null,
+                'governance_profile' => trim((string) ($item['governance_profile'] ?? '')) ?: 'growth_content.default.v1',
+            ];
+        }
+
+        return $objects;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $contentObjects
+     * @return list<array<string,mixed>>
+     */
+    private function summarizeContentObjects(array $contentObjects): array
+    {
+        return array_map(static function (array $item): array {
+            return [
+                'type' => (string) ($item['content_object_type'] ?? 'unknown'),
+                'enabled' => ! in_array((string) ($item['draft_state'] ?? 'not_in_scope'), ['not_in_scope'], true),
+                'draft_state' => (string) ($item['draft_state'] ?? 'unknown'),
+                'review_state' => (string) ($item['review_state'] ?? 'unknown'),
+                'release_candidate_status' => (string) ($item['release_candidate_status'] ?? 'unknown'),
+                'runtime_bound' => is_array($item['runtime_artifact_ref'] ?? null),
+            ];
+        }, $contentObjects);
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $artifact
+     * @return array<string,mixed>|null
+     */
+    private function decorateArtifactRef(?array $artifact, string $type, string $objectId): ?array
+    {
+        if (! is_array($artifact) || $artifact === []) {
+            return null;
+        }
+
+        return array_merge($artifact, [
+            'content_object_type' => $type,
+            'content_object_id' => $objectId,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $experimentScope
+     * @return array<string,mixed>
+     */
+    private function buildObjectExperimentScope(string $type, array $experimentScope, bool $enabled): array
+    {
+        if (! $enabled) {
+            return [
+                'stable_files' => 0,
+                'experiment_files' => 0,
+                'commercial_overlay_files' => 0,
+                'experiment_keys' => [],
+                'overlay_targets' => [],
+            ];
+        }
+
+        if (in_array($type, ['experiment_overlay', 'cta_overlay', 'release_candidate_metadata'], true)) {
+            return $experimentScope;
+        }
+
+        return [
+            'stable_files' => (int) ($experimentScope['stable_files'] ?? 0),
+            'experiment_files' => 0,
+            'commercial_overlay_files' => 0,
+            'experiment_keys' => [],
+            'overlay_targets' => [],
+        ];
+    }
+
+    private function isRuntimeBindableObject(string $type): bool
+    {
+        return in_array($type, [
+            'narrative_fragment',
+            'calibration_copy',
+            'cta_overlay',
+            'faq_explainability_copy',
+            'scene_fragment',
+            'action_fragment',
+            'experiment_overlay',
+        ], true);
+    }
+
+    private function resolveObjectDraftState(
+        string $type,
+        bool $enabled,
+        string $draftState,
+        string $compileStatus,
+        string $governanceStatus
+    ): string {
+        if (! $enabled) {
+            return 'not_in_scope';
+        }
+
+        return match ($type) {
+            'locale_variant_draft' => $compileStatus === 'compiled' && $governanceStatus === 'passing'
+                ? 'locale_variant_draft_ready'
+                : 'locale_variant_draft_pending',
+            'release_candidate_metadata' => $compileStatus === 'compiled' && $governanceStatus === 'passing'
+                ? 'release_metadata_ready'
+                : 'release_metadata_pending',
+            default => $draftState,
+        };
+    }
+
+    private function resolveObjectReviewState(
+        string $type,
+        bool $enabled,
+        string $reviewState,
+        string $compileStatus,
+        string $governanceStatus
+    ): string {
+        if (! $enabled) {
+            return 'not_in_scope';
+        }
+
+        return match ($type) {
+            'locale_variant_draft' => $compileStatus === 'compiled' && $governanceStatus === 'passing'
+                ? 'locale_review_ready'
+                : 'locale_review_pending',
+            'release_candidate_metadata' => $compileStatus === 'compiled' && $governanceStatus === 'passing'
+                ? 'release_review_ready'
+                : 'release_review_pending',
+            default => $reviewState,
+        };
+    }
+
+    private function resolveObjectReleaseCandidateStatus(
+        string $type,
+        bool $enabled,
+        string $releaseCandidateStatus,
+        string $compileStatus,
+        string $governanceStatus
+    ): string {
+        if (! $enabled) {
+            return 'not_in_scope';
+        }
+
+        return match ($type) {
+            'locale_variant_draft' => 'draft_only',
+            'release_candidate_metadata' => $compileStatus === 'compiled' && $governanceStatus === 'passing'
+                ? ($releaseCandidateStatus === 'published' ? 'published_release_metadata' : 'ready_for_release_review')
+                : 'not_ready',
+            default => $releaseCandidateStatus,
+        };
     }
 
     /**

--- a/backend/tests/Feature/Ops/ContentPackControlPlaneWorkspaceTest.php
+++ b/backend/tests/Feature/Ops/ContentPackControlPlaneWorkspaceTest.php
@@ -68,7 +68,13 @@ final class ContentPackControlPlaneWorkspaceTest extends TestCase
             ->assertSee('Content control plane')
             ->assertSee('Draft state')
             ->assertSee('Runtime artifact ref')
-            ->assertSee('First-wave managed objects');
+            ->assertSee('First-wave managed objects')
+            ->assertSee('Object-level contracts')
+            ->assertSee('narrative_fragment')
+            ->assertSee('release_candidate_metadata')
+            ->assertSee('locale_variant_draft')
+            ->assertSee('draft_only')
+            ->assertSee('release_metadata_pending');
     }
 
     private function createSelectedOrg(): Organization

--- a/backend/tests/Unit/Services/Content/ContentControlPlaneServiceTest.php
+++ b/backend/tests/Unit/Services/Content/ContentControlPlaneServiceTest.php
@@ -58,10 +58,68 @@ final class ContentControlPlaneServiceTest extends TestCase
         $this->assertArrayHasKey('locale_scope', $contract);
         $this->assertArrayHasKey('experiment_scope', $contract);
         $this->assertArrayHasKey('runtime_artifact_ref', $contract);
+        $this->assertArrayHasKey('content_objects_v1', $contract);
         $this->assertSame('compiled', $contract['compile_status']);
         $this->assertSame('passing', $contract['governance_status']);
         $this->assertNull($contract['runtime_artifact_ref']);
         $this->assertNotEmpty($contract['content_object_inventory']);
+
+        $objects = collect($contract['content_objects_v1']);
+        $this->assertNotEmpty($objects);
+        $this->assertEqualsCanonicalizing([
+            'narrative_fragment',
+            'calibration_copy',
+            'cta_overlay',
+            'faq_explainability_copy',
+            'scene_fragment',
+            'action_fragment',
+            'locale_variant_draft',
+            'experiment_overlay',
+            'release_candidate_metadata',
+        ], $objects->pluck('content_object_type')->all());
+
+        $requiredKeys = [
+            'content_object_v1',
+            'content_object_id',
+            'content_object_type',
+            'authoring_scope',
+            'draft_state',
+            'revision_no',
+            'review_state',
+            'preview_target',
+            'compile_status',
+            'governance_status',
+            'release_candidate_status',
+            'publish_target',
+            'rollback_target',
+            'locale_scope',
+            'experiment_scope',
+            'runtime_artifact_ref',
+            'source_pack_version_id',
+            'source_release_id',
+            'governance_profile',
+        ];
+
+        foreach ($objects as $object) {
+            foreach ($requiredKeys as $key) {
+                $this->assertArrayHasKey($key, $object);
+            }
+        }
+
+        $this->assertTrue($objects->every(fn (array $object): bool => $object['runtime_artifact_ref'] === null));
+
+        $objectsByType = $objects->keyBy('content_object_type');
+        $this->assertSame('locale_variant_draft_ready', $objectsByType['locale_variant_draft']['draft_state']);
+        $this->assertSame('locale_review_ready', $objectsByType['locale_variant_draft']['review_state']);
+        $this->assertSame('draft_only', $objectsByType['locale_variant_draft']['release_candidate_status']);
+        $this->assertNull($objectsByType['locale_variant_draft']['publish_target']);
+        $this->assertNull($objectsByType['locale_variant_draft']['runtime_artifact_ref']);
+
+        $this->assertSame('release_metadata_ready', $objectsByType['release_candidate_metadata']['draft_state']);
+        $this->assertSame('release_review_ready', $objectsByType['release_candidate_metadata']['review_state']);
+        $this->assertSame('ready_for_release_review', $objectsByType['release_candidate_metadata']['release_candidate_status']);
+        $this->assertNull($objectsByType['release_candidate_metadata']['publish_target']);
+        $this->assertNull($objectsByType['release_candidate_metadata']['runtime_artifact_ref']);
     }
 
     public function test_draft_requires_publish_before_runtime_artifact_ref_exists(): void
@@ -78,6 +136,9 @@ final class ContentControlPlaneServiceTest extends TestCase
 
         $this->assertSame('draft_ready', $draftContract['draft_state']);
         $this->assertNull($draftContract['runtime_artifact_ref']);
+        $this->assertTrue(collect($draftContract['content_objects_v1'])->every(
+            fn (array $object): bool => $object['runtime_artifact_ref'] === null
+        ));
 
         $this->insertSuccessfulPublishRelease(
             (string) $version->id,
@@ -94,6 +155,17 @@ final class ContentControlPlaneServiceTest extends TestCase
         $this->assertSame('published', $publishedContract['draft_state']);
         $this->assertIsArray($publishedContract['runtime_artifact_ref']);
         $this->assertSame((string) $version->content_package_version, $publishedContract['runtime_artifact_ref']['pack_version']);
+
+        $publishedObjects = collect($publishedContract['content_objects_v1'])->keyBy('content_object_type');
+        $this->assertIsArray($publishedObjects['narrative_fragment']['runtime_artifact_ref']);
+        $this->assertSame((string) $version->id, $publishedObjects['narrative_fragment']['source_pack_version_id']);
+        $this->assertNotNull($publishedObjects['narrative_fragment']['source_release_id']);
+        $this->assertNull($publishedObjects['locale_variant_draft']['runtime_artifact_ref']);
+        $this->assertNull($publishedObjects['locale_variant_draft']['source_release_id']);
+        $this->assertSame('draft_only', $publishedObjects['locale_variant_draft']['release_candidate_status']);
+        $this->assertNull($publishedObjects['release_candidate_metadata']['runtime_artifact_ref']);
+        $this->assertNull($publishedObjects['release_candidate_metadata']['source_release_id']);
+        $this->assertSame('published_release_metadata', $publishedObjects['release_candidate_metadata']['release_candidate_status']);
     }
 
     public function test_published_version_exposes_previous_release_as_rollback_target(): void
@@ -137,6 +209,13 @@ final class ContentControlPlaneServiceTest extends TestCase
         $this->assertSame('published', $contract['release_candidate_status']);
         $this->assertIsArray($contract['rollback_target']);
         $this->assertSame($previousReleaseId, $contract['rollback_target']['release_id']);
+
+        $publishedObject = collect($contract['content_objects_v1'])
+            ->first(fn (array $object): bool => is_array($object['runtime_artifact_ref'] ?? null));
+
+        $this->assertIsArray($publishedObject);
+        $this->assertIsArray($publishedObject['rollback_target']);
+        $this->assertSame($previousReleaseId, $publishedObject['rollback_target']['release_id']);
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR ships PR-13A for backend content control plane expansion.

It extends the existing pack-level `content_control_plane_v1` into first-wave object-level coordination for growth content, while keeping compiled/versioned artifacts as the only runtime truth and keeping Filament/Ops as the only authoring/review/release surface.

## Problem
The repo already had a solid CMS-Lite foundation for content packs:
- DB-backed authoring/review/release coordination
- compile/lint/governance/self-check pipelines
- publish/rollback/release queue flows
- compiled/versioned artifact runtime truth

But that control plane still stopped at the pack bundle level. It could coordinate a whole content pack release, yet it did not expose first-wave object-level metadata for growth content objects like narrative fragments, calibration copy, CTA overlays, FAQ/explainability copy, scene/action fragments, locale variants, or experiment/release metadata.

That made it hard to expand the control plane for C-end growth content without either overloading pack-level metadata or drifting toward DB-backed runtime truth.

## Root cause
The existing control plane had the right top-level contract and the right infrastructure, but it lacked an object-level contract layer that could:
- express draft/review/release-candidate state per growth content object
- map object metadata back to compile/governance/publish/rollback state
- show those object contracts on the Filament/Ops surface
- preserve the boundary where runtime truth only appears after a published artifact exists

## What changed
- Preserved the existing top-level `content_control_plane_v1` pack contract.
- Added object-level coordination via `content_objects_v1`.
- Added first-wave managed object coverage for:
  - `narrative_fragment`
  - `calibration_copy`
  - `cta_overlay`
  - `faq_explainability_copy`
  - `scene_fragment`
  - `action_fragment`
  - `locale_variant_draft`
  - `experiment_overlay`
  - `release_candidate_metadata`
- Each object now emits:
  - `content_object_v1`
  - `content_object_id`
  - `content_object_type`
  - `authoring_scope`
  - `draft_state`
  - `revision_no`
  - `review_state`
  - `preview_target`
  - `compile_status`
  - `governance_status`
  - `release_candidate_status`
  - `publish_target`
  - `rollback_target`
  - `locale_scope`
  - `experiment_scope`
  - `runtime_artifact_ref`
  - `source_pack_version_id`
  - `source_release_id`
  - `governance_profile`
- Extended the Filament/Ops content pack version edit surface to display object-level control-plane contracts directly.
- Tightened object semantics so object state is no longer a blind copy of pack state. In particular:
  - pure draft/metadata objects now have object-specific draft/review/release-candidate states
  - `runtime_artifact_ref` and `source_release_id` are only exposed for runtime-bindable object types
  - pure draft/control-plane metadata objects no longer masquerade as runtime-bound content after a pack publish
- Added targeted backend tests proving:
  - draft objects do not become runtime truth
  - published runtime-bindable objects can expose artifact refs
  - rollback remains traceable
  - object-level metadata is visible on the Filament/Ops surface

## Scope guardrails preserved
- No migration
- No new dependency
- No new auth
- No DB-as-runtime-truth behavior
- No frontend authoring shell
- No SEO/GEO delivery implementation
- No compile/publish/rollback pipeline rewrite
- No MBTI/Big Five runtime truth changes

## Validation
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter="ContentControlPlaneServiceTest|ContentPackControlPlaneWorkspaceTest|Packs2DualWritePublishTest|ContentPackLint|MbtiContentGovernance"
```

Result: `12 passed`, `537 assertions`
