### PR TITLE
[codex] Ship PR-13B SEO metadata authority backend

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -10,6 +10,7 @@ use App\Models\Article;
 use App\Services\Cms\ArticlePublishService;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\ArticleService;
+use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -22,6 +23,7 @@ class ArticleController extends Controller
         private readonly ArticleService $articleService,
         private readonly ArticlePublishService $articlePublishService,
         private readonly ArticleSeoService $articleSeoService,
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
 
     /**
@@ -117,9 +119,13 @@ class ArticleController extends Controller
 
         $article->loadMissing($this->articleRelations());
 
+        $meta = $this->articleSeoService->buildSeoPayload($article);
+        $jsonLd = $this->articleSeoService->generateJsonLd($article);
+
         return response()->json([
             'ok' => true,
             'article' => $this->articlePayload($article),
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'article_public_detail'),
         ]);
     }
 
@@ -160,9 +166,33 @@ class ArticleController extends Controller
             return response()->json(['error' => 'not found'], 404);
         }
 
+        $meta = $this->articleSeoService->buildSeoPayload($article);
+        $jsonLd = $this->articleSeoService->generateJsonLd($article);
+
         return response()->json([
-            'meta' => $this->articleSeoService->buildSeoPayload($article),
-            'jsonld' => $this->articleSeoService->generateJsonLd($article),
+            'meta' => $meta,
+            'jsonld' => $jsonLd,
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'article_public_detail'),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function buildSeoSurface(array $meta, array $jsonLd, string $surfaceType): array
+    {
+        return $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'public_indexable_detail',
+            'surface_type' => $surfaceType,
+            'canonical_url' => $meta['canonical'] ?? null,
+            'robots_policy' => $meta['robots'] ?? null,
+            'title' => $meta['title'] ?? null,
+            'description' => $meta['description'] ?? null,
+            'og_payload' => is_array($meta['og'] ?? null) ? $meta['og'] : [],
+            'twitter_payload' => is_array($meta['twitter'] ?? null) ? $meta['twitter'] : [],
+            'alternates' => is_array($meta['alternates'] ?? null) ? $meta['alternates'] : [],
+            'structured_data' => $jsonLd,
         ]);
     }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerGuideController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerGuideController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Controller;
 use App\Models\CareerGuide;
 use App\Services\Cms\CareerGuideSeoService;
 use App\Services\Cms\CareerGuideService;
+use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -20,6 +21,7 @@ final class CareerGuideController extends Controller
     public function __construct(
         private readonly CareerGuideService $careerGuideService,
         private readonly CareerGuideSeoService $careerGuideSeoService,
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
 
     public function index(Request $request): JsonResponse
@@ -75,6 +77,9 @@ final class CareerGuideController extends Controller
             return $this->notFoundResponse('career guide not found.');
         }
 
+        $meta = $this->careerGuideSeoService->buildSeoPayload($guide);
+        $jsonLd = $this->careerGuideSeoService->buildJsonLd($guide);
+
         return response()->json([
             'ok' => true,
             'guide' => $this->careerGuideService->detailPayload($guide),
@@ -83,6 +88,7 @@ final class CareerGuideController extends Controller
             'related_articles' => $this->careerGuideService->relatedArticlesPayload($guide),
             'related_personality_profiles' => $this->careerGuideService->relatedPersonalityProfilesPayload($guide),
             'seo_meta' => $this->careerGuideService->seoMetaPayload($guide),
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'career_guide_public_detail'),
         ]);
     }
 
@@ -103,9 +109,33 @@ final class CareerGuideController extends Controller
             return response()->json(['error' => 'not found'], 404);
         }
 
+        $meta = $this->careerGuideSeoService->buildSeoPayload($guide);
+        $jsonLd = $this->careerGuideSeoService->buildJsonLd($guide);
+
         return response()->json([
-            'meta' => $this->careerGuideSeoService->buildSeoPayload($guide),
-            'jsonld' => $this->careerGuideSeoService->buildJsonLd($guide),
+            'meta' => $meta,
+            'jsonld' => $jsonLd,
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'career_guide_public_detail'),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function buildSeoSurface(array $meta, array $jsonLd, string $surfaceType): array
+    {
+        return $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'public_indexable_detail',
+            'surface_type' => $surfaceType,
+            'canonical_url' => $meta['canonical'] ?? null,
+            'robots_policy' => $meta['robots'] ?? null,
+            'title' => $meta['title'] ?? null,
+            'description' => $meta['description'] ?? null,
+            'og_payload' => is_array($meta['og'] ?? null) ? $meta['og'] : [],
+            'twitter_payload' => is_array($meta['twitter'] ?? null) ? $meta['twitter'] : [],
+            'alternates' => is_array($meta['alternates'] ?? null) ? $meta['alternates'] : [],
+            'structured_data' => $jsonLd,
         ]);
     }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
@@ -10,6 +10,7 @@ use App\Models\CareerJob;
 use App\Models\CareerJobSection;
 use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\CareerJobService;
+use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -21,6 +22,7 @@ final class CareerJobController extends Controller
     public function __construct(
         private readonly CareerJobService $careerJobService,
         private readonly CareerJobSeoService $careerJobSeoService,
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
 
     public function index(Request $request): JsonResponse
@@ -75,6 +77,9 @@ final class CareerJobController extends Controller
             return $this->notFoundResponse('career job not found.');
         }
 
+        $meta = $this->careerJobSeoService->buildMeta($job, $validated['locale']);
+        $jsonLd = $this->careerJobSeoService->buildJsonLd($job, $validated['locale']);
+
         return response()->json([
             'ok' => true,
             'job' => $this->careerJobService->detailPayload($job),
@@ -83,6 +88,7 @@ final class CareerJobController extends Controller
                 $job->sections->all()
             ),
             'seo_meta' => $this->careerJobService->seoMetaPayload($job->seoMeta),
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'career_job_public_detail'),
         ]);
     }
 
@@ -103,9 +109,33 @@ final class CareerJobController extends Controller
             return response()->json(['error' => 'not found'], 404);
         }
 
+        $meta = $this->careerJobSeoService->buildMeta($job, $validated['locale']);
+        $jsonLd = $this->careerJobSeoService->buildJsonLd($job, $validated['locale']);
+
         return response()->json([
-            'meta' => $this->careerJobSeoService->buildMeta($job, $validated['locale']),
-            'jsonld' => $this->careerJobSeoService->buildJsonLd($job, $validated['locale']),
+            'meta' => $meta,
+            'jsonld' => $jsonLd,
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'career_job_public_detail'),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function buildSeoSurface(array $meta, array $jsonLd, string $surfaceType): array
+    {
+        return $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'public_indexable_detail',
+            'surface_type' => $surfaceType,
+            'canonical_url' => $meta['canonical'] ?? null,
+            'robots_policy' => $meta['robots'] ?? null,
+            'title' => $meta['title'] ?? null,
+            'description' => $meta['description'] ?? null,
+            'og_payload' => is_array($meta['og'] ?? null) ? $meta['og'] : [],
+            'twitter_payload' => is_array($meta['twitter'] ?? null) ? $meta['twitter'] : [],
+            'alternates' => is_array($meta['alternates'] ?? null) ? $meta['alternates'] : [],
+            'structured_data' => $jsonLd,
         ]);
     }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerRecommendationController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerRecommendationController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\API\V0_5\Cms;
 use App\Http\Controllers\Concerns\RespondsWithNotFound;
 use App\Http\Controllers\Controller;
 use App\Services\Cms\CareerRecommendationService;
+use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -17,6 +18,7 @@ final class CareerRecommendationController extends Controller
 
     public function __construct(
         private readonly CareerRecommendationService $careerRecommendationService,
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
 
     public function index(Request $request): JsonResponse
@@ -50,6 +52,28 @@ final class CareerRecommendationController extends Controller
         if (! is_array($payload)) {
             return $this->notFoundResponse('career recommendation not found.');
         }
+
+        $payload['seo_surface_v1'] = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'public_indexable_detail',
+            'surface_type' => 'career_recommendation_public_detail',
+            'canonical_url' => data_get($payload, 'seo.canonical'),
+            'robots_policy' => 'index,follow',
+            'title' => data_get($payload, 'seo.title'),
+            'description' => data_get($payload, 'seo.description'),
+            'og_payload' => [
+                'title' => data_get($payload, 'seo.title'),
+                'description' => data_get($payload, 'seo.description'),
+                'type' => 'article',
+                'url' => data_get($payload, 'seo.canonical'),
+            ],
+            'twitter_payload' => [
+                'card' => 'summary_large_image',
+                'title' => data_get($payload, 'seo.title'),
+                'description' => data_get($payload, 'seo.description'),
+            ],
+            'alternates' => is_array(data_get($payload, 'seo.alternates')) ? data_get($payload, 'seo.alternates') : [],
+            'structured_data' => [],
+        ]);
 
         return response()->json($payload);
     }

--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -14,6 +14,7 @@ use App\Models\PersonalityProfileVariantSection;
 use App\Models\PersonalityProfileVariantSeoMeta;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\PersonalityProfileService;
+use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -25,6 +26,7 @@ class PersonalityController extends Controller
     public function __construct(
         private readonly PersonalityProfileService $personalityProfileService,
         private readonly PersonalityProfileSeoService $personalityProfileSeoService,
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
 
     public function index(Request $request): JsonResponse
@@ -86,6 +88,8 @@ class PersonalityController extends Controller
         /** @var PersonalityProfileVariant|null $variant */
         $variant = $routeProfile['variant'];
         $projection = $this->personalityProfileService->buildPublicProjection($profile, $variant);
