### PR TITLE
[codex] Ship PR-13E public content expansion backend

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/PublicGatewaySurfaceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/PublicGatewaySurfaceController.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_3;
+
+use App\Http\Controllers\Controller;
+use App\Services\PublicSurface\PublicGatewaySurfaceService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class PublicGatewaySurfaceController extends Controller
+{
+    public function __construct(
+        private readonly PublicGatewaySurfaceService $publicGatewaySurfaceService,
+    ) {}
+
+    public function home(Request $request): JsonResponse
+    {
+        return response()->json([
+            'ok' => true,
+            'landing_surface_v1' => $this->publicGatewaySurfaceService->buildHomeSurface(
+                $this->resolveLocale($request)
+            ),
+        ]);
+    }
+
+    public function tests(Request $request): JsonResponse
+    {
+        return response()->json([
+            'ok' => true,
+            'landing_surface_v1' => $this->publicGatewaySurfaceService->buildTestsIndexSurface(
+                $this->resolveLocale($request)
+            ),
+        ]);
+    }
+
+    public function help(Request $request): JsonResponse
+    {
+        return response()->json([
+            'ok' => true,
+            'landing_surface_v1' => $this->publicGatewaySurfaceService->buildHelpIndexSurface(
+                $this->resolveLocale($request)
+            ),
+        ]);
+    }
+
+    public function helpDetail(Request $request, string $slug): JsonResponse
+    {
+        $payload = $this->publicGatewaySurfaceService->buildHelpDetailSurface(
+            $this->resolveLocale($request),
+            $slug
+        );
+
+        if ($payload === null) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'NOT_FOUND',
+                'message' => 'help page not found.',
+            ], 404);
+        }
+
+        return response()->json(array_merge(['ok' => true], $payload));
+    }
+
+    private function resolveLocale(Request $request): string
+    {
+        $raw = trim((string) (
+            $request->query('locale')
+            ?? $request->header('X-FAP-Locale')
+            ?? 'en'
+        ));
+
+        $normalized = strtolower(str_replace('_', '-', $raw));
+
+        return str_starts_with($normalized, 'zh') ? 'zh-CN' : 'en';
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -10,6 +10,8 @@ use App\Models\Article;
 use App\Services\Cms\ArticlePublishService;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\ArticleService;
+use App\Services\PublicSurface\AnswerSurfaceContractService;
+use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -23,6 +25,8 @@ class ArticleController extends Controller
         private readonly ArticleService $articleService,
         private readonly ArticlePublishService $articlePublishService,
         private readonly ArticleSeoService $articleSeoService,
+        private readonly AnswerSurfaceContractService $answerSurfaceContractService,
+        private readonly LandingSurfaceContractService $landingSurfaceContractService,
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
 
@@ -69,6 +73,10 @@ class ArticleController extends Controller
                 'total' => (int) $paginator->total(),
                 'last_page' => (int) $paginator->lastPage(),
             ],
+            'landing_surface_v1' => $this->buildIndexLandingSurface(
+                $items,
+                $validated['locale'] ?? 'en'
+            ),
         ]);
     }
 
@@ -126,6 +134,8 @@ class ArticleController extends Controller
             'ok' => true,
             'article' => $this->articlePayload($article),
             'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'article_public_detail'),
+            'landing_surface_v1' => $this->buildDetailLandingSurface($article, $locale),
+            'answer_surface_v1' => $this->buildDetailAnswerSurface($article, $locale),
         ]);
     }
 
@@ -193,6 +203,253 @@ class ArticleController extends Controller
             'twitter_payload' => is_array($meta['twitter'] ?? null) ? $meta['twitter'] : [],
             'alternates' => is_array($meta['alternates'] ?? null) ? $meta['alternates'] : [],
             'structured_data' => $jsonLd,
