### PR TITLE
[codex] add report artifacts posture to control-plane

### DIFF
--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -39,6 +39,7 @@ final class StorageControlPlaneStatusService
             'inventory' => $inventory,
             'retention' => $this->retentionSection(),
             'report_artifacts_archive' => $this->reportArtifactsArchiveSection(),
+            'report_artifacts_posture' => $this->reportArtifactsPostureSection(),
             'reports_artifacts_lifecycle' => $this->reportsArtifactsLifecycleSection($inventory),
             'blob_coverage' => $this->blobCoverageSection(),
             'exact_authority' => $this->exactAuthoritySection(),
@@ -285,6 +286,77 @@ final class StorageControlPlaneStatusService
             ],
         ], $this->freshnessFromTimestamp(
             $latestGeneratedAt,
+            'audit-derived',
+            self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
+            'not_available'
+        ));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function reportArtifactsPostureSection(): array
+    {
+        $archiveAudit = $this->latestAuditForAction('storage_archive_report_artifacts');
+        $rehydrateAudit = $this->latestAuditForAction('storage_rehydrate_report_artifacts');
+        $shrinkAudit = $this->latestAuditForAction('storage_shrink_archived_report_artifacts');
+
+        $archive = $this->reportArtifactsPostureNode($archiveAudit, [
+            'candidate_count',
+            'copied_count',
+            'verified_count',
+            'already_archived_count',
+            'failed_count',
+            'results_count',
+        ]);
+        $rehydrate = $this->reportArtifactsPostureNode($rehydrateAudit, [
+            'candidate_count',
+            'rehydrated_count',
+            'verified_count',
+            'skipped_count',
+            'blocked_count',
+            'failed_count',
+            'results_count',
+        ]);
+        $shrink = $this->reportArtifactsPostureNode($shrinkAudit, [
+            'candidate_count',
+            'deleted_count',
+            'skipped_missing_local_count',
+            'blocked_missing_remote_count',
+            'blocked_missing_archive_proof_count',
+            'blocked_missing_rehydrate_proof_count',
+            'blocked_hash_mismatch_count',
+            'failed_count',
+            'results_count',
+        ]);
+
+        $statuses = [
+            $archive['status'] ?? 'not_available',
+            $rehydrate['status'] ?? 'not_available',
+            $shrink['status'] ?? 'not_available',
+        ];
+
+        $overallStatus = match (true) {
+            count(array_filter($statuses, static fn (string $status): bool => $status !== 'not_available')) === 0 => 'not_available',
+            in_array('not_available', $statuses, true) => 'partial',
+            default => 'ok',
+        };
+
+        $lastUpdatedAt = $this->latestTimestamp([
+            $archive['latest_generated_at'] ?? null,
+            $rehydrate['latest_generated_at'] ?? null,
+            $shrink['latest_generated_at'] ?? null,
+        ]);
+
+        return array_merge([
+            'status' => $overallStatus,
+            'durable_receipt_source' => 'audit_logs.meta_json',
+            'target_disk' => $this->consistentReportArtifactsTargetDisk([$archiveAudit, $rehydrateAudit, $shrinkAudit]),
+            'archive' => $archive,
+            'rehydrate' => $rehydrate,
+            'shrink' => $shrink,
+        ], $this->freshnessFromTimestamp(
+            $lastUpdatedAt,
             'audit-derived',
             self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
             'not_available'
@@ -768,6 +840,116 @@ final class StorageControlPlaneStatusService
     }
 
     /**
+     * @param  list<string>  $summaryFields
+     * @return array<string,mixed>
+     */
+    private function reportArtifactsPostureNode(?object $audit, array $summaryFields): array
+    {
+        $summary = [];
+        foreach ($summaryFields as $field) {
+            $summary[$field] = 0;
+        }
+
+        if ($audit === null) {
+            return array_merge([
+                'status' => 'not_available',
+                'latest_generated_at' => null,
+                'latest_mode' => null,
+                'latest_plan_path' => null,
+                'latest_run_path' => null,
+                'latest_run_path_exists' => false,
+                'latest_summary' => $summary,
+            ], $this->freshnessFromTimestamp(
+                null,
+                'audit-derived',
+                self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
+                'not_available'
+            ));
+        }
+
+        $meta = $this->decodeAuditMeta($audit);
+        $latestGeneratedAt = $this->normalizeTimestamp($audit->created_at);
+        $latestRunPath = $this->normalizeOptionalString($meta['run_path'] ?? null);
+
+        foreach ($summaryFields as $field) {
+            if ($field === 'results_count') {
+                $summary[$field] = (int) ($meta['results_count'] ?? count((array) ($meta['results'] ?? [])));
+
+                continue;
+            }
+
+            $summary[$field] = (int) ($meta[$field] ?? data_get($meta, 'summary.'.$field, 0));
+        }
+
+        return array_merge([
+            'status' => 'ok',
+            'latest_generated_at' => $latestGeneratedAt,
+            'latest_mode' => $this->normalizeOptionalString($meta['mode'] ?? null),
+            'latest_plan_path' => $this->normalizeOptionalString($meta['plan_path'] ?? $meta['plan'] ?? null),
+            'latest_run_path' => $latestRunPath,
+            'latest_run_path_exists' => $latestRunPath !== null && file_exists($latestRunPath),
+            'latest_summary' => $summary,
+        ], $this->freshnessFromTimestamp(
+            $latestGeneratedAt,
+            'audit-derived',
+            self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
+            'not_available'
+        ));
+    }
+
+    /**
+     * @param  list<object|null>  $audits
+     */
+    private function consistentReportArtifactsTargetDisk(array $audits): ?string
+    {
+        $disks = [];
+
+        foreach ($audits as $audit) {
+            if ($audit === null) {
+                continue;
+            }
+
+            $disk = $this->normalizeOptionalString($this->decodeAuditMeta($audit)['target_disk'] ?? null);
+            if ($disk !== null) {
+                $disks[$disk] = true;
+            }
+        }
+
+        if ($disks === [] || count($disks) > 1) {
+            return null;
+        }
+
+        return array_key_first($disks);
+    }
+
+    /**
+     * @param  list<?string>  $timestamps
+     */
+    private function latestTimestamp(array $timestamps): ?string
+    {
+        $latest = null;
+
+        foreach ($timestamps as $timestamp) {
+            $normalized = $this->normalizeTimestamp($timestamp);
+            if ($normalized === null) {
+                continue;
+            }
+
+            try {
+                $candidate = Carbon::parse($normalized);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if ($latest === null || $candidate->greaterThan($latest)) {
+                $latest = $candidate;
+            }
+        }
+
+        return $latest?->toIso8601String();
+    }
+
+    /**
      * @param  array<string,mixed>  $payload
      * @return array<string,mixed>
      */
@@ -835,7 +1017,9 @@ final class StorageControlPlaneStatusService
             ['path' => 'retention.scopes.reports_backups', 'label' => 'reports backups retention dry-run'],
             ['path' => 'retention.scopes.content_releases_retention', 'label' => 'content releases retention dry-run'],
             ['path' => 'retention.scopes.legacy_private_private_cleanup', 'label' => 'legacy private cleanup dry-run'],
-            ['path' => 'report_artifacts_archive', 'label' => 'report artifacts archive'],
+            ['path' => 'report_artifacts_posture.archive', 'label' => 'report artifacts archive posture'],
+            ['path' => 'report_artifacts_posture.rehydrate', 'label' => 'report artifacts rehydrate posture'],
+            ['path' => 'report_artifacts_posture.shrink', 'label' => 'report artifacts shrink posture'],
             ['path' => 'reports_artifacts_lifecycle', 'label' => 'reports artifacts lifecycle'],
             ['path' => 'blob_coverage.blob_gc', 'label' => 'blob gc dry-run'],
             ['path' => 'blob_coverage.blob_offload', 'label' => 'blob offload dry-run'],

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php
@@ -62,6 +62,8 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
     {
         $this->seedMinimalTruth();
         $archiveTruth = $this->seedReportArtifactsArchiveTruth();
+        $rehydrateTruth = $this->seedReportArtifactsRehydrateTruth();
+        $shrinkTruth = $this->seedReportArtifactsShrinkTruth();
 
         $auditCountBefore = DB::table('audit_logs')->count();
         $filesBefore = $this->storageFilesSnapshot();
@@ -77,6 +79,7 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertSame('snapshotted', $payload['status']);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
         $this->assertArrayHasKey('report_artifacts_archive', $payload);
+        $this->assertArrayHasKey('report_artifacts_posture', $payload);
         $this->assertArrayHasKey('reports_artifacts_lifecycle', $payload);
         $this->assertArrayHasKey('materialized_cache', $payload);
         $this->assertArrayHasKey('cost_reclaim_posture', $payload);
@@ -105,6 +108,22 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
         $this->assertTrue((bool) data_get($payload, 'report_artifacts_archive.latest_run_path_exists'));
         $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.results_count'));
         $this->assertArrayHasKey('freshness_state', data_get($payload, 'report_artifacts_archive', []));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_posture.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_posture.durable_receipt_source'));
+        $this->assertSame('s3', data_get($payload, 'report_artifacts_posture.target_disk'));
+        $this->assertSame($archiveTruth['plan_path'], data_get($payload, 'report_artifacts_posture.archive.latest_plan_path'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_posture.archive.latest_run_path'));
+        $this->assertTrue((bool) data_get($payload, 'report_artifacts_posture.archive.latest_run_path_exists'));
+        $this->assertSame($rehydrateTruth['plan_path'], data_get($payload, 'report_artifacts_posture.rehydrate.latest_plan_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_posture.rehydrate.latest_run_path_exists'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.skipped_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.blocked_count'));
+        $this->assertSame($shrinkTruth['plan_path'], data_get($payload, 'report_artifacts_posture.shrink.latest_plan_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_posture.shrink.latest_run_path_exists'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_remote_count'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_archive_proof_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_hash_mismatch_count'));
+        $this->assertArrayHasKey('freshness_state', data_get($payload, 'report_artifacts_posture', []));
         $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
         $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
         $this->assertSame(0, data_get($payload, 'materialized_cache.bucket_count'));
@@ -299,6 +318,88 @@ final class StorageControlPlaneSnapshotCommandTest extends TestCase
             'plan_path' => $planPath,
             'run_path' => $runPath,
         ];
+    }
+
+    /**
+     * @return array{plan_path:string}
+     */
+    private function seedReportArtifactsRehydrateTruth(): array
+    {
+        $planPath = storage_path('app/private/report_artifact_rehydrate_plans/rehydrate-plan.json');
+        $this->writeRaw($planPath, "{\"schema\":\"storage_rehydrate_report_artifacts_plan.v1\"}\n");
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_rehydrate_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_rehydrate',
+            'meta_json' => json_encode([
+                'schema' => 'storage_rehydrate_report_artifacts_plan.v1',
+                'mode' => 'dry_run',
+                'target_disk' => 's3',
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'candidate_count' => 3,
+                'rehydrated_count' => 0,
+                'verified_count' => 0,
+                'skipped_count' => 2,
+                'blocked_count' => 1,
+                'failed_count' => 0,
+                'results_count' => 0,
+                'durable_receipt_source' => 'audit_logs.meta_json',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_snapshot_command',
+            'request_id' => null,
+            'reason' => 'manual_archive_rehydrate',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(9),
+        ]);
+
+        return ['plan_path' => $planPath];
+    }
+
+    /**
+     * @return array{plan_path:string}
+     */
+    private function seedReportArtifactsShrinkTruth(): array
+    {
+        $planPath = storage_path('app/private/report_artifact_shrink_plans/shrink-plan.json');
+        $this->writeRaw($planPath, "{\"schema\":\"storage_shrink_archived_report_artifacts_plan.v1\"}\n");
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_shrink_archived_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_shrink',
+            'meta_json' => json_encode([
+                'schema' => 'storage_shrink_archived_report_artifacts_plan.v1',
+                'mode' => 'dry_run',
+                'target_disk' => 's3',
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'candidate_count' => 3,
+                'deleted_count' => 0,
+                'skipped_missing_local_count' => 0,
+                'blocked_missing_remote_count' => 1,
+                'blocked_missing_archive_proof_count' => 2,
+                'blocked_missing_rehydrate_proof_count' => 0,
+                'blocked_hash_mismatch_count' => 1,
+                'failed_count' => 0,
+                'results_count' => 0,
+                'durable_receipt_source' => 'audit_logs.meta_json',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_snapshot_command',
+            'request_id' => null,
+            'reason' => 'manual_archive_backed_shrink',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(8),
+        ]);
+
+        return ['plan_path' => $planPath];
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php
@@ -57,6 +57,8 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->seedMinimalTruth();
         $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
         $archiveTruth = $this->seedReportArtifactsArchiveTruth();
+        $rehydrateTruth = $this->seedReportArtifactsRehydrateTruth();
+        $shrinkTruth = $this->seedReportArtifactsShrinkTruth();
         $bucket = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -86,6 +88,7 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertArrayHasKey('purge', $payload);
         $this->assertArrayHasKey('retirement', $payload);
         $this->assertArrayHasKey('report_artifacts_archive', $payload);
+        $this->assertArrayHasKey('report_artifacts_posture', $payload);
         $this->assertArrayHasKey('reports_artifacts_lifecycle', $payload);
         $this->assertArrayHasKey('materialized_cache', $payload);
         $this->assertArrayHasKey('cost_reclaim_posture', $payload);
@@ -128,6 +131,23 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.results_count'));
         $this->assertSame('fresh', data_get($payload, 'report_artifacts_archive.freshness_state'));
         $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_archive.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_posture.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_posture.durable_receipt_source'));
+        $this->assertSame('s3', data_get($payload, 'report_artifacts_posture.target_disk'));
+        $this->assertSame($archiveTruth['plan_path'], data_get($payload, 'report_artifacts_posture.archive.latest_plan_path'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_posture.archive.latest_run_path'));
+        $this->assertTrue((bool) data_get($payload, 'report_artifacts_posture.archive.latest_run_path_exists'));
+        $this->assertSame($rehydrateTruth['plan_path'], data_get($payload, 'report_artifacts_posture.rehydrate.latest_plan_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_posture.rehydrate.latest_run_path_exists'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.skipped_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.blocked_count'));
+        $this->assertSame($shrinkTruth['plan_path'], data_get($payload, 'report_artifacts_posture.shrink.latest_plan_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_posture.shrink.latest_run_path_exists'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_remote_count'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_archive_proof_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_hash_mismatch_count'));
+        $this->assertSame('fresh', data_get($payload, 'report_artifacts_posture.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_posture.freshness_source_type'));
         $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
         $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
         $this->assertSame(1, data_get($payload, 'materialized_cache.bucket_count'));
@@ -225,6 +245,19 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertNull(data_get($payload, 'report_artifacts_archive.freshness_age_seconds'));
         $this->assertSame('not_available', data_get($payload, 'report_artifacts_archive.freshness_state'));
         $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_archive.freshness_source_type'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_posture.durable_receipt_source'));
+        $this->assertNull(data_get($payload, 'report_artifacts_posture.target_disk'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.archive.status'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.rehydrate.status'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.shrink.status'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_posture.archive.latest_summary.candidate_count'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.blocked_count'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_archive_proof_count'));
+        $this->assertNull(data_get($payload, 'report_artifacts_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'report_artifacts_posture.freshness_age_seconds'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_posture.freshness_source_type'));
         $this->assertSame('never_run', data_get($payload, 'retention.status'));
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'blob_coverage.blob_gc.status'));
@@ -257,7 +290,13 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
         $this->assertSame('disk-derived', data_get($payload, 'cost_reclaim_posture.freshness_source_type'));
         $this->assertNull($this->reclaimCategory($payload, 'v2_materialized_cache'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
-        $this->assertSame(['inventory', 'report_artifacts_archive', 'reports_artifacts_lifecycle'], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertSame([
+            'inventory',
+            'report_artifacts_posture.archive',
+            'report_artifacts_posture.rehydrate',
+            'report_artifacts_posture.shrink',
+            'reports_artifacts_lifecycle',
+        ], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertContains('quarantine', data_get($payload, 'attention_digest.never_run_sections', []));
     }
 
@@ -330,6 +369,88 @@ final class StorageControlPlaneSnapshotServiceTest extends TestCase
             'plan_path' => $planPath,
             'run_path' => $runPath,
         ];
+    }
+
+    /**
+     * @return array{plan_path:string}
+     */
+    private function seedReportArtifactsRehydrateTruth(): array
+    {
+        $planPath = storage_path('app/private/report_artifact_rehydrate_plans/rehydrate-plan.json');
+        $this->writeRaw($planPath, "{\"schema\":\"storage_rehydrate_report_artifacts_plan.v1\"}\n");
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_rehydrate_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_rehydrate',
+            'meta_json' => json_encode([
+                'schema' => 'storage_rehydrate_report_artifacts_plan.v1',
+                'mode' => 'dry_run',
+                'target_disk' => 's3',
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'candidate_count' => 3,
+                'rehydrated_count' => 0,
+                'verified_count' => 0,
+                'skipped_count' => 2,
+                'blocked_count' => 1,
+                'failed_count' => 0,
+                'results_count' => 0,
+                'durable_receipt_source' => 'audit_logs.meta_json',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_snapshot_service',
+            'request_id' => null,
+            'reason' => 'manual_archive_rehydrate',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(9),
+        ]);
+
+        return ['plan_path' => $planPath];
+    }
+
+    /**
+     * @return array{plan_path:string}
+     */
+    private function seedReportArtifactsShrinkTruth(): array
+    {
+        $planPath = storage_path('app/private/report_artifact_shrink_plans/shrink-plan.json');
+        $this->writeRaw($planPath, "{\"schema\":\"storage_shrink_archived_report_artifacts_plan.v1\"}\n");
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_shrink_archived_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_shrink',
+            'meta_json' => json_encode([
+                'schema' => 'storage_shrink_archived_report_artifacts_plan.v1',
+                'mode' => 'dry_run',
+                'target_disk' => 's3',
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'candidate_count' => 3,
+                'deleted_count' => 0,
+                'skipped_missing_local_count' => 0,
+                'blocked_missing_remote_count' => 1,
+                'blocked_missing_archive_proof_count' => 2,
+                'blocked_missing_rehydrate_proof_count' => 0,
+                'blocked_hash_mismatch_count' => 1,
+                'failed_count' => 0,
+                'results_count' => 0,
+                'durable_receipt_source' => 'audit_logs.meta_json',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_snapshot_service',
+            'request_id' => null,
+            'reason' => 'manual_archive_backed_shrink',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(8),
+        ]);
+
+        return ['plan_path' => $planPath];
     }
 
     private function writeRaw(string $path, string $contents): void

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php
@@ -62,6 +62,8 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
     {
         $this->seedMinimalTruth();
         $archiveTruth = $this->seedReportArtifactsArchiveTruth();
+        $rehydrateTruth = $this->seedReportArtifactsRehydrateTruth();
+        $shrinkTruth = $this->seedReportArtifactsShrinkTruth();
 
         $auditCountBefore = DB::table('audit_logs')->count();
         $filesBefore = $this->storageFilesSnapshot();
@@ -89,6 +91,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('runtime_truth', $payload);
         $this->assertArrayHasKey('automation_readiness', $payload);
         $this->assertArrayHasKey('report_artifacts_archive', $payload);
+        $this->assertArrayHasKey('report_artifacts_posture', $payload);
         $this->assertArrayHasKey('reports_artifacts_lifecycle', $payload);
         $this->assertArrayHasKey('attention_digest', $payload);
         $this->assertSame('ok', data_get($payload, 'inventory.status'));
@@ -126,6 +129,25 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertArrayHasKey('freshness_age_seconds', data_get($payload, 'report_artifacts_archive', []));
         $this->assertArrayHasKey('freshness_state', data_get($payload, 'report_artifacts_archive', []));
         $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'report_artifacts_archive', []));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_posture.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_posture.durable_receipt_source'));
+        $this->assertSame('s3', data_get($payload, 'report_artifacts_posture.target_disk'));
+        $this->assertSame($archiveTruth['plan_path'], data_get($payload, 'report_artifacts_posture.archive.latest_plan_path'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_posture.archive.latest_run_path'));
+        $this->assertTrue((bool) data_get($payload, 'report_artifacts_posture.archive.latest_run_path_exists'));
+        $this->assertSame($rehydrateTruth['plan_path'], data_get($payload, 'report_artifacts_posture.rehydrate.latest_plan_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_posture.rehydrate.latest_run_path_exists'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.skipped_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.blocked_count'));
+        $this->assertSame($shrinkTruth['plan_path'], data_get($payload, 'report_artifacts_posture.shrink.latest_plan_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_posture.shrink.latest_run_path_exists'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_remote_count'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_archive_proof_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_hash_mismatch_count'));
+        $this->assertArrayHasKey('last_updated_at', data_get($payload, 'report_artifacts_posture', []));
+        $this->assertArrayHasKey('freshness_age_seconds', data_get($payload, 'report_artifacts_posture', []));
+        $this->assertArrayHasKey('freshness_state', data_get($payload, 'report_artifacts_posture', []));
+        $this->assertArrayHasKey('freshness_source_type', data_get($payload, 'report_artifacts_posture', []));
         $this->assertSame('remote_rehydrate_enabled', data_get($payload, 'runtime_truth.v2_readiness'));
         $this->assertSame('ok', data_get($payload, 'materialized_cache.status'));
         $this->assertSame(storage_path('app/private/packs_v2_materialized'), data_get($payload, 'materialized_cache.root_path'));
@@ -239,7 +261,7 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
         $this->assertStringContainsString('attention_digest.overall_state=degraded', $output);
         $this->assertStringContainsString('attention_digest.counts.stale=0', $output);
         $this->assertStringContainsString('attention_digest.counts.never_run=', $output);
-        $this->assertStringContainsString('attention_digest.counts.not_available=1', $output);
+        $this->assertStringContainsString('attention_digest.counts.not_available=3', $output);
     }
 
     private function seedMinimalTruth(): void
@@ -326,6 +348,94 @@ final class StorageControlPlaneStatusCommandTest extends TestCase
             'plan_path' => $planPath,
             'run_path' => $runPath,
         ];
+    }
+
+    /**
+     * @return array{plan_path:string}
+     */
+    private function seedReportArtifactsRehydrateTruth(): array
+    {
+        $planPath = storage_path('app/private/report_artifact_rehydrate_plans/rehydrate-plan.json');
+        $this->writeJson($planPath, [
+            'schema' => 'storage_rehydrate_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+        ]);
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_rehydrate_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_rehydrate',
+            'meta_json' => json_encode([
+                'schema' => 'storage_rehydrate_report_artifacts_plan.v1',
+                'mode' => 'dry_run',
+                'target_disk' => 's3',
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'candidate_count' => 3,
+                'rehydrated_count' => 0,
+                'verified_count' => 0,
+                'skipped_count' => 2,
+                'blocked_count' => 1,
+                'failed_count' => 0,
+                'results_count' => 0,
+                'durable_receipt_source' => 'audit_logs.meta_json',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_status',
+            'request_id' => null,
+            'reason' => 'manual_archive_rehydrate',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(9),
+        ]);
+
+        return ['plan_path' => $planPath];
+    }
+
+    /**
+     * @return array{plan_path:string}
+     */
+    private function seedReportArtifactsShrinkTruth(): array
+    {
+        $planPath = storage_path('app/private/report_artifact_shrink_plans/shrink-plan.json');
+        $this->writeJson($planPath, [
+            'schema' => 'storage_shrink_archived_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+        ]);
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_shrink_archived_report_artifacts',
+            'target_type' => 'storage',
+            'target_id' => 'report_artifacts_shrink',
+            'meta_json' => json_encode([
+                'schema' => 'storage_shrink_archived_report_artifacts_plan.v1',
+                'mode' => 'dry_run',
+                'target_disk' => 's3',
+                'plan' => $planPath,
+                'plan_path' => $planPath,
+                'candidate_count' => 3,
+                'deleted_count' => 0,
+                'skipped_missing_local_count' => 0,
+                'blocked_missing_remote_count' => 1,
+                'blocked_missing_archive_proof_count' => 2,
+                'blocked_missing_rehydrate_proof_count' => 0,
+                'blocked_hash_mismatch_count' => 1,
+                'failed_count' => 0,
+                'results_count' => 0,
+                'durable_receipt_source' => 'audit_logs.meta_json',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test/storage_control_plane_status',
+            'request_id' => null,
+            'reason' => 'manual_archive_backed_shrink',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(8),
+        ]);
+
+        return ['plan_path' => $planPath];
     }
 
     /**

--- a/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php
@@ -57,6 +57,8 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->seedControlPlaneTruth();
         $lifecycleFiles = $this->seedReportsArtifactsLifecycleTruth();
         $archiveTruth = $this->seedReportArtifactsArchiveTruth();
+        $rehydrateTruth = $this->seedReportArtifactsRehydrateTruth();
+        $shrinkTruth = $this->seedReportArtifactsShrinkTruth();
         $bucketOne = [
             '.materialization.json' => json_encode([
                 'storage_path' => 'private/packs_v2/BIG5_OCEAN/v1/release-a',
@@ -121,6 +123,36 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame(3, data_get($payload, 'report_artifacts_archive.latest_summary.results_count'));
         $this->assertSame('fresh', data_get($payload, 'report_artifacts_archive.freshness_state'));
         $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_archive.freshness_source_type'));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_posture.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_posture.durable_receipt_source'));
+        $this->assertSame('s3', data_get($payload, 'report_artifacts_posture.target_disk'));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_posture.archive.status'));
+        $this->assertSame($archiveTruth['plan_path'], data_get($payload, 'report_artifacts_posture.archive.latest_plan_path'));
+        $this->assertSame($archiveTruth['run_path'], data_get($payload, 'report_artifacts_posture.archive.latest_run_path'));
+        $this->assertTrue((bool) data_get($payload, 'report_artifacts_posture.archive.latest_run_path_exists'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_posture.archive.latest_summary.candidate_count'));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_posture.rehydrate.status'));
+        $this->assertSame('dry_run', data_get($payload, 'report_artifacts_posture.rehydrate.latest_mode'));
+        $this->assertSame($rehydrateTruth['plan_path'], data_get($payload, 'report_artifacts_posture.rehydrate.latest_plan_path'));
+        $this->assertNull(data_get($payload, 'report_artifacts_posture.rehydrate.latest_run_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_posture.rehydrate.latest_run_path_exists'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.candidate_count'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.skipped_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.blocked_count'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.results_count'));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_posture.shrink.status'));
+        $this->assertSame('dry_run', data_get($payload, 'report_artifacts_posture.shrink.latest_mode'));
+        $this->assertSame($shrinkTruth['plan_path'], data_get($payload, 'report_artifacts_posture.shrink.latest_plan_path'));
+        $this->assertNull(data_get($payload, 'report_artifacts_posture.shrink.latest_run_path'));
+        $this->assertFalse((bool) data_get($payload, 'report_artifacts_posture.shrink.latest_run_path_exists'));
+        $this->assertSame(3, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.candidate_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_remote_count'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_archive_proof_count'));
+        $this->assertSame(1, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_hash_mismatch_count'));
+        $this->assertSame('fresh', data_get($payload, 'report_artifacts_posture.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_posture.freshness_source_type'));
+        $this->assertIsString(data_get($payload, 'report_artifacts_posture.last_updated_at'));
+        $this->assertIsInt(data_get($payload, 'report_artifacts_posture.freshness_age_seconds'));
         $this->assertSame(1, data_get($payload, 'blob_coverage.counts.storage_blobs'));
         $this->assertSame(1, data_get($payload, 'blob_coverage.counts.verified_storage_blob_locations_by_disk.s3'));
         $this->assertSame('fresh', data_get($payload, 'blob_coverage.blob_gc.freshness_state'));
@@ -241,6 +273,19 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertNull(data_get($payload, 'report_artifacts_archive.freshness_age_seconds'));
         $this->assertSame('not_available', data_get($payload, 'report_artifacts_archive.freshness_state'));
         $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_archive.freshness_source_type'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_posture.durable_receipt_source'));
+        $this->assertNull(data_get($payload, 'report_artifacts_posture.target_disk'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.archive.status'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.rehydrate.status'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.shrink.status'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_posture.archive.latest_summary.candidate_count'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_posture.rehydrate.latest_summary.blocked_count'));
+        $this->assertSame(0, data_get($payload, 'report_artifacts_posture.shrink.latest_summary.blocked_missing_archive_proof_count'));
+        $this->assertNull(data_get($payload, 'report_artifacts_posture.last_updated_at'));
+        $this->assertNull(data_get($payload, 'report_artifacts_posture.freshness_age_seconds'));
+        $this->assertSame('not_available', data_get($payload, 'report_artifacts_posture.freshness_state'));
+        $this->assertSame('audit-derived', data_get($payload, 'report_artifacts_posture.freshness_source_type'));
         $this->assertSame('never_run', data_get($payload, 'retention.status'));
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.reports_backups.freshness_state'));
         $this->assertSame('never_run', data_get($payload, 'retention.scopes.content_releases_retention.freshness_state'));
@@ -292,18 +337,26 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
         $this->assertSame('unknown_freshness', data_get($payload, 'runtime_truth.freshness_state'));
         $this->assertSame('unknown_freshness', data_get($payload, 'automation_readiness.freshness_state'));
         $this->assertSame('degraded', data_get($payload, 'attention_digest.overall_state'));
-        $this->assertSame(['inventory', 'report_artifacts_archive', 'reports_artifacts_lifecycle'], data_get($payload, 'attention_digest.not_available_sections'));
+        $this->assertSame([
+            'inventory',
+            'report_artifacts_posture.archive',
+            'report_artifacts_posture.rehydrate',
+            'report_artifacts_posture.shrink',
+            'reports_artifacts_lifecycle',
+        ], data_get($payload, 'attention_digest.not_available_sections'));
         $this->assertContains('rehydrate', data_get($payload, 'attention_digest.never_run_sections', []));
         $this->assertContains('retention.scopes.reports_backups', data_get($payload, 'attention_digest.never_run_sections', []));
         $this->assertSame([], data_get($payload, 'attention_digest.stale_sections'));
-        $this->assertSame(3, data_get($payload, 'attention_digest.counts.not_available'));
+        $this->assertSame(5, data_get($payload, 'attention_digest.counts.not_available'));
         $this->assertGreaterThan(0, (int) data_get($payload, 'attention_digest.counts.never_run'));
         $attentionMessages = array_values(array_filter(array_map(
             static fn ($item): ?string => is_array($item) ? ($item['message'] ?? null) : null,
             (array) data_get($payload, 'attention_digest.attention_items', [])
         )));
         $this->assertContains('inventory is not available', $attentionMessages);
-        $this->assertContains('report artifacts archive is not available', $attentionMessages);
+        $this->assertContains('report artifacts archive posture is not available', $attentionMessages);
+        $this->assertContains('report artifacts rehydrate posture is not available', $attentionMessages);
+        $this->assertContains('report artifacts shrink posture is not available', $attentionMessages);
         $this->assertContains('reports artifacts lifecycle is not available', $attentionMessages);
     }
 
@@ -612,6 +665,86 @@ final class StorageControlPlaneStatusServiceTest extends TestCase
             'plan_path' => $planPath,
             'run_path' => $runPath,
         ];
+    }
+
+    /**
+     * @return array{plan_path:string}
+     */
+    private function seedReportArtifactsRehydrateTruth(): array
+    {
+        $planPath = storage_path('app/private/report_artifact_rehydrate_plans/rehydrate-plan.json');
+        $this->writeJson($planPath, [
+            'schema' => 'storage_rehydrate_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+        ]);
+
+        $this->insertAudit('storage_rehydrate_report_artifacts', 'report_artifacts_rehydrate', [
+            'schema' => 'storage_rehydrate_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+            'target_disk' => 's3',
+            'plan' => $planPath,
+            'plan_path' => $planPath,
+            'candidate_count' => 3,
+            'rehydrated_count' => 0,
+            'verified_count' => 0,
+            'skipped_count' => 2,
+            'blocked_count' => 1,
+            'failed_count' => 0,
+            'results_count' => 0,
+            'durable_receipt_source' => 'audit_logs.meta_json',
+            'summary' => [
+                'candidate_count' => 3,
+                'rehydrated_count' => 0,
+                'verified_count' => 0,
+                'skipped_count' => 2,
+                'blocked_count' => 1,
+                'failed_count' => 0,
+            ],
+        ], 'success', 'manual_archive_rehydrate', now()->subMinutes(9));
+
+        return ['plan_path' => $planPath];
+    }
+
+    /**
+     * @return array{plan_path:string}
+     */
+    private function seedReportArtifactsShrinkTruth(): array
+    {
+        $planPath = storage_path('app/private/report_artifact_shrink_plans/shrink-plan.json');
+        $this->writeJson($planPath, [
+            'schema' => 'storage_shrink_archived_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+        ]);
+
+        $this->insertAudit('storage_shrink_archived_report_artifacts', 'report_artifacts_shrink', [
+            'schema' => 'storage_shrink_archived_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+            'target_disk' => 's3',
+            'plan' => $planPath,
+            'plan_path' => $planPath,
+            'candidate_count' => 3,
+            'deleted_count' => 0,
+            'skipped_missing_local_count' => 0,
+            'blocked_missing_remote_count' => 1,
+            'blocked_missing_archive_proof_count' => 2,
+            'blocked_missing_rehydrate_proof_count' => 0,
+            'blocked_hash_mismatch_count' => 1,
+            'failed_count' => 0,
+            'results_count' => 0,
+            'durable_receipt_source' => 'audit_logs.meta_json',
+            'summary' => [
+                'candidate_count' => 3,
+                'deleted_count' => 0,
+                'skipped_missing_local_count' => 0,
+                'blocked_missing_remote_count' => 1,
+                'blocked_missing_archive_proof_count' => 2,
+                'blocked_missing_rehydrate_proof_count' => 0,
+                'blocked_hash_mismatch_count' => 1,
+                'failed_count' => 0,
+            ],
+        ], 'success', 'manual_archive_backed_shrink', now()->subMinutes(8));
+
+        return ['plan_path' => $planPath];
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR adds a unified `report_artifacts_posture` read-model to control-plane status for the report artifacts lifecycle.

Scope is intentionally narrow:

- add a new top-level `report_artifacts_posture` section to `storage:control-plane-status --json`
- aggregate latest posture from archive, rehydrate, and shrink durable audit truth
- let `storage:control-plane-snapshot --json` inherit the section automatically
- let `storage:refresh-control-plane --dry-run --json` surface the section naturally through the final snapshot
- attach standard freshness and standard attention-digest integration for the three child posture nodes

This PR does **not**:

- change any archive / rehydrate / shrink execution behavior
- change any command signature
- add a new command, service, config, route, middleware, migration, or scheduler step
- change any runtime reader / writer / fallback contract
- change canonical output path semantics
- change legacy fallback semantics

## Root cause

The report artifacts lifecycle already has a complete execution loop:

- archive
- durable archive receipt truth
- rehydrate-to-local
- shrink local canonical files

But the operator view in control-plane was still fragmented:

- archive already had a first-class section
- rehydrate had durable audit truth but no report-artifacts control-plane section
- shrink had durable audit truth but no control-plane section
- shrink blocked reasons were only visible in command output and audit receipts

The gap was therefore not an execute gap. It was a posture / control-plane integration gap.

## What changed

### 1. Unified posture section

`StorageControlPlaneStatusService` now exposes a new top-level section:

- `report_artifacts_posture`

This section reads latest durable truth from:

- `storage_archive_report_artifacts`
- `storage_rehydrate_report_artifacts`
- `storage_shrink_archived_report_artifacts`

Each child posture exposes:

- `status`
- `latest_generated_at`
- `latest_mode`
- `latest_plan_path`
- `latest_run_path`
- `latest_run_path_exists`
- `latest_summary`
- `last_updated_at`
- `freshness_age_seconds`
- `freshness_state`
- `freshness_source_type = audit-derived`

The top-level section exposes:

- `status`
- `durable_receipt_source = audit_logs.meta_json`
- `target_disk`
- `archive`
- `rehydrate`
- `shrink`
- `last_updated_at`
- `freshness_age_seconds`
- `freshness_state`
- `freshness_source_type = audit-derived`

### 2. Existing archive section preserved

The existing `report_artifacts_archive` section is preserved as-is.

This PR does not rename it, remove it, or change its contract. The new posture section is an additional unified read surface, not a replacement.

### 3. Standard attention integration only

Attention digest integration is added only through the existing standard path-based freshness / not_available logic for:

- `report_artifacts_posture.archive`
- `report_artifacts_posture.rehydrate`
- `report_artifacts_posture.shrink`

No new business-specific attention rules were introduced.

## Validation

Focused:

- `tests/Feature/Storage/StorageControlPlaneStatusServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneStatusCommandTest.php`
- `tests/Feature/Storage/StorageControlPlaneSnapshotServiceTest.php`
- `tests/Feature/Storage/StorageControlPlaneSnapshotCommandTest.php`

Regression:

- `tests/Feature/Storage/StorageControlPlaneRefreshServiceTest.php`
- `tests/Feature/Storage/StorageRefreshControlPlaneCommandTest.php`
- `tests/Feature/Storage/ReportArtifactsArchiveServiceTest.php`
- `tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php`
- `tests/Feature/Storage/ReportArtifactsRehydrateServiceTest.php`
- `tests/Feature/Storage/StorageRehydrateReportArtifactsCommandTest.php`
- `tests/Feature/Storage/ReportArtifactsShrinkServiceTest.php`
- `tests/Feature/Storage/StorageShrinkArchivedReportArtifactsCommandTest.php`
- `tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php`
- `tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php`

Live checks:

- `php artisan storage:archive-report-artifacts --dry-run --disk=s3`
- `php artisan storage:rehydrate-report-artifacts --dry-run --disk=s3`
- `php artisan storage:shrink-archived-report-artifacts --dry-run --disk=s3`
- `php artisan storage:control-plane-status --json`
- `php artisan storage:control-plane-snapshot --json`
- `php artisan storage:refresh-control-plane --dry-run --json`
- `php artisan storage:inventory --json`
- `php artisan storage:analyze-cost --json`
- `bash backend/scripts/ci_verify_mbti.sh`

Key live results:

- `report_artifacts_posture.status = ok`
- `report_artifacts_posture.target_disk = s3`
- archive posture summary is visible
- rehydrate posture summary is visible
- shrink posture summary is visible
- shrink blocked counts are visible in control-plane
- snapshot inherits the new section automatically
- refresh surfaces the new section without adding a new step
- no execute/runtime/fallback contract changed