+        $meta = $this->personalityProfileSeoService->buildMeta($profile, $variant);
+        $jsonLd = $this->personalityProfileSeoService->buildJsonLd($profile, $variant);
 
         return response()->json([
             'ok' => true,
@@ -93,6 +97,7 @@ class PersonalityController extends Controller
             'sections' => $this->publicSectionPayloads($profile, $variant),
             'seo_meta' => $this->seoMetaPayload($profile, $variant),
             'mbti_public_projection_v1' => $projection,
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'mbti_personality_public_detail'),
         ]);
     }
 
@@ -118,10 +123,33 @@ class PersonalityController extends Controller
         $profile = $routeProfile['profile'];
         /** @var PersonalityProfileVariant|null $variant */
         $variant = $routeProfile['variant'];
+        $meta = $this->personalityProfileSeoService->buildMeta($profile, $variant);
+        $jsonLd = $this->personalityProfileSeoService->buildJsonLd($profile, $variant);
 
         return response()->json([
-            'meta' => $this->personalityProfileSeoService->buildMeta($profile, $variant),
-            'jsonld' => $this->personalityProfileSeoService->buildJsonLd($profile, $variant),
+            'meta' => $meta,
+            'jsonld' => $jsonLd,
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'mbti_personality_public_detail'),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function buildSeoSurface(array $meta, array $jsonLd, string $surfaceType): array
+    {
+        return $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'public_indexable_detail',
+            'surface_type' => $surfaceType,
+            'canonical_url' => $meta['canonical'] ?? null,
+            'robots_policy' => $meta['robots'] ?? null,
+            'title' => $meta['title'] ?? null,
+            'description' => $meta['description'] ?? null,
+            'og_payload' => is_array($meta['og'] ?? null) ? $meta['og'] : [],
+            'twitter_payload' => is_array($meta['twitter'] ?? null) ? $meta['twitter'] : [],
+            'alternates' => is_array($meta['alternates'] ?? null) ? $meta['alternates'] : [],
+            'structured_data' => $jsonLd,
         ]);
     }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