+        ]);
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $items
+     * @return array<string,mixed>
+     */
+    private function buildIndexLandingSurface(array $items, string $locale): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $discoverabilityItems = array_values(array_filter(array_map(
+            static function (array $item): ?array {
+                $slug = trim((string) ($item['slug'] ?? ''));
+                $title = trim((string) ($item['title'] ?? ''));
+                if ($slug === '' || $title === '') {
+                    return null;
+                }
+
+                $locale = trim((string) ($item['locale'] ?? 'en'));
+                $segment = $locale === 'zh-CN' ? 'zh' : 'en';
+
+                return [
+                    'key' => $slug,
+                    'title' => $title,
+                    'summary' => trim((string) ($item['excerpt'] ?? '')),
+                    'href' => '/'.$segment.'/articles/'.$slug,
+                    'kind' => 'article_detail',
+                    'badge_label' => is_array($item['category'] ?? null)
+                        ? trim((string) (($item['category']['name'] ?? '')))
+                        : null,
+                ];
+            },
+            array_slice($items, 0, 6)
+        )));
+        $firstHref = $discoverabilityItems[0]['href'] ?? '/'.$segment.'/articles';
+
+        return $this->landingSurfaceContractService->build([
+            'landing_scope' => 'public_indexable_hub',
+            'entry_surface' => 'article_index',
+            'entry_type' => 'content_hub',
+            'summary_blocks' => [
+                [
+                    'key' => 'articles_index',
+                    'title' => $locale === 'zh-CN' ? '文章与洞察' : 'Articles and insights',
+                    'body' => $locale === 'zh-CN'
+                        ? '从公开文章进入人格、主题、职业与测试主链。'
+                        : 'Use public articles to continue into personality, topic, career, and assessment surfaces.',
+                    'kind' => 'answer_first',
+                ],
+            ],
+            'discoverability_items' => $discoverabilityItems,
+            'discoverability_keys' => array_column($discoverabilityItems, 'key'),
+            'continue_reading_keys' => ['article_detail', 'topics_index', 'personality_index'],
+            'start_test_target' => '/'.$segment.'/tests/mbti-personality-test-16-personality-types',
+            'content_continue_target' => $firstHref,
+            'cta_bundle' => [
+                [
+                    'key' => 'featured_article',
+                    'label' => $locale === 'zh-CN' ? '阅读精选文章' : 'Read featured article',
+                    'href' => $firstHref,
+                    'kind' => 'content_continue',
+                ],
+                [
+                    'key' => 'topic_hub',
+                    'label' => $locale === 'zh-CN' ? '查看主题聚合' : 'Browse topic hubs',
+                    'href' => '/'.$segment.'/topics',
+                    'kind' => 'discover',
+                ],
+                [
+                    'key' => 'start_test',
+                    'label' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
+                    'href' => '/'.$segment.'/tests/mbti-personality-test-16-personality-types',
+                    'kind' => 'start_test',
+                ],
+            ],
+            'indexability_state' => 'indexable',
+            'attribution_scope' => 'public_article_landing',
+            'surface_family' => 'article',
+            'primary_content_ref' => 'articles_index',
+            'related_surface_keys' => ['topics_index', 'personality_index', 'tests_index'],
+            'fingerprint_seed' => [
+                'locale' => $locale,
+                'discoverability_keys' => array_column($discoverabilityItems, 'key'),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildDetailLandingSurface(Article $article, string $locale): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $slug = trim((string) $article->slug);
+
+        return $this->landingSurfaceContractService->build([
+            'landing_scope' => 'public_indexable_detail',
+            'entry_surface' => 'article_detail',
+            'entry_type' => 'editorial_article',
+            'summary_blocks' => [
+                [
+                    'key' => 'article_hero',
+                    'title' => (string) $article->title,
+                    'body' => trim((string) ($article->excerpt ?? '')),
+                    'kind' => 'answer_first',
+                ],
+            ],
+            'discoverability_keys' => ['article_index', 'topic_hub', 'personality_hub', 'career_recommendations'],
+            'continue_reading_keys' => ['article_index', 'topic_hub'],
+            'start_test_target' => '/'.$segment.'/tests/mbti-personality-test-16-personality-types',
+            'content_continue_target' => '/'.$segment.'/articles',
+            'cta_bundle' => [
+                [
+                    'key' => 'back_to_articles',
+                    'label' => $locale === 'zh-CN' ? '返回文章列表' : 'Back to articles',
+                    'href' => '/'.$segment.'/articles',
+                    'kind' => 'content_continue',
+                ],
+                [
+                    'key' => 'topic_hub',
+                    'label' => $locale === 'zh-CN' ? '查看主题聚合' : 'Browse topic hubs',
+                    'href' => '/'.$segment.'/topics',
+                    'kind' => 'discover',
+                ],
+                [
+                    'key' => 'start_test',
+                    'label' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
+                    'href' => '/'.$segment.'/tests/mbti-personality-test-16-personality-types',
+                    'kind' => 'start_test',
+                ],
+            ],
+            'indexability_state' => $article->is_indexable ? 'indexable' : 'noindex',
+            'attribution_scope' => 'public_article_detail',
+            'surface_family' => 'article',
+            'primary_content_ref' => $slug,
+            'related_surface_keys' => ['topic_hub', 'personality_hub', 'tests_index'],
+            'fingerprint_seed' => [
+                'slug' => $slug,
+                'locale' => $locale,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildDetailAnswerSurface(Article $article, string $locale): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $category = $article->relationLoaded('category') && $article->category
+            ? trim((string) ($article->category->name ?? ''))
+            : null;
+        $tagNames = $article->relationLoaded('tags')
+            ? array_values(array_filter(array_map(
+                static fn ($tag): string => trim((string) ($tag->name ?? '')),
+                $article->tags->all()
+            )))
+            : [];
+        $faqBlocks = [
+            [
+                'key' => 'article_use',
+                'question' => $locale === 'zh-CN' ? '什么时候适合阅读这篇文章？' : 'When should I use this article?',
+                'answer' => $locale === 'zh-CN'
+                    ? '当你想把公开内容和测评、人格画像或职业建议串起来时，先从这篇文章的核心摘要开始。'
+                    : 'Use this article when you want to connect public content with tests, personality profiles, or career guidance from a single starting point.',
+            ],
+            [
+                'key' => 'article_limits',
+                'question' => $locale === 'zh-CN' ? '这篇文章会替代正式判断吗？' : 'Does this replace formal judgment?',
+                'answer' => $locale === 'zh-CN'
+                    ? '不会。它只提供公开解释和行动线索，不替代医疗、法律或专业诊断。'
+                    : 'No. It offers public explanation and action cues, but does not replace medical, legal, or professional judgment.',
+            ],
+        ];
+
+        $compareBlocks = array_values(array_filter([
+            $category !== null
+                ? [
+                    'key' => 'article_category',
+                    'title' => $locale === 'zh-CN' ? '内容分类' : 'Content category',
+                    'body' => $category,
+                    'kind' => 'content_compare',
+                ]
+                : null,
+            $tagNames !== []
+                ? [
+                    'key' => 'article_tags',
+                    'title' => $locale === 'zh-CN' ? '相关标签' : 'Related tags',
+                    'body' => implode($locale === 'zh-CN' ? '、' : ', ', array_slice($tagNames, 0, 4)),
+                    'kind' => 'content_compare',
+                ]
+                : null,
+        ]));
+
+        $nextStepBlocks = [
+            [
+                'key' => 'articles_index',
+                'title' => $locale === 'zh-CN' ? '继续浏览文章' : 'Continue with articles',
+                'body' => $locale === 'zh-CN' ? '回到文章目录，继续扩展公开内容阅读链路。' : 'Return to the article hub to keep expanding the public reading chain.',
+                'href' => '/'.$segment.'/articles',
+                'kind' => 'content_continue',
+            ],
+            [
+                'key' => 'topic_hub',
+                'title' => $locale === 'zh-CN' ? '进入主题聚合' : 'Go to topic hubs',
+                'body' => $locale === 'zh-CN' ? '把文章阅读继续到更结构化的主题入口。' : 'Continue from the article into a more structured topic entry surface.',
+                'href' => '/'.$segment.'/topics',
+                'kind' => 'discover',
+            ],
+            [
+                'key' => 'start_test',
+                'title' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
+                'body' => $locale === 'zh-CN' ? '如果你想把阅读转成自我测量，可以从测试入口开始。' : 'If you want to turn reading into self-measurement, continue into an assessment.',
+                'href' => '/'.$segment.'/tests/mbti-personality-test-16-personality-types',
+                'kind' => 'start_test',
+            ],
+        ];
+
+        return $this->answerSurfaceContractService->build([
+            'answer_scope' => 'public_indexable_detail',
+            'surface_type' => 'article_public_detail',
+            'summary_blocks' => [
+                [
+                    'key' => 'article_summary',
+                    'title' => (string) $article->title,
+                    'body' => trim((string) ($article->excerpt ?? '')),
+                    'kind' => 'answer_first',
+                ],
+            ],
+            'faq_blocks' => $faqBlocks,
+            'compare_blocks' => $compareBlocks,
+            'next_step_blocks' => $nextStepBlocks,
+            'evidence_refs' => array_values(array_filter(array_merge(
+                ['article:'.trim((string) $article->slug)],
+                $category !== null ? ['category:'.$category] : [],
+                array_map(static fn (string $tag): string => 'tag:'.$tag, array_slice($tagNames, 0, 4))
+            ))),
+            'public_safety_state' => 'public_indexable',
+            'indexability_state' => $article->is_indexable ? 'indexable' : 'noindex',
+            'attribution_scope' => 'public_article_answer',
+            'primary_content_ref' => trim((string) $article->slug),
+            'related_surface_keys' => ['articles_index', 'topic_hub', 'tests_index'],
+            'fingerprint_seed' => [
+                'slug' => trim((string) $article->slug),
+                'locale' => $locale,
+                'tag_count' => count($tagNames),
+            ],
         ]);
     }
 
@@ -403,6 +660,11 @@ class ArticleController extends Controller
         $raw = trim((string) $request->query('org_id', '0'));
 
         return preg_match('/^\d+$/', $raw) === 1 ? (int) $raw : 0;
+    }
+
+    private function frontendLocaleSegment(string $locale): string
+    {
+        return $locale === 'zh-CN' ? 'zh' : 'en';
     }
 
     /**

--- a/backend/app/Services/PublicSurface/LandingSurfaceContractService.php
+++ b/backend/app/Services/PublicSurface/LandingSurfaceContractService.php
@@ -12,6 +12,7 @@ final class LandingSurfaceContractService
      *   entry_surface:string,
      *   entry_type:string,
      *   summary_blocks?:array<int,array<string,mixed>>,
+     *   discoverability_items?:array<int,array<string,mixed>>,
      *   discoverability_keys?:array<int,string>,
      *   continue_reading_keys?:array<int,string>,
      *   start_test_target?:?string,
@@ -37,6 +38,7 @@ final class LandingSurfaceContractService
         $entrySurface = $this->normalizeString($context['entry_surface'] ?? null) ?? 'public_entry';
         $entryType = $this->normalizeString($context['entry_type'] ?? null) ?? 'public_content';
         $summaryBlocks = $this->normalizeSummaryBlocks($context['summary_blocks'] ?? []);
+        $discoverabilityItems = $this->normalizeDiscoverabilityItems($context['discoverability_items'] ?? []);
         $discoverabilityKeys = $this->normalizeStringList($context['discoverability_keys'] ?? []);
         $continueReadingKeys = $this->normalizeStringList($context['continue_reading_keys'] ?? []);
         $startTestTarget = $this->normalizeString($context['start_test_target'] ?? null);
@@ -60,6 +62,7 @@ final class LandingSurfaceContractService
         $fingerprintSeed['entry_surface'] = $entrySurface;
         $fingerprintSeed['entry_type'] = $entryType;
         $fingerprintSeed['summary_blocks'] = $summaryBlocks;
+        $fingerprintSeed['discoverability_items'] = $discoverabilityItems;
         $fingerprintSeed['discoverability_keys'] = $discoverabilityKeys;
         $fingerprintSeed['continue_reading_keys'] = $continueReadingKeys;
         $fingerprintSeed['start_test_target'] = $startTestTarget;
@@ -84,6 +87,7 @@ final class LandingSurfaceContractService
             'entry_surface' => $entrySurface,
             'entry_type' => $entryType,
             'summary_blocks' => $summaryBlocks,
+            'discoverability_items' => $discoverabilityItems,
             'discoverability_keys' => $discoverabilityKeys,
             'continue_reading_keys' => $continueReadingKeys,
             'start_test_target' => $startTestTarget,
@@ -111,6 +115,48 @@ final class LandingSurfaceContractService
         $normalized = trim((string) $value);
 
         return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  array<int,mixed>  $items
+     * @return list<array<string,string|null>>
+     */
+    private function normalizeDiscoverabilityItems(array $items): array
+    {
+        $normalized = [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $key = $this->normalizeString($item['key'] ?? null);
+            $title = $this->normalizeString($item['title'] ?? null);
+            $summary = $this->normalizeString($item['summary'] ?? $item['body'] ?? null);
+            $href = $this->normalizeString($item['href'] ?? $item['url'] ?? null);
+            $kind = $this->normalizeString($item['kind'] ?? null);
+            $badgeLabel = $this->normalizeString($item['badge_label'] ?? $item['badge'] ?? null);
+
+            if ($title === null || $href === null) {
+                continue;
+            }
+
+            $dedupeKey = $key ?? $href;
+            if (isset($normalized[$dedupeKey])) {
+                continue;
+            }
+
+            $normalized[$dedupeKey] = [
+                'key' => $key ?? $href,
+                'title' => $title,
+                'summary' => $summary,
+                'href' => $href,
+                'kind' => $kind,
+                'badge_label' => $badgeLabel,
+            ];
+        }
+
+        return array_values($normalized);
     }
 
     /**

--- a/backend/app/Services/PublicSurface/PublicGatewaySurfaceService.php
+++ b/backend/app/Services/PublicSurface/PublicGatewaySurfaceService.php
@@ -1,0 +1,567 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\PublicSurface;
+
+use App\Services\Scale\ScaleRegistry;
+
+final class PublicGatewaySurfaceService
+{
+    /**
+     * @var list<string>
+     */
+    private const HOME_HIGHLIGHTED_SLUGS = [
+        'mbti-personality-test-16-personality-types',
+        'big-five-personality-test-ocean-model',
+        'clinical-depression-anxiety-assessment-professional-edition',
+        'depression-screening-test-standard-edition',
+        'iq-test-intelligence-quotient-assessment',
+        'eq-test-emotional-intelligence-assessment',
+    ];
+
+    public function __construct(
+        private readonly ScaleRegistry $scaleRegistry,
+        private readonly LandingSurfaceContractService $landingSurfaceContractService,
+        private readonly AnswerSurfaceContractService $answerSurfaceContractService,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildHomeSurface(string $locale): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $items = $this->buildScaleDiscoverabilityItems($locale, self::HOME_HIGHLIGHTED_SLUGS, 6);
+        $featuredHref = $items[0]['href'] ?? '/'.$segment.'/tests';
+
+        return $this->landingSurfaceContractService->build([
+            'landing_scope' => 'public_indexable_hub',
+            'entry_surface' => 'home_gateway',
+            'entry_type' => 'public_home',
+            'summary_blocks' => [
+                [
+                    'key' => 'home_primary',
+                    'title' => $locale === 'zh-CN' ? '从科学测评开始' : 'Start with a scientific assessment',
+                    'body' => $locale === 'zh-CN'
+                        ? '用统一的公开入口连接测评、人格画像、主题内容与职业建议。'
+                        : 'Use one public entry surface to connect tests, personality hubs, topic content, and career guidance.',
+                    'kind' => 'answer_first',
+                ],
+            ],
+            'discoverability_items' => $items,
+            'discoverability_keys' => array_column($items, 'key'),
+            'continue_reading_keys' => ['tests_index', 'personality_hub', 'topic_hub'],
+            'start_test_target' => $featuredHref,
+            'content_continue_target' => '/'.$segment.'/tests',
+            'cta_bundle' => [
+                [
+                    'key' => 'start_test',
+                    'label' => $locale === 'zh-CN' ? '开始测评' : 'Start a test',
+                    'href' => $featuredHref,
+                    'kind' => 'start_test',
+                ],
+                [
+                    'key' => 'browse_tests',
+                    'label' => $locale === 'zh-CN' ? '查看全部测评' : 'Browse all tests',
+                    'href' => '/'.$segment.'/tests',
+                    'kind' => 'discover',
+                ],
+                [
+                    'key' => 'browse_topics',
+                    'label' => $locale === 'zh-CN' ? '查看主题聚合' : 'Browse topic hubs',
+                    'href' => '/'.$segment.'/topics',
+                    'kind' => 'discover',
+                ],
+            ],
+            'indexability_state' => 'indexable',
+            'attribution_scope' => 'public_home_landing',
+            'surface_family' => 'home',
+            'primary_content_ref' => 'home',
+            'related_surface_keys' => ['tests_index', 'topics_index', 'personality_index'],
+            'fingerprint_seed' => [
+                'locale' => $locale,
+                'highlighted_keys' => array_column($items, 'key'),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildTestsIndexSurface(string $locale): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $items = $this->buildScaleDiscoverabilityItems($locale, null, 24);
+        $topItems = array_slice($items, 0, 6);
+        $featuredHref = $topItems[0]['href'] ?? '/'.$segment.'/tests/mbti-personality-test-16-personality-types';
+
+        return $this->landingSurfaceContractService->build([
+            'landing_scope' => 'public_indexable_hub',
+            'entry_surface' => 'tests_index',
+            'entry_type' => 'test_directory',
+            'summary_blocks' => [
+                [
+                    'key' => 'tests_index',
+                    'title' => $locale === 'zh-CN' ? '测评目录' : 'Assessment directory',
+                    'body' => $locale === 'zh-CN'
+                        ? '从统一目录进入人格、临床、智力与情绪相关测评。'
+                        : 'Browse personality, clinical, intelligence, and emotional assessment entry points from one directory.',
+                    'kind' => 'answer_first',
+                ],
+            ],
+            'discoverability_items' => $topItems,
+            'discoverability_keys' => array_column($items, 'key'),
+            'continue_reading_keys' => ['test_detail', 'topics_index', 'personality_index'],
+            'start_test_target' => $featuredHref,
+            'content_continue_target' => '/'.$segment.'/topics',
+            'cta_bundle' => [
+                [
+                    'key' => 'start_test',
+                    'label' => $locale === 'zh-CN' ? '开始推荐测评' : 'Start a featured test',
+                    'href' => $featuredHref,
+                    'kind' => 'start_test',
+                ],
+                [
+                    'key' => 'personality_hub',
+                    'label' => $locale === 'zh-CN' ? '人格画像' : 'Personality hub',
+                    'href' => '/'.$segment.'/personality',
+                    'kind' => 'discover',
+                ],
+                [
+                    'key' => 'topic_hub',
+                    'label' => $locale === 'zh-CN' ? '主题聚合' : 'Topic hubs',
+                    'href' => '/'.$segment.'/topics',
+                    'kind' => 'discover',
+                ],
+            ],
+            'indexability_state' => 'indexable',
+            'attribution_scope' => 'public_tests_landing',
+            'surface_family' => 'tests',
+            'primary_content_ref' => 'tests_index',
+            'related_surface_keys' => ['test_detail', 'topics_index', 'personality_index'],
+            'fingerprint_seed' => [
+                'locale' => $locale,
+                'discoverability_keys' => array_column($items, 'key'),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildHelpIndexSurface(string $locale): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $pages = $this->helpPages($locale);
+
+        return $this->landingSurfaceContractService->build([
+            'landing_scope' => 'public_indexable_hub',
+            'entry_surface' => 'help_hub',
+            'entry_type' => 'support_hub',
+            'summary_blocks' => [
+                [
+                    'key' => 'help_home',
+                    'title' => $locale === 'zh-CN' ? '帮助中心' : 'Help center',
+                    'body' => $locale === 'zh-CN'
+                        ? '用正式入口处理订单找回、邮件偏好、退订和常见支持问题。'
+                        : 'Use formal public entry points for order lookup, email preferences, unsubscribe, and common support questions.',
+                    'kind' => 'answer_first',
+                ],
+            ],
+            'discoverability_items' => array_map(fn (array $page): array => [
+                'key' => $page['slug'],
+                'title' => $page['title'],
+                'summary' => $page['summary'],
+                'href' => '/'.$segment.'/help/'.$page['slug'],
+                'kind' => 'help_detail',
+                'badge_label' => $locale === 'zh-CN' ? '帮助' : 'Help',
+            ], $pages),
+            'discoverability_keys' => array_column($pages, 'slug'),
+            'continue_reading_keys' => array_column($pages, 'slug'),
+            'content_continue_target' => '/'.$segment.'/help/faq',
+            'cta_bundle' => [
+                [
+                    'key' => 'order_lookup',
+                    'label' => $locale === 'zh-CN' ? '订单查询' : 'Order lookup',
+                    'href' => '/'.$segment.'/orders/lookup',
+                    'kind' => 'formal_entry',
+                ],
+                [
+                    'key' => 'email_preferences',
+                    'label' => $locale === 'zh-CN' ? '邮件偏好' : 'Email preferences',
+                    'href' => '/'.$segment.'/email/preferences',
+                    'kind' => 'formal_entry',
+                ],
+                [
+                    'key' => 'unsubscribe',
+                    'label' => $locale === 'zh-CN' ? '退订邮件' : 'Unsubscribe',
+                    'href' => '/'.$segment.'/email/unsubscribe',
+                    'kind' => 'formal_entry',
+                ],
+            ],
+            'indexability_state' => 'indexable',
+            'attribution_scope' => 'public_help_landing',
+            'surface_family' => 'help',
+            'primary_content_ref' => 'help_home',
+            'related_surface_keys' => array_column($pages, 'slug'),
+            'fingerprint_seed' => [
+                'locale' => $locale,
+                'help_slugs' => array_column($pages, 'slug'),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{landing_surface_v1:array<string,mixed>,answer_surface_v1:array<string,mixed>}|null
+     */
+    public function buildHelpDetailSurface(string $locale, string $slug): ?array
+    {
+        $normalizedSlug = trim(strtolower($slug));
+        $segment = $this->frontendLocaleSegment($locale);
+        $page = $this->findHelpPage($locale, $normalizedSlug);
+        if ($page === null) {
+            return null;
+        }
+
+        $relatedItems = array_values(array_filter(array_map(function (array $candidate) use ($page, $segment): ?array {
+            if ($candidate['slug'] === $page['slug']) {
+                return null;
+            }
+
+            return [
+                'key' => $candidate['slug'],
+                'title' => $candidate['title'],
+                'summary' => $candidate['summary'],
+                'href' => '/'.$segment.'/help/'.$candidate['slug'],
+                'kind' => 'help_detail',
+                'badge_label' => null,
+            ];
+        }, $this->helpPages($locale))));
+
+        $landingSurface = $this->landingSurfaceContractService->build([
+            'landing_scope' => 'public_indexable_detail',
+            'entry_surface' => 'help_detail',
+            'entry_type' => 'support_article',
+            'summary_blocks' => [
+                [
+                    'key' => 'help_answer',
+                    'title' => $page['title'],
+                    'body' => $page['summary'],
+                    'kind' => 'answer_first',
+                ],
+            ],
+            'discoverability_items' => $relatedItems,
+            'discoverability_keys' => array_column($relatedItems, 'key'),
+            'continue_reading_keys' => array_column($relatedItems, 'key'),
+            'content_continue_target' => '/'.$segment.'/help',
+            'cta_bundle' => [
+                [
+                    'key' => 'back_to_help',
+                    'label' => $locale === 'zh-CN' ? '返回帮助中心' : 'Back to help center',
+                    'href' => '/'.$segment.'/help',
+                    'kind' => 'content_continue',
+                ],
+                [
+                    'key' => 'order_lookup',
+                    'label' => $locale === 'zh-CN' ? '订单查询' : 'Order lookup',
+                    'href' => '/'.$segment.'/orders/lookup',
+                    'kind' => 'formal_entry',
+                ],
+            ],
+            'indexability_state' => 'indexable',
+            'attribution_scope' => 'public_help_detail',
+            'surface_family' => 'help',
+            'primary_content_ref' => $page['slug'],
+            'related_surface_keys' => array_column($relatedItems, 'key'),
+            'fingerprint_seed' => [
+                'locale' => $locale,
+                'slug' => $page['slug'],
+            ],
+        ]);
+
+        $answerSurface = $this->answerSurfaceContractService->build([
+            'answer_scope' => 'public_indexable_detail',
+            'surface_type' => 'help_detail',
+            'summary_blocks' => [
+                [
+                    'key' => 'help_summary',
+                    'title' => $page['title'],
+                    'body' => $page['summary'],
+                    'kind' => 'answer_first',
+                ],
+            ],
+            'faq_blocks' => $page['faq_blocks'],
+            'next_step_blocks' => $this->answerSurfaceContractService->buildNextStepBlocksFromCtas($landingSurface['cta_bundle'] ?? []),
+            'evidence_refs' => ['help:'.$page['slug']],
+            'public_safety_state' => 'public_indexable',
+            'indexability_state' => 'indexable',
+            'attribution_scope' => 'public_help_answer',
+            'landing_surface_ref' => $page['slug'],
+            'primary_content_ref' => $page['slug'],
+            'related_surface_keys' => array_column($relatedItems, 'key'),
+            'fingerprint_seed' => [
+                'locale' => $locale,
+                'slug' => $page['slug'],
+                'faq_count' => count($page['faq_blocks']),
+            ],
+        ]);
+
+        return [
+            'landing_surface_v1' => $landingSurface,
+            'answer_surface_v1' => $answerSurface,
+        ];
+    }
+
+    /**
+     * @param  list<string>|null  $preferredSlugs
+     * @return list<array<string,string|null>>
+     */
+    private function buildScaleDiscoverabilityItems(string $locale, ?array $preferredSlugs = null, ?int $limit = null): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $rows = $this->scaleRegistry->listActivePublic(0);
+        $visible = [];
+
+        foreach ($rows as $row) {
+            if (! is_array($row) || ! (bool) ($row['is_public'] ?? true) || ! (bool) ($row['is_active'] ?? true)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['primary_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $visible[$slug] = $row;
+        }
+
+        $orderedRows = [];
+        if (is_array($preferredSlugs) && $preferredSlugs !== []) {
+            foreach ($preferredSlugs as $slug) {
+                if (isset($visible[$slug])) {
+                    $orderedRows[] = $visible[$slug];
+                }
+            }
+        } else {
+            foreach ($visible as $row) {
+                $orderedRows[] = $row;
+            }
+        }
+
+        $items = [];
+        foreach ($orderedRows as $row) {
+            $slug = trim((string) ($row['primary_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $seo = $this->resolveScaleSeoByLocale($row, $locale);
+            $items[] = [
+                'key' => $slug,
+                'title' => $seo['title'] ?? strtoupper(trim((string) ($row['code'] ?? $slug))),
+                'summary' => $this->resolveScaleSummaryByLocale($row, $locale) ?? $seo['description'],
+                'href' => '/'.$segment.'/tests/'.$slug,
+                'kind' => 'test_detail',
+                'badge_label' => strtoupper(trim((string) ($row['code'] ?? ''))),
+            ];
+
+            if ($limit !== null && count($items) >= $limit) {
+                break;
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @return array{title:?string,description:?string}
+     */
+    private function resolveScaleSeoByLocale(array $row, string $locale): array
+    {
+        $seoI18n = $this->toArray($row['seo_i18n_json'] ?? null);
+        $lang = $this->localeToLanguage($locale);
+        $defaultLocale = (string) ($row['default_locale'] ?? 'en');
+        $defaultLang = $this->localeToLanguage($defaultLocale);
+
+        $byLang = $this->toArray($seoI18n[$lang] ?? null);
+        if ($byLang === [] && $defaultLang !== '') {
+            $byLang = $this->toArray($seoI18n[$defaultLang] ?? null);
+        }
+        if ($byLang === []) {
+            $byLang = $this->toArray($seoI18n['en'] ?? null);
+        }
+
+        $legacy = $this->toArray($row['seo_schema_json'] ?? null);
+
+        return [
+            'title' => $this->trimOrNull($byLang['title'] ?? null)
+                ?? $this->trimOrNull($legacy['title'] ?? null)
+                ?? $this->trimOrNull($legacy['name'] ?? null),
+            'description' => $this->trimOrNull($byLang['description'] ?? null)
+                ?? $this->trimOrNull($legacy['description'] ?? null),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     */
+    private function resolveScaleSummaryByLocale(array $row, string $locale): ?string
+    {
+        $lang = $this->localeToLanguage($locale);
+        $report = $this->toArray($row['report_summary_i18n_json'] ?? null);
+        $content = $this->toArray($row['content_i18n_json'] ?? null);
+
+        $reportByLang = $this->toArray($report[$lang] ?? null);
+        $contentByLang = $this->toArray($content[$lang] ?? null);
+
+        return $this->trimOrNull($reportByLang['summary'] ?? null)
+            ?? $this->trimOrNull($contentByLang['landing_copy'] ?? null)
+            ?? $this->trimOrNull($contentByLang['summary'] ?? null);
+    }
+
+    /**
+     * @return list<array{
+     *   slug:string,
+     *   title:string,
+     *   summary:string,
+     *   faq_blocks:list<array<string,string>>
+     * }>
+     */
+    private function helpPages(string $locale): array
+    {
+        $isZh = $locale === 'zh-CN';
+
+        return [
+            [
+                'slug' => 'faq',
+                'title' => $isZh ? '常见问题' : 'Frequently Asked Questions',
+                'summary' => $isZh
+                    ? '先用正式入口处理报告找回、邮件偏好、退订和支付支持，再查看常见问题。'
+                    : 'Start with the formal entry paths for report recovery, email preferences, unsubscribe, and payment support, then review the common questions.',
+                'faq_blocks' => [
+                    [
+                        'key' => 'faq_report',
+                        'question' => $isZh ? '如何找回报告？' : 'How do I recover my report?',
+                        'answer' => $isZh
+                            ? '先用订单号和购买邮箱进入订单查询，再确认交付状态或重发邮件。'
+                            : 'Start with Order lookup using your order number and purchase email, then review delivery status or resend the email.',
+                    ],
+                    [
+                        'key' => 'faq_unsubscribe',
+                        'question' => $isZh ? '如何退订邮件？' : 'How do I unsubscribe from emails?',
+                        'answer' => $isZh
+                            ? '使用邮件偏好或邮件内专属退订链接，不要把退订和报告找回混为一体。'
+                            : 'Use Manage email preferences or the dedicated unsubscribe link in any email instead of treating unsubscribe as report recovery.',
+                    ],
+                ],
+            ],
+            [
+                'slug' => 'about',
+                'title' => $isZh ? '关于费马测试' : 'About FermatMind',
+                'summary' => $isZh
+                    ? '了解费马测试的测评定位、内容边界和公开可读入口。'
+                    : 'Learn what FermatMind assessments cover, where the content boundaries are, and which public entry points are available.',
+                'faq_blocks' => [],
+            ],
+            [
+                'slug' => 'team',
+                'title' => $isZh ? '团队信息' : 'Team information',
+                'summary' => $isZh
+                    ? '查看团队与协作边界，了解谁在建设这些公开内容与测评入口。'
+                    : 'Review the team and collaboration boundaries behind the public content and assessment entry surfaces.',
+                'faq_blocks' => [],
+            ],
+            [
+                'slug' => 'used-and-mentioned',
+                'title' => $isZh ? '使用与提及' : 'Used and mentioned',
+                'summary' => $isZh
+                    ? '查看产品被使用、被提及与公开引用的场景。'
+                    : 'Review where the product is used, mentioned, and publicly referenced.',
+                'faq_blocks' => [],
+            ],
+            [
+                'slug' => 'for-business-and-research',
+                'title' => $isZh ? '企业与研究合作' : 'Business and research',
+                'summary' => $isZh
+                    ? '说明企业和研究使用场景与授权边界。'
+                    : 'Understand business and research use cases together with the authorization boundaries.',
+                'faq_blocks' => [],
+            ],
+            [
+                'slug' => 'contact',
+                'title' => $isZh ? '联系支持' : 'Contact support',
+                'summary' => $isZh
+                    ? '先完成正式入口，再联系支持，避免重复工单与无效往返。'
+                    : 'Finish the formal recovery or email-control paths first, then contact support to avoid duplicate tickets.',
+                'faq_blocks' => [
+                    [
+                        'key' => 'contact_when',
+                        'question' => $isZh ? '什么时候应该联系支持？' : 'When should I contact support?',
+                        'answer' => $isZh
+                            ? '当订单查询、邮件偏好和退订路径都不能解决你的问题时，再联系支持。'
+                            : 'Contact support after Order lookup, email preferences, and unsubscribe paths still cannot resolve the issue.',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array{slug:string,title:string,summary:string,faq_blocks:list<array<string,string>>}|null
+     */
+    private function findHelpPage(string $locale, string $slug): ?array
+    {
+        foreach ($this->helpPages($locale) as $page) {
+            if ($page['slug'] === $slug) {
+                return $page;
+            }
+        }
+
+        return null;
+    }
+
+    private function frontendLocaleSegment(string $locale): string
+    {
+        return $locale === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    private function localeToLanguage(string $locale): string
+    {
+        $locale = strtolower(trim($locale));
+        if ($locale === '') {
+            return 'en';
+        }
+
+        $parts = explode('-', str_replace('_', '-', $locale));
+
+        return strtolower((string) ($parts[0] ?? 'en'));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function toArray(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && trim($value) !== '') {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+
+    private function trimOrNull(mixed $value): ?string
+    {
+        $trimmed = trim((string) $value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\API\V0_3\MbtiCompareInviteController;
 use App\Http\Controllers\API\V0_3\MeController as MeV03Controller;
 use App\Http\Controllers\API\V0_3\OrgInvitesController;
 use App\Http\Controllers\API\V0_3\OrgsController;
+use App\Http\Controllers\API\V0_3\PublicGatewaySurfaceController;
 use App\Http\Controllers\API\V0_3\ScalesController;
 use App\Http\Controllers\API\V0_3\ScalesLookupController;
 use App\Http\Controllers\API\V0_3\ScalesSitemapSourceController;
@@ -153,6 +154,10 @@ Route::prefix('v0.3')->middleware([
         Route::get('/scales', [ScalesController::class, 'index']);
         Route::get('/scales/lookup', [ScalesLookupController::class, 'lookup']);
         Route::get('/scales/sitemap-source', [ScalesSitemapSourceController::class, 'index']);
+        Route::get('/public-gateways/home', [PublicGatewaySurfaceController::class, 'home']);
+        Route::get('/public-gateways/tests', [PublicGatewaySurfaceController::class, 'tests']);
+        Route::get('/public-gateways/help', [PublicGatewaySurfaceController::class, 'help']);
+        Route::get('/public-gateways/help/{slug}', [PublicGatewaySurfaceController::class, 'helpDetail']);
         Route::get('/scales/{scale_code}/questions', [ScalesController::class, 'questions']);
         Route::get('/scales/{scale_code}', [ScalesController::class, 'show']);
 

--- a/backend/tests/Feature/V0_3/PublicGatewaySurfaceTest.php
+++ b/backend/tests/Feature/V0_3/PublicGatewaySurfaceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PublicGatewaySurfaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_home_gateway_returns_landing_surface_with_highlighted_discoverability_items(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        $this->artisan('fap:scales:sync-slugs');
+
+        $response = $this->getJson('/api/v0.3/public-gateways/home?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('landing_surface_v1.landing_contract_version', 'landing.surface.v1')
+            ->assertJsonPath('landing_surface_v1.entry_surface', 'home_gateway')
+            ->assertJsonPath('landing_surface_v1.entry_type', 'public_home')
+            ->assertJsonPath('landing_surface_v1.discoverability_items.0.key', 'mbti-personality-test-16-personality-types');
+    }
+
+    public function test_tests_gateway_returns_indexable_test_directory_surface(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        $this->artisan('fap:scales:sync-slugs');
+
+        $response = $this->getJson('/api/v0.3/public-gateways/tests?locale=zh');
+
+        $response->assertOk()
+            ->assertJsonPath('landing_surface_v1.entry_surface', 'tests_index')
+            ->assertJsonPath('landing_surface_v1.indexability_state', 'indexable')
+            ->assertJsonCount(6, 'landing_surface_v1.discoverability_items');
+    }
+
+    public function test_help_gateway_returns_landing_surface_and_detail_answer_surface(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+
+        $this->getJson('/api/v0.3/public-gateways/help?locale=en')
+            ->assertOk()
+            ->assertJsonPath('landing_surface_v1.entry_surface', 'help_hub')
+            ->assertJsonPath('landing_surface_v1.discoverability_items.0.key', 'faq');
+
+        $this->getJson('/api/v0.3/public-gateways/help/faq?locale=en')
+            ->assertOk()
+            ->assertJsonPath('landing_surface_v1.entry_surface', 'help_detail')
+            ->assertJsonPath('answer_surface_v1.answer_contract_version', 'answer.surface.v1')
+            ->assertJsonPath('answer_surface_v1.surface_type', 'help_detail')
+            ->assertJsonPath('answer_surface_v1.faq_blocks.0.key', 'faq_report');
+    }
+}

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -42,7 +42,10 @@ final class ArticlePublicApiTest extends TestCase
             ->assertJsonPath('pagination.per_page', 20)
             ->assertJsonPath('pagination.total', 21)
             ->assertJsonPath('pagination.last_page', 2)
-            ->assertJsonCount(20, 'items');
+            ->assertJsonCount(20, 'items')
+            ->assertJsonPath('landing_surface_v1.landing_contract_version', 'landing.surface.v1')
+            ->assertJsonPath('landing_surface_v1.entry_surface', 'article_index')
+            ->assertJsonPath('landing_surface_v1.entry_type', 'content_hub');
 
         $this->assertSame(
             ['en'],
@@ -116,6 +119,32 @@ final class ArticlePublicApiTest extends TestCase
 
         $this->assertSame($canonical.'#article', data_get($response->json(), 'jsonld.@id'));
         $this->assertStringNotContainsString($legacyCanonical, (string) $response->getContent());
+    }
+
+    public function test_article_detail_includes_landing_and_answer_surfaces(): void
+    {
+        $article = $this->createArticle([
+            'slug' => 'career-fit-guide',
+            'locale' => 'en',
+            'title' => 'Career Fit Guide',
+            'excerpt' => 'Use article-level insight to continue into tests and public hubs.',
+        ]);
+
+        $this->createSeoMeta($article, [
+            'seo_title' => 'Career Fit Guide | FermatMind',
+            'seo_description' => 'Use article-level insight to continue into tests and public hubs.',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/articles/career-fit-guide?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('landing_surface_v1.landing_contract_version', 'landing.surface.v1')
+            ->assertJsonPath('landing_surface_v1.entry_surface', 'article_detail')
+            ->assertJsonPath('landing_surface_v1.entry_type', 'editorial_article')
+            ->assertJsonPath('answer_surface_v1.answer_contract_version', 'answer.surface.v1')
+            ->assertJsonPath('answer_surface_v1.surface_type', 'article_public_detail')
+            ->assertJsonPath('answer_surface_v1.summary_blocks.0.key', 'article_summary')
+            ->assertJsonPath('answer_surface_v1.next_step_blocks.0.href', '/en/articles');
     }
 
     public function test_article_seo_does_not_fake_missing_locale_alternates(): void


### PR DESCRIPTION
## Summary
This PR ships the backend half of PR-13E for wider public content expansion and wider acquisition family coverage.

It extends the existing public authority stack into article, help, home, and tests-index families without changing canonical runtime truth or expanding into a new SEO/GEO platform.

## Problem
PR-13A through PR-13D established the core authority layers:
- `content_control_plane_v1`
- `seo_surface_v1`
- `landing_surface_v1`
- `answer_surface_v1`

But wider public families were still inconsistent.
- article index/detail still lacked landing and answer authority
- help center still lived as frontend-local content orchestration
- home highlighted tests and tests index still depended on route-local discoverability ordering

That meant the core first-wave public families were authority-safe, but wider acquisition families were not yet flowing through the same backend-owned contracts.

## What changed
- Extended `landing_surface_v1` with structured `discoverability_items`.
- Added backend public gateway endpoints for:
  - home
  - tests index
  - help hub
  - help detail
- Added `PublicGatewaySurfaceService` to normalize wider-family landing/discoverability truth.
- Attached `landing_surface_v1` to article index/detail.
- Attached `answer_surface_v1` to article detail.
- Preserved existing boundaries:
  - `seo_surface_v1` remains metadata-only
  - `landing_surface_v1` remains entry / CTA / continue / discoverability authority
  - `answer_surface_v1` remains additive answer authority
  - canonical runtime content truth remains unchanged

## Scope guardrails preserved
- No migration
- No new dependency
- No new auth
- No GEO platform work
- No full SEO rewrite
- No homepage redesign
- No new CMS/headless platform
- No Team/Relationship/Partner/Widget expansion

## Validation
- `php artisan test --filter="PublicGatewaySurfaceTest|ArticlePublicApiTest"`
- `php artisan test --filter="PublicGatewaySurfaceTest|ArticlePublicApiTest|PersonalityPublicApiTest|TopicsPublicApiTest|CareerRecommendationPublicApiTest|CareerGuidePublicApiTest|CareerJobPublicApiTest|ShareSummaryContractTest|ScalesLookupTest"`
