### PR TITLE
[codex] add archived report artifacts shrink surface

### DIFF
--- a/backend/app/Console/Commands/StorageShrinkArchivedReportArtifacts.php
+++ b/backend/app/Console/Commands/StorageShrinkArchivedReportArtifacts.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\ReportArtifactsShrinkService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class StorageShrinkArchivedReportArtifacts extends Command
+{
+    protected $signature = 'storage:shrink-archived-report-artifacts
+        {--dry-run : Build a shrink plan for archived and rehydratable local canonical report artifacts}
+        {--execute : Execute shrink from an existing plan}
+        {--disk=s3 : Remote object storage disk that still holds archived canonical artifacts}
+        {--plan= : Absolute or storage-relative plan path required for execute mode}
+        {--json : Emit the full payload as JSON}';
+
+    protected $description = 'Manual-only single-file shrink surface that deletes only local canonical report artifacts already covered by archive and rehydrate truth.';
+
+    public function __construct(
+        private readonly ReportArtifactsShrinkService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $disk = trim((string) ($this->option('disk') ?? 's3'));
+
+        try {
+            $this->ensureTargetDiskIsRemote($disk);
+
+            if ($dryRun) {
+                $plan = $this->service->buildPlan($disk);
+                $planPath = $this->persistPlan($plan);
+                $payload = $plan + ['plan' => $planPath];
+
+                return $this->emitPayload($payload);
+            }
+
+            $planOption = trim((string) ($this->option('plan') ?? ''));
+            if ($planOption === '') {
+                $this->error('--execute requires --plan.');
+
+                return self::FAILURE;
+            }
+
+            $resolvedPlanPath = $this->resolvePlanPath($planOption);
+            $plan = $this->readPlan($resolvedPlanPath);
+            $planDisk = trim((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+            if ($planDisk !== $disk) {
+                $this->error('plan disk mismatch: '.$planDisk.' != '.$disk);
+
+                return self::FAILURE;
+            }
+
+            $plan['_meta'] = [
+                'plan_path' => $resolvedPlanPath,
+            ];
+            $payload = $this->service->executePlan($plan);
+
+            return $this->emitPayload($payload);
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function ensureTargetDiskIsRemote(string $disk): void
+    {
+        $driver = trim((string) config('filesystems.disks.'.$disk.'.driver', ''));
+        if ($driver === '') {
+            throw new \RuntimeException('shrink target disk is not configured: filesystems.disks.'.$disk.' is missing.');
+        }
+
+        if ($driver === 'local') {
+            throw new \RuntimeException('shrink target disk must be remote: local disks are not allowed.');
+        }
+
+        if ($driver === 's3' && trim((string) config('filesystems.disks.'.$disk.'.bucket', '')) === '') {
+            throw new \RuntimeException('shrink target disk is not configured: filesystems.disks.'.$disk.'.bucket is empty.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function emitPayload(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode archived report artifacts shrink json.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return (($payload['status'] ?? 'executed') === 'partial_failure') ? self::FAILURE : self::SUCCESS;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('disk='.(string) ($payload['disk'] ?? ''));
+        $this->line('target_disk='.(string) ($payload['target_disk'] ?? ''));
+        $this->line('schema='.(string) ($payload['schema'] ?? ''));
+        $this->line('plan='.(string) ($payload['plan'] ?? ''));
+        $this->line('candidate_count='.(int) ($summary['candidate_count'] ?? 0));
+        $this->line('deleted_count='.(int) ($summary['deleted_count'] ?? 0));
+        $this->line('skipped_missing_local_count='.(int) ($summary['skipped_missing_local_count'] ?? 0));
+        $this->line('blocked_missing_remote_count='.(int) ($summary['blocked_missing_remote_count'] ?? 0));
+        $this->line('blocked_missing_archive_proof_count='.(int) ($summary['blocked_missing_archive_proof_count'] ?? 0));
+        $this->line('blocked_missing_rehydrate_proof_count='.(int) ($summary['blocked_missing_rehydrate_proof_count'] ?? 0));
+        $this->line('blocked_hash_mismatch_count='.(int) ($summary['blocked_hash_mismatch_count'] ?? 0));
+        $this->line('failed_count='.(int) ($summary['failed_count'] ?? 0));
+
+        if (isset($payload['run_path'])) {
+            $this->line('run_path='.(string) $payload['run_path']);
+        }
+
+        return (($payload['status'] ?? 'executed') === 'partial_failure') ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function persistPlan(array $plan): string
+    {
+        $planDir = storage_path('app/private/report_artifact_shrink_plans');
+        File::ensureDirectoryExists($planDir);
+
+        $planPath = $planDir.DIRECTORY_SEPARATOR.now()->format('Ymd_His').'_report_artifact_shrink_'.substr(bin2hex(random_bytes(4)), 0, 8).'.json';
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode report artifact shrink plan json.');
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        return $planPath;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readPlan(string $planPath): array
+    {
+        if (! is_file($planPath)) {
+            throw new \RuntimeException('plan not found: '.$planPath);
+        }
+
+        $decoded = json_decode((string) File::get($planPath), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('invalid report artifact shrink plan json: '.$planPath);
+        }
+
+        if ((string) ($decoded['schema'] ?? '') !== 'storage_shrink_archived_report_artifacts_plan.v1') {
+            throw new \RuntimeException('plan schema mismatch.');
+        }
+
+        return $decoded;
+    }
+
+    private function resolvePlanPath(string $planOption): string
+    {
+        if (str_starts_with($planOption, DIRECTORY_SEPARATOR)) {
+            return $planOption;
+        }
+
+        $basePathCandidate = base_path($planOption);
+        if (is_file($basePathCandidate)) {
+            return $basePathCandidate;
+        }
+
+        return storage_path('app/private/'.ltrim($planOption, '/\\'));
+    }
+}

--- a/backend/app/Services/Storage/ReportArtifactsShrinkService.php
+++ b/backend/app/Services/Storage/ReportArtifactsShrinkService.php
@@ -1,0 +1,749 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Finder\SplFileInfo;
+
+final class ReportArtifactsShrinkService
+{
+    private const PLAN_SCHEMA = 'storage_shrink_archived_report_artifacts_plan.v1';
+
+    private const RUN_SCHEMA = 'storage_shrink_archived_report_artifacts_run.v1';
+
+    private const ARCHIVE_AUDIT_ACTION = 'storage_archive_report_artifacts';
+
+    private const SHRINK_AUDIT_ACTION = 'storage_shrink_archived_report_artifacts';
+
+    /**
+     * @var array<string,bool>
+     */
+    private array $remoteArchiveIndexLoaded = [];
+
+    /**
+     * @var array<string,array<string,bool>>
+     */
+    private array $remoteArchiveObjectsByDisk = [];
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildPlan(string $targetDisk): array
+    {
+        $targetDisk = $this->normalizeDisk($targetDisk);
+        $localFiles = $this->collectLocalCanonicalFiles();
+        $archiveProofsByPath = $this->collectArchiveProofsByPath($targetDisk);
+
+        $candidates = [];
+        $blocked = [];
+        $summary = [
+            'candidate_count' => 0,
+            'deleted_count' => 0,
+            'skipped_missing_local_count' => 0,
+            'blocked_missing_remote_count' => 0,
+            'blocked_missing_archive_proof_count' => 0,
+            'blocked_missing_rehydrate_proof_count' => 0,
+            'blocked_hash_mismatch_count' => 0,
+            'failed_count' => 0,
+        ];
+
+        foreach ($localFiles as $localFile) {
+            $evaluation = $this->evaluateLocalFile($localFile, $archiveProofsByPath, $targetDisk);
+
+            if (($evaluation['status'] ?? null) === 'candidate') {
+                $candidates[] = $evaluation['candidate'];
+                $summary['candidate_count']++;
+
+                continue;
+            }
+
+            $blocked[] = $evaluation['blocked'];
+            $reason = (string) ($evaluation['blocked']['status'] ?? '');
+            if ($reason === 'blocked_missing_remote') {
+                $summary['blocked_missing_remote_count']++;
+
+                continue;
+            }
+
+            if ($reason === 'blocked_missing_archive_proof') {
+                $summary['blocked_missing_archive_proof_count']++;
+
+                continue;
+            }
+
+            if ($reason === 'blocked_missing_rehydrate_proof') {
+                $summary['blocked_missing_rehydrate_proof_count']++;
+
+                continue;
+            }
+
+            if ($reason === 'blocked_hash_mismatch') {
+                $summary['blocked_hash_mismatch_count']++;
+            }
+        }
+
+        usort($candidates, static fn (array $left, array $right): int => strcmp((string) ($left['local_path'] ?? ''), (string) ($right['local_path'] ?? '')));
+        usort($blocked, static fn (array $left, array $right): int => strcmp((string) ($left['local_path'] ?? ''), (string) ($right['local_path'] ?? '')));
+
+        $payload = [
+            'schema' => self::PLAN_SCHEMA,
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'disk' => $targetDisk,
+            'target_disk' => $targetDisk,
+            'summary' => $summary,
+            'candidates' => $candidates,
+            'blocked' => $blocked,
+        ];
+
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    public function executePlan(array $plan): array
+    {
+        $this->assertPlanSchema($plan);
+
+        $targetDisk = $this->normalizeDisk((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+        $candidates = is_array($plan['candidates'] ?? null) ? array_values($plan['candidates']) : [];
+        $summary = [
+            'candidate_count' => count($candidates),
+            'deleted_count' => 0,
+            'skipped_missing_local_count' => 0,
+            'blocked_missing_remote_count' => 0,
+            'blocked_missing_archive_proof_count' => 0,
+            'blocked_missing_rehydrate_proof_count' => 0,
+            'blocked_hash_mismatch_count' => 0,
+            'failed_count' => 0,
+        ];
+        $results = [];
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $result = $this->executeCandidate($candidate, $targetDisk);
+            $results[] = $result;
+
+            $status = (string) ($result['status'] ?? '');
+            if ($status === 'deleted') {
+                $summary['deleted_count']++;
+
+                continue;
+            }
+
+            if ($status === 'skipped_missing_local') {
+                $summary['skipped_missing_local_count']++;
+
+                continue;
+            }
+
+            if ($status === 'blocked_missing_remote') {
+                $summary['blocked_missing_remote_count']++;
+
+                continue;
+            }
+
+            if ($status === 'blocked_missing_archive_proof') {
+                $summary['blocked_missing_archive_proof_count']++;
+
+                continue;
+            }
+
+            if ($status === 'blocked_missing_rehydrate_proof') {
+                $summary['blocked_missing_rehydrate_proof_count']++;
+
+                continue;
+            }
+
+            if ($status === 'blocked_hash_mismatch') {
+                $summary['blocked_hash_mismatch_count']++;
+
+                continue;
+            }
+
+            $summary['failed_count']++;
+        }
+
+        $status = $summary['failed_count'] > 0 ? 'partial_failure' : 'executed';
+        $runDir = $this->runDirectory();
+        $runPath = $runDir.DIRECTORY_SEPARATOR.'run.json';
+
+        $payload = [
+            'schema' => self::RUN_SCHEMA,
+            'mode' => 'execute',
+            'status' => $status,
+            'generated_at' => now()->toIso8601String(),
+            'disk' => $targetDisk,
+            'target_disk' => $targetDisk,
+            'plan' => trim((string) data_get($plan, '_meta.plan_path', '')),
+            'plan_path' => trim((string) data_get($plan, '_meta.plan_path', '')),
+            'summary' => $summary,
+            'results' => $results,
+        ];
+
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode report artifact shrink run receipt.');
+        }
+
+        File::put($runPath, $encoded.PHP_EOL);
+        $payload['run_path'] = $runPath;
+
+        $this->recordAudit($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function collectLocalCanonicalFiles(): array
+    {
+        $artifactsRoot = storage_path('app/private/artifacts');
+        if (! is_dir($artifactsRoot)) {
+            return [];
+        }
+
+        $files = [];
+
+        foreach (['reports', 'pdf'] as $subdir) {
+            $root = $artifactsRoot.DIRECTORY_SEPARATOR.$subdir;
+            if (! is_dir($root)) {
+                continue;
+            }
+
+            foreach (File::allFiles($root) as $file) {
+                $candidate = $this->localCanonicalFileFromSplFile($file, $artifactsRoot);
+                if ($candidate === null) {
+                    continue;
+                }
+
+                $files[] = $candidate;
+            }
+        }
+
+        usort($files, static fn (array $left, array $right): int => strcmp((string) ($left['local_path'] ?? ''), (string) ($right['local_path'] ?? '')));
+
+        return $files;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function localCanonicalFileFromSplFile(SplFileInfo $file, string $artifactsRoot): ?array
+    {
+        if (! $file->isFile()) {
+            return null;
+        }
+
+        $absolutePath = $file->getPathname();
+        $relativePath = $this->relativePathWithinArtifacts($absolutePath, $artifactsRoot);
+        if ($relativePath === '') {
+            return null;
+        }
+
+        $context = $this->canonicalContextForRelativePath($relativePath);
+        if ($context === null) {
+            return null;
+        }
+
+        $bytes = max(0, (int) ($file->getSize() ?: 0));
+        $sha256 = hash_file('sha256', $absolutePath);
+        if (! is_string($sha256) || $sha256 === '') {
+            throw new \RuntimeException('failed to hash local canonical artifact: '.$absolutePath);
+        }
+
+        return [
+            'kind' => $context['kind'],
+            'local_path' => 'artifacts/'.$relativePath,
+            'source_path' => 'artifacts/'.$relativePath,
+            'local_sha256' => $sha256,
+            'local_bytes' => $bytes,
+            'scale_code' => $context['scale_code'],
+            'attempt_id' => $context['attempt_id'],
+        ];
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function collectArchiveProofsByPath(string $targetDisk): array
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return [];
+        }
+
+        $rows = DB::table('audit_logs')
+            ->where('action', self::ARCHIVE_AUDIT_ACTION)
+            ->orderByDesc('id')
+            ->get(['id', 'created_at', 'meta_json']);
+
+        $proofs = [];
+
+        foreach ($rows as $row) {
+            $meta = $this->decodeJsonObject($row->meta_json ?? null);
+            if (($meta['mode'] ?? null) !== 'execute') {
+                continue;
+            }
+
+            $results = is_array($meta['results'] ?? null) ? array_values($meta['results']) : [];
+            foreach ($results as $result) {
+                if (! is_array($result)) {
+                    continue;
+                }
+
+                $proof = $this->archiveProofFromResult($result, $targetDisk, (int) $row->id, $row->created_at);
+                if ($proof === null) {
+                    continue;
+                }
+
+                $sourcePath = (string) $proof['local_path'];
+                if (isset($proofs[$sourcePath])) {
+                    continue;
+                }
+
+                $proofs[$sourcePath] = $proof;
+            }
+        }
+
+        return $proofs;
+    }
+
+    /**
+     * @param  array<string,mixed>  $result
+     * @return array<string,mixed>|null
+     */
+    private function archiveProofFromResult(array $result, string $targetDisk, int $auditId, mixed $createdAt): ?array
+    {
+        $archivedStatus = $this->normalizeOptionalString($result['status'] ?? null);
+        if (! in_array($archivedStatus, ['copied', 'already_archived'], true)) {
+            return null;
+        }
+
+        $localPath = $this->normalizeOptionalString($result['source_path'] ?? null);
+        if ($localPath === null || ! $this->isExactCanonicalLocalPath($localPath)) {
+            return null;
+        }
+
+        $resultTargetDisk = $this->normalizeOptionalString($result['target_disk'] ?? null);
+        if ($resultTargetDisk !== null && $resultTargetDisk !== $targetDisk) {
+            return null;
+        }
+
+        $targetObjectKey = $this->normalizeOptionalString($result['target_object_key'] ?? null);
+        $sourceSha256 = $this->normalizeOptionalString($result['source_sha256'] ?? $result['planned_sha256'] ?? null);
+        $sourceBytes = $this->normalizeNullableInt($result['source_bytes'] ?? $result['planned_bytes'] ?? null);
+        $context = $this->canonicalContextForLocalPath($localPath);
+        if ($context === null) {
+            return null;
+        }
+
+        return [
+            'kind' => $this->normalizeOptionalString($result['kind'] ?? null) ?? $context['kind'],
+            'local_path' => $localPath,
+            'target_disk' => $targetDisk,
+            'target_object_key' => $targetObjectKey,
+            'source_sha256' => $sourceSha256,
+            'source_bytes' => $sourceBytes,
+            'archived_status' => $archivedStatus,
+            'archive_audit_id' => $auditId,
+            'archive_recorded_at' => $this->normalizeTimestamp($createdAt),
+            'rehydrate_ready' => $targetObjectKey !== null && $sourceSha256 !== null && $sourceBytes !== null,
+            'scale_code' => $result['scale_code'] ?? $context['scale_code'],
+            'attempt_id' => $result['attempt_id'] ?? $context['attempt_id'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $localFile
+     * @param  array<string,array<string,mixed>>  $archiveProofsByPath
+     * @return array<string,mixed>
+     */
+    private function evaluateLocalFile(array $localFile, array $archiveProofsByPath, string $targetDisk): array
+    {
+        $localPath = (string) ($localFile['local_path'] ?? '');
+        $archiveProof = $archiveProofsByPath[$localPath] ?? null;
+
+        if ($archiveProof === null) {
+            return [
+                'status' => 'blocked',
+                'blocked' => $this->blockedEntry($localFile, 'blocked_missing_archive_proof', 'ARCHIVE_EXECUTE_PROOF_MISSING'),
+            ];
+        }
+
+        if (($archiveProof['rehydrate_ready'] ?? false) !== true) {
+            return [
+                'status' => 'blocked',
+                'blocked' => $this->blockedEntry($localFile, 'blocked_missing_rehydrate_proof', 'REHYDRATE_PROOF_INCOMPLETE', $archiveProof),
+            ];
+        }
+
+        $targetObjectKey = $this->normalizeOptionalString($archiveProof['target_object_key'] ?? null);
+        if ($targetObjectKey === null || ! $this->remoteObjectExists($targetDisk, $targetObjectKey)) {
+            return [
+                'status' => 'blocked',
+                'blocked' => $this->blockedEntry($localFile, 'blocked_missing_remote', 'REMOTE_OBJECT_MISSING', $archiveProof),
+            ];
+        }
+
+        $localSha256 = $this->normalizeOptionalString($localFile['local_sha256'] ?? null);
+        $sourceSha256 = $this->normalizeOptionalString($archiveProof['source_sha256'] ?? null);
+        if ($localSha256 === null || $sourceSha256 === null || ! hash_equals($sourceSha256, $localSha256)) {
+            return [
+                'status' => 'blocked',
+                'blocked' => $this->blockedEntry($localFile, 'blocked_hash_mismatch', 'LOCAL_HASH_MISMATCH', $archiveProof),
+            ];
+        }
+
+        return [
+            'status' => 'candidate',
+            'candidate' => [
+                'kind' => $localFile['kind'],
+                'local_path' => $localPath,
+                'target_disk' => $targetDisk,
+                'target_object_key' => $targetObjectKey,
+                'source_sha256' => $sourceSha256,
+                'source_bytes' => (int) ($archiveProof['source_bytes'] ?? 0),
+                'archive_audit_id' => (int) ($archiveProof['archive_audit_id'] ?? 0),
+                'rehydrate_ready' => true,
+                'archived_status' => $archiveProof['archived_status'] ?? null,
+                'scale_code' => $archiveProof['scale_code'] ?? $localFile['scale_code'] ?? null,
+                'attempt_id' => $archiveProof['attempt_id'] ?? $localFile['attempt_id'] ?? null,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $localFile
+     * @param  array<string,mixed>|null  $archiveProof
+     * @return array<string,mixed>
+     */
+    private function blockedEntry(array $localFile, string $status, string $reason, ?array $archiveProof = null): array
+    {
+        return [
+            'status' => $status,
+            'reason' => $reason,
+            'kind' => $localFile['kind'] ?? null,
+            'local_path' => $localFile['local_path'] ?? null,
+            'target_disk' => $archiveProof['target_disk'] ?? null,
+            'target_object_key' => $archiveProof['target_object_key'] ?? null,
+            'source_sha256' => $archiveProof['source_sha256'] ?? null,
+            'source_bytes' => $archiveProof['source_bytes'] ?? null,
+            'archive_audit_id' => $archiveProof['archive_audit_id'] ?? null,
+            'rehydrate_ready' => $archiveProof['rehydrate_ready'] ?? false,
+            'scale_code' => $archiveProof['scale_code'] ?? $localFile['scale_code'] ?? null,
+            'attempt_id' => $archiveProof['attempt_id'] ?? $localFile['attempt_id'] ?? null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     * @return array<string,mixed>
+     */
+    private function executeCandidate(array $candidate, string $targetDisk): array
+    {
+        $baseResult = [
+            'kind' => $candidate['kind'] ?? null,
+            'local_path' => $candidate['local_path'] ?? null,
+            'target_disk' => $targetDisk,
+            'target_object_key' => $candidate['target_object_key'] ?? null,
+            'source_sha256' => $candidate['source_sha256'] ?? null,
+            'source_bytes' => $candidate['source_bytes'] ?? null,
+            'archive_audit_id' => $candidate['archive_audit_id'] ?? null,
+            'rehydrate_ready' => $candidate['rehydrate_ready'] ?? false,
+            'scale_code' => $candidate['scale_code'] ?? null,
+            'attempt_id' => $candidate['attempt_id'] ?? null,
+        ];
+
+        $archiveAuditId = (int) ($candidate['archive_audit_id'] ?? 0);
+        $archivedStatus = $this->normalizeOptionalString($candidate['archived_status'] ?? null);
+        if ($archiveAuditId <= 0 || ! in_array($archivedStatus, ['copied', 'already_archived'], true)) {
+            return $baseResult + [
+                'status' => 'blocked_missing_archive_proof',
+                'reason' => 'ARCHIVE_EXECUTE_PROOF_MISSING',
+            ];
+        }
+
+        $localPath = $this->normalizeOptionalString($candidate['local_path'] ?? null);
+        $targetObjectKey = $this->normalizeOptionalString($candidate['target_object_key'] ?? null);
+        $sourceSha256 = $this->normalizeOptionalString($candidate['source_sha256'] ?? null);
+        $sourceBytes = $this->normalizeNullableInt($candidate['source_bytes'] ?? null);
+        $rehydrateReady = ($candidate['rehydrate_ready'] ?? false) === true;
+
+        if ($localPath === null || ! $this->isExactCanonicalLocalPath($localPath)) {
+            return $baseResult + [
+                'status' => 'blocked_missing_rehydrate_proof',
+                'reason' => 'REHYDRATE_PROOF_INCOMPLETE',
+            ];
+        }
+
+        if ($targetObjectKey === null || $sourceSha256 === null || $sourceBytes === null || ! $rehydrateReady) {
+            return $baseResult + [
+                'status' => 'blocked_missing_rehydrate_proof',
+                'reason' => 'REHYDRATE_PROOF_INCOMPLETE',
+            ];
+        }
+
+        $absoluteLocalPath = storage_path('app/private/'.$localPath);
+        if (! is_file($absoluteLocalPath)) {
+            return $baseResult + [
+                'status' => 'skipped_missing_local',
+                'reason' => 'LOCAL_CANONICAL_ALREADY_MISSING',
+            ];
+        }
+
+        if (! $this->remoteObjectExists($targetDisk, $targetObjectKey)) {
+            return $baseResult + [
+                'status' => 'blocked_missing_remote',
+                'reason' => 'REMOTE_OBJECT_MISSING',
+            ];
+        }
+
+        $currentSha256 = hash_file('sha256', $absoluteLocalPath);
+        if (! is_string($currentSha256) || $currentSha256 === '' || ! hash_equals($sourceSha256, $currentSha256)) {
+            return $baseResult + [
+                'status' => 'blocked_hash_mismatch',
+                'reason' => 'LOCAL_HASH_MISMATCH',
+                'local_sha256' => is_string($currentSha256) ? $currentSha256 : null,
+            ];
+        }
+
+        $deleted = @unlink($absoluteLocalPath);
+        if (! $deleted || is_file($absoluteLocalPath)) {
+            return $baseResult + [
+                'status' => 'failed',
+                'reason' => 'LOCAL_DELETE_FAILED',
+            ];
+        }
+
+        return $baseResult + [
+            'status' => 'deleted',
+            'reason' => 'LOCAL_CANONICAL_DELETED',
+            'deleted_at' => now()->toIso8601String(),
+            'verified_local_sha256' => $currentSha256,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function recordAudit(array $payload): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+        $results = is_array($payload['results'] ?? null) ? array_values($payload['results']) : [];
+        $planPath = $this->normalizeOptionalString($payload['plan_path'] ?? $payload['plan'] ?? null);
+        $runPath = $this->normalizeOptionalString($payload['run_path'] ?? null);
+        $failedCount = (int) ($summary['failed_count'] ?? 0);
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => self::SHRINK_AUDIT_ACTION,
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_shrink',
+            'meta_json' => json_encode([
+                'schema' => $payload['schema'] ?? null,
+                'mode' => $payload['mode'] ?? null,
+                'target_disk' => $payload['target_disk'] ?? null,
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'run_path' => $runPath,
+                'candidate_count' => (int) ($summary['candidate_count'] ?? 0),
+                'deleted_count' => (int) ($summary['deleted_count'] ?? 0),
+                'skipped_missing_local_count' => (int) ($summary['skipped_missing_local_count'] ?? 0),
+                'blocked_missing_remote_count' => (int) ($summary['blocked_missing_remote_count'] ?? 0),
+                'blocked_missing_archive_proof_count' => (int) ($summary['blocked_missing_archive_proof_count'] ?? 0),
+                'blocked_missing_rehydrate_proof_count' => (int) ($summary['blocked_missing_rehydrate_proof_count'] ?? 0),
+                'blocked_hash_mismatch_count' => (int) ($summary['blocked_hash_mismatch_count'] ?? 0),
+                'failed_count' => $failedCount,
+                'results_count' => count($results),
+                'durable_receipt_source' => 'audit_logs.meta_json',
+                'summary' => $summary,
+                'results' => $results,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'artisan/storage:shrink-archived-report-artifacts',
+            'request_id' => null,
+            'reason' => 'manual_archive_backed_shrink',
+            'result' => $failedCount > 0 ? 'partial_failure' : 'success',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function assertPlanSchema(array $plan): void
+    {
+        if ((string) ($plan['schema'] ?? '') !== self::PLAN_SCHEMA) {
+            throw new \RuntimeException('report artifact shrink plan schema mismatch.');
+        }
+    }
+
+    private function normalizeDisk(string $disk): string
+    {
+        $normalized = trim($disk);
+        if ($normalized === '') {
+            throw new \RuntimeException('target disk is required.');
+        }
+
+        return $normalized;
+    }
+
+    private function runDirectory(): string
+    {
+        $dir = storage_path('app/private/report_artifact_shrink_runs/'.now()->format('Ymd_His').'_'.substr(bin2hex(random_bytes(4)), 0, 8));
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    private function remoteObjectExists(string $targetDisk, string $targetObjectKey): bool
+    {
+        if (str_starts_with($targetObjectKey, 'report_artifacts_archive/')) {
+            $this->primeRemoteArchiveIndex($targetDisk);
+
+            return isset($this->remoteArchiveObjectsByDisk[$targetDisk][$targetObjectKey]);
+        }
+
+        return Storage::disk($targetDisk)->exists($targetObjectKey);
+    }
+
+    private function primeRemoteArchiveIndex(string $targetDisk): void
+    {
+        if (($this->remoteArchiveIndexLoaded[$targetDisk] ?? false) === true) {
+            return;
+        }
+
+        $this->remoteArchiveIndexLoaded[$targetDisk] = true;
+
+        try {
+            $files = Storage::disk($targetDisk)->allFiles('report_artifacts_archive');
+        } catch (\Throwable) {
+            $files = [];
+        }
+
+        $index = [];
+        foreach ($files as $file) {
+            if (! is_string($file) || trim($file) === '') {
+                continue;
+            }
+
+            $index[$file] = true;
+        }
+
+        $this->remoteArchiveObjectsByDisk[$targetDisk] = $index;
+    }
+
+    private function relativePathWithinArtifacts(string $absolutePath, string $artifactsRoot): string
+    {
+        $root = rtrim(str_replace('\\', '/', $artifactsRoot), '/');
+        $path = str_replace('\\', '/', $absolutePath);
+        $prefix = $root.'/';
+
+        if (! str_starts_with($path, $prefix)) {
+            return '';
+        }
+
+        return ltrim(substr($path, strlen($prefix)), '/');
+    }
+
+    private function isExactCanonicalLocalPath(string $localPath): bool
+    {
+        return $this->canonicalContextForLocalPath($localPath) !== null;
+    }
+
+    /**
+     * @return array{kind:string,scale_code:string,attempt_id:string}|null
+     */
+    private function canonicalContextForLocalPath(string $localPath): ?array
+    {
+        if (preg_match('#^artifacts/reports/([^/]+)/([^/]+)/report\.json$#', $localPath, $matches) === 1) {
+            return [
+                'kind' => 'report_json',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+            ];
+        }
+
+        if (preg_match('#^artifacts/pdf/([^/]+)/([^/]+)/[^/]+/report_(free|full)\.pdf$#', $localPath, $matches) === 1) {
+            return [
+                'kind' => 'report_'.$matches[3].'_pdf',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{kind:string,scale_code:string,attempt_id:string}|null
+     */
+    private function canonicalContextForRelativePath(string $relativePath): ?array
+    {
+        return $this->canonicalContextForLocalPath('artifacts/'.$relativePath);
+    }
+
+    private function normalizeOptionalString(mixed $value): ?string
+    {
+        if (! is_scalar($value) || $value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeNullableInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return max(0, (int) $value);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonObject(mixed $value): array
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function normalizeTimestamp(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $timestamp = trim((string) $value);
+
+        return $timestamp === '' ? null : $timestamp;
+    }
+}

--- a/backend/tests/Feature/Storage/ReportArtifactsShrinkServiceTest.php
+++ b/backend/tests/Feature/Storage/ReportArtifactsShrinkServiceTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ReportArtifactsRehydrateService;
+use App\Services\Storage\ReportArtifactsShrinkService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ReportArtifactsShrinkServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-report-artifacts-shrink-service-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('filesystems.disks.s3.bucket', 'report-artifacts-shrink-service-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.report-shrink.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_service_deletes_archived_report_and_pdf_and_rehydrate_still_restores_them(): void
+    {
+        $reportBytes = json_encode(['attempt' => 'shrink-report'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($reportBytes);
+        $reportPath = 'artifacts/reports/MBTI/shrink-report/report.json';
+        Storage::disk('local')->put($reportPath, $reportBytes);
+        Storage::disk('s3')->put('report_artifacts_archive/reports/MBTI/shrink-report/report.json', $reportBytes);
+
+        $pdfBytes = '%PDF-1.4 shrink full';
+        $pdfPath = 'artifacts/pdf/BIG5/shrink-pdf/hash/report_full.pdf';
+        Storage::disk('local')->put($pdfPath, $pdfBytes);
+        Storage::disk('s3')->put('report_artifacts_archive/pdf/BIG5/shrink-pdf/hash/report_full.pdf', $pdfBytes);
+
+        $legacyPath = 'private/reports/BIG5/shrink-pdf/hash/report_full.pdf';
+        Storage::disk('local')->put($legacyPath, '%PDF legacy untouched');
+
+        $this->seedArchiveAudit([
+            $this->archiveResult('report_json', $reportPath, 'report_artifacts_archive/reports/MBTI/shrink-report/report.json', hash('sha256', $reportBytes), strlen($reportBytes), 'copied', 'MBTI', 'shrink-report'),
+            $this->archiveResult('report_full_pdf', $pdfPath, 'report_artifacts_archive/pdf/BIG5/shrink-pdf/hash/report_full.pdf', hash('sha256', $pdfBytes), strlen($pdfBytes), 'already_archived', 'BIG5', 'shrink-pdf'),
+        ]);
+
+        /** @var ReportArtifactsShrinkService $service */
+        $service = app(ReportArtifactsShrinkService::class);
+
+        $plan = $service->buildPlan('s3');
+        $this->assertSame('storage_shrink_archived_report_artifacts_plan.v1', $plan['schema']);
+        $this->assertSame(2, data_get($plan, 'summary.candidate_count'));
+        $this->assertSame(0, data_get($plan, 'summary.blocked_missing_archive_proof_count'));
+        $this->assertSame(0, data_get($plan, 'summary.blocked_missing_remote_count'));
+        $this->assertTrue((bool) data_get($plan, 'candidates.0.rehydrate_ready'));
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_shrink_plans/test-plan.json')];
+        $result = $service->executePlan($plan);
+
+        $this->assertSame('executed', $result['status']);
+        $this->assertSame(2, data_get($result, 'summary.deleted_count'));
+        $this->assertSame(0, data_get($result, 'summary.failed_count'));
+        $this->assertFileExists((string) ($result['run_path'] ?? ''));
+        $this->assertFalse(Storage::disk('local')->exists($reportPath));
+        $this->assertFalse(Storage::disk('local')->exists($pdfPath));
+        $this->assertTrue(Storage::disk('s3')->exists('report_artifacts_archive/reports/MBTI/shrink-report/report.json'));
+        $this->assertTrue(Storage::disk('s3')->exists('report_artifacts_archive/pdf/BIG5/shrink-pdf/hash/report_full.pdf'));
+        $this->assertTrue(Storage::disk('local')->exists($legacyPath));
+
+        $shrinkAudit = DB::table('audit_logs')
+            ->where('action', 'storage_shrink_archived_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($shrinkAudit);
+        $shrinkMeta = json_decode((string) $shrinkAudit->meta_json, true);
+        $this->assertIsArray($shrinkMeta);
+        $this->assertSame(2, $shrinkMeta['deleted_count'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $shrinkMeta['durable_receipt_source'] ?? null);
+
+        /** @var ReportArtifactsRehydrateService $rehydrateService */
+        $rehydrateService = app(ReportArtifactsRehydrateService::class);
+        $rehydratePlan = $rehydrateService->buildPlan('s3');
+        $this->assertSame(2, data_get($rehydratePlan, 'summary.candidate_count'));
+        $this->assertSame(0, data_get($rehydratePlan, 'summary.blocked_count'));
+        $this->assertSame(0, data_get($rehydratePlan, 'summary.skipped_count'));
+
+        $rehydratePlan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_rehydrate_plans/restore-plan.json')];
+        $rehydrateResult = $rehydrateService->executePlan($rehydratePlan);
+
+        $this->assertSame('executed', $rehydrateResult['status']);
+        $this->assertSame(2, data_get($rehydrateResult, 'summary.rehydrated_count'));
+        $this->assertTrue(Storage::disk('local')->exists($reportPath));
+        $this->assertTrue(Storage::disk('local')->exists($pdfPath));
+        $this->assertSame(hash('sha256', $reportBytes), hash('sha256', (string) Storage::disk('local')->get($reportPath)));
+        $this->assertSame(hash('sha256', $pdfBytes), hash('sha256', (string) Storage::disk('local')->get($pdfPath)));
+    }
+
+    public function test_service_blocks_missing_archive_proof_incomplete_rehydrate_proof_and_missing_remote(): void
+    {
+        $missingArchivePath = 'artifacts/reports/MBTI/no-archive/report.json';
+        Storage::disk('local')->put($missingArchivePath, '{"missing":"archive"}');
+
+        $missingRehydratePath = 'artifacts/pdf/BIG5/incomplete/hash/report_free.pdf';
+        Storage::disk('local')->put($missingRehydratePath, '%PDF incomplete');
+
+        $missingRemotePath = 'artifacts/reports/MBTI/missing-remote/report.json';
+        $missingRemoteBytes = '{"missing":"remote"}';
+        Storage::disk('local')->put($missingRemotePath, $missingRemoteBytes);
+
+        $this->seedArchiveAudit([
+            [
+                'status' => 'copied',
+                'kind' => 'report_free_pdf',
+                'source_path' => $missingRehydratePath,
+                'target_disk' => 's3',
+                'target_object_key' => '',
+                'source_sha256' => '',
+                'source_bytes' => 0,
+                'scale_code' => 'BIG5',
+                'attempt_id' => 'incomplete',
+            ],
+            $this->archiveResult('report_json', $missingRemotePath, 'report_artifacts_archive/reports/MBTI/missing-remote/report.json', hash('sha256', $missingRemoteBytes), strlen($missingRemoteBytes), 'copied', 'MBTI', 'missing-remote'),
+        ]);
+
+        /** @var ReportArtifactsShrinkService $service */
+        $service = app(ReportArtifactsShrinkService::class);
+
+        $plan = $service->buildPlan('s3');
+
+        $this->assertSame(0, data_get($plan, 'summary.candidate_count'));
+        $this->assertSame(1, data_get($plan, 'summary.blocked_missing_archive_proof_count'));
+        $this->assertSame(1, data_get($plan, 'summary.blocked_missing_rehydrate_proof_count'));
+        $this->assertSame(1, data_get($plan, 'summary.blocked_missing_remote_count'));
+    }
+
+    public function test_service_execute_skips_missing_local_and_blocks_hash_mismatch_visibly(): void
+    {
+        $skipPath = 'artifacts/reports/MBTI/missing-local/report.json';
+        $skipBytes = '{"skip":true}';
+        Storage::disk('local')->put($skipPath, $skipBytes);
+        Storage::disk('s3')->put('report_artifacts_archive/reports/MBTI/missing-local/report.json', $skipBytes);
+
+        $mismatchPath = 'artifacts/pdf/BIG5/hash-mismatch/hash/report_free.pdf';
+        $mismatchBytes = '%PDF original bytes';
+        Storage::disk('local')->put($mismatchPath, $mismatchBytes);
+        Storage::disk('s3')->put('report_artifacts_archive/pdf/BIG5/hash-mismatch/hash/report_free.pdf', $mismatchBytes);
+
+        $legacyPath = 'private/reports/BIG5/hash-mismatch/hash/report_free.pdf';
+        Storage::disk('local')->put($legacyPath, '%PDF legacy');
+
+        $this->seedArchiveAudit([
+            $this->archiveResult('report_json', $skipPath, 'report_artifacts_archive/reports/MBTI/missing-local/report.json', hash('sha256', $skipBytes), strlen($skipBytes), 'copied', 'MBTI', 'missing-local'),
+            $this->archiveResult('report_free_pdf', $mismatchPath, 'report_artifacts_archive/pdf/BIG5/hash-mismatch/hash/report_free.pdf', hash('sha256', $mismatchBytes), strlen($mismatchBytes), 'copied', 'BIG5', 'hash-mismatch'),
+        ]);
+
+        /** @var ReportArtifactsShrinkService $service */
+        $service = app(ReportArtifactsShrinkService::class);
+
+        $plan = $service->buildPlan('s3');
+        $this->assertSame(2, data_get($plan, 'summary.candidate_count'));
+
+        Storage::disk('local')->delete($skipPath);
+        Storage::disk('local')->put($mismatchPath, '%PDF mutated bytes');
+
+        $plan['_meta'] = ['plan_path' => storage_path('app/private/report_artifact_shrink_plans/mixed.json')];
+        $result = $service->executePlan($plan);
+
+        $this->assertSame('executed', $result['status']);
+        $this->assertSame(0, data_get($result, 'summary.deleted_count'));
+        $this->assertSame(1, data_get($result, 'summary.skipped_missing_local_count'));
+        $this->assertSame(1, data_get($result, 'summary.blocked_hash_mismatch_count'));
+        $this->assertSame(0, data_get($result, 'summary.failed_count'));
+        $this->assertTrue(Storage::disk('local')->exists($mismatchPath));
+        $this->assertTrue(Storage::disk('local')->exists($legacyPath));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_shrink_archived_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $meta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($meta);
+        $this->assertSame(1, $meta['skipped_missing_local_count'] ?? null);
+        $this->assertSame(1, $meta['blocked_hash_mismatch_count'] ?? null);
+        $this->assertSame(0, $meta['failed_count'] ?? null);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $results
+     */
+    private function seedArchiveAudit(array $results): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_archive_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_archive',
+            'meta_json' => json_encode([
+                'schema' => 'storage_archive_report_artifacts_run.v1',
+                'mode' => 'execute',
+                'target_disk' => 's3',
+                'results' => $results,
+                'summary' => [
+                    'candidate_count' => count($results),
+                    'copied_count' => count(array_filter($results, static fn (array $result): bool => ($result['status'] ?? null) === 'copied')),
+                    'verified_count' => count(array_filter($results, static fn (array $result): bool => in_array((string) ($result['status'] ?? ''), ['copied', 'already_archived'], true))),
+                    'already_archived_count' => count(array_filter($results, static fn (array $result): bool => ($result['status'] ?? null) === 'already_archived')),
+                    'failed_count' => 0,
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'phpunit',
+            'request_id' => null,
+            'reason' => 'seed_archive_receipt',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function archiveResult(
+        string $kind,
+        string $sourcePath,
+        string $targetObjectKey,
+        string $sha256,
+        int $bytes,
+        string $status,
+        string $scaleCode,
+        string $attemptId,
+    ): array {
+        return [
+            'status' => $status,
+            'kind' => $kind,
+            'source_path' => $sourcePath,
+            'target_disk' => 's3',
+            'target_object_key' => $targetObjectKey,
+            'source_sha256' => $sha256,
+            'source_bytes' => $bytes,
+            'target_bytes' => $bytes,
+            'scale_code' => $scaleCode,
+            'attempt_id' => $attemptId,
+            'verified_at' => now()->toIso8601String(),
+        ];
+    }
+}

--- a/backend/tests/Feature/Storage/StorageShrinkArchivedReportArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageShrinkArchivedReportArtifactsCommandTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Console\Commands\StorageShrinkArchivedReportArtifacts;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageShrinkArchivedReportArtifactsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-report-artifacts-shrink-command-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        config()->set('filesystems.disks.s3.bucket', 'report-artifacts-shrink-command-bucket');
+        config()->set('filesystems.disks.s3.region', 'ap-guangzhou');
+        config()->set('filesystems.disks.s3.endpoint', 'https://cos.report-shrink-command.test');
+        Storage::forgetDisk('local');
+        Storage::fake('s3');
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(StorageShrinkArchivedReportArtifacts::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+        Storage::forgetDisk('s3');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_requires_exactly_one_mode_and_plan_for_execute(): void
+    {
+        $this->artisan('storage:shrink-archived-report-artifacts')
+            ->expectsOutputToContain('exactly one of --dry-run or --execute is required.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:shrink-archived-report-artifacts --dry-run --execute')
+            ->expectsOutputToContain('exactly one of --dry-run or --execute is required.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:shrink-archived-report-artifacts --execute --disk=s3')
+            ->expectsOutputToContain('--execute requires --plan.')
+            ->assertExitCode(1);
+    }
+
+    public function test_command_dry_run_execute_json_and_skipped_missing_local_are_visible(): void
+    {
+        $reportBytes = json_encode(['attempt' => 'command-shrink'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($reportBytes);
+        $reportPath = 'artifacts/reports/MBTI/command-shrink/report.json';
+        Storage::disk('local')->put($reportPath, $reportBytes);
+        Storage::disk('s3')->put('report_artifacts_archive/reports/MBTI/command-shrink/report.json', $reportBytes);
+
+        $this->seedArchiveAudit([
+            [
+                'status' => 'copied',
+                'kind' => 'report_json',
+                'source_path' => $reportPath,
+                'target_disk' => 's3',
+                'target_object_key' => 'report_artifacts_archive/reports/MBTI/command-shrink/report.json',
+                'source_sha256' => hash('sha256', $reportBytes),
+                'source_bytes' => strlen($reportBytes),
+                'target_bytes' => strlen($reportBytes),
+                'scale_code' => 'MBTI',
+                'attempt_id' => 'command-shrink',
+                'verified_at' => now()->toIso8601String(),
+            ],
+        ]);
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+        ]));
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('candidate_count=1', $dryRunOutput);
+        $this->assertStringContainsString('deleted_count=0', $dryRunOutput);
+        $this->assertStringContainsString('blocked_missing_archive_proof_count=0', $dryRunOutput);
+
+        preg_match('/^plan=(.+)$/m', $dryRunOutput, $matches);
+        $planPath = trim((string) ($matches[1] ?? ''));
+        $this->assertFileExists($planPath);
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('deleted_count=1', $executeOutput);
+        $this->assertStringContainsString('run_path=', $executeOutput);
+        $this->assertFalse(Storage::disk('local')->exists($reportPath));
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+        $skipOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $skipOutput);
+        $this->assertStringContainsString('deleted_count=0', $skipOutput);
+        $this->assertStringContainsString('skipped_missing_local_count=1', $skipOutput);
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--json' => true,
+        ]));
+        $jsonPayload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($jsonPayload);
+        $this->assertSame('storage_shrink_archived_report_artifacts_plan.v1', $jsonPayload['schema'] ?? null);
+        $this->assertSame(0, data_get($jsonPayload, 'summary.candidate_count'));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_shrink_archived_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $meta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($meta);
+        $this->assertSame('dry_run', $meta['mode'] ?? null);
+        $this->assertSame('audit_logs.meta_json', $meta['durable_receipt_source'] ?? null);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $results
+     */
+    private function seedArchiveAudit(array $results): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_archive_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_archive',
+            'meta_json' => json_encode([
+                'schema' => 'storage_archive_report_artifacts_run.v1',
+                'mode' => 'execute',
+                'target_disk' => 's3',
+                'results' => $results,
+                'summary' => [
+                    'candidate_count' => count($results),
+                    'copied_count' => count(array_filter($results, static fn (array $result): bool => ($result['status'] ?? null) === 'copied')),
+                    'verified_count' => count(array_filter($results, static fn (array $result): bool => in_array((string) ($result['status'] ?? ''), ['copied', 'already_archived'], true))),
+                    'already_archived_count' => count(array_filter($results, static fn (array $result): bool => ($result['status'] ?? null) === 'already_archived')),
+                    'failed_count' => 0,
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'phpunit',
+            'request_id' => null,
+            'reason' => 'seed_archive_receipt',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a manual-only shrink surface for archived report artifacts.

The new surface is intentionally narrow:

- plan-first
- execute-from-plan
- single-file only
- delete local canonical files only
- no direct remote read
- no cutover
- no reader or fallback changes
- no legacy path changes

The shrink candidate set is restricted to exact canonical files only:

- `artifacts/reports/**/report.json`
- `artifacts/pdf/**/report_free.pdf`
- `artifacts/pdf/**/report_full.pdf`

A file is only eligible when it is simultaneously covered by:

- archive durable truth from `storage_archive_report_artifacts`
- remote object still existing on `s3`
- rehydrate-ready proof completeness
- a fresh local hash match against archived `source_sha256`

## Root cause

PR-41 introduced archive/export for canonical report artifacts.
PR-42A made archive receipt truth durable through `audit_logs.meta_json` and exposed latest archive truth through control-plane.
PR-42B added explicit rehydrate-to-local for exact canonical files.

At that point the missing piece was no longer archive or rehydrate. The remaining gap was a bounded retention/shrink surface that could delete only the local canonical copy for files that are already archive-backed and recoverable.

## What changed

### New command

`storage:shrink-archived-report-artifacts`

Options:

- `--dry-run`
- `--execute`
- `--disk=s3`
- `--plan=`
- `--json`

Rules:

- exactly one of `--dry-run` or `--execute`
- `--execute` requires `--plan`
- target disk must be a configured remote disk

### New service

`ReportArtifactsShrinkService`

Responsibilities:

- scan current local canonical files under `storage/app/private/artifacts/**`
- intersect them with archive durable truth from `audit_logs`
- require rehydrate-ready proof completeness
- require live remote existence
- require live local hash equality with archived `source_sha256`
- write plan / run / audit truth
- delete only the local canonical file itself

### Result classification

Plan and execute both use explicit proof-based result buckets:

- `deleted`
- `skipped_missing_local`
- `blocked_missing_remote`
- `blocked_missing_archive_proof`
- `blocked_missing_rehydrate_proof`
- `blocked_hash_mismatch`
- `failed`

This keeps the three proof-missing report JSON files out of the delete path.

## Behavioral guarantees

This PR does **not**:

- delete legacy fallback files
- delete directories or prefixes
- delete remote archived objects
- change `ArtifactStore`
- change `ReportPdfArtifactStore`
- change report generation or persistence
- change archive pipeline behavior
- change rehydrate pipeline behavior
- change runtime readers or fallback semantics
- add scheduler/config/migration/route/middleware changes

## Validation

Focused:

- `tests/Feature/Storage/ReportArtifactsShrinkServiceTest.php`
- `tests/Feature/Storage/StorageShrinkArchivedReportArtifactsCommandTest.php`

Regression:

- `tests/Feature/Storage/ReportArtifactsArchiveServiceTest.php`
- `tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php`
- `tests/Feature/Storage/ReportArtifactsRehydrateServiceTest.php`
- `tests/Feature/Storage/StorageRehydrateReportArtifactsCommandTest.php`
- `tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php`
- `tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php`
- `tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php`
- `tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php`
- `tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php`

Live checks performed in the isolated worktree:

- `php artisan storage:shrink-archived-report-artifacts --dry-run --disk=s3`
- `php artisan storage:shrink-archived-report-artifacts --execute --disk=s3 --plan=...`
- `php artisan storage:rehydrate-report-artifacts --dry-run --disk=s3`
- `php artisan storage:rehydrate-report-artifacts --execute --disk=s3 --plan=...`
- `php artisan storage:archive-report-artifacts --dry-run --disk=s3`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan storage:refresh-control-plane --dry-run --json`
- `php artisan storage:inventory --json`
- `php artisan storage:analyze-cost --json`
- `bash backend/scripts/ci_verify_mbti.sh`

Key live results:

- shrink dry-run:
  - `candidate_count=2929`
  - `blocked_missing_archive_proof_count=3`
- shrink execute:
  - `deleted_count=2929`
  - `failed_count=0`
- rehydrate execute after delete:
  - `rehydrated_count=2929`
  - `verified_count=2929`
  - `failed_count=0`
- archive dry-run after restore:
  - `candidate_count=2932`
- legacy `reports/**` remained untouched
- existing control-plane archive section remained intact
- MBTI CI master chain stayed green

## Effect

This PR gives operators a proof-based, manual shrink surface for canonical report artifacts while preserving all existing runtime contracts. It closes the storage-shrink gap without introducing read-path cutover or fallback changes.