@@ -12,6 +12,7 @@ use App\Models\TopicProfileSeoMeta;
 use App\Services\Cms\TopicEntryResolverService;
 use App\Services\Cms\TopicProfileSeoService;
 use App\Services\Cms\TopicProfileService;
+use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -24,6 +25,7 @@ final class TopicController extends Controller
         private readonly TopicProfileService $topicProfileService,
         private readonly TopicEntryResolverService $topicEntryResolverService,
         private readonly TopicProfileSeoService $topicProfileSeoService,
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
 
     public function index(Request $request): JsonResponse
@@ -78,6 +80,9 @@ final class TopicController extends Controller
             return $this->notFoundResponse('topic not found.');
         }
 
+        $meta = $this->topicProfileSeoService->buildMeta($profile, $validated['locale']);
+        $jsonLd = $this->topicProfileSeoService->buildJsonLd($profile, $validated['locale']);
+
         return response()->json([
             'ok' => true,
             'profile' => $this->profileDetailPayload($profile),
@@ -87,6 +92,7 @@ final class TopicController extends Controller
             ),
             'entry_groups' => $this->topicEntryResolverService->resolveGroupedEntries($profile, $validated['locale']),
             'seo_meta' => $this->seoMetaPayload($profile->seoMeta),
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'topic_public_detail'),
         ]);
     }
 
@@ -107,9 +113,33 @@ final class TopicController extends Controller
             return response()->json(['error' => 'not found'], 404);
         }
 
+        $meta = $this->topicProfileSeoService->buildMeta($profile, $validated['locale']);
+        $jsonLd = $this->topicProfileSeoService->buildJsonLd($profile, $validated['locale']);
+
         return response()->json([
-            'meta' => $this->topicProfileSeoService->buildMeta($profile, $validated['locale']),
-            'jsonld' => $this->topicProfileSeoService->buildJsonLd($profile, $validated['locale']),
+            'meta' => $meta,
+            'jsonld' => $jsonLd,
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'topic_public_detail'),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function buildSeoSurface(array $meta, array $jsonLd, string $surfaceType): array
+    {
+        return $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'public_indexable_detail',
+            'surface_type' => $surfaceType,
+            'canonical_url' => $meta['canonical'] ?? null,
+            'robots_policy' => $meta['robots'] ?? null,
+            'title' => $meta['title'] ?? null,
+            'description' => $meta['description'] ?? null,
+            'og_payload' => is_array($meta['og'] ?? null) ? $meta['og'] : [],
+            'twitter_payload' => is_array($meta['twitter'] ?? null) ? $meta['twitter'] : [],
+            'alternates' => is_array($meta['alternates'] ?? null) ? $meta['alternates'] : [],
+            'structured_data' => $jsonLd,
         ]);
     }
 

