### PR TITLE
[codex] add archive receipt durability to control-plane

### DIFF
--- a/backend/app/Services/Storage/ReportArtifactsArchiveService.php
+++ b/backend/app/Services/Storage/ReportArtifactsArchiveService.php
@@ -29,7 +29,7 @@ final class ReportArtifactsArchiveService
         $candidates = $this->collectCandidates($targetDisk);
         $summary = $this->buildSummary($candidates);
 
-        return [
+        $payload = [
             'schema' => self::PLAN_SCHEMA,
             'mode' => 'dry_run',
             'status' => 'planned',
@@ -44,6 +44,14 @@ final class ReportArtifactsArchiveService
             ],
             'candidates' => $candidates,
         ];
+
+        $this->recordAudit($payload + [
+            'plan_path' => null,
+            'run_path' => null,
+            'results' => [],
+        ]);
+
+        return $payload;
     }
 
     /**
@@ -105,6 +113,7 @@ final class ReportArtifactsArchiveService
             'disk' => $targetDisk,
             'target_disk' => $targetDisk,
             'plan' => trim((string) data_get($plan, '_meta.plan_path', '')),
+            'plan_path' => trim((string) data_get($plan, '_meta.plan_path', '')),
             'summary' => $summary,
             'results' => $results,
         ];
@@ -402,6 +411,12 @@ final class ReportArtifactsArchiveService
             return;
         }
 
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+        $results = is_array($payload['results'] ?? null) ? array_values($payload['results']) : [];
+        $planPath = $this->normalizeOptionalString($payload['plan_path'] ?? $payload['plan'] ?? null);
+        $runPath = $this->normalizeOptionalString($payload['run_path'] ?? null);
+        $failedCount = (int) ($summary['failed_count'] ?? 0);
+
         DB::table('audit_logs')->insert([
             'org_id' => 0,
             'actor_admin_id' => null,
@@ -412,18 +427,37 @@ final class ReportArtifactsArchiveService
                 'schema' => $payload['schema'] ?? null,
                 'mode' => $payload['mode'] ?? null,
                 'target_disk' => $payload['target_disk'] ?? null,
-                'plan' => $payload['plan'] ?? null,
-                'run_path' => $payload['run_path'] ?? null,
-                'summary' => $payload['summary'] ?? [],
-                'results' => $payload['results'] ?? [],
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'run_path' => $runPath,
+                'candidate_count' => (int) ($summary['candidate_count'] ?? 0),
+                'copied_count' => (int) ($summary['copied_count'] ?? 0),
+                'verified_count' => (int) ($summary['verified_count'] ?? 0),
+                'already_archived_count' => (int) ($summary['already_archived_count'] ?? 0),
+                'failed_count' => $failedCount,
+                'results_count' => count($results),
+                'durable_receipt_source' => 'audit_logs.meta_json',
+                'summary' => $summary,
+                'results' => $results,
             ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'ip' => null,
             'user_agent' => 'artisan/storage:archive-report-artifacts',
             'request_id' => null,
             'reason' => 'manual_archive_copy',
-            'result' => ($payload['status'] ?? 'executed') === 'executed' ? 'success' : 'partial_failure',
+            'result' => $failedCount > 0 ? 'partial_failure' : 'success',
             'created_at' => now(),
         ]);
+    }
+
+    private function normalizeOptionalString(mixed $value): ?string
+    {
+        if (! is_scalar($value) || $value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
     }
 
     /**

--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -38,6 +38,7 @@ final class StorageControlPlaneStatusService
             'generated_at' => now()->toIso8601String(),
             'inventory' => $inventory,
             'retention' => $this->retentionSection(),
+            'report_artifacts_archive' => $this->reportArtifactsArchiveSection(),
             'reports_artifacts_lifecycle' => $this->reportsArtifactsLifecycleSection($inventory),
             'blob_coverage' => $this->blobCoverageSection(),
             'exact_authority' => $this->exactAuthoritySection(),
@@ -225,6 +226,67 @@ final class StorageControlPlaneStatusService
             $latestInventoryGeneratedAt,
             'audit-derived',
             self::INVENTORY_STALE_AFTER_SECONDS,
+            'not_available'
+        ));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function reportArtifactsArchiveSection(): array
+    {
+        $audit = $this->latestAuditForAction('storage_archive_report_artifacts');
+        if ($audit === null) {
+            return array_merge([
+                'status' => 'not_available',
+                'durable_receipt_source' => 'audit_logs.meta_json',
+                'target_disk' => null,
+                'latest_generated_at' => null,
+                'latest_mode' => null,
+                'latest_plan_path' => null,
+                'latest_run_path' => null,
+                'latest_run_path_exists' => false,
+                'latest_summary' => [
+                    'candidate_count' => 0,
+                    'copied_count' => 0,
+                    'verified_count' => 0,
+                    'already_archived_count' => 0,
+                    'failed_count' => 0,
+                    'results_count' => 0,
+                ],
+            ], $this->freshnessFromTimestamp(
+                null,
+                'audit-derived',
+                self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
+                'not_available'
+            ));
+        }
+
+        $meta = $this->decodeAuditMeta($audit);
+        $latestGeneratedAt = $this->normalizeTimestamp($audit->created_at);
+        $latestRunPath = $this->normalizeOptionalString($meta['run_path'] ?? null);
+
+        return array_merge([
+            'status' => 'ok',
+            'durable_receipt_source' => (string) ($meta['durable_receipt_source'] ?? 'audit_logs.meta_json'),
+            'target_disk' => $this->normalizeOptionalString($meta['target_disk'] ?? null),
+            'latest_generated_at' => $latestGeneratedAt,
+            'latest_mode' => $this->normalizeOptionalString($meta['mode'] ?? null),
+            'latest_plan_path' => $this->normalizeOptionalString($meta['plan_path'] ?? $meta['plan'] ?? null),
+            'latest_run_path' => $latestRunPath,
+            'latest_run_path_exists' => $latestRunPath !== null && file_exists($latestRunPath),
+            'latest_summary' => [
+                'candidate_count' => (int) ($meta['candidate_count'] ?? data_get($meta, 'summary.candidate_count', 0)),
+                'copied_count' => (int) ($meta['copied_count'] ?? data_get($meta, 'summary.copied_count', 0)),
+                'verified_count' => (int) ($meta['verified_count'] ?? data_get($meta, 'summary.verified_count', 0)),
+                'already_archived_count' => (int) ($meta['already_archived_count'] ?? data_get($meta, 'summary.already_archived_count', 0)),
+                'failed_count' => (int) ($meta['failed_count'] ?? data_get($meta, 'summary.failed_count', 0)),
+                'results_count' => (int) ($meta['results_count'] ?? count((array) ($meta['results'] ?? []))),
+            ],
+        ], $this->freshnessFromTimestamp(
+            $latestGeneratedAt,
+            'audit-derived',
+            self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
             'not_available'
         ));
     }
@@ -694,6 +756,17 @@ final class StorageControlPlaneStatusService
         return $normalized === '' ? null : $normalized;
     }
 
+    private function normalizeOptionalString(mixed $value): ?string
+    {
+        if (! is_scalar($value) || $value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
     /**
      * @param  array<string,mixed>  $payload
      * @return array<string,mixed>
@@ -762,6 +835,7 @@ final class StorageControlPlaneStatusService
             ['path' => 'retention.scopes.reports_backups', 'label' => 'reports backups retention dry-run'],
             ['path' => 'retention.scopes.content_releases_retention', 'label' => 'content releases retention dry-run'],
             ['path' => 'retention.scopes.legacy_private_private_cleanup', 'label' => 'legacy private cleanup dry-run'],
+            ['path' => 'report_artifacts_archive', 'label' => 'report artifacts archive'],
             ['path' => 'reports_artifacts_lifecycle', 'label' => 'reports artifacts lifecycle'],
             ['path' => 'blob_coverage.blob_gc', 'label' => 'blob gc dry-run'],
             ['path' => 'blob_coverage.blob_offload', 'label' => 'blob offload dry-run'],

--- a/backend/tests/Feature/Storage/ReportArtifactsArchiveServiceTest.php
+++ b/backend/tests/Feature/Storage/ReportArtifactsArchiveServiceTest.php
@@ -71,6 +71,29 @@ final class ReportArtifactsArchiveServiceTest extends TestCase
         $this->assertSame(1, data_get($plan, 'summary.kind_counts.report_json'));
         $this->assertSame(1, data_get($plan, 'summary.kind_counts.report_free_pdf'));
 
+        $dryRunAudit = DB::table('audit_logs')
+            ->where('action', 'storage_archive_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($dryRunAudit);
+        $this->assertSame('success', $dryRunAudit->result);
+        $dryRunMeta = json_decode((string) $dryRunAudit->meta_json, true);
+        $this->assertIsArray($dryRunMeta);
+        $this->assertSame('dry_run', $dryRunMeta['mode'] ?? null);
+        $this->assertSame('s3', $dryRunMeta['target_disk'] ?? null);
+        $this->assertArrayHasKey('plan_path', $dryRunMeta);
+        $this->assertNull($dryRunMeta['plan_path']);
+        $this->assertArrayHasKey('run_path', $dryRunMeta);
+        $this->assertNull($dryRunMeta['run_path']);
+        $this->assertSame(2, $dryRunMeta['candidate_count'] ?? null);
+        $this->assertSame(0, $dryRunMeta['copied_count'] ?? null);
+        $this->assertSame(0, $dryRunMeta['verified_count'] ?? null);
+        $this->assertSame(0, $dryRunMeta['already_archived_count'] ?? null);
+        $this->assertSame(0, $dryRunMeta['failed_count'] ?? null);
+        $this->assertSame(0, $dryRunMeta['results_count'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $dryRunMeta['durable_receipt_source'] ?? null);
+
         $plan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_archive_plans/test-plan.json')];
         $result = $service->executePlan($plan);
 
@@ -91,6 +114,25 @@ final class ReportArtifactsArchiveServiceTest extends TestCase
             'target_id' => 'report_artifacts_archive',
             'result' => 'success',
         ]);
+
+        $executeAudit = DB::table('audit_logs')
+            ->where('action', 'storage_archive_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($executeAudit);
+        $executeMeta = json_decode((string) $executeAudit->meta_json, true);
+        $this->assertIsArray($executeMeta);
+        $this->assertSame('execute', $executeMeta['mode'] ?? null);
+        $this->assertSame($plan['_meta']['plan_path'], $executeMeta['plan_path'] ?? null);
+        $this->assertSame($result['run_path'], $executeMeta['run_path'] ?? null);
+        $this->assertSame(2, $executeMeta['candidate_count'] ?? null);
+        $this->assertSame(2, $executeMeta['copied_count'] ?? null);
+        $this->assertSame(2, $executeMeta['verified_count'] ?? null);
+        $this->assertSame(0, $executeMeta['already_archived_count'] ?? null);
+        $this->assertSame(0, $executeMeta['failed_count'] ?? null);
+        $this->assertSame(2, $executeMeta['results_count'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $executeMeta['durable_receipt_source'] ?? null);
     }
 
     public function test_service_excludes_non_canonical_files_and_marks_already_archived_when_target_matches(): void
@@ -148,6 +190,16 @@ final class ReportArtifactsArchiveServiceTest extends TestCase
         $this->assertSame('partial_failure', $audit->result);
         $meta = json_decode((string) $audit->meta_json, true);
         $this->assertIsArray($meta);
+        $this->assertSame('execute', $meta['mode'] ?? null);
+        $this->assertSame($plan['_meta']['plan_path'], $meta['plan_path'] ?? null);
+        $this->assertSame($result['run_path'], $meta['run_path'] ?? null);
+        $this->assertSame(1, $meta['candidate_count'] ?? null);
+        $this->assertSame(0, $meta['copied_count'] ?? null);
+        $this->assertSame(0, $meta['verified_count'] ?? null);
+        $this->assertSame(0, $meta['already_archived_count'] ?? null);
+        $this->assertSame(1, $meta['failed_count'] ?? null);
+        $this->assertSame(1, $meta['results_count'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $meta['durable_receipt_source'] ?? null);
         $this->assertSame(1, data_get($meta, 'summary.failed_count'));
     }
 

--- a/backend/tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php
@@ -8,6 +8,7 @@ use App\Console\Commands\StorageArchiveReportArtifacts;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -102,6 +103,19 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         $planPath = trim((string) ($matches[1] ?? ''));
         $this->assertFileExists($planPath);
 
+        $dryRunAudit = DB::table('audit_logs')
+            ->where('action', 'storage_archive_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($dryRunAudit);
+        $dryRunMeta = json_decode((string) $dryRunAudit->meta_json, true);
+        $this->assertIsArray($dryRunMeta);
+        $this->assertSame('dry_run', $dryRunMeta['mode'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $dryRunMeta['durable_receipt_source'] ?? null);
+        $this->assertSame(2, $dryRunMeta['candidate_count'] ?? null);
+        $this->assertSame(0, $dryRunMeta['results_count'] ?? null);
+
         $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
             '--execute' => true,
             '--disk' => 's3',
@@ -113,6 +127,19 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         $this->assertStringContainsString('copied_count=2', $executeOutput);
         $this->assertStringContainsString('verified_count=2', $executeOutput);
         $this->assertStringContainsString('run_path=', $executeOutput);
+
+        $executeAudit = DB::table('audit_logs')
+            ->where('action', 'storage_archive_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($executeAudit);
+        $executeMeta = json_decode((string) $executeAudit->meta_json, true);
+        $this->assertIsArray($executeMeta);
+        $this->assertSame('execute', $executeMeta['mode'] ?? null);
+        $this->assertSame($planPath, $executeMeta['plan_path'] ?? null);
+        $this->assertSame(2, $executeMeta['verified_count'] ?? null);
+        $this->assertSame(2, $executeMeta['results_count'] ?? null);
 
         Storage::disk('s3')->assertExists('report_artifacts_archive/reports/MBTI/command-report/report.json');
         Storage::disk('s3')->assertExists('report_artifacts_archive/pdf/BIG5/command-pdf/manifest-123/report_full.pdf');

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -61,6 +61,7 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
     public function test_command_outputs_full_json_and_persists_snapshot(): void
     {
         $this->seedMinimalTruth();
+        $archiveTruth = $this->seedReportArtifactsArchiveTruth();
 
         $auditCountBefore = DB::table('audit_logs')->count();
         $filesBefore = $this->storageFilesSnapshot();
@@ -75,6 +76,7 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame('storage_control_plane_snapshot.v1', $payload['snapshot_schema']);
         $this->assertSame('snapshotted', $payload['status']);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
+        $this->assertArrayHasKey('report_artifacts_archive', $payload);
         $this->assertArrayHasKey('reports_artifacts_lifecycle', $payload);
         $this->assertArrayHasKey('materialized_cache', $payload);
         $this->assertArrayHasKey('cost_reclaim_posture', $payload);
@@ -96,6 +98,13 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertArrayHasKey('freshness_age_seconds', data_get($payload, 'reports_artifacts_lifecycle', []));
         $this->assertArrayHasKey('freshness_state', data_get($payload, 'reports_artifacts_lifecycle', []));
         $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'reports_artifacts_lifecycle', []));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_archive.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_archive.durable_receipt_source'));
+        $this->assertSame($archiveTruth['plan_path'], data_get($payload, 'report_artifacts_archive.latest_plan_path'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_archive.latest_run_path'));
+        $this->assertTrue((bool) data_get($payload, 'report_artifacts_archive.latest_run_path_exists'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.results_count'));
+        $this->assertArrayHasKey('freshness_state', data_get($payload, 'report_artifacts_archive', []));
         $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
         $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
         $this->assertSame(0, data_get($payload, 'materialized_cache.bucket_count'));
@@ -111,7 +120,7 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame('ok', data_get($payload, 'cost_reclaim_posture.status'));
         $this->assertSame('storage_cost_analyzer.v1', data_get($payload, 'cost_reclaim_posture.source_schema_version'));
         $this->assertSame(storage_path(), data_get($payload, 'cost_reclaim_posture.root_path'));
-        $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.summary.total_bytes'));
+        $this->assertGreaterThan(0, (int) data_get($payload, 'cost_reclaim_posture.summary.total_bytes'));
         $this->assertSame(0, data_get($payload, 'cost_reclaim_posture.by_category.v2_materialized_cache.bytes'));
         $this->assertContains('runtime_or_data_truth', data_get($payload, 'cost_reclaim_posture.no_touch_categories', []));
         $this->assertNull(data_get($payload, 'cost_reclaim_posture.last_updated_at'));
@@ -147,6 +156,7 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
     {
         $this->seedMinimalTruth();
         $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
+        $archiveTruth = $this->seedReportArtifactsArchiveTruth(false);
         $bucket = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -171,6 +181,9 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
         $this->assertSame($lifecycleFiles['legacy_bytes'], data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.bytes'));
         $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_archive.latest_run_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_archive.latest_run_path_exists'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.verified_count'));
         $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
         $this->assertSame(3, data_get($payload, 'materialized_cache.total_files'));
         $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'materialized_cache.total_bytes'));
@@ -238,6 +251,54 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
     {
         File::ensureDirectoryExists(dirname($path));
         File::put($path, $contents);
+    }
+
+    /**
+     * @return array{plan_path:string,run_path:string}
+     */
+    private function seedReportArtifactsArchiveTruth(bool $runPathExists = true): array
+    {
+        $planPath = storage_path('app/private/report_artifact_archive_plans/archive-plan.json');
+        $runPath = storage_path('app/private/report_artifact_archive_runs/archive-run/run.json');
+        $this->writeRaw($planPath, "{\"schema\":\"storage_archive_report_artifacts_plan.v1\"}\n");
+
+        if ($runPathExists) {
+            $this->writeRaw($runPath, "{\"schema\":\"storage_archive_report_artifacts_run.v1\"}\n");
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_archive_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_archive',
+            'meta_json' => json_encode([
+                'schema' => 'storage_archive_report_artifacts_run.v1',
+                'mode' => 'execute',
+                'target_disk' => 's3',
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'run_path' => $runPath,
+                'candidate_count' => 3,
+                'copied_count' => 2,
+                'verified_count' => 3,
+                'already_archived_count' => 1,
+                'failed_count' => 0,
+                'results_count' => 3,
+                'durable_receipt_source' => 'audit_logs.meta_json',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_snapshot_command',
+            'request_id' => null,
+            'reason' => 'manual_archive_copy',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(10),
+        ]);
+
+        return [
+            'plan_path' => $planPath,
+            'run_path' => $runPath,
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -56,6 +56,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
     {
         $this->seedMinimalTruth();
         $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
+        $archiveTruth = $this->seedReportArtifactsArchiveTruth();
         $bucket = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -84,6 +85,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertArrayHasKey('restore', $payload);
         $this->assertArrayHasKey('purge', $payload);
         $this->assertArrayHasKey('retirement', $payload);
+        $this->assertArrayHasKey('report_artifacts_archive', $payload);
         $this->assertArrayHasKey('reports_artifacts_lifecycle', $payload);
         $this->assertArrayHasKey('materialized_cache', $payload);
         $this->assertArrayHasKey('cost_reclaim_posture', $payload);
@@ -115,6 +117,17 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('none_proven', data_get($payload, 'reports_artifacts_lifecycle.archive_candidate_status'));
         $this->assertSame('fresh', data_get($payload, 'reports_artifacts_lifecycle.freshness_state'));
         $this->assertSame('audit-derived', data_get($payload, 'reports_artifacts_lifecycle.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_archive.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_archive.durable_receipt_source'));
+        $this->assertSame('s3', data_get($payload, 'report_artifacts_archive.target_disk'));
+        $this->assertSame('execute', data_get($payload, 'report_artifacts_archive.latest_mode'));
+        $this->assertSame($archiveTruth['plan_path'], data_get($payload, 'report_artifacts_archive.latest_plan_path'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_archive.latest_run_path'));
+        $this->assertTrue((bool) data_get($payload, 'report_artifacts_archive.latest_run_path_exists'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.candidate_count'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.results_count'));
+        $this->assertSame('fresh', data_get($payload, 'report_artifacts_archive.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_archive.freshness_source_type'));
         $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
         $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
         $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
@@ -201,6 +214,17 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertNull(data_get($payload, 'reports_artifacts_lifecycle.freshness_age_seconds'));
         $this->assertSame('not_available', data_get($payload, 'reports_artifacts_lifecycle.freshness_state'));
         $this->assertSame('audit-derived', data_get($payload, 'reports_artifacts_lifecycle.freshness_source_type'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_archive.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_archive.durable_receipt_source'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.latest_plan_path'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.latest_run_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_archive.latest_run_path_exists'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_archive.latest_summary.candidate_count'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_archive.latest_summary.results_count'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.last_updated_at'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.freshness_age_seconds'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_archive.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_archive.freshness_source_type'));
         $this->assertSame('never_run', data_get($payload, 'retention.status'));
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_gc.status'));
@@ -233,7 +257,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
-        $this->assertSame(['inventory', 'reports_artifacts_lifecycle'], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertSame(['inventory', 'report_artifacts_archive', 'reports_artifacts_lifecycle'], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertContains('quarantine', data_get($payload, 'attention_digest.never_run_sections', []));
     }
 
@@ -258,6 +282,54 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
             'result' => 'success',
             'created_at' => now(),
         ]);
+    }
+
+    /**
+     * @return array{plan_path:string,run_path:string}
+     */
+    private function seedReportArtifactsArchiveTruth(bool $runPathExists = true): array
+    {
+        $planPath = storage_path('app/private/report_artifact_archive_plans/archive-plan.json');
+        $runPath = storage_path('app/private/report_artifact_archive_runs/archive-run/run.json');
+        $this->writeRaw($planPath, "{\"schema\":\"storage_archive_report_artifacts_plan.v1\"}\n");
+
+        if ($runPathExists) {
+            $this->writeRaw($runPath, "{\"schema\":\"storage_archive_report_artifacts_run.v1\"}\n");
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_archive_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_archive',
+            'meta_json' => json_encode([
+                'schema' => 'storage_archive_report_artifacts_run.v1',
+                'mode' => 'execute',
+                'target_disk' => 's3',
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'run_path' => $runPath,
+                'candidate_count' => 3,
+                'copied_count' => 2,
+                'verified_count' => 3,
+                'already_archived_count' => 1,
+                'failed_count' => 0,
+                'results_count' => 3,
+                'durable_receipt_source' => 'audit_logs.meta_json',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_snapshot_service',
+            'request_id' => null,
+            'reason' => 'manual_archive_copy',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(10),
+        ]);
+
+        return [
+            'plan_path' => $planPath,
+            'run_path' => $runPath,
+        ];
     }
 
     private function writeRaw(string $path, string $contents): void

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -61,6 +61,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
     public function test_command_outputs_full_json_without_mutation_or_audit_inserts(): void
     {
         $this->seedMinimalTruth();
+        $archiveTruth = $this->seedReportArtifactsArchiveTruth();
 
         $auditCountBefore = DB::table('audit_logs')->count();
         $filesBefore = $this->storageFilesSnapshot();
@@ -87,6 +88,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('cost_reclaim_posture', $payload);
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
+        $this->assertArrayHasKey('report_artifacts_archive', $payload);
         $this->assertArrayHasKey('reports_artifacts_lifecycle', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
@@ -111,6 +113,19 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('freshness_age_seconds', data_get($payload, 'reports_artifacts_lifecycle', []));
         $this->assertArrayHasKey('freshness_state', data_get($payload, 'reports_artifacts_lifecycle', []));
         $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'reports_artifacts_lifecycle', []));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_archive.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_archive.durable_receipt_source'));
+        $this->assertSame('s3', data_get($payload, 'report_artifacts_archive.target_disk'));
+        $this->assertSame('execute', data_get($payload, 'report_artifacts_archive.latest_mode'));
+        $this->assertSame($archiveTruth['plan_path'], data_get($payload, 'report_artifacts_archive.latest_plan_path'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_archive.latest_run_path'));
+        $this->assertTrue((bool) data_get($payload, 'report_artifacts_archive.latest_run_path_exists'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.candidate_count'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.results_count'));
+        $this->assertArrayHasKey('last_updated_at', data_get($payload, 'report_artifacts_archive', []));
+        $this->assertArrayHasKey('freshness_age_seconds', data_get($payload, 'report_artifacts_archive', []));
+        $this->assertArrayHasKey('freshness_state', data_get($payload, 'report_artifacts_archive', []));
+        $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'report_artifacts_archive', []));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
         $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
         $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
@@ -155,6 +170,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
     {
         $this->seedMinimalTruth();
         $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
+        $archiveTruth = $this->seedReportArtifactsArchiveTruth(false);
         $bucket = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -179,6 +195,9 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertSame(2, data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.pdf_files'));
         $this->assertSame($lifecycleFiles['legacy_bytes'], data_get($payload, 'reports_artifacts_lifecycle.legacy_fallback_live.bytes'));
         $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.safe_to_prune_derived.timestamp_backup_json_files'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_archive.latest_run_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_archive.latest_run_path_exists'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.verified_count'));
         $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
         $this->assertSame(3, data_get($payload, 'materialized_cache.total_files'));
         $this->assertSame($this->totalBytesForFiles($bucket), data_get($payload, 'materialized_cache.total_bytes'));
@@ -217,10 +236,10 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertStringContainsString('inventory.status=ok', $output);
         $this->assertStringContainsString('runtime_truth.v2_readiness=remote_rehydrate_enabled', $output);
         $this->assertStringContainsString('automation_readiness.auto_dry_run_ok=', $output);
-        $this->assertStringContainsString('attention_digest.overall_state=attention_required', $output);
+        $this->assertStringContainsString('attention_digest.overall_state=degraded', $output);
         $this->assertStringContainsString('attention_digest.counts.stale=0', $output);
         $this->assertStringContainsString('attention_digest.counts.never_run=', $output);
-        $this->assertStringContainsString('attention_digest.counts.not_available=0', $output);
+        $this->assertStringContainsString('attention_digest.counts.not_available=1', $output);
     }
 
     private function seedMinimalTruth(): void
@@ -253,6 +272,60 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
             'result' => 'success',
             'created_at' => $now,
         ]);
+    }
+
+    /**
+     * @return array{plan_path:string,run_path:string}
+     */
+    private function seedReportArtifactsArchiveTruth(bool $runPathExists = true): array
+    {
+        $planPath = storage_path('app/private/report_artifact_archive_plans/archive-plan.json');
+        $runPath = storage_path('app/private/report_artifact_archive_runs/archive-run/run.json');
+        $this->writeJson($planPath, [
+            'schema' => 'storage_archive_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+        ]);
+
+        if ($runPathExists) {
+            $this->writeJson($runPath, [
+                'schema' => 'storage_archive_report_artifacts_run.v1',
+                'mode' => 'execute',
+            ]);
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_archive_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_archive',
+            'meta_json' => json_encode([
+                'schema' => 'storage_archive_report_artifacts_run.v1',
+                'mode' => 'execute',
+                'target_disk' => 's3',
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'run_path' => $runPath,
+                'candidate_count' => 3,
+                'copied_count' => 2,
+                'verified_count' => 3,
+                'already_archived_count' => 1,
+                'failed_count' => 0,
+                'results_count' => 3,
+                'durable_receipt_source' => 'audit_logs.meta_json',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_status',
+            'request_id' => null,
+            'reason' => 'manual_archive_copy',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(10),
+        ]);
+
+        return [
+            'plan_path' => $planPath,
+            'run_path' => $runPath,
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -56,6 +56,7 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
     {
         $this->seedControlPlaneTruth();
         $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
+        $archiveTruth = $this->seedReportArtifactsArchiveTruth();
         $bucketOne = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -105,6 +106,21 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('none_proven', data_get($payload, 'reports_artifacts_lifecycle.archive_candidate_status'));
         $this->assertSame('fresh', data_get($payload, 'reports_artifacts_lifecycle.freshness_state'));
         $this->assertSame('audit-derived', data_get($payload, 'reports_artifacts_lifecycle.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_archive.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_archive.durable_receipt_source'));
+        $this->assertSame('s3', data_get($payload, 'report_artifacts_archive.target_disk'));
+        $this->assertSame('execute', data_get($payload, 'report_artifacts_archive.latest_mode'));
+        $this->assertSame($archiveTruth['plan_path'], data_get($payload, 'report_artifacts_archive.latest_plan_path'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_archive.latest_run_path'));
+        $this->assertTrue((bool) data_get($payload, 'report_artifacts_archive.latest_run_path_exists'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.candidate_count'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_archive.latest_summary.copied_count'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.verified_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_archive.latest_summary.already_archived_count'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_archive.latest_summary.failed_count'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.results_count'));
+        $this->assertSame('fresh', data_get($payload, 'report_artifacts_archive.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_archive.freshness_source_type'));
         $this->assertSame(1, data_get($payload, 'blob_coverage.counts.storage_blobs'));
         $this->assertSame(1, data_get($payload, 'blob_coverage.counts.verified_storage_blob_locations_by_disk.s3'));
         $this->assertSame('fresh', data_get($payload, 'blob_coverage.blob_gc.freshness_state'));
@@ -211,6 +227,20 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertNull(data_get($payload, 'reports_artifacts_lifecycle.freshness_age_seconds'));
         $this->assertSame('not_available', data_get($payload, 'reports_artifacts_lifecycle.freshness_state'));
         $this->assertSame('audit-derived', data_get($payload, 'reports_artifacts_lifecycle.freshness_source_type'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_archive.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_archive.durable_receipt_source'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.target_disk'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.latest_generated_at'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.latest_mode'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.latest_plan_path'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.latest_run_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_archive.latest_run_path_exists'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_archive.latest_summary.candidate_count'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_archive.latest_summary.results_count'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.last_updated_at'));
+        $this->assertNull(data_get($payload, 'report_artifacts_archive.freshness_age_seconds'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_archive.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_archive.freshness_source_type'));
         $this->assertSame('never_run', data_get($payload, 'retention.status'));
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.content_releases_retention.freshness_state'));
@@ -262,17 +292,18 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
-        $this->assertSame(['inventory', 'reports_artifacts_lifecycle'], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertSame(['inventory', 'report_artifacts_archive', 'reports_artifacts_lifecycle'], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertContains('rehydrate', data_get($payload, 'attention_digest.never_run_sections', []));
         $this->assertContains('retention.scopes.reports_backups', data_get($payload, 'attention_digest.never_run_sections', []));
         $this->assertSame([], data_get($payload, 'attention_digest.stale_sections'));
-        $this->assertSame(2, data_get($payload, 'attention_digest.counts.not_available'));
+        $this->assertSame(3, data_get($payload, 'attention_digest.counts.not_available'));
         $this->assertGreaterThan(0, (int) data_get($payload, 'attention_digest.counts.never_run'));
         $attentionMessages = array_values(array_filter(array_map(
             static fn ($item): ?string => is_array($item) ? ($item['message'] ?? null) : null,
             (array) data_get($payload, 'attention_digest.attention_items', [])
         )));
         $this->assertContains('inventory is not available', $attentionMessages);
+        $this->assertContains('report artifacts archive is not available', $attentionMessages);
         $this->assertContains('reports artifacts lifecycle is not available', $attentionMessages);
     }
 
@@ -528,6 +559,59 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
                 'skipped_count' => 0,
             ],
         ], 'success', 'exact_root_retirement', $now->copy()->subMinutes(40));
+    }
+
+    /**
+     * @return array{plan_path:string,run_path:string}
+     */
+    private function seedReportArtifactsArchiveTruth(bool $runPathExists = true): array
+    {
+        $planPath = storage_path('app/private/report_artifact_archive_plans/archive-plan.json');
+        $runPath = storage_path('app/private/report_artifact_archive_runs/archive-run/run.json');
+        $this->writeJson($planPath, [
+            'schema' => 'storage_archive_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+        ]);
+
+        if ($runPathExists) {
+            $this->writeJson($runPath, [
+                'schema' => 'storage_archive_report_artifacts_run.v1',
+                'mode' => 'execute',
+            ]);
+        }
+
+        $this->insertAudit('storage_archive_report_artifacts', 'report_artifacts_archive', [
+            'schema' => 'storage_archive_report_artifacts_run.v1',
+            'mode' => 'execute',
+            'target_disk' => 's3',
+            'plan' => $planPath,
+            'plan_path' => $planPath,
+            'run_path' => $runPath,
+            'candidate_count' => 3,
+            'copied_count' => 2,
+            'verified_count' => 3,
+            'already_archived_count' => 1,
+            'failed_count' => 0,
+            'results_count' => 3,
+            'durable_receipt_source' => 'audit_logs.meta_json',
+            'summary' => [
+                'candidate_count' => 3,
+                'copied_count' => 2,
+                'verified_count' => 3,
+                'already_archived_count' => 1,
+                'failed_count' => 0,
+            ],
+            'results' => [
+                ['status' => 'copied'],
+                ['status' => 'copied'],
+                ['status' => 'already_archived'],
+            ],
+        ], 'success', 'manual_archive_copy', now()->subMinutes(10));
+
+        return [
+            'plan_path' => $planPath,
+            'run_path' => $runPath,
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR tightens the archive receipt contract for `storage:archive-report-artifacts` and exposes the latest archive truth in control-plane status.

Scope is intentionally narrow:

- make `audit_logs.meta_json` the primary durable archive receipt truth
- add `report_artifacts_archive` to `storage:control-plane-status --json`
- let `storage:control-plane-snapshot --json` inherit it automatically
- let `storage:refresh-control-plane --dry-run --json` surface it naturally through the final snapshot

This PR does **not**:

- change archive command signatures
- change archive copy behavior
- delete any files
- do cutover
- change runtime readers or fallback behavior
- change write paths

## Root cause

PR-41 already created archive truth, but that truth was split between:

- durable DB audit rows
- non-durable filesystem plan/run artifacts under the executing worktree

That meant operators could end up with:

- successful archive audit rows
- `run_path_exists=false`
- no local `run.json` in the current worktree

The actual durable truth was already in `audit_logs.meta_json`, but the contract was not explicit and control-plane had no first-class archive section.

## What changed

### 1. Durable archive receipt contract

`ReportArtifactsArchiveService` now guarantees that `audit_logs.meta_json` always carries a stable archive receipt envelope for both `dry_run` and `execute`:

- `target_disk`
- `mode`
- `plan_path`
- `run_path`
- `candidate_count`
- `copied_count`
- `verified_count`
- `already_archived_count`
- `failed_count`
- `results_count`
- `durable_receipt_source = audit_logs.meta_json`

`run.json` remains a secondary operator artifact, but it is no longer required as the primary receipt source.

### 2. Control-plane archive section

`StorageControlPlaneStatusService` now exposes:

- `report_artifacts_archive`

Section shape:

- `status`
- `durable_receipt_source`
- `target_disk`
- `latest_generated_at`
- `latest_mode`
- `latest_plan_path`
- `latest_run_path`
- `latest_run_path_exists`
- `latest_summary`
  - `candidate_count`
  - `copied_count`
  - `verified_count`
  - `already_archived_count`
  - `failed_count`
  - `results_count`
- `last_updated_at`
- `freshness_age_seconds`
- `freshness_state`
- `freshness_source_type = audit-derived`

Important behavior:

- the section reads latest truth from archive audit rows
- it does not scan `run.json` for primary truth
- `run_path_exists` is exposed only as a health signal
- freshness uses the existing standard helper and thresholds
- attention digest integration is standard freshness-based only

### 3. Snapshot / refresh inheritance

No changes were made to snapshot or refresh services.

- snapshot inherits the new section automatically
- refresh still has the same step count and surfaces the section through the final snapshot

## Validation

Focused:

- `tests/Feature/Storage/ReportArtifactsArchiveServiceTest.php`
- `tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php`
- `tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`

Regression:

- `tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php`
- `tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php`
- `tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php`
- `tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php`
- `tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php`
- `tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php`

Live checks:

- `php artisan storage:archive-report-artifacts --dry-run --disk=s3`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan storage:refresh-control-plane --dry-run --json`
- `php artisan storage:analyze-cost --json`
- `php artisan storage:inventory --json`
- `bash backend/scripts/ci_verify_mbti.sh`

Key live results:

- `report_artifacts_archive.status = ok`
- `report_artifacts_archive.latest_mode = dry_run`
- `report_artifacts_archive.latest_run_path_exists = false`
- `report_artifacts_archive.durable_receipt_source = audit_logs.meta_json`
- latest archive summary remains readable even when `run.json` is absent
- snapshot inherits the section automatically
- refresh exposes the section without adding a new step
- no write/read/fallback/runtime contract changed
