### PR TITLE
[codex] add report artifacts rehydrate surface

### DIFF
--- a/backend/app/Console/Commands/StorageRehydrateReportArtifacts.php
+++ b/backend/app/Console/Commands/StorageRehydrateReportArtifacts.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\ReportArtifactsRehydrateService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class StorageRehydrateReportArtifacts extends Command
+{
+    protected $signature = 'storage:rehydrate-report-artifacts
+        {--dry-run : Build a rehydrate plan from durable archive truth}
+        {--execute : Execute rehydrate from an existing plan}
+        {--disk=s3 : Remote object storage disk that holds archived canonical artifacts}
+        {--plan= : Absolute or storage-relative plan path required for execute mode}
+        {--json : Emit the full payload as JSON}';
+
+    protected $description = 'Manual-only single-file rehydrate surface that restores archived canonical report artifacts back to their exact local canonical paths.';
+
+    public function __construct(
+        private readonly ReportArtifactsRehydrateService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $disk = trim((string) ($this->option('disk') ?? 's3'));
+
+        try {
+            $this->ensureTargetDiskIsRemote($disk);
+
+            if ($dryRun) {
+                $plan = $this->service->buildPlan($disk);
+                $planPath = $this->persistPlan($plan);
+                $payload = $plan + ['plan' => $planPath];
+
+                return $this->emitPayload($payload);
+            }
+
+            $planOption = trim((string) ($this->option('plan') ?? ''));
+            if ($planOption === '') {
+                $this->error('--execute requires --plan.');
+
+                return self::FAILURE;
+            }
+
+            $resolvedPlanPath = $this->resolvePlanPath($planOption);
+            $plan = $this->readPlan($resolvedPlanPath);
+            $planDisk = trim((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+            if ($planDisk !== $disk) {
+                $this->error('plan disk mismatch: '.$planDisk.' != '.$disk);
+
+                return self::FAILURE;
+            }
+
+            $plan['_meta'] = [
+                'plan_path' => $resolvedPlanPath,
+            ];
+            $payload = $this->service->executePlan($plan);
+
+            return $this->emitPayload($payload);
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function ensureTargetDiskIsRemote(string $disk): void
+    {
+        $driver = trim((string) config('filesystems.disks.'.$disk.'.driver', ''));
+        if ($driver === '') {
+            throw new \RuntimeException('rehydrate target disk is not configured: filesystems.disks.'.$disk.' is missing.');
+        }
+
+        if ($driver === 'local') {
+            throw new \RuntimeException('rehydrate target disk must be remote: local disks are not allowed.');
+        }
+
+        if ($driver === 's3' && trim((string) config('filesystems.disks.'.$disk.'.bucket', '')) === '') {
+            throw new \RuntimeException('rehydrate target disk is not configured: filesystems.disks.'.$disk.'.bucket is empty.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function emitPayload(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode report artifact rehydrate json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return (($payload['status'] ?? 'executed') === 'partial_failure') ? self::FAILURE : self::SUCCESS;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('disk='.(string) ($payload['disk'] ?? ''));
+        $this->line('target_disk='.(string) ($payload['target_disk'] ?? ''));
+        $this->line('schema='.(string) ($payload['schema'] ?? ''));
+        $this->line('plan='.(string) ($payload['plan'] ?? ''));
+        $this->line('candidate_count='.(int) ($summary['candidate_count'] ?? 0));
+        $this->line('rehydrated_count='.(int) ($summary['rehydrated_count'] ?? 0));
+        $this->line('verified_count='.(int) ($summary['verified_count'] ?? 0));
+        $this->line('skipped_count='.(int) ($summary['skipped_count'] ?? 0));
+        $this->line('blocked_count='.(int) ($summary['blocked_count'] ?? 0));
+        $this->line('failed_count='.(int) ($summary['failed_count'] ?? 0));
+
+        if (isset($payload['run_path'])) {
+            $this->line('run_path='.(string) $payload['run_path']);
+        }
+
+        return (($payload['status'] ?? 'executed') === 'partial_failure') ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function persistPlan(array $plan): string
+    {
+        $planDir = storage_path('app/private/report_artifact_rehydrate_plans');
+        File::ensureDirectoryExists($planDir);
+
+        $planPath = $planDir.DIRECTORY_SEPARATOR.now()->format('Ymd_His').'_report_artifact_rehydrate_'.substr(bin2hex(random_bytes(4)), 0, 8).'.json';
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode report artifact rehydrate plan json.');
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        return $planPath;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readPlan(string $planPath): array
+    {
+        if (! is_file($planPath)) {
+            throw new \RuntimeException('plan not found: '.$planPath);
+        }
+
+        $decoded = json_decode((string) File::get($planPath), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('invalid report artifact rehydrate plan json: '.$planPath);
+        }
+
+        if ((string) ($decoded['schema'] ?? '') !== 'storage_rehydrate_report_artifacts_plan.v1') {
+            throw new \RuntimeException('plan schema mismatch.');
+        }
+
+        return $decoded;
+    }
+
+    private function resolvePlanPath(string $planOption): string
+    {
+        if (str_starts_with($planOption, DIRECTORY_SEPARATOR)) {
+            return $planOption;
+        }
+
+        $basePathCandidate = base_path($planOption);
+        if (is_file($basePathCandidate)) {
+            return $basePathCandidate;
+        }
+
+        return storage_path('app/private/'.ltrim($planOption, '/\\'));
+    }
+}

--- a/backend/app/Services/Storage/ReportArtifactsRehydrateService.php
+++ b/backend/app/Services/Storage/ReportArtifactsRehydrateService.php
@@ -1,0 +1,620 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+final class ReportArtifactsRehydrateService
+{
+    private const PLAN_SCHEMA = 'storage_rehydrate_report_artifacts_plan.v1';
+
+    private const RUN_SCHEMA = 'storage_rehydrate_report_artifacts_run.v1';
+
+    private const ARCHIVE_AUDIT_ACTION = 'storage_archive_report_artifacts';
+
+    private const REHYDRATE_AUDIT_ACTION = 'storage_rehydrate_report_artifacts';
+
+    /**
+     * @var array<string,bool>
+     */
+    private array $remoteArchiveIndexLoaded = [];
+
+    /**
+     * @var array<string,array<string,bool>>
+     */
+    private array $remoteArchiveObjectsByDisk = [];
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildPlan(string $targetDisk): array
+    {
+        $targetDisk = $this->normalizeDisk($targetDisk);
+        $candidates = $this->collectCandidates($targetDisk);
+        $summary = $this->buildPlanSummary($candidates, $targetDisk);
+
+        $payload = [
+            'schema' => self::PLAN_SCHEMA,
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'disk' => $targetDisk,
+            'target_disk' => $targetDisk,
+            'summary' => $summary,
+            'candidates' => $candidates,
+        ];
+
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    public function executePlan(array $plan): array
+    {
+        $this->assertPlanSchema($plan);
+
+        $targetDisk = $this->normalizeDisk((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+        $candidates = is_array($plan['candidates'] ?? null) ? array_values($plan['candidates']) : [];
+        $summary = [
+            'candidate_count' => count($candidates),
+            'rehydrated_count' => 0,
+            'verified_count' => 0,
+            'skipped_count' => 0,
+            'blocked_count' => 0,
+            'failed_count' => 0,
+        ];
+        $results = [];
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $result = $this->executeCandidate($candidate, $targetDisk);
+            $results[] = $result;
+
+            $status = (string) ($result['status'] ?? '');
+            if ($status === 'rehydrated') {
+                $summary['rehydrated_count']++;
+                $summary['verified_count']++;
+
+                continue;
+            }
+
+            if ($status === 'skipped') {
+                $summary['skipped_count']++;
+
+                continue;
+            }
+
+            if ($status === 'blocked') {
+                $summary['blocked_count']++;
+
+                continue;
+            }
+
+            $summary['failed_count']++;
+        }
+
+        $status = $summary['failed_count'] > 0 ? 'partial_failure' : 'executed';
+        $runDir = $this->runDirectory();
+        $runPath = $runDir.DIRECTORY_SEPARATOR.'run.json';
+
+        $payload = [
+            'schema' => self::RUN_SCHEMA,
+            'mode' => 'execute',
+            'status' => $status,
+            'generated_at' => now()->toIso8601String(),
+            'disk' => $targetDisk,
+            'target_disk' => $targetDisk,
+            'plan' => trim((string) data_get($plan, '_meta.plan_path', '')),
+            'plan_path' => trim((string) data_get($plan, '_meta.plan_path', '')),
+            'summary' => $summary,
+            'results' => $results,
+        ];
+
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode report artifact rehydrate run receipt.');
+        }
+
+        File::put($runPath, $encoded.PHP_EOL);
+        $payload['run_path'] = $runPath;
+
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function collectCandidates(string $targetDisk): array
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return [];
+        }
+
+        $rows = DB::table('audit_logs')
+            ->where('action', self::ARCHIVE_AUDIT_ACTION)
+            ->orderByDesc('id')
+            ->get(['id', 'created_at', 'meta_json']);
+
+        $candidatesBySourcePath = [];
+
+        foreach ($rows as $row) {
+            $meta = $this->decodeJsonObject($row->meta_json ?? null);
+            if (($meta['mode'] ?? null) !== 'execute') {
+                continue;
+            }
+
+            $results = is_array($meta['results'] ?? null) ? array_values($meta['results']) : [];
+            foreach ($results as $result) {
+                if (! is_array($result)) {
+                    continue;
+                }
+
+                $candidate = $this->candidateFromArchiveResult($result, $targetDisk, (int) $row->id, $row->created_at);
+                if ($candidate === null) {
+                    continue;
+                }
+
+                $sourcePath = (string) $candidate['source_path'];
+                if (isset($candidatesBySourcePath[$sourcePath])) {
+                    continue;
+                }
+
+                $candidatesBySourcePath[$sourcePath] = $candidate;
+            }
+        }
+
+        $candidates = array_values($candidatesBySourcePath);
+        usort($candidates, static fn (array $left, array $right): int => strcmp((string) ($left['source_path'] ?? ''), (string) ($right['source_path'] ?? '')));
+
+        return $candidates;
+    }
+
+    /**
+     * @param  array<string,mixed>  $result
+     * @return array<string,mixed>|null
+     */
+    private function candidateFromArchiveResult(array $result, string $targetDisk, int $auditId, mixed $createdAt): ?array
+    {
+        $archivedStatus = $this->normalizeOptionalString($result['status'] ?? null);
+        if (! in_array($archivedStatus, ['copied', 'already_archived'], true)) {
+            return null;
+        }
+
+        $sourcePath = $this->normalizeOptionalString($result['source_path'] ?? null);
+        $targetObjectKey = $this->normalizeOptionalString($result['target_object_key'] ?? null);
+        $sourceSha256 = $this->normalizeOptionalString($result['source_sha256'] ?? $result['planned_sha256'] ?? null);
+        $sourceBytes = $this->normalizeNullableInt($result['source_bytes'] ?? $result['planned_bytes'] ?? null);
+
+        if ($sourcePath === null || ! $this->isExactCanonicalSourcePath($sourcePath)) {
+            return null;
+        }
+
+        if ($targetObjectKey === null || $sourceSha256 === null || $sourceBytes === null) {
+            return null;
+        }
+
+        $resultTargetDisk = $this->normalizeOptionalString($result['target_disk'] ?? null);
+        if ($resultTargetDisk !== null && $resultTargetDisk !== $targetDisk) {
+            return null;
+        }
+
+        $context = $this->canonicalContextForSourcePath($sourcePath);
+        if ($context === null) {
+            return null;
+        }
+
+        return [
+            'kind' => $context['kind'],
+            'source_path' => $sourcePath,
+            'target_disk' => $targetDisk,
+            'target_object_key' => $targetObjectKey,
+            'source_sha256' => $sourceSha256,
+            'source_bytes' => $sourceBytes,
+            'archived_status' => $archivedStatus,
+            'scale_code' => $result['scale_code'] ?? $context['scale_code'],
+            'attempt_id' => $result['attempt_id'] ?? $context['attempt_id'],
+            'archive_audit_id' => $auditId,
+            'archive_recorded_at' => $this->normalizeTimestamp($createdAt),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $candidates
+     * @return array<string,int>
+     */
+    private function buildPlanSummary(array $candidates, string $targetDisk): array
+    {
+        $summary = [
+            'candidate_count' => count($candidates),
+            'rehydrated_count' => 0,
+            'verified_count' => 0,
+            'skipped_count' => 0,
+            'blocked_count' => 0,
+            'failed_count' => 0,
+        ];
+
+        foreach ($candidates as $candidate) {
+            $precheck = $this->precheckCandidate($candidate, $targetDisk);
+            $status = (string) ($precheck['status'] ?? '');
+            if ($status === 'skipped') {
+                $summary['skipped_count']++;
+
+                continue;
+            }
+
+            if ($status === 'blocked') {
+                $summary['blocked_count']++;
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     * @return array{status:string,reason:string}
+     */
+    private function precheckCandidate(array $candidate, string $targetDisk): array
+    {
+        $sourcePath = $this->normalizeOptionalString($candidate['source_path'] ?? null);
+        $targetObjectKey = $this->normalizeOptionalString($candidate['target_object_key'] ?? null);
+        $sourceSha256 = $this->normalizeOptionalString($candidate['source_sha256'] ?? null);
+        $sourceBytes = $this->normalizeNullableInt($candidate['source_bytes'] ?? null);
+
+        if ($sourcePath === null || $targetObjectKey === null || $sourceSha256 === null || $sourceBytes === null) {
+            return [
+                'status' => 'blocked',
+                'reason' => 'ARCHIVE_PROOF_INCOMPLETE',
+            ];
+        }
+
+        $absolutePath = storage_path('app/private/'.$sourcePath);
+        if (is_file($absolutePath)) {
+            return [
+                'status' => 'skipped',
+                'reason' => 'LOCAL_CANONICAL_ALREADY_EXISTS',
+            ];
+        }
+
+        if (! $this->remoteObjectExists($targetDisk, $targetObjectKey)) {
+            return [
+                'status' => 'blocked',
+                'reason' => 'REMOTE_OBJECT_MISSING',
+            ];
+        }
+
+        return [
+            'status' => 'ready',
+            'reason' => 'READY_FOR_REHYDRATE',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     * @return array<string,mixed>
+     */
+    private function executeCandidate(array $candidate, string $targetDisk): array
+    {
+        $sourcePath = $this->normalizeOptionalString($candidate['source_path'] ?? null);
+        $targetObjectKey = $this->normalizeOptionalString($candidate['target_object_key'] ?? null);
+        $sourceSha256 = $this->normalizeOptionalString($candidate['source_sha256'] ?? null);
+        $sourceBytes = $this->normalizeNullableInt($candidate['source_bytes'] ?? null);
+        $kind = $this->normalizeOptionalString($candidate['kind'] ?? null) ?? 'unknown';
+
+        $baseResult = [
+            'kind' => $kind,
+            'source_path' => $sourcePath,
+            'target_disk' => $targetDisk,
+            'target_object_key' => $targetObjectKey,
+            'source_sha256' => $sourceSha256,
+            'source_bytes' => $sourceBytes,
+            'archived_status' => $candidate['archived_status'] ?? null,
+            'scale_code' => $candidate['scale_code'] ?? null,
+            'attempt_id' => $candidate['attempt_id'] ?? null,
+        ];
+
+        $precheck = $this->precheckCandidate($candidate, $targetDisk);
+        if ($precheck['status'] === 'skipped') {
+            return $baseResult + [
+                'status' => 'skipped',
+                'reason' => $precheck['reason'],
+            ];
+        }
+
+        if ($precheck['status'] === 'blocked') {
+            return $baseResult + [
+                'status' => 'blocked',
+                'reason' => $precheck['reason'],
+            ];
+        }
+
+        if ($sourcePath === null || $targetObjectKey === null || $sourceSha256 === null || $sourceBytes === null) {
+            return $baseResult + [
+                'status' => 'blocked',
+                'reason' => 'ARCHIVE_PROOF_INCOMPLETE',
+            ];
+        }
+
+        $absoluteTargetPath = storage_path('app/private/'.$sourcePath);
+        $targetDirectory = dirname($absoluteTargetPath);
+        File::ensureDirectoryExists($targetDirectory);
+        $tmpPath = $absoluteTargetPath.'.rehydrate_tmp_'.substr(bin2hex(random_bytes(4)), 0, 8);
+
+        try {
+            $stream = Storage::disk($targetDisk)->readStream($targetObjectKey);
+        } catch (\Throwable) {
+            $stream = false;
+        }
+
+        if (! is_resource($stream)) {
+            return $baseResult + [
+                'status' => 'blocked',
+                'reason' => 'REMOTE_OBJECT_MISSING',
+            ];
+        }
+
+        $localStream = @fopen($tmpPath, 'wb');
+        if ($localStream === false) {
+            fclose($stream);
+
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'LOCAL_TEMP_OPEN_FAILED',
+            ];
+        }
+
+        try {
+            stream_copy_to_stream($stream, $localStream);
+        } finally {
+            fclose($stream);
+            fclose($localStream);
+        }
+
+        $rehydratedSha256 = hash_file('sha256', $tmpPath);
+        if (! is_string($rehydratedSha256) || $rehydratedSha256 === '') {
+            @unlink($tmpPath);
+
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'LOCAL_HASH_FAILED',
+            ];
+        }
+
+        if ($rehydratedSha256 !== $sourceSha256) {
+            @unlink($tmpPath);
+
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'LOCAL_HASH_MISMATCH',
+                'rehydrated_sha256' => $rehydratedSha256,
+            ];
+        }
+
+        if (is_file($absoluteTargetPath)) {
+            @unlink($tmpPath);
+
+            return $baseResult + [
+                'status' => 'skipped',
+                'reason' => 'LOCAL_CANONICAL_ALREADY_EXISTS',
+            ];
+        }
+
+        if (! @rename($tmpPath, $absoluteTargetPath)) {
+            @unlink($tmpPath);
+
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'LOCAL_MOVE_FAILED',
+            ];
+        }
+
+        return $baseResult + [
+            'status' => 'rehydrated',
+            'reason' => 'REMOTE_OBJECT_DOWNLOADED_AND_VERIFIED',
+            'rehydrated_at' => now()->toIso8601String(),
+            'verified_at' => now()->toIso8601String(),
+            'rehydrated_sha256' => $rehydratedSha256,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+        $results = is_array($payload['results'] ?? null) ? array_values($payload['results']) : [];
+        $planPath = $this->normalizeOptionalString($payload['plan_path'] ?? $payload['plan'] ?? null);
+        $runPath = $this->normalizeOptionalString($payload['run_path'] ?? null);
+        $failedCount = (int) ($summary['failed_count'] ?? 0);
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => self::REHYDRATE_AUDIT_ACTION,
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_rehydrate',
+            'meta_json' => json_encode([
+                'schema' => $payload['schema'] ?? null,
+                'mode' => $payload['mode'] ?? null,
+                'target_disk' => $payload['target_disk'] ?? null,
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'run_path' => $runPath,
+                'candidate_count' => (int) ($summary['candidate_count'] ?? 0),
+                'rehydrated_count' => (int) ($summary['rehydrated_count'] ?? 0),
+                'verified_count' => (int) ($summary['verified_count'] ?? 0),
+                'skipped_count' => (int) ($summary['skipped_count'] ?? 0),
+                'blocked_count' => (int) ($summary['blocked_count'] ?? 0),
+                'failed_count' => $failedCount,
+                'results_count' => count($results),
+                'durable_receipt_source' => 'audit_logs.meta_json',
+                'summary' => $summary,
+                'results' => $results,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'artisan/storage:rehydrate-report-artifacts',
+            'request_id' => null,
+            'reason' => 'manual_archive_rehydrate',
+            'result' => $failedCount > 0 ? 'partial_failure' : 'success',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function assertPlanSchema(array $plan): void
+    {
+        if ((string) ($plan['schema'] ?? '') !== self::PLAN_SCHEMA) {
+            throw new \RuntimeException('report artifact rehydrate plan schema mismatch.');
+        }
+    }
+
+    private function normalizeDisk(string $disk): string
+    {
+        $normalized = trim($disk);
+        if ($normalized === '') {
+            throw new \RuntimeException('target disk is required.');
+        }
+
+        return $normalized;
+    }
+
+    private function runDirectory(): string
+    {
+        $dir = storage_path('app/private/report_artifact_rehydrate_runs/'.now()->format('Ymd_His').'_'.substr(bin2hex(random_bytes(4)), 0, 8));
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    private function remoteObjectExists(string $targetDisk, string $targetObjectKey): bool
+    {
+        if (str_starts_with($targetObjectKey, 'report_artifacts_archive/')) {
+            $this->primeRemoteArchiveIndex($targetDisk);
+
+            return isset($this->remoteArchiveObjectsByDisk[$targetDisk][$targetObjectKey]);
+        }
+
+        return Storage::disk($targetDisk)->exists($targetObjectKey);
+    }
+
+    private function primeRemoteArchiveIndex(string $targetDisk): void
+    {
+        if (($this->remoteArchiveIndexLoaded[$targetDisk] ?? false) === true) {
+            return;
+        }
+
+        $this->remoteArchiveIndexLoaded[$targetDisk] = true;
+
+        try {
+            $files = Storage::disk($targetDisk)->allFiles('report_artifacts_archive');
+        } catch (\Throwable) {
+            $files = [];
+        }
+
+        $index = [];
+        foreach ($files as $file) {
+            if (! is_string($file) || trim($file) === '') {
+                continue;
+            }
+
+            $index[$file] = true;
+        }
+
+        $this->remoteArchiveObjectsByDisk[$targetDisk] = $index;
+    }
+
+    private function normalizeOptionalString(mixed $value): ?string
+    {
+        if (! is_scalar($value) || $value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeNullableInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return max(0, (int) $value);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonObject(mixed $value): array
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function normalizeTimestamp(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $timestamp = trim((string) $value);
+
+        return $timestamp === '' ? null : $timestamp;
+    }
+
+    private function isExactCanonicalSourcePath(string $sourcePath): bool
+    {
+        return $this->canonicalContextForSourcePath($sourcePath) !== null;
+    }
+
+    /**
+     * @return array{kind:string,scale_code:string,attempt_id:string}|null
+     */
+    private function canonicalContextForSourcePath(string $sourcePath): ?array
+    {
+        if (preg_match('#^artifacts/reports/([^/]+)/([^/]+)/report\.json$#', $sourcePath, $matches) === 1) {
+            return [
+                'kind' => 'report_json',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+            ];
+        }
+
+        if (preg_match('#^artifacts/pdf/([^/]+)/([^/]+)/[^/]+/report_(free|full)\.pdf$#', $sourcePath, $matches) === 1) {
+            return [
+                'kind' => 'report_'.$matches[3].'_pdf',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+            ];
+        }
+
+        return null;
+    }
+}

--- a/backend/tests/Feature/Storage/ReportArtifactsRehydrateServiceTest.php
+++ b/backend/tests/Feature/Storage/ReportArtifactsRehydrateServiceTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ReportArtifactsRehydrateService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ReportArtifactsRehydrateServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-report-artifacts-rehydrate-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('filesystems.disks.s3.bucket', 'report-artifacts-rehydrate-service-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.report-rehydrate.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_rehydrates_archived_report_and_pdf_to_exact_local_canonical_paths(): void
+    {
+        $reportBytes = json_encode(['attempt' => 'rehydrate-report'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($reportBytes);
+        $reportPath = 'artifacts/reports/MBTI/rehydrate-report/report.json';
+        $reportSha = hash('sha256', $reportBytes);
+        Storage::disk('s3')->put('report_artifacts_archive/reports/MBTI/rehydrate-report/report.json', $reportBytes);
+
+        $pdfBytes = '%PDF-1.4 rehydrate full';
+        $pdfPath = 'artifacts/pdf/BIG5/rehydrate-pdf/nohash/report_full.pdf';
+        $pdfSha = hash('sha256', $pdfBytes);
+        Storage::disk('s3')->put('report_artifacts_archive/pdf/BIG5/rehydrate-pdf/nohash/report_full.pdf', $pdfBytes);
+
+        $legacyPath = 'private/reports/BIG5/rehydrate-pdf/nohash/report_full.pdf';
+        Storage::disk('local')->put($legacyPath, '%PDF legacy untouched');
+
+        $this->seedArchiveAudit([
+            $this->archiveResult('report_json', $reportPath, 'report_artifacts_archive/reports/MBTI/rehydrate-report/report.json', $reportSha, strlen($reportBytes), 'copied', 'MBTI', 'rehydrate-report'),
+            $this->archiveResult('report_full_pdf', $pdfPath, 'report_artifacts_archive/pdf/BIG5/rehydrate-pdf/nohash/report_full.pdf', $pdfSha, strlen($pdfBytes), 'already_archived', 'BIG5', 'rehydrate-pdf'),
+        ]);
+
+        /** @var ReportArtifactsRehydrateService $service */
+        $service = app(ReportArtifactsRehydrateService::class);
+
+        $plan = $service->buildPlan('s3');
+        $this->assertSame('storage_rehydrate_report_artifacts_plan.v1', $plan['schema']);
+        $this->assertSame(2, data_get($plan, 'summary.candidate_count'));
+        $this->assertSame(0, data_get($plan, 'summary.skipped_count'));
+        $this->assertSame(0, data_get($plan, 'summary.blocked_count'));
+
+        $dryRunAudit = DB::table('audit_logs')
+            ->where('action', 'storage_rehydrate_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($dryRunAudit);
+        $this->assertSame('success', $dryRunAudit->result);
+        $dryRunMeta = json_decode((string) $dryRunAudit->meta_json, true);
+        $this->assertIsArray($dryRunMeta);
+        $this->assertSame('dry_run', $dryRunMeta['mode'] ?? null);
+        $this->assertSame(2, $dryRunMeta['candidate_count'] ?? null);
+        $this->assertSame(0, $dryRunMeta['results_count'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $dryRunMeta['durable_receipt_source'] ?? null);
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_rehydrate_plans/test-plan.json')];
+        $result = $service->executePlan($plan);
+
+        $this->assertSame('executed', $result['status']);
+        $this->assertSame(2, data_get($result, 'summary.rehydrated_count'));
+        $this->assertSame(2, data_get($result, 'summary.verified_count'));
+        $this->assertSame(0, data_get($result, 'summary.failed_count'));
+        $this->assertFileExists((string) ($result['run_path'] ?? ''));
+
+        $this->assertTrue(Storage::disk('local')->exists($reportPath));
+        $this->assertTrue(Storage::disk('local')->exists($pdfPath));
+        $this->assertSame($reportSha, hash('sha256', (string) Storage::disk('local')->get($reportPath)));
+        $this->assertSame($pdfSha, hash('sha256', (string) Storage::disk('local')->get($pdfPath)));
+        $this->assertTrue(Storage::disk('local')->exists($legacyPath));
+    }
+
+    public function test_service_blocks_missing_remote_and_excludes_incomplete_archive_truth(): void
+    {
+        $validPath = 'artifacts/reports/MBTI/blocked-report/report.json';
+        $validSha = hash('sha256', '{"ok":true}');
+
+        $this->seedArchiveAudit([
+            $this->archiveResult('report_json', $validPath, 'report_artifacts_archive/reports/MBTI/blocked-report/report.json', $validSha, 11, 'copied', 'MBTI', 'blocked-report'),
+            [
+                'status' => 'copied',
+                'kind' => 'report_json',
+                'source_path' => 'artifacts/reports/MBTI/incomplete/report.json',
+                'target_disk' => 's3',
+                'target_object_key' => '',
+                'source_sha256' => '',
+                'source_bytes' => 0,
+            ],
+        ]);
+
+        /** @var ReportArtifactsRehydrateService $service */
+        $service = app(ReportArtifactsRehydrateService::class);
+
+        $plan = $service->buildPlan('s3');
+        $this->assertSame(1, data_get($plan, 'summary.candidate_count'));
+        $this->assertSame(1, data_get($plan, 'summary.blocked_count'));
+        $this->assertSame($validPath, data_get($plan, 'candidates.0.source_path'));
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_rehydrate_plans/blocked.json')];
+        $result = $service->executePlan($plan);
+
+        $this->assertSame('executed', $result['status']);
+        $this->assertSame(0, data_get($result, 'summary.rehydrated_count'));
+        $this->assertSame(1, data_get($result, 'summary.blocked_count'));
+        $this->assertSame('blocked', data_get($result, 'results.0.status'));
+        $this->assertSame('REMOTE_OBJECT_MISSING', data_get($result, 'results.0.reason'));
+        $this->assertFalse(Storage::disk('local')->exists($validPath));
+    }
+
+    public function test_service_skips_existing_local_and_fails_hash_mismatch_visibly(): void
+    {
+        $existingPath = 'artifacts/reports/MBTI/existing-report/report.json';
+        Storage::disk('local')->put($existingPath, '{"existing":true}');
+        $existingBytes = '{"existing":true}';
+        Storage::disk('s3')->put('report_artifacts_archive/reports/MBTI/existing-report/report.json', $existingBytes);
+
+        $mismatchPath = 'artifacts/pdf/BIG5/mismatch-pdf/nohash/report_free.pdf';
+        Storage::disk('s3')->put('report_artifacts_archive/pdf/BIG5/mismatch-pdf/nohash/report_free.pdf', '%PDF-real');
+
+        $legacyPath = 'private/reports/BIG5/mismatch-pdf/nohash/report_free.pdf';
+        Storage::disk('local')->put($legacyPath, '%PDF legacy');
+
+        $this->seedArchiveAudit([
+            $this->archiveResult('report_json', $existingPath, 'report_artifacts_archive/reports/MBTI/existing-report/report.json', hash('sha256', $existingBytes), strlen($existingBytes), 'copied', 'MBTI', 'existing-report'),
+            $this->archiveResult('report_free_pdf', $mismatchPath, 'report_artifacts_archive/pdf/BIG5/mismatch-pdf/nohash/report_free.pdf', hash('sha256', '%PDF-wrong'), strlen('%PDF-real'), 'copied', 'BIG5', 'mismatch-pdf'),
+        ]);
+
+        /** @var ReportArtifactsRehydrateService $service */
+        $service = app(ReportArtifactsRehydrateService::class);
+
+        $plan = $service->buildPlan('s3');
+        $this->assertSame(2, data_get($plan, 'summary.candidate_count'));
+        $this->assertSame(1, data_get($plan, 'summary.skipped_count'));
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_rehydrate_plans/mixed.json')];
+        $result = $service->executePlan($plan);
+
+        $this->assertSame('partial_failure', $result['status']);
+        $this->assertSame(1, data_get($result, 'summary.skipped_count'));
+        $this->assertSame(1, data_get($result, 'summary.failed_count'));
+        $this->assertContains(
+            ['status' => 'skipped', 'reason' => 'LOCAL_CANONICAL_ALREADY_EXISTS'],
+            array_map(
+                static fn (array $item): array => [
+                    'status' => (string) ($item['status'] ?? ''),
+                    'reason' => (string) ($item['reason'] ?? ''),
+                ],
+                data_get($result, 'results', [])
+            )
+        );
+        $this->assertContains(
+            ['status' => 'failed', 'reason' => 'LOCAL_HASH_MISMATCH'],
+            array_map(
+                static fn (array $item): array => [
+                    'status' => (string) ($item['status'] ?? ''),
+                    'reason' => (string) ($item['reason'] ?? ''),
+                ],
+                data_get($result, 'results', [])
+            )
+        );
+        $this->assertSame('{"existing":true}', (string) Storage::disk('local')->get($existingPath));
+        $this->assertFalse(Storage::disk('local')->exists($mismatchPath));
+        $this->assertTrue(Storage::disk('local')->exists($legacyPath));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_rehydrate_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $this->assertSame('partial_failure', $audit->result);
+        $meta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($meta);
+        $this->assertSame(1, $meta['skipped_count'] ?? null);
+        $this->assertSame(1, $meta['failed_count'] ?? null);
+        $this->assertSame(2, $meta['results_count'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $meta['durable_receipt_source'] ?? null);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $results
+     */
+    private function seedArchiveAudit(array $results): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_archive_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_archive',
+            'meta_json' => json_encode([
+                'schema' => 'storage_archive_report_artifacts_run.v1',
+                'mode' => 'execute',
+                'target_disk' => 's3',
+                'results' => $results,
+                'summary' => [
+                    'candidate_count' => count($results),
+                    'copied_count' => count(array_filter($results, static fn (array $result): bool => ($result['status'] ?? null) === 'copied')),
+                    'verified_count' => count(array_filter($results, static fn (array $result): bool => in_array((string) ($result['status'] ?? ''), ['copied', 'already_archived'], true))),
+                    'already_archived_count' => count(array_filter($results, static fn (array $result): bool => ($result['status'] ?? null) === 'already_archived')),
+                    'failed_count' => 0,
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'phpunit',
+            'request_id' => null,
+            'reason' => 'seed_archive_receipt',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function archiveResult(
+        string $kind,
+        string $sourcePath,
+        string $targetObjectKey,
+        string $sourceSha256,
+        int $sourceBytes,
+        string $status,
+        string $scaleCode,
+        string $attemptId,
+    ): array {
+        return [
+            'status' => $status,
+            'kind' => $kind,
+            'source_path' => $sourcePath,
+            'target_disk' => 's3',
+            'target_object_key' => $targetObjectKey,
+            'source_sha256' => $sourceSha256,
+            'source_bytes' => $sourceBytes,
+            'target_bytes' => $sourceBytes,
+            'scale_code' => $scaleCode,
+            'attempt_id' => $attemptId,
+            'verified_at' => now()->toIso8601String(),
+        ];
+    }
+}

--- a/backend/tests/Feature/Storage/StorageRehydrateReportArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageRehydrateReportArtifactsCommandTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageRehydrateReportArtifacts;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageRehydrateReportArtifactsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-report-artifacts-rehydrate-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('filesystems.disks.s3.bucket', 'report-artifacts-rehydrate-command-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.report-rehydrate-command.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageRehydrateReportArtifacts::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_requires_exactly_one_mode_and_plan_for_execute(): void
+    {
+        $this->artisan('storage:rehydrate-report-artifacts')
+            ->expectsOutputToContain('exactly one of --dry-run or --execute is required.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:rehydrate-report-artifacts --dry-run --execute')
+            ->expectsOutputToContain('exactly one of --dry-run or --execute is required.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:rehydrate-report-artifacts --execute --disk=s3')
+            ->expectsOutputToContain('--execute requires --plan.')
+            ->assertExitCode(1);
+    }
+
+    public function test_command_dry_run_execute_json_and_skip_are_visible(): void
+    {
+        $reportBytes = json_encode(['attempt' => 'command-rehydrate'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($reportBytes);
+        $reportPath = 'artifacts/reports/MBTI/command-rehydrate/report.json';
+        $reportSha = hash('sha256', $reportBytes);
+        Storage::disk('s3')->put('report_artifacts_archive/reports/MBTI/command-rehydrate/report.json', $reportBytes);
+
+        $this->seedArchiveAudit([
+            [
+                'status' => 'copied',
+                'kind' => 'report_json',
+                'source_path' => $reportPath,
+                'target_disk' => 's3',
+                'target_object_key' => 'report_artifacts_archive/reports/MBTI/command-rehydrate/report.json',
+                'source_sha256' => $reportSha,
+                'source_bytes' => strlen($reportBytes),
+                'target_bytes' => strlen($reportBytes),
+                'scale_code' => 'MBTI',
+                'attempt_id' => 'command-rehydrate',
+                'verified_at' => now()->toIso8601String(),
+            ],
+        ]);
+
+        $this->assertSame(0, Artisan::call('storage:rehydrate-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('candidate_count=1', $dryRunOutput);
+        $this->assertStringContainsString('rehydrated_count=0', $dryRunOutput);
+        $this->assertStringContainsString('skipped_count=0', $dryRunOutput);
+        $this->assertStringContainsString('blocked_count=0', $dryRunOutput);
+
+        preg_match('/^plan=(.+)$/m', $dryRunOutput, $matches);
+        $planPath = trim((string) ($matches[1] ?? ''));
+        $this->assertFileExists($planPath);
+
+        $dryRunAudit = DB::table('audit_logs')
+            ->where('action', 'storage_rehydrate_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($dryRunAudit);
+        $dryRunMeta = json_decode((string) $dryRunAudit->meta_json, true);
+        $this->assertIsArray($dryRunMeta);
+        $this->assertSame('dry_run', $dryRunMeta['mode'] ?? null);
+        $this->assertSame(1, $dryRunMeta['candidate_count'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $dryRunMeta['durable_receipt_source'] ?? null);
+
+        $this->assertSame(0, Artisan::call('storage:rehydrate-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('candidate_count=1', $executeOutput);
+        $this->assertStringContainsString('rehydrated_count=1', $executeOutput);
+        $this->assertStringContainsString('verified_count=1', $executeOutput);
+        $this->assertStringContainsString('run_path=', $executeOutput);
+
+        $this->assertTrue(Storage::disk('local')->exists($reportPath));
+
+        $this->assertSame(0, Artisan::call('storage:rehydrate-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--json' => true,
+        ]));
+        $jsonPayload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($jsonPayload);
+        $this->assertSame('storage_rehydrate_report_artifacts_plan.v1', $jsonPayload['schema'] ?? null);
+        $this->assertSame(1, data_get($jsonPayload, 'summary.candidate_count'));
+        $this->assertSame(1, data_get($jsonPayload, 'summary.skipped_count'));
+
+        $this->assertSame(0, Artisan::call('storage:rehydrate-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+        $skipOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $skipOutput);
+        $this->assertStringContainsString('skipped_count=1', $skipOutput);
+        $this->assertStringContainsString('rehydrated_count=0', $skipOutput);
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_rehydrate_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $meta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($meta);
+        $this->assertSame(1, $meta['skipped_count'] ?? null);
+        $this->assertSame(0, $meta['failed_count'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $meta['durable_receipt_source'] ?? null);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $results
+     */
+    private function seedArchiveAudit(array $results): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_archive_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_archive',
+            'meta_json' => json_encode([
+                'schema' => 'storage_archive_report_artifacts_run.v1',
+                'mode' => 'execute',
+                'target_disk' => 's3',
+                'results' => $results,
+                'summary' => [
+                    'candidate_count' => count($results),
+                    'copied_count' => count(array_filter($results, static fn (array $result): bool => ($result['status'] ?? null) === 'copied')),
+                    'verified_count' => count(array_filter($results, static fn (array $result): bool => in_array((string) ($result['status'] ?? ''), ['copied', 'already_archived'], true))),
+                    'already_archived_count' => count(array_filter($results, static fn (array $result): bool => ($result['status'] ?? null) === 'already_archived')),
+                    'failed_count' => 0,
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'phpunit',
+            'request_id' => null,
+            'reason' => 'seed_archive_receipt',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a manual-only, plan-first rehydrate surface for archived report artifacts.

The new surface is intentionally narrow:

- single-file execution only
- explicit rehydrate-to-local only
- no direct remote read fallback
- no cutover
- no delete
- no changes to existing report readers, writers, or fallback semantics

It restores exact canonical files back to their exact local canonical paths from durable archive truth in `audit_logs.meta_json`.

## Root cause

The repository already had:

- canonical local report artifact paths
- archive/export to `s3`
- durable archive receipt truth in `audit_logs.meta_json`
- control-plane visibility for archive latest summary

What was missing was a formal manual recovery surface for the case where local canonical files are absent.

That made the gap a rehydrate-readiness problem, not an archive problem and not a retention/delete problem.

## What changed

### New command

`storage:rehydrate-report-artifacts`

Options:

- `--dry-run`
- `--execute`
- `--disk=s3`
- `--plan=`
- `--json`

Rules:

- exactly one of `--dry-run` or `--execute`
- `--execute` requires `--plan`
- target disk must be configured and remote

### New service

`ReportArtifactsRehydrateService`

Responsibilities:

- build a plan from durable archive execute truth only
- validate that each candidate is an exact canonical report artifact path
- rehydrate one canonical file at a time
- verify local SHA-256 after download
- persist plan, run receipt, and audit truth

### Candidate rules

Candidates are accepted only when archive durable truth proves:

- `action = storage_archive_report_artifacts`
- archive result status is `copied` or `already_archived`
- `target_disk` matches the requested disk
- `target_object_key` is present
- `source_path` is present
- `source_sha256` is present
- source path is one of:
  - `artifacts/reports/**/report.json`
  - `artifacts/pdf/**/report_free.pdf`
  - `artifacts/pdf/**/report_full.pdf`

Non-canonical paths and incomplete archive proof are excluded.

### Execute semantics

The execution unit is a single canonical file.

For each candidate:

1. fresh revalidate archive proof
2. remote object must still exist
3. local canonical path must not already exist
4. download to exact canonical local path
5. recompute local `sha256`
6. require exact match to archived `source_sha256`

Result handling:

- existing local file => `skipped`
- missing remote object => `blocked`
- hash mismatch => `failed`
- verified restore => `rehydrated`

### Truth surfaces

Plan files:

- `storage/app/private/report_artifact_rehydrate_plans/*.json`

Run receipts:

- `storage/app/private/report_artifact_rehydrate_runs/{run_id}/run.json`

Audit action:

- `storage_rehydrate_report_artifacts`

## What this PR does not change

This PR does **not**:

- change `ArtifactStore`
- change `ReportPdfArtifactStore`
- change `GenerateReportJob`
- change `ReportPersistence`
- change archive command/service behavior
- change control-plane status/snapshot/refresh
- introduce remote read fallback
- introduce cutover
- introduce delete or retention logic

## Validation

Focused tests:

- `tests/Feature/Storage/ReportArtifactsRehydrateServiceTest.php`
- `tests/Feature/Storage/StorageRehydrateReportArtifactsCommandTest.php`

Regression tests:

- `tests/Feature/Storage/ReportArtifactsArchiveServiceTest.php`
- `tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php`
- `tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php`
- `tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php`
- `tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php`
- `tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php`
- `tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php`

Live validation in isolated worktree:

- `php artisan storage:rehydrate-report-artifacts --dry-run --disk=s3`
- `php artisan storage:rehydrate-report-artifacts --execute --disk=s3 --plan=...`
- `php artisan storage:archive-report-artifacts --dry-run --disk=s3`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan storage:refresh-control-plane --dry-run --json`
- `php artisan storage:inventory --json`
- `bash backend/scripts/ci_verify_mbti.sh`

Key live results:

- first dry-run: `candidate_count=2929`, `blocked_count=0`
- execute: `rehydrated_count=2929`, `verified_count=2929`, `failed_count=0`
- second dry-run after restore: `skipped_count=2929`
- local canonical files restored to exact canonical paths
- legacy paths remained untouched
- run receipt written successfully
- all required focused, regression, live, and CI checks passed