--- a/backend/app/Services/PublicSurface/SeoSurfaceContractService.php
+++ b/backend/app/Services/PublicSurface/SeoSurfaceContractService.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\PublicSurface;
+
+final class SeoSurfaceContractService
+{
+    /**
+     * @param  array{
+     *   metadata_scope:string,
+     *   surface_type:string,
+     *   canonical_url:?string,
+     *   robots_policy?:?string,
+     *   title:?string,
+     *   description:?string,
+     *   og_payload?:array<string,mixed>,
+     *   twitter_payload?:array<string,mixed>,
+     *   alternates?:array<string,mixed>,
+     *   structured_data?:mixed,
+     *   indexability_state?:?string,
+     *   sitemap_state?:?string,
+     *   llms_exposure_state?:?string,
+     *   share_safety_state?:?string,
+     *   public_summary_fingerprint?:?string,
+     *   runtime_artifact_ref?:?string,
+     *   fingerprint_seed?:array<string,mixed>
+     * } $context
+     * @return array<string,mixed>
+     */
+    public function build(array $context): array
+    {
+        $metadataScope = $this->normalizeString($context['metadata_scope'] ?? null) ?? 'public_detail';
+        $surfaceType = $this->normalizeString($context['surface_type'] ?? null) ?? 'public_surface';
+        $canonicalUrl = $this->normalizeString($context['canonical_url'] ?? null);
+        $robotsPolicy = $this->normalizeString($context['robots_policy'] ?? null) ?? 'index,follow';
+        $title = $this->normalizeString($context['title'] ?? null);
+        $description = $this->normalizeString($context['description'] ?? null);
+        $alternates = $this->normalizeStringMap($context['alternates'] ?? []);
+        $structuredDataKeys = $this->extractStructuredDataKeys($context['structured_data'] ?? null);
+
+        $ogPayload = $this->normalizePayload($context['og_payload'] ?? [], $title, $description, $canonicalUrl);
+        $twitterPayload = $this->normalizePayload($context['twitter_payload'] ?? [], $title, $description, null);
+
+        $indexabilityState = $this->normalizeString($context['indexability_state'] ?? null)
+            ?? $this->resolveIndexabilityState($robotsPolicy);
+        $sitemapState = $this->normalizeString($context['sitemap_state'] ?? null)
+            ?? ($indexabilityState === 'indexable' ? 'included' : 'excluded');
+        $llmsExposureState = $this->normalizeString($context['llms_exposure_state'] ?? null)
+            ?? ($indexabilityState === 'indexable' ? 'allow' : 'withhold');
+        $shareSafetyState = $this->normalizeString($context['share_safety_state'] ?? null);
+        $publicSummaryFingerprint = $this->normalizeString($context['public_summary_fingerprint'] ?? null);
+        $runtimeArtifactRef = $this->normalizeString($context['runtime_artifact_ref'] ?? null);
+
+        $fingerprintSeed = is_array($context['fingerprint_seed'] ?? null)
+            ? $context['fingerprint_seed']
+            : [];
+        $fingerprintSeed['metadata_scope'] = $metadataScope;
+        $fingerprintSeed['surface_type'] = $surfaceType;
+        $fingerprintSeed['canonical_url'] = $canonicalUrl;
+        $fingerprintSeed['robots_policy'] = $robotsPolicy;
+        $fingerprintSeed['title'] = $title;
+        $fingerprintSeed['description'] = $description;
+        $fingerprintSeed['alternates'] = $alternates;
+        $fingerprintSeed['og_payload'] = $ogPayload;
+        $fingerprintSeed['twitter_payload'] = $twitterPayload;
+        $fingerprintSeed['structured_data_keys'] = $structuredDataKeys;
+        $fingerprintSeed['indexability_state'] = $indexabilityState;
+        $fingerprintSeed['sitemap_state'] = $sitemapState;
+        $fingerprintSeed['llms_exposure_state'] = $llmsExposureState;
+        $fingerprintSeed['share_safety_state'] = $shareSafetyState;
+        $fingerprintSeed['public_summary_fingerprint'] = $publicSummaryFingerprint;
+        $fingerprintSeed['runtime_artifact_ref'] = $runtimeArtifactRef;
+
+        return [
+            'version' => 'seo.surface.v1',
+            'metadata_contract_version' => 'seo.surface.v1',
+            'metadata_fingerprint' => sha1((string) json_encode($fingerprintSeed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'metadata_scope' => $metadataScope,
+            'surface_type' => $surfaceType,
+            'canonical_url' => $canonicalUrl,
+            'robots_policy' => $robotsPolicy,
+            'title' => $title,
+            'description' => $description,
+            'og_payload' => $ogPayload,
+            'twitter_payload' => $twitterPayload,
+            'alternates' => $alternates,
+            'structured_data_keys' => $structuredDataKeys,
+            'indexability_state' => $indexabilityState,
+            'sitemap_state' => $sitemapState,
+            'llms_exposure_state' => $llmsExposureState,
+            'share_safety_state' => $shareSafetyState,
+            'public_summary_fingerprint' => $publicSummaryFingerprint,
+            'runtime_artifact_ref' => $runtimeArtifactRef,
+        ];
+    }
+
+    private function resolveIndexabilityState(string $robotsPolicy): string
+    {
+        $tokens = array_map(
+            static fn (string $token): string => trim(strtolower($token)),
+            explode(',', $robotsPolicy)
+        );
+
+        return in_array('noindex', $tokens, true) ? 'noindex' : 'indexable';
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    private function normalizePayload(array $payload, ?string $title, ?string $description, ?string $url): array
+    {
+        return array_filter([
+            'title' => $this->normalizeString($payload['title'] ?? null) ?? $title,
+            'description' => $this->normalizeString($payload['description'] ?? null) ?? $description,
+            'image' => $this->normalizeString($payload['image'] ?? null),
+            'type' => $this->normalizeString($payload['type'] ?? null),
+            'card' => $this->normalizeString($payload['card'] ?? null),
+            'url' => $this->normalizeString($payload['url'] ?? null) ?? $url,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @param  array<string,mixed>  $map
+     * @return array<string,string>
+     */
+    private function normalizeStringMap(array $map): array
+    {
+        $normalized = [];
+
+        foreach ($map as $key => $value) {
+            $normalizedValue = $this->normalizeString($value);
+            if ($normalizedValue === null) {
+                continue;
+            }
+
+            $normalized[(string) $key] = $normalizedValue;
+        }
+
+        ksort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractStructuredDataKeys(mixed $value): array
+    {
+        $keys = [];
+        $this->collectStructuredDataKeys($value, $keys);
+        $keys = array_values(array_unique(array_filter($keys)));
+        sort($keys);
+
+        return $keys;
+    }
+
+    /**
+     * @param  array<int,string>  $keys
+     */
+    private function collectStructuredDataKeys(mixed $value, array &$keys): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        $type = $value['@type'] ?? null;
+        if (is_string($type) && trim($type) !== '') {
+            $keys[] = trim($type);
+        } elseif (is_array($type)) {
+            foreach ($type as $item) {
+                if (is_string($item) && trim($item) !== '') {
+                    $keys[] = trim($item);
+                }
+            }
+        }
+
+        foreach ($value as $child) {
+            $this->collectStructuredDataKeys($child, $keys);
+        }
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -15,6 +15,7 @@ use App\Services\InsightGraph\InsightGraphContractService;
 use App\Services\InsightGraph\PartnerReadContractService;
 use App\Services\InsightGraph\WidgetSurfaceContractService;
 use App\Services\PublicSurface\PublicSurfaceContractService;
+use App\Services\PublicSurface\SeoSurfaceContractService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportComposer;
 use App\Services\Scale\ScaleIdentityWriteProjector;
@@ -36,6 +37,7 @@ class ShareService
         private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private readonly BigFivePublicProjectionService $bigFivePublicProjectionService,
         private readonly PublicSurfaceContractService $publicSurfaceContractService,
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly InsightGraphContractService $insightGraphContractService,
         private readonly PartnerReadContractService $partnerReadContractService,
         private readonly WidgetSurfaceContractService $widgetSurfaceContractService,
@@ -811,6 +813,7 @@ class ShareService
             $big5Projection,
             $publicSafeReport
         );
+        $payload['seo_surface_v1'] = $this->buildSeoSurfaceContract($payload, $locale, $scaleCode, $resolvedShareId);
         $payload['insight_graph_v1'] = $this->insightGraphContractService->buildForShare(
             $payload,
             is_array($payload['public_surface_v1'] ?? null) ? $payload['public_surface_v1'] : []
@@ -914,6 +917,55 @@ class ShareService
     }
 
     /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    private function buildSeoSurfaceContract(array $payload, string $locale, string $scaleCode, string $shareId): array
+    {
+        $canonicalUrl = trim((string) data_get($payload, 'public_surface_v1.canonical_url', ''));
+        $canonicalUrl = $canonicalUrl !== '' ? $canonicalUrl : ($shareId !== '' ? $this->buildLocalizedShareUrl($shareId, $locale) : null);
+
+        $title = trim((string) ($payload['title'] ?? ''));
+        $summary = trim((string) ($payload['summary'] ?? ''));
+        $typeCode = trim((string) ($payload['type_code'] ?? ''));
+        $surfaceType = $scaleCode === 'BIG5_OCEAN' ? 'big5_share_public_safe' : 'mbti_share_public_safe';
+
+        return $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'public_share_safe',
+            'surface_type' => $surfaceType,
+            'canonical_url' => $canonicalUrl,
+            'robots_policy' => data_get($payload, 'public_surface_v1.robots_policy', 'noindex,follow'),
+            'title' => $title !== '' ? $title : $typeCode,
+            'description' => $summary !== '' ? $summary : trim((string) ($payload['subtitle'] ?? '')),
+            'og_payload' => [
+                'title' => $title !== '' ? $title : $typeCode,
+                'description' => $summary !== '' ? $summary : trim((string) ($payload['subtitle'] ?? '')),
+                'image' => $shareId !== '' ? $this->buildLocalizedShareOgUrl($shareId) : null,
+                'type' => 'website',
+                'url' => $canonicalUrl,
+            ],
+            'twitter_payload' => [
+                'card' => 'summary_large_image',
+                'title' => $title !== '' ? $title : $typeCode,
+                'description' => $summary !== '' ? $summary : trim((string) ($payload['subtitle'] ?? '')),
+                'image' => $shareId !== '' ? $this->buildLocalizedShareOgUrl($shareId) : null,
+            ],
+            'structured_data' => [],
+            'indexability_state' => 'noindex',
+            'sitemap_state' => 'excluded',
+            'llms_exposure_state' => 'withhold',
+            'share_safety_state' => 'public_share_safe',
+            'public_summary_fingerprint' => data_get($payload, 'public_surface_v1.public_summary_fingerprint'),
+            'fingerprint_seed' => [
+                'scale_code' => $scaleCode,
+                'locale' => $locale,
+                'type_code' => $typeCode,
+                'entry_surface' => data_get($payload, 'public_surface_v1.entry_surface'),
+            ],
+        ]);
+    }
+
+    /**
      * @param  array<string, mixed>  $payload
      * @return array<string, mixed>
      */
@@ -954,6 +1006,11 @@ class ShareService
         $segment = $locale === 'zh-CN' ? 'zh' : 'en';
 
         return rtrim((string) config('app.frontend_url', 'http://localhost'), '/').'/'.$segment.'/share/'.$shareId;
+    }
+
+    private function buildLocalizedShareOgUrl(string $shareId): string
+    {
+        return rtrim((string) config('app.frontend_url', 'http://localhost'), '/').'/og/share/'.$shareId;
     }
 
     private function resolveCompareCtaLabel(string $locale): string

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -80,6 +80,11 @@ final class ShareSummaryContractTest extends TestCase
         $this->assertSame($response->json('type_name'), $response->json('mbti_public_projection_v1.profile.type_name'));
         $this->assertSame($response->json('dimensions'), $response->json('mbti_public_projection_v1.dimensions'));
         $this->assertSame('public.surface.v1', $response->json('public_surface_v1.version'));
+        $this->assertSame('seo.surface.v1', $response->json('seo_surface_v1.metadata_contract_version'));
+        $this->assertSame('public_share_safe', $response->json('seo_surface_v1.metadata_scope'));
+        $this->assertSame('mbti_share_public_safe', $response->json('seo_surface_v1.surface_type'));
+        $this->assertSame('noindex,follow', $response->json('seo_surface_v1.robots_policy'));
+        $this->assertSame('noindex', $response->json('seo_surface_v1.indexability_state'));
         $this->assertSame('mbti_share_landing', $response->json('public_surface_v1.entry_surface'));
         $this->assertSame('noindex,follow', $response->json('public_surface_v1.robots_policy'));
         $this->assertSame('share_public_surface', $response->json('public_surface_v1.attribution_scope'));
@@ -183,6 +188,7 @@ final class ShareSummaryContractTest extends TestCase
             'mbti_public_summary_v1',
             'mbti_public_projection_v1',
             'public_surface_v1',
+            'seo_surface_v1',
             'insight_graph_v1',
             'embed_surface_v1',
             'widget_surface_v1',
@@ -234,6 +240,8 @@ final class ShareSummaryContractTest extends TestCase
             ->assertJsonPath('type_code', 'BIG5')
             ->assertJsonPath('type_name', 'Big Five personality')
             ->assertJsonPath('public_surface_v1.version', 'public.surface.v1')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'big5_share_public_safe')
             ->assertJsonPath('public_surface_v1.entry_surface', 'big5_share_landing')
             ->assertJsonPath('public_surface_v1.robots_policy', 'noindex,follow')
             ->assertJsonPath('public_surface_v1.attribution_scope', 'share_public_surface')

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -106,6 +106,8 @@ final class ArticlePublicApiTest extends TestCase
 
         $response->assertOk()
             ->assertJsonPath('meta.canonical', $canonical)
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'article_public_detail')
             ->assertJsonPath('meta.alternates.en', $canonical)
             ->assertJsonPath('meta.alternates.zh', $zhCanonical)
             ->assertJsonPath('meta.alternates.zh-CN', $zhCanonical)

--- a/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
@@ -212,6 +212,8 @@ final class CareerGuidePublicApiTest extends TestCase
         $response->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('guide.guide_code', 'from-mbti-to-job-fit')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'career_guide_public_detail')
             ->assertJsonPath('guide.category_slug', 'assessment-usage')
             ->assertJsonPath('guide.body_md', '# Guide body')
             ->assertJsonPath('related_jobs.0.job_code', 'product-manager')
@@ -313,6 +315,8 @@ final class CareerGuidePublicApiTest extends TestCase
 
         $response->assertOk()
             ->assertJsonPath('meta.title', 'From MBTI to Job Fit | FermatMind')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'career_guide_public_detail')
             ->assertJsonPath(
                 'meta.canonical',
                 'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit'
@@ -372,6 +376,7 @@ final class CareerGuidePublicApiTest extends TestCase
                 'meta.canonical',
                 'https://staging.fermatmind.com/en/career/guides/solo-guide'
             )
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
             ->assertJsonPath(
                 'meta.alternates.en',
                 'https://staging.fermatmind.com/en/career/guides/solo-guide'

--- a/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
@@ -246,6 +246,8 @@ final class CareerJobPublicApiTest extends TestCase
         $response->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('job.job_code', 'product-manager')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'career_job_public_detail')
             ->assertJsonPath('job.industry_label', 'Technology')
             ->assertJsonPath('job.salary.currency', 'USD')
             ->assertJsonPath('job.outlook.summary', 'Growing')
@@ -401,6 +403,8 @@ final class CareerJobPublicApiTest extends TestCase
         $enResponse->assertOk()
             ->assertJsonPath('meta.title', 'Product Manager Career Guide | FermatMind')
             ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/career/jobs/product-manager')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'career_job_public_detail')
             ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/career/jobs/product-manager')
             ->assertJsonPath('meta.alternates.zh-CN', 'https://staging.fermatmind.com/zh/career/jobs/product-manager')
             ->assertJsonPath('meta.robots', 'index,follow')
@@ -411,6 +415,7 @@ final class CareerJobPublicApiTest extends TestCase
         $zhResponse = $this->getJson('/api/v0.5/career-jobs/product-manager/seo?locale=zh-CN');
         $zhResponse->assertOk()
             ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/career/jobs/product-manager')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
             ->assertJsonPath('meta.robots', 'noindex,follow')
             ->assertJsonPath('jsonld.name', (string) $zhJob->title)
             ->assertJsonPath('jsonld.mainEntityOfPage', 'https://staging.fermatmind.com/zh/career/jobs/product-manager');

--- a/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
@@ -299,6 +299,9 @@ final class CareerRecommendationPublicApiTest extends TestCase
 
         $enResponse->assertOk()
             ->assertJsonPath('runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'career_recommendation_public_detail')
+            ->assertJsonPath('seo_surface_v1.indexability_state', 'indexable')
             ->assertJsonPath('canonical_type_code', 'INTJ')
             ->assertJsonPath('public_route_slug', 'intj-a')
             ->assertJsonPath('graph_type_code', 'INTJ')
@@ -325,6 +328,7 @@ final class CareerRecommendationPublicApiTest extends TestCase
 
         $zhResponse->assertOk()
             ->assertJsonPath('runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
             ->assertJsonPath('canonical_type_code', 'INTJ')
             ->assertJsonPath('public_route_slug', 'intj-a')
             ->assertJsonPath('graph_type_code', 'INTJ')

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -195,6 +195,8 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonCount(1, 'sections')
             ->assertJsonPath('sections.0.section_key', 'overview')
             ->assertJsonPath('seo_meta.seo_title', 'INTJ Personality Type')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'mbti_personality_public_detail')
             ->assertJsonPath('mbti_public_projection_v1.display_type', 'INTJ')
             ->assertJsonPath('mbti_public_projection_v1.canonical_type_code', 'INTJ')
             ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', null)
@@ -326,6 +328,8 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('meta.title', 'INTJ-A Personality Type: Traits, Careers, and Growth | FermatMind')
             ->assertJsonPath('meta.description', 'Explore INTJ-A traits, strengths, blind spots, work style, relationships, and growth advice.')
             ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/personality/intj-a')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'mbti_personality_public_detail')
             ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/personality/intj-a')
             ->assertJsonPath('meta.alternates.zh-CN', 'https://staging.fermatmind.com/zh/personality/intj-a')
             ->assertJsonPath('meta.robots', 'index,follow');
@@ -340,6 +344,7 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('meta.title', 'INTJ-T 人格类型：特质、职业与成长 | FermatMind')
             ->assertJsonPath('meta.description', '探索 INTJ-T 的特质、优势、关系模式与成长建议。')
             ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/personality/intj-t')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
             ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/personality/intj-t')
             ->assertJsonPath('meta.alternates.zh-CN', 'https://staging.fermatmind.com/zh/personality/intj-t')
             ->assertJsonPath('meta.robots', 'noindex,follow');

--- a/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
@@ -231,6 +231,8 @@ final class TopicsPublicApiTest extends TestCase
             ->assertJsonCount(1, 'sections')
             ->assertJsonPath('sections.0.section_key', 'overview')
             ->assertJsonPath('seo_meta.seo_title', 'MBTI Guide and Type Hub | FermatMind')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'topic_public_detail')
             ->assertJsonPath('entry_groups.featured.0.entry_type', 'personality_profile')
             ->assertJsonPath('entry_groups.featured.0.title', (string) $personality->title)
             ->assertJsonPath('entry_groups.featured.0.url', '/en/personality/intj')
@@ -361,6 +363,8 @@ final class TopicsPublicApiTest extends TestCase
         $enResponse->assertOk()
             ->assertJsonPath('meta.title', 'MBTI Guide and Type Hub | FermatMind')
             ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/topics/mbti')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'topic_public_detail')
             ->assertJsonPath('meta.robots', 'index,follow');
         self::assertSame('CollectionPage', data_get($enResponse->json(), 'jsonld.@type'));
         self::assertSame(
@@ -371,6 +375,7 @@ final class TopicsPublicApiTest extends TestCase
         $zhResponse = $this->getJson('/api/v0.5/topics/mbti/seo?locale=zh-CN');
         $zhResponse->assertOk()
             ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/topics/mbti')
+            ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
             ->assertJsonPath('meta.robots', 'noindex,follow');
         self::assertSame(
             'https://staging.fermatmind.com/zh/topics/mbti',

--- a/backend/tests/Unit/Services/PublicSurface/SeoSurfaceContractServiceTest.php
+++ b/backend/tests/Unit/Services/PublicSurface/SeoSurfaceContractServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\PublicSurface;
+
+use App\Services\PublicSurface\SeoSurfaceContractService;
+use Tests\TestCase;
+
+final class SeoSurfaceContractServiceTest extends TestCase
+{
+    public function test_it_builds_a_backend_owned_seo_surface_contract(): void
+    {
+        $service = new SeoSurfaceContractService();
+
+        $contract = $service->build([
+            'metadata_scope' => 'public_indexable_detail',
+            'surface_type' => 'article_public_detail',
+            'canonical_url' => 'https://staging.fermatmind.com/en/articles/how-to-read-mbti-results',
+            'robots_policy' => 'index,follow',
+            'title' => 'How to Read MBTI Results',
+            'description' => 'A practical guide to reading MBTI results.',
+            'og_payload' => [
+                'title' => 'How to Read MBTI Results',
+                'description' => 'A practical guide to reading MBTI results.',
+                'type' => 'article',
+                'url' => 'https://staging.fermatmind.com/en/articles/how-to-read-mbti-results',
+            ],
+            'twitter_payload' => [
+                'card' => 'summary_large_image',
+                'title' => 'How to Read MBTI Results',
+                'description' => 'A practical guide to reading MBTI results.',
+            ],
+            'alternates' => [
+                'en' => 'https://staging.fermatmind.com/en/articles/how-to-read-mbti-results',
+                'zh-CN' => 'https://staging.fermatmind.com/zh/articles/how-to-read-mbti-results',
+            ],
+            'structured_data' => [
+                '@context' => 'https://schema.org',
+                '@type' => 'Article',
+                'mainEntity' => [
+                    '@type' => 'BreadcrumbList',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('seo.surface.v1', $contract['metadata_contract_version']);
+        $this->assertSame('public_indexable_detail', $contract['metadata_scope']);
+        $this->assertSame('article_public_detail', $contract['surface_type']);
+        $this->assertSame('https://staging.fermatmind.com/en/articles/how-to-read-mbti-results', $contract['canonical_url']);
+        $this->assertSame('index,follow', $contract['robots_policy']);
+        $this->assertSame('How to Read MBTI Results', $contract['title']);
+        $this->assertSame('A practical guide to reading MBTI results.', $contract['description']);
+        $this->assertSame('indexable', $contract['indexability_state']);
+        $this->assertSame('included', $contract['sitemap_state']);
+        $this->assertSame('allow', $contract['llms_exposure_state']);
+        $this->assertSame(['Article', 'BreadcrumbList'], $contract['structured_data_keys']);
+        $this->assertIsString($contract['metadata_fingerprint']);
+        $this->assertNotSame('', $contract['metadata_fingerprint']);
+    }
+
+    public function test_it_defaults_non_indexable_states_from_robots_policy(): void
+    {
+        $service = new SeoSurfaceContractService();
+
+        $contract = $service->build([
+            'metadata_scope' => 'public_share_safe',
+            'surface_type' => 'mbti_share_public_safe',
+            'canonical_url' => 'https://staging.fermatmind.com/zh/share/share_123',
+            'robots_policy' => 'noindex,follow',
+            'title' => 'INTJ - Architect',
+            'description' => 'Public share-safe summary',
+        ]);
+
+        $this->assertSame('noindex', $contract['indexability_state']);
+        $this->assertSame('excluded', $contract['sitemap_state']);
+        $this->assertSame('withhold', $contract['llms_exposure_state']);
+        $this->assertNull($contract['runtime_artifact_ref']);
+    }
+}


### PR DESCRIPTION
## Summary
This PR ships the backend half of PR-13B for first-wave SEO metadata authority.

It introduces backend-owned `seo_surface_v1`, unifies family-specific public/share metadata seeds behind one delivery metadata contract, and attaches that contract to the first-wave public/share/acquisition families without changing runtime content truth.

## Problem
The backend already exposed strong metadata seeds through share-safe contracts, MBTI public payload builders, and V0.5 public CMS families, but those seeds were not normalized into a single delivery metadata authority.

That left frontend routes consuming different payload shapes and making family-specific truth decisions for canonical URLs, robots, titles, descriptions, OG payloads, and structured data.

## Root Cause
The repo had the right metadata inputs, but no shared backend contract that could consistently express SEO delivery metadata across public/share surfaces while keeping content control plane data as source-only and keeping compiled/runtime content truth unchanged.

## What Changed
- Added `SeoSurfaceContractService`.
- Emit backend-owned `seo_surface_v1` with:
  - `metadata_contract_version`
  - `metadata_fingerprint`
  - `metadata_scope`
  - `surface_type`
  - `canonical_url`
  - `robots_policy`
  - `title`
  - `description`
  - `og_payload`
  - `structured_data_keys`
  - `indexability_state`
  - plus alternates/twitter/sitemap/llms/share-safety helpers
- Attached `seo_surface_v1` to first-wave families:
  - MBTI share/public-safe
  - MBTI public/personality public
  - career recommendation public
  - article / topic / career guide / career job public families
- Preserved the boundary where content control plane remains authoring source only and runtime truth still comes from the published content/runtime pipeline.
- Added targeted backend tests for the SEO surface contract and first-wave public family regressions.

## Scope Guardrails
- No migration
- No new dependency
- No new auth
- No GEO / answer block implementation
- No full sitemap/robots/llms platform rewrite
- No DB-as-delivery-truth behavior
- No change to MBTI / Big Five scoring or runtime content truth

## Validation
- `php artisan test --filter="SeoSurfaceContractServiceTest|ShareSummaryContractTest|PersonalityPublicApiTest|CareerRecommendationPublicApiTest|ArticlePublicApiTest|TopicsPublicApiTest|CareerJobPublicApiTest|CareerGuidePublicApiTest"`
