### PR TITLE
[codex] Ship CE-1 MBTI content inventory and taxonomy expansion

### DIFF
--- a/backend/app/Filament/Ops/Resources/ContentPackVersionResource.php
+++ b/backend/app/Filament/Ops/Resources/ContentPackVersionResource.php
@@ -112,6 +112,10 @@ class ContentPackVersionResource extends Resource
                         ->label('Experiment / overlay scope')
                         ->content(fn (?ContentPackVersion $record): HtmlString => self::renderExperimentScope($record))
                         ->columnSpanFull(),
+                    Forms\Components\Placeholder::make('cp.content_inventory_v1')
+                        ->label('MBTI content inventory')
+                        ->content(fn (?ContentPackVersion $record): HtmlString => self::renderInventoryContract($record))
+                        ->columnSpanFull(),
                     Forms\Components\Placeholder::make('cp.content_object_inventory')
                         ->label('First-wave managed objects')
                         ->content(fn (?ContentPackVersion $record): HtmlString => self::renderObjectInventory($record))
@@ -223,6 +227,18 @@ class ContentPackVersionResource extends Resource
                     'experiment_keys' => [],
                     'overlay_targets' => [],
                 ],
+                'content_inventory_v1' => [
+                    'inventory_status' => 'not_applicable',
+                    'inventory_contract_version' => 0,
+                    'inventory_fingerprint' => null,
+                    'governance_profile' => null,
+                    'fragment_family_count' => 0,
+                    'fragment_family_keys' => [],
+                    'selection_tag_count' => 0,
+                    'selection_tag_keys' => [],
+                    'section_family_count' => 0,
+                    'section_family_keys' => [],
+                ],
                 'runtime_artifact_ref' => null,
                 'content_object_inventory' => [],
                 'content_objects_v1' => [],
@@ -289,6 +305,33 @@ class ContentPackVersionResource extends Resource
             'commercial_overlay_files='.(int) ($scope['commercial_overlay_files'] ?? 0),
             'experiment_keys='.($experimentKeys !== '' ? $experimentKeys : 'none'),
             'overlay_targets='.($overlayTargets !== '' ? $overlayTargets : 'none'),
+        ];
+
+        return new HtmlString('<ul><li>'.implode('</li><li>', array_map('e', $items)).'</li></ul>');
+    }
+
+    private static function renderInventoryContract(?ContentPackVersion $record): HtmlString
+    {
+        $inventory = self::controlPlaneValue($record, 'content_inventory_v1', []);
+        if (! is_array($inventory) || $inventory === []) {
+            return new HtmlString('<span>No MBTI content inventory contract available yet.</span>');
+        }
+
+        $fragmentFamilyKeys = implode(', ', (array) ($inventory['fragment_family_keys'] ?? []));
+        $sectionFamilyKeys = implode(', ', (array) ($inventory['section_family_keys'] ?? []));
+        $selectionTagKeys = implode(', ', (array) ($inventory['selection_tag_keys'] ?? []));
+
+        $items = [
+            'inventory_status='.(string) ($inventory['inventory_status'] ?? 'unknown'),
+            'inventory_contract_version='.(int) ($inventory['inventory_contract_version'] ?? 0),
+            'inventory_fingerprint='.(string) ($inventory['inventory_fingerprint'] ?? 'none'),
+            'governance_profile='.(string) ($inventory['governance_profile'] ?? 'none'),
+            'fragment_family_count='.(int) ($inventory['fragment_family_count'] ?? 0),
+            'fragment_family_keys='.($fragmentFamilyKeys !== '' ? $fragmentFamilyKeys : 'none'),
+            'selection_tag_count='.(int) ($inventory['selection_tag_count'] ?? 0),
+            'selection_tag_keys='.($selectionTagKeys !== '' ? $selectionTagKeys : 'none'),
+            'section_family_count='.(int) ($inventory['section_family_count'] ?? 0),
+            'section_family_keys='.($sectionFamilyKeys !== '' ? $sectionFamilyKeys : 'none'),
         ];
 
         return new HtmlString('<ul><li>'.implode('</li><li>', array_map('e', $items)).'</li></ul>');

--- a/backend/app/Internal/SelfCheck/SelfCheckContentEngineCore.php
+++ b/backend/app/Internal/SelfCheck/SelfCheckContentEngineCore.php
@@ -2982,6 +2982,7 @@ public function containsAny(string $haystack, array $needles): bool
         'rules'            => 'rules',
         'section_policies' => 'section_policies',
         'dynamic_sections' => 'dynamic_sections',
+        'inventory'        => 'inventory',
         'content_governance' => 'content_governance',
         'meta'             => 'meta',
 

--- a/backend/app/Services/Content/ContentCompileService.php
+++ b/backend/app/Services/Content/ContentCompileService.php
@@ -207,6 +207,15 @@ final class ContentCompileService
             'variables.used.json',
         ];
 
+        $inventoryDoc = $this->mbtiGovernance->loadInventoryDocument($baseDir);
+        if (is_array($inventoryDoc)) {
+            $this->writeJson(
+                $compiledDir . DIRECTORY_SEPARATOR . 'inventory.spec.json',
+                $this->mbtiGovernance->compileInventorySpec($pack, $inventoryDoc)
+            );
+            $compiledFiles[] = 'inventory.spec.json';
+        }
+
         if ($this->mbtiGovernance->appliesTo($pack)) {
             $governanceDoc = $this->mbtiGovernance->loadDocument($baseDir);
             if (is_array($governanceDoc)) {

--- a/backend/app/Services/Content/ContentControlPlaneService.php
+++ b/backend/app/Services/Content/ContentControlPlaneService.php
@@ -63,6 +63,7 @@ final class ContentControlPlaneService
                 'rollback_target' => $release['rollback_target'],
                 'locale_scope' => $localeScope,
                 'experiment_scope' => $governance['experiment_scope'],
+                'content_inventory_v1' => $governance['content_inventory_v1'],
                 'runtime_artifact_ref' => $release['runtime_artifact_ref'],
                 'cultural_context' => $governance['cultural_context'],
                 'content_object_inventory' => $this->summarizeContentObjects($contentObjects),
@@ -132,6 +133,7 @@ final class ContentControlPlaneService
      *   status:string,
      *   cultural_context:?string,
      *   experiment_scope:array<string,mixed>,
+     *   content_inventory_v1:array<string,mixed>,
      *   content_object_inventory:list<array<string,mixed>>
      * }
      */
@@ -151,6 +153,7 @@ final class ContentControlPlaneService
                     'experiment_keys' => [],
                     'overlay_targets' => [],
                 ],
+                'content_inventory_v1' => $this->defaultInventorySummary(false),
                 'content_object_inventory' => $this->defaultObjectInventory(
                     trim((string) ($manifest['region'] ?? '')) !== '' && trim((string) ($manifest['locale'] ?? '')) !== '',
                     false,
@@ -163,6 +166,7 @@ final class ContentControlPlaneService
 
         $errors = $this->mbtiGovernance->lintPack($pack);
         $document = $this->mbtiGovernance->loadDocument($baseDir);
+        $inventoryDocument = $this->mbtiGovernance->loadInventoryDocument($baseDir);
         $filePolicies = is_array($document['file_policies'] ?? null) ? $document['file_policies'] : [];
 
         $stableFiles = 0;
@@ -216,6 +220,9 @@ final class ContentControlPlaneService
                 'experiment_keys' => $experimentKeys,
                 'overlay_targets' => $overlayTargets,
             ],
+            'content_inventory_v1' => is_array($inventoryDocument)
+                ? $this->mbtiGovernance->summarizeInventory($inventoryDocument)
+                : $this->defaultInventorySummary(true),
             'content_object_inventory' => $this->defaultObjectInventory(
                 trim((string) ($document['cultural_context'] ?? '')) !== '',
                 $narrativeFiles > 0,
@@ -223,6 +230,25 @@ final class ContentControlPlaneService
                 $commercialOverlayFiles > 0,
                 true,
             ),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function defaultInventorySummary(bool $enabled): array
+    {
+        return [
+            'inventory_status' => $enabled ? 'missing' : 'not_applicable',
+            'inventory_contract_version' => 0,
+            'inventory_fingerprint' => null,
+            'governance_profile' => null,
+            'fragment_family_count' => 0,
+            'fragment_family_keys' => [],
+            'selection_tag_count' => 0,
+            'selection_tag_keys' => [],
+            'section_family_count' => 0,
+            'section_family_keys' => [],
         ];
     }
 

--- a/backend/app/Services/Content/MbtiContentGovernanceService.php
+++ b/backend/app/Services/Content/MbtiContentGovernanceService.php
@@ -6,6 +6,70 @@ namespace App\Services\Content;
 
 final class MbtiContentGovernanceService
 {
+    private const INVENTORY_FILE = 'mbti_content_inventory.json';
+
+    private const INVENTORY_SCHEMA = 'fap.mbti.content_inventory.v1';
+
+    /**
+     * @var list<string>
+     */
+    private const REQUIRED_FRAGMENT_FAMILIES = [
+        'explainability_fragment',
+        'boundary_fragment',
+        'stress_fragment',
+        'recovery_fragment',
+        'scene_fragment',
+        'work_fragment',
+        'relationship_fragment',
+        'action_fragment',
+        'watchout_fragment',
+        'recommendation_fragment',
+        'cta_bundle_fragment',
+        'tone_fragment',
+        'revisit_fragment',
+        'adaptive_response_fragment',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const REQUIRED_SELECTION_TAG_KEYS = [
+        'section_key',
+        'block_family',
+        'axis_band',
+        'boundary_flag',
+        'scene_key',
+        'intent_cluster',
+        'memory_state',
+        'adaptive_state',
+        'cross_assessment_key',
+        'tone_mode',
+        'access_tier',
+        'locale_scope',
+        'evidence_ref',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const REQUIRED_SECTION_KEYS = [
+        'overview',
+        'trait_overview',
+        'traits.why_this_type',
+        'growth.summary',
+        'growth.stability_confidence',
+        'traits.adjacent_type_contrast',
+        'growth.next_actions',
+        'growth.watchouts',
+        'career.summary',
+        'career.next_step',
+        'career.work_experiments',
+        'relationships.summary',
+        'relationships.try_this_week',
+        'recommendation.surface',
+        'cta.surface',
+    ];
+
     /**
      * @var list<string>
      */
@@ -66,12 +130,37 @@ final class MbtiContentGovernanceService
         return $baseDir.DIRECTORY_SEPARATOR.'report_content_governance.json';
     }
 
+    public function inventoryPath(string $baseDir): string
+    {
+        return $baseDir.DIRECTORY_SEPARATOR.self::INVENTORY_FILE;
+    }
+
     /**
      * @return array<string,mixed>|null
      */
     public function loadDocument(string $baseDir): ?array
     {
         $path = $this->governancePath($baseDir);
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $raw = file_get_contents($path);
+        if (! is_string($raw) || trim($raw) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function loadInventoryDocument(string $baseDir): ?array
+    {
+        $path = $this->inventoryPath($baseDir);
         if (! is_file($path)) {
             return null;
         }
@@ -163,6 +252,18 @@ final class MbtiContentGovernanceService
                     'taxonomy.block_kinds',
                     "Dynamic block kind '{$blockKind}' is missing from governance taxonomy."
                 );
+            }
+        }
+
+        $inventoryPath = $this->inventoryPath($baseDir);
+        if (! is_file($inventoryPath)) {
+            $errors[] = $this->error($path, 'inventory.doc', 'MBTI pack requires mbti_content_inventory.json.');
+        } else {
+            $inventoryDoc = $this->loadInventoryDocument($baseDir);
+            if (! is_array($inventoryDoc)) {
+                $errors[] = $this->error($inventoryPath, 'inventory.doc', 'Invalid inventory JSON.');
+            } else {
+                $errors = array_merge($errors, $this->lintInventory($inventoryPath, $inventoryDoc, $manifest, $context));
             }
         }
 
@@ -289,6 +390,200 @@ final class MbtiContentGovernanceService
         foreach (self::REQUIRED_POLICY_FILES as $fileName) {
             if (! is_file($baseDir.DIRECTORY_SEPARATOR.$fileName)) {
                 $errors[] = $this->error($path, "file_policies.{$fileName}", "{$fileName} is missing from the MBTI pack root.");
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $pack
+     * @param  array<string,mixed>  $doc
+     * @return array<string,mixed>
+     */
+    public function compileInventorySpec(array $pack, array $doc): array
+    {
+        $fragmentFamilies = is_array($doc['fragment_families'] ?? null) ? array_values($doc['fragment_families']) : [];
+        $selectionTagSchema = is_array($doc['selection_tag_schema'] ?? null) ? $doc['selection_tag_schema'] : [];
+        $sectionFamilyMatrix = is_array($doc['section_family_matrix'] ?? null) ? array_values($doc['section_family_matrix']) : [];
+
+        return [
+            'schema' => 'fap.mbti.content_inventory.compiled.v1',
+            'pack_id' => (string) ($pack['pack_id'] ?? ''),
+            'version' => (string) ($pack['version'] ?? ''),
+            'generated_at' => now()->toIso8601String(),
+            'inventory_contract_version' => (int) ($doc['inventory_contract_version'] ?? 1),
+            'inventory_fingerprint' => (string) ($doc['inventory_fingerprint'] ?? ''),
+            'governance_profile' => (string) ($doc['governance_profile'] ?? 'mbti_content_inventory.v1'),
+            'fragment_families' => $fragmentFamilies,
+            'selection_tag_schema' => $selectionTagSchema,
+            'section_family_matrix' => $sectionFamilyMatrix,
+            'summary' => $this->summarizeInventory($doc),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function summarizeInventory(array $doc): array
+    {
+        $fragmentFamilies = array_values(array_filter((array) ($doc['fragment_families'] ?? []), 'is_array'));
+        $selectionTagSchema = is_array($doc['selection_tag_schema'] ?? null) ? $doc['selection_tag_schema'] : [];
+        $sectionFamilyMatrix = array_values(array_filter((array) ($doc['section_family_matrix'] ?? []), 'is_array'));
+
+        $fragmentFamilyKeys = [];
+        foreach ($fragmentFamilies as $family) {
+            $key = trim((string) ($family['key'] ?? ''));
+            if ($key !== '') {
+                $fragmentFamilyKeys[] = $key;
+            }
+        }
+
+        $sectionKeys = [];
+        foreach ($sectionFamilyMatrix as $row) {
+            $key = trim((string) ($row['section_key'] ?? ''));
+            if ($key !== '') {
+                $sectionKeys[] = $key;
+            }
+        }
+
+        return [
+            'inventory_contract_version' => (int) ($doc['inventory_contract_version'] ?? 1),
+            'inventory_fingerprint' => (string) ($doc['inventory_fingerprint'] ?? ''),
+            'governance_profile' => (string) ($doc['governance_profile'] ?? 'mbti_content_inventory.v1'),
+            'fragment_family_count' => count($fragmentFamilyKeys),
+            'fragment_family_keys' => $fragmentFamilyKeys,
+            'selection_tag_count' => count($selectionTagSchema),
+            'selection_tag_keys' => array_keys($selectionTagSchema),
+            'section_family_count' => count($sectionKeys),
+            'section_family_keys' => $sectionKeys,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $doc
+     * @return list<array{file:string,block_id:string,message:string}>
+     */
+    private function lintInventory(string $path, array $doc, array $manifest, string $context): array
+    {
+        $errors = [];
+
+        if (($doc['schema'] ?? null) !== self::INVENTORY_SCHEMA) {
+            $errors[] = $this->error($path, 'inventory.schema', "schema must be '".self::INVENTORY_SCHEMA."'.");
+        }
+
+        if ((int) ($doc['inventory_contract_version'] ?? 0) < 1) {
+            $errors[] = $this->error($path, 'inventory.inventory_contract_version', 'inventory_contract_version must be >= 1.');
+        }
+
+        if (trim((string) ($doc['pack_id'] ?? '')) !== (string) ($manifest['pack_id'] ?? '')) {
+            $errors[] = $this->error($path, 'inventory.pack_id', 'inventory pack_id must match manifest pack_id.');
+        }
+
+        if (trim((string) ($doc['cultural_context'] ?? '')) !== $context) {
+            $errors[] = $this->error($path, 'inventory.cultural_context', 'inventory cultural_context must match manifest region/locale.');
+        }
+
+        if (trim((string) ($doc['inventory_fingerprint'] ?? '')) === '') {
+            $errors[] = $this->error($path, 'inventory.inventory_fingerprint', 'inventory_fingerprint must be non-empty.');
+        }
+
+        if (trim((string) ($doc['governance_profile'] ?? '')) === '') {
+            $errors[] = $this->error($path, 'inventory.governance_profile', 'governance_profile must be non-empty.');
+        }
+
+        $fragmentFamilies = array_values(array_filter((array) ($doc['fragment_families'] ?? []), 'is_array'));
+        if ($fragmentFamilies === []) {
+            $errors[] = $this->error($path, 'inventory.fragment_families', 'fragment_families must be a non-empty array.');
+        }
+
+        $familyIndex = [];
+        foreach ($fragmentFamilies as $index => $family) {
+            $familyPath = 'fragment_families.'.$index;
+            $key = trim((string) ($family['key'] ?? ''));
+            if ($key === '') {
+                $errors[] = $this->error($path, $familyPath.'.key', 'fragment family requires key.');
+                continue;
+            }
+
+            if (isset($familyIndex[$key])) {
+                $errors[] = $this->error($path, $familyPath.'.key', "fragment family '{$key}' appears more than once.");
+            }
+            $familyIndex[$key] = true;
+
+            if (! in_array($key, self::REQUIRED_FRAGMENT_FAMILIES, true)) {
+                $errors[] = $this->error($path, $familyPath.'.key', "fragment family '{$key}' is not part of the CE-1 required inventory.");
+            }
+
+            if (trim((string) ($family['label'] ?? '')) === '') {
+                $errors[] = $this->error($path, $familyPath.'.label', "fragment family '{$key}' requires label.");
+            }
+
+            $allowedSections = array_values(array_filter(array_map('strval', (array) ($family['allowed_section_keys'] ?? []))));
+            if ($allowedSections === []) {
+                $errors[] = $this->error($path, $familyPath.'.allowed_section_keys', "fragment family '{$key}' requires allowed_section_keys.");
+            }
+
+            $selectionTags = array_values(array_filter(array_map('strval', (array) ($family['selection_tags'] ?? []))));
+            if ($selectionTags === []) {
+                $errors[] = $this->error($path, $familyPath.'.selection_tags', "fragment family '{$key}' requires selection_tags.");
+            } else {
+                foreach ($selectionTags as $selectionTag) {
+                    if (! in_array($selectionTag, self::REQUIRED_SELECTION_TAG_KEYS, true)) {
+                        $errors[] = $this->error($path, $familyPath.'.selection_tags', "fragment family '{$key}' references unknown selection tag '{$selectionTag}'.");
+                    }
+                }
+            }
+        }
+
+        foreach (self::REQUIRED_FRAGMENT_FAMILIES as $requiredKey) {
+            if (! isset($familyIndex[$requiredKey])) {
+                $errors[] = $this->error($path, 'inventory.fragment_families', "Missing required fragment family '{$requiredKey}'.");
+            }
+        }
+
+        $tagSchema = is_array($doc['selection_tag_schema'] ?? null) ? $doc['selection_tag_schema'] : [];
+        foreach (self::REQUIRED_SELECTION_TAG_KEYS as $requiredTagKey) {
+            $tagSchemaNode = is_array($tagSchema[$requiredTagKey] ?? null) ? $tagSchema[$requiredTagKey] : null;
+            if ($tagSchemaNode === null) {
+                $errors[] = $this->error($path, 'inventory.selection_tag_schema', "Missing selection tag schema for '{$requiredTagKey}'.");
+                continue;
+            }
+
+            if (trim((string) ($tagSchemaNode['type'] ?? '')) === '') {
+                $errors[] = $this->error($path, 'inventory.selection_tag_schema', "Selection tag '{$requiredTagKey}' requires type.");
+            }
+        }
+
+        $sectionMatrix = array_values(array_filter((array) ($doc['section_family_matrix'] ?? []), 'is_array'));
+        $matrixIndex = [];
+        foreach ($sectionMatrix as $index => $row) {
+            $sectionKey = trim((string) ($row['section_key'] ?? ''));
+            if ($sectionKey === '') {
+                $errors[] = $this->error($path, 'inventory.section_family_matrix.'.$index.'.section_key', 'section_family_matrix requires section_key.');
+                continue;
+            }
+
+            $matrixIndex[$sectionKey] = true;
+
+            $primaryFamily = trim((string) ($row['primary_family'] ?? ''));
+            if ($primaryFamily === '') {
+                $errors[] = $this->error($path, 'inventory.section_family_matrix.'.$index.'.primary_family', "section '{$sectionKey}' requires primary_family.");
+            } elseif (! isset($familyIndex[$primaryFamily])) {
+                $errors[] = $this->error($path, 'inventory.section_family_matrix.'.$index.'.primary_family', "section '{$sectionKey}' references unknown fragment family '{$primaryFamily}'.");
+            }
+
+            $secondaryFamilies = array_values(array_filter(array_map('strval', (array) ($row['secondary_families'] ?? []))));
+            foreach ($secondaryFamilies as $secondaryFamily) {
+                if (! isset($familyIndex[$secondaryFamily])) {
+                    $errors[] = $this->error($path, 'inventory.section_family_matrix.'.$index.'.secondary_families', "section '{$sectionKey}' references unknown fragment family '{$secondaryFamily}'.");
+                }
+            }
+        }
+
+        foreach (self::REQUIRED_SECTION_KEYS as $requiredSectionKey) {
+            if (! isset($matrixIndex[$requiredSectionKey])) {
+                $errors[] = $this->error($path, 'inventory.section_family_matrix', "Missing required section mapping '{$requiredSectionKey}'.");
             }
         }
 

--- a/backend/tests/Feature/Content/ContentPackLintTest.php
+++ b/backend/tests/Feature/Content/ContentPackLintTest.php
@@ -24,6 +24,7 @@ final class ContentPackLintTest extends TestCase
         $this->assertFileExists($compiledDir . '/rules.normalized.json');
         $this->assertFileExists($compiledDir . '/sections.spec.json');
         $this->assertFileExists($compiledDir . '/variables.used.json');
+        $this->assertFileExists($compiledDir . '/inventory.spec.json');
         $this->assertFileExists($compiledDir . '/governance.spec.json');
         $this->assertFileExists($compiledDir . '/manifest.json');
     }

--- a/backend/tests/Feature/Content/MbtiContentInventoryContractTest.php
+++ b/backend/tests/Feature/Content/MbtiContentInventoryContractTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use Tests\TestCase;
+
+final class MbtiContentInventoryContractTest extends TestCase
+{
+    private function contentPath(string $file): string
+    {
+        return base_path('../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/'.$file);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $file): array
+    {
+        $raw = file_get_contents($this->contentPath($file));
+        $this->assertIsString($raw, "Unable to read {$file}");
+
+        $decoded = json_decode($raw, true);
+        $this->assertIsArray($decoded, "Invalid JSON in {$file}");
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readFixture(string $file): array
+    {
+        $path = base_path('tests/Fixtures/'.$file);
+        $raw = file_get_contents($path);
+        $this->assertIsString($raw, "Unable to read fixture {$file}");
+
+        $decoded = json_decode($raw, true);
+        $this->assertIsArray($decoded, "Invalid JSON in fixture {$file}");
+
+        return $decoded;
+    }
+
+    public function test_mbti_inventory_contract_defines_fragment_families_tags_and_section_matrix(): void
+    {
+        $inventory = $this->readJson('mbti_content_inventory.json');
+
+        $this->assertSame('fap.mbti.content_inventory.v1', $inventory['schema'] ?? null);
+        $this->assertSame(1, $inventory['inventory_contract_version'] ?? null);
+        $this->assertSame('MBTI.cn-mainland.zh-CN.v0.3', $inventory['pack_id'] ?? null);
+        $this->assertSame('CN_MAINLAND.zh-CN', $inventory['cultural_context'] ?? null);
+        $this->assertSame('mbti_content_inventory_v1.cn-mainland.zh-CN.2026-03', $inventory['inventory_fingerprint'] ?? null);
+        $this->assertSame('mbti_content_inventory.v1', $inventory['governance_profile'] ?? null);
+
+        $families = array_values(array_filter((array) ($inventory['fragment_families'] ?? []), 'is_array'));
+        $familyKeys = array_values(array_filter(array_map(
+            static fn (array $family): string => trim((string) ($family['key'] ?? '')),
+            $families
+        )));
+
+        $this->assertEqualsCanonicalizing([
+            'explainability_fragment',
+            'boundary_fragment',
+            'stress_fragment',
+            'recovery_fragment',
+            'scene_fragment',
+            'work_fragment',
+            'relationship_fragment',
+            'action_fragment',
+            'watchout_fragment',
+            'recommendation_fragment',
+            'cta_bundle_fragment',
+            'tone_fragment',
+            'revisit_fragment',
+            'adaptive_response_fragment',
+        ], $familyKeys);
+
+        $selectionTagSchema = is_array($inventory['selection_tag_schema'] ?? null) ? $inventory['selection_tag_schema'] : [];
+        foreach ([
+            'section_key',
+            'block_family',
+            'axis_band',
+            'boundary_flag',
+            'scene_key',
+            'intent_cluster',
+            'memory_state',
+            'adaptive_state',
+            'cross_assessment_key',
+            'tone_mode',
+            'access_tier',
+            'locale_scope',
+            'evidence_ref',
+        ] as $tagKey) {
+            $this->assertArrayHasKey($tagKey, $selectionTagSchema);
+            $this->assertNotSame('', trim((string) ($selectionTagSchema[$tagKey]['type'] ?? '')));
+        }
+
+        $matrix = array_values(array_filter((array) ($inventory['section_family_matrix'] ?? []), 'is_array'));
+        $matrixIndex = [];
+        foreach ($matrix as $row) {
+            $sectionKey = trim((string) ($row['section_key'] ?? ''));
+            if ($sectionKey !== '') {
+                $matrixIndex[$sectionKey] = $row;
+            }
+        }
+
+        foreach ([
+            'overview',
+            'trait_overview',
+            'traits.why_this_type',
+            'growth.summary',
+            'growth.stability_confidence',
+            'traits.adjacent_type_contrast',
+            'growth.next_actions',
+            'growth.watchouts',
+            'career.summary',
+            'career.next_step',
+            'career.work_experiments',
+            'relationships.summary',
+            'relationships.try_this_week',
+            'recommendation.surface',
+            'cta.surface',
+        ] as $sectionKey) {
+            $this->assertArrayHasKey($sectionKey, $matrixIndex);
+            $this->assertNotSame('', trim((string) ($matrixIndex[$sectionKey]['primary_family'] ?? '')));
+        }
+
+        $this->assertSame('scene_fragment', $matrixIndex['overview']['primary_family'] ?? null);
+        $this->assertSame('explainability_fragment', $matrixIndex['traits.why_this_type']['primary_family'] ?? null);
+        $this->assertSame('action_fragment', $matrixIndex['growth.next_actions']['primary_family'] ?? null);
+        $this->assertSame('cta_bundle_fragment', $matrixIndex['cta.surface']['primary_family'] ?? null);
+    }
+
+    public function test_compiled_inventory_artifact_matches_expected_summary_contract(): void
+    {
+        $this->artisan('content:lint --pack=MBTI.cn-mainland.zh-CN.v0.3')->assertExitCode(0);
+        $this->artisan('content:compile --pack=MBTI.cn-mainland.zh-CN.v0.3')->assertExitCode(0);
+
+        $compiled = $this->readJson('compiled/inventory.spec.json');
+        $compiledManifest = $this->readJson('compiled/manifest.json');
+        $fixture = $this->readFixture('mbti_content_inventory_snapshot_expected.json');
+
+        $actual = [
+            'inventory_contract_version' => $compiled['inventory_contract_version'] ?? null,
+            'inventory_fingerprint' => $compiled['inventory_fingerprint'] ?? null,
+            'governance_profile' => $compiled['governance_profile'] ?? null,
+            'fragment_family_keys' => data_get($compiled, 'summary.fragment_family_keys', []),
+            'selection_tag_keys' => data_get($compiled, 'summary.selection_tag_keys', []),
+            'section_family_keys' => data_get($compiled, 'summary.section_family_keys', []),
+        ];
+
+        $this->assertSame($fixture, $actual);
+        $this->assertContains('inventory.spec.json', (array) ($compiledManifest['files'] ?? []));
+    }
+}

--- a/backend/tests/Fixtures/mbti_content_inventory_snapshot_expected.json
+++ b/backend/tests/Fixtures/mbti_content_inventory_snapshot_expected.json
@@ -1,0 +1,53 @@
+{
+  "inventory_contract_version": 1,
+  "inventory_fingerprint": "mbti_content_inventory_v1.cn-mainland.zh-CN.2026-03",
+  "governance_profile": "mbti_content_inventory.v1",
+  "fragment_family_keys": [
+    "explainability_fragment",
+    "boundary_fragment",
+    "stress_fragment",
+    "recovery_fragment",
+    "scene_fragment",
+    "work_fragment",
+    "relationship_fragment",
+    "action_fragment",
+    "watchout_fragment",
+    "recommendation_fragment",
+    "cta_bundle_fragment",
+    "tone_fragment",
+    "revisit_fragment",
+    "adaptive_response_fragment"
+  ],
+  "selection_tag_keys": [
+    "section_key",
+    "block_family",
+    "axis_band",
+    "boundary_flag",
+    "scene_key",
+    "intent_cluster",
+    "memory_state",
+    "adaptive_state",
+    "cross_assessment_key",
+    "tone_mode",
+    "access_tier",
+    "locale_scope",
+    "evidence_ref"
+  ],
+  "section_family_keys": [
+    "overview",
+    "trait_overview",
+    "traits.why_this_type",
+    "growth.summary",
+    "growth.stability_confidence",
+    "traits.adjacent_type_contrast",
+    "growth.next_actions",
+    "growth.watchouts",
+    "career.summary",
+    "career.next_step",
+    "career.work_experiments",
+    "relationships.summary",
+    "relationships.try_this_week",
+    "recommendation.surface",
+    "cta.surface"
+  ]
+}

--- a/backend/tests/Unit/Services/Content/ContentControlPlaneServiceTest.php
+++ b/backend/tests/Unit/Services/Content/ContentControlPlaneServiceTest.php
@@ -57,12 +57,22 @@ final class ContentControlPlaneServiceTest extends TestCase
         $this->assertArrayHasKey('rollback_target', $contract);
         $this->assertArrayHasKey('locale_scope', $contract);
         $this->assertArrayHasKey('experiment_scope', $contract);
+        $this->assertArrayHasKey('content_inventory_v1', $contract);
         $this->assertArrayHasKey('runtime_artifact_ref', $contract);
         $this->assertArrayHasKey('content_objects_v1', $contract);
         $this->assertSame('compiled', $contract['compile_status']);
         $this->assertSame('passing', $contract['governance_status']);
         $this->assertNull($contract['runtime_artifact_ref']);
         $this->assertNotEmpty($contract['content_object_inventory']);
+
+        $inventory = $contract['content_inventory_v1'];
+        $this->assertSame(1, $inventory['inventory_contract_version']);
+        $this->assertSame('mbti_content_inventory.v1', $inventory['governance_profile']);
+        $this->assertSame('mbti_content_inventory_v1.cn-mainland.zh-CN.2026-03', $inventory['inventory_fingerprint']);
+        $this->assertSame(14, $inventory['fragment_family_count']);
+        $this->assertContains('traits.why_this_type', $inventory['section_family_keys']);
+        $this->assertContains('cta.surface', $inventory['section_family_keys']);
+        $this->assertArrayHasKey('selection_tag_keys', $inventory);
 
         $objects = collect($contract['content_objects_v1']);
         $this->assertNotEmpty($objects);
@@ -139,6 +149,7 @@ final class ContentControlPlaneServiceTest extends TestCase
         $this->assertTrue(collect($draftContract['content_objects_v1'])->every(
             fn (array $object): bool => $object['runtime_artifact_ref'] === null
         ));
+        $this->assertSame(14, $draftContract['content_inventory_v1']['fragment_family_count']);
 
         $this->insertSuccessfulPublishRelease(
             (string) $version->id,
@@ -155,6 +166,7 @@ final class ContentControlPlaneServiceTest extends TestCase
         $this->assertSame('published', $publishedContract['draft_state']);
         $this->assertIsArray($publishedContract['runtime_artifact_ref']);
         $this->assertSame((string) $version->content_package_version, $publishedContract['runtime_artifact_ref']['pack_version']);
+        $this->assertSame('mbti_content_inventory.v1', $publishedContract['content_inventory_v1']['governance_profile']);
 
         $publishedObjects = collect($publishedContract['content_objects_v1'])->keyBy('content_object_type');
         $this->assertIsArray($publishedObjects['narrative_fragment']['runtime_artifact_ref']);
@@ -209,6 +221,7 @@ final class ContentControlPlaneServiceTest extends TestCase
         $this->assertSame('published', $contract['release_candidate_status']);
         $this->assertIsArray($contract['rollback_target']);
         $this->assertSame($previousReleaseId, $contract['rollback_target']['release_id']);
+        $this->assertSame(14, $contract['content_inventory_v1']['fragment_family_count']);
 
         $publishedObject = collect($contract['content_objects_v1'])
             ->first(fn (array $object): bool => is_array($object['runtime_artifact_ref'] ?? null));

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.normalized.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.normalized.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.cards.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-02-21T04:27:39+00:00",
+    "generated_at": "2026-03-22T12:22:44+00:00",
     "sections": {
         "career": {
             "items": [

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.tag_index.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.tag_index.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.tag_index.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-02-21T04:27:39+00:00",
+    "generated_at": "2026-03-22T12:22:44+00:00",
     "sections": {
         "career": {
             "axis:AT:A": [

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/governance.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/governance.spec.json
@@ -2,7 +2,7 @@
     "schema": "fap.mbti.content_governance.compiled.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-20T07:04:26+00:00",
+    "generated_at": "2026-03-22T12:22:44+00:00",
     "required_layers": [
         "skeleton",
         "intensity",

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/inventory.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/inventory.spec.json
@@ -1,0 +1,778 @@
+{
+    "schema": "fap.mbti.content_inventory.compiled.v1",
+    "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
+    "version": "v0.3",
+    "generated_at": "2026-03-22T12:22:44+00:00",
+    "inventory_contract_version": 1,
+    "inventory_fingerprint": "mbti_content_inventory_v1.cn-mainland.zh-CN.2026-03",
+    "governance_profile": "mbti_content_inventory.v1",
+    "fragment_families": [
+        {
+            "key": "explainability_fragment",
+            "label": "Explainability fragment",
+            "description": "Why-this-type, contrast, and stability explanation blocks.",
+            "layer_scope": [
+                "boundary",
+                "explainability"
+            ],
+            "allowed_section_keys": [
+                "overview",
+                "trait_overview",
+                "traits.why_this_type",
+                "growth.stability_confidence",
+                "traits.adjacent_type_contrast"
+            ],
+            "block_kinds": [
+                "why_this_type",
+                "adjacent_type_contrast",
+                "stability_explanation"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "axis_band",
+                "boundary_flag",
+                "scene_key",
+                "tone_mode",
+                "access_tier",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "boundary_fragment",
+            "label": "Boundary fragment",
+            "description": "Boundary-state and borderline-axis explanation blocks.",
+            "layer_scope": [
+                "boundary"
+            ],
+            "allowed_section_keys": [
+                "overview",
+                "trait_overview",
+                "traits.why_this_type",
+                "growth.stability_confidence",
+                "traits.adjacent_type_contrast",
+                "growth.watchouts"
+            ],
+            "block_kinds": [
+                "boundary",
+                "borderline_axis"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "axis_band",
+                "boundary_flag",
+                "scene_key",
+                "tone_mode",
+                "access_tier",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "stress_fragment",
+            "label": "Stress fragment",
+            "description": "Stress, overload, and stability-under-pressure materials.",
+            "layer_scope": [
+                "scene",
+                "boundary"
+            ],
+            "allowed_section_keys": [
+                "growth.stability_confidence",
+                "growth.watchouts"
+            ],
+            "block_kinds": [
+                "stress_recovery",
+                "watchout"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "axis_band",
+                "boundary_flag",
+                "scene_key",
+                "intent_cluster",
+                "memory_state",
+                "tone_mode",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "recovery_fragment",
+            "label": "Recovery fragment",
+            "description": "Recovery, reset, and revisit materials for the next pass.",
+            "layer_scope": [
+                "scene",
+                "action"
+            ],
+            "allowed_section_keys": [
+                "growth.next_actions",
+                "growth.watchouts",
+                "career.work_experiments",
+                "relationships.try_this_week"
+            ],
+            "block_kinds": [
+                "stress_recovery",
+                "weekly_experiment"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "intent_cluster",
+                "memory_state",
+                "adaptive_state",
+                "tone_mode",
+                "access_tier",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "scene_fragment",
+            "label": "Scene fragment",
+            "description": "Scene fingerprints and scene-specific summary blocks.",
+            "layer_scope": [
+                "scene"
+            ],
+            "allowed_section_keys": [
+                "overview",
+                "trait_overview",
+                "growth.summary",
+                "career.summary",
+                "relationships.summary",
+                "traits.why_this_type"
+            ],
+            "block_kinds": [
+                "scene"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "scene_key",
+                "intent_cluster",
+                "memory_state",
+                "tone_mode",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "work_fragment",
+            "label": "Work fragment",
+            "description": "Work style, work environment, and career bridge materials.",
+            "layer_scope": [
+                "scene",
+                "action"
+            ],
+            "allowed_section_keys": [
+                "career.summary",
+                "career.next_step",
+                "career.work_experiments"
+            ],
+            "block_kinds": [
+                "work_style",
+                "work_env",
+                "role_fit",
+                "collaboration_fit",
+                "career_next_step",
+                "work_experiment"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "scene_key",
+                "intent_cluster",
+                "adaptive_state",
+                "tone_mode",
+                "access_tier",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "relationship_fragment",
+            "label": "Relationship fragment",
+            "description": "Relationship and communication materials.",
+            "layer_scope": [
+                "scene",
+                "action"
+            ],
+            "allowed_section_keys": [
+                "relationships.summary",
+                "relationships.try_this_week"
+            ],
+            "block_kinds": [
+                "communication",
+                "relationship_practice"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "scene_key",
+                "intent_cluster",
+                "memory_state",
+                "tone_mode",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "action_fragment",
+            "label": "Action fragment",
+            "description": "Next action, experiment, and bridge steps.",
+            "layer_scope": [
+                "action"
+            ],
+            "allowed_section_keys": [
+                "growth.next_actions",
+                "career.next_step",
+                "career.work_experiments",
+                "relationships.try_this_week"
+            ],
+            "block_kinds": [
+                "next_action",
+                "weekly_experiment",
+                "work_experiment",
+                "relationship_practice"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "intent_cluster",
+                "memory_state",
+                "adaptive_state",
+                "tone_mode",
+                "access_tier",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "watchout_fragment",
+            "label": "Watchout fragment",
+            "description": "Watchout and resistance materials for same-type divergence.",
+            "layer_scope": [
+                "boundary",
+                "action"
+            ],
+            "allowed_section_keys": [
+                "growth.watchouts",
+                "growth.stability_confidence"
+            ],
+            "block_kinds": [
+                "watchout",
+                "boundary"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "boundary_flag",
+                "intent_cluster",
+                "memory_state",
+                "adaptive_state",
+                "tone_mode",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "recommendation_fragment",
+            "label": "Recommendation fragment",
+            "description": "Recommendation pool and reading-path materials.",
+            "layer_scope": [
+                "scene",
+                "action"
+            ],
+            "allowed_section_keys": [
+                "recommendation.surface",
+                "career.next_step"
+            ],
+            "block_kinds": [
+                "recommendation"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "intent_cluster",
+                "memory_state",
+                "adaptive_state",
+                "access_tier",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "cta_bundle_fragment",
+            "label": "CTA bundle fragment",
+            "description": "Primary CTA, secondary CTA, and funnel-copy bundles.",
+            "layer_scope": [
+                "action"
+            ],
+            "allowed_section_keys": [
+                "cta.surface",
+                "recommendation.surface"
+            ],
+            "block_kinds": [
+                "cta_bundle"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "intent_cluster",
+                "adaptive_state",
+                "access_tier",
+                "tone_mode",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "tone_fragment",
+            "label": "Tone fragment",
+            "description": "Tone and phrasing variants that shape how a block reads.",
+            "layer_scope": [
+                "skeleton",
+                "boundary",
+                "explainability",
+                "scene",
+                "action"
+            ],
+            "allowed_section_keys": [
+                "overview",
+                "trait_overview",
+                "traits.why_this_type",
+                "growth.stability_confidence",
+                "traits.adjacent_type_contrast",
+                "growth.next_actions",
+                "growth.watchouts",
+                "career.summary",
+                "career.next_step",
+                "career.work_experiments",
+                "relationships.summary",
+                "relationships.try_this_week",
+                "recommendation.surface",
+                "cta.surface"
+            ],
+            "block_kinds": [
+                "tone"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "tone_mode",
+                "access_tier",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "revisit_fragment",
+            "label": "Revisit fragment",
+            "description": "Memory-aware revisit and continuity materials.",
+            "layer_scope": [
+                "action",
+                "scene"
+            ],
+            "allowed_section_keys": [
+                "overview",
+                "growth.summary",
+                "growth.next_actions",
+                "career.summary",
+                "career.next_step",
+                "relationships.summary",
+                "relationships.try_this_week"
+            ],
+            "block_kinds": [
+                "revisit"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "memory_state",
+                "adaptive_state",
+                "intent_cluster",
+                "tone_mode",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        },
+        {
+            "key": "adaptive_response_fragment",
+            "label": "Adaptive response fragment",
+            "description": "Adaptive and self-healing response materials for follow-through.",
+            "layer_scope": [
+                "action",
+                "boundary"
+            ],
+            "allowed_section_keys": [
+                "growth.next_actions",
+                "growth.watchouts",
+                "career.next_step",
+                "career.work_experiments",
+                "relationships.try_this_week",
+                "cta.surface"
+            ],
+            "block_kinds": [
+                "adaptive_response"
+            ],
+            "selection_tags": [
+                "section_key",
+                "block_family",
+                "adaptive_state",
+                "memory_state",
+                "intent_cluster",
+                "tone_mode",
+                "access_tier",
+                "locale_scope",
+                "evidence_ref"
+            ]
+        }
+    ],
+    "selection_tag_schema": {
+        "section_key": {
+            "type": "string",
+            "values": [
+                "overview",
+                "trait_overview",
+                "traits.why_this_type",
+                "growth.summary",
+                "growth.stability_confidence",
+                "growth.next_actions",
+                "growth.watchouts",
+                "career.summary",
+                "career.next_step",
+                "career.work_experiments",
+                "relationships.summary",
+                "relationships.try_this_week",
+                "traits.adjacent_type_contrast",
+                "recommendation.surface",
+                "cta.surface"
+            ]
+        },
+        "block_family": {
+            "type": "string",
+            "values": [
+                "explainability_fragment",
+                "boundary_fragment",
+                "stress_fragment",
+                "recovery_fragment",
+                "scene_fragment",
+                "work_fragment",
+                "relationship_fragment",
+                "action_fragment",
+                "watchout_fragment",
+                "recommendation_fragment",
+                "cta_bundle_fragment",
+                "tone_fragment",
+                "revisit_fragment",
+                "adaptive_response_fragment"
+            ]
+        },
+        "axis_band": {
+            "type": "string",
+            "values": [
+                "EI",
+                "SN",
+                "TF",
+                "JP",
+                "AT"
+            ]
+        },
+        "boundary_flag": {
+            "type": "string",
+            "values": [
+                "core",
+                "borderline",
+                "boundary_buffered",
+                "contrast",
+                "resume"
+            ]
+        },
+        "scene_key": {
+            "type": "string",
+            "values": [
+                "overview",
+                "growth",
+                "work",
+                "decision",
+                "stress_recovery",
+                "relationship",
+                "communication"
+            ]
+        },
+        "intent_cluster": {
+            "type": "string",
+            "values": [
+                "clarity",
+                "stability",
+                "action",
+                "career",
+                "relationship",
+                "revisit",
+                "adaptive"
+            ]
+        },
+        "memory_state": {
+            "type": "string",
+            "values": [
+                "fresh",
+                "carryover",
+                "revisit",
+                "resumed",
+                "stale"
+            ]
+        },
+        "adaptive_state": {
+            "type": "string",
+            "values": [
+                "baseline",
+                "adaptive",
+                "self_healing",
+                "guardrail"
+            ]
+        },
+        "cross_assessment_key": {
+            "type": "string",
+            "values": [
+                "MBTI",
+                "BigFive",
+                "EQ60",
+                "ClinicalCombo",
+                "SDS20"
+            ]
+        },
+        "tone_mode": {
+            "type": "string",
+            "values": [
+                "neutral",
+                "warm",
+                "direct",
+                "reflective",
+                "pragmatic"
+            ]
+        },
+        "access_tier": {
+            "type": "string",
+            "values": [
+                "stable",
+                "experiment",
+                "commercial_overlay"
+            ]
+        },
+        "locale_scope": {
+            "type": "string",
+            "values": [
+                "CN_MAINLAND.zh-CN",
+                "GLOBAL.en"
+            ]
+        },
+        "evidence_ref": {
+            "type": "string",
+            "description": "Stable reference to authored evidence or compiled artifact sections."
+        }
+    },
+    "section_family_matrix": [
+        {
+            "section_key": "overview",
+            "primary_family": "scene_fragment",
+            "secondary_families": [
+                "explainability_fragment",
+                "revisit_fragment",
+                "tone_fragment"
+            ],
+            "content_goal": "Intro and same-type overview framing."
+        },
+        {
+            "section_key": "trait_overview",
+            "primary_family": "explainability_fragment",
+            "secondary_families": [
+                "boundary_fragment",
+                "scene_fragment",
+                "tone_fragment"
+            ],
+            "content_goal": "Trait-level intro with boundary-aware phrasing."
+        },
+        {
+            "section_key": "traits.why_this_type",
+            "primary_family": "explainability_fragment",
+            "secondary_families": [
+                "boundary_fragment",
+                "scene_fragment",
+                "tone_fragment"
+            ],
+            "content_goal": "Why this type and where it diverges from neighbors."
+        },
+        {
+            "section_key": "growth.summary",
+            "primary_family": "revisit_fragment",
+            "secondary_families": [
+                "stress_fragment",
+                "explainability_fragment",
+                "tone_fragment"
+            ],
+            "content_goal": "Growth summary with revisit-aware framing."
+        },
+        {
+            "section_key": "growth.stability_confidence",
+            "primary_family": "stress_fragment",
+            "secondary_families": [
+                "recovery_fragment",
+                "boundary_fragment",
+                "watchout_fragment"
+            ],
+            "content_goal": "Stability, pressure, and recovery framing."
+        },
+        {
+            "section_key": "traits.adjacent_type_contrast",
+            "primary_family": "explainability_fragment",
+            "secondary_families": [
+                "boundary_fragment",
+                "revisit_fragment"
+            ],
+            "content_goal": "Contrast with adjacent types and boundary states."
+        },
+        {
+            "section_key": "growth.next_actions",
+            "primary_family": "action_fragment",
+            "secondary_families": [
+                "recovery_fragment",
+                "revisit_fragment",
+                "adaptive_response_fragment"
+            ],
+            "content_goal": "Next actions with memory-aware follow-through."
+        },
+        {
+            "section_key": "growth.watchouts",
+            "primary_family": "watchout_fragment",
+            "secondary_families": [
+                "recovery_fragment",
+                "adaptive_response_fragment"
+            ],
+            "content_goal": "Watchouts, resistance, and recovery."
+        },
+        {
+            "section_key": "career.summary",
+            "primary_family": "work_fragment",
+            "secondary_families": [
+                "action_fragment",
+                "tone_fragment",
+                "recommendation_fragment"
+            ],
+            "content_goal": "Career overview and work style summary."
+        },
+        {
+            "section_key": "career.next_step",
+            "primary_family": "work_fragment",
+            "secondary_families": [
+                "action_fragment",
+                "revisit_fragment",
+                "adaptive_response_fragment"
+            ],
+            "content_goal": "Career bridge into the next concrete step."
+        },
+        {
+            "section_key": "career.work_experiments",
+            "primary_family": "work_fragment",
+            "secondary_families": [
+                "action_fragment",
+                "recovery_fragment"
+            ],
+            "content_goal": "Work experiments and adjustment loops."
+        },
+        {
+            "section_key": "relationships.summary",
+            "primary_family": "relationship_fragment",
+            "secondary_families": [
+                "action_fragment",
+                "tone_fragment"
+            ],
+            "content_goal": "Relationship and communication summary."
+        },
+        {
+            "section_key": "relationships.try_this_week",
+            "primary_family": "relationship_fragment",
+            "secondary_families": [
+                "action_fragment",
+                "recovery_fragment",
+                "adaptive_response_fragment"
+            ],
+            "content_goal": "Concrete relationship experiment for this week."
+        },
+        {
+            "section_key": "recommendation.surface",
+            "primary_family": "recommendation_fragment",
+            "secondary_families": [
+                "revisit_fragment",
+                "adaptive_response_fragment"
+            ],
+            "content_goal": "Recommendation pool and reading path."
+        },
+        {
+            "section_key": "cta.surface",
+            "primary_family": "cta_bundle_fragment",
+            "secondary_families": [
+                "adaptive_response_fragment",
+                "tone_fragment"
+            ],
+            "content_goal": "CTA bundle and funnel-copy surface."
+        }
+    ],
+    "summary": {
+        "inventory_contract_version": 1,
+        "inventory_fingerprint": "mbti_content_inventory_v1.cn-mainland.zh-CN.2026-03",
+        "governance_profile": "mbti_content_inventory.v1",
+        "fragment_family_count": 14,
+        "fragment_family_keys": [
+            "explainability_fragment",
+            "boundary_fragment",
+            "stress_fragment",
+            "recovery_fragment",
+            "scene_fragment",
+            "work_fragment",
+            "relationship_fragment",
+            "action_fragment",
+            "watchout_fragment",
+            "recommendation_fragment",
+            "cta_bundle_fragment",
+            "tone_fragment",
+            "revisit_fragment",
+            "adaptive_response_fragment"
+        ],
+        "selection_tag_count": 13,
+        "selection_tag_keys": [
+            "section_key",
+            "block_family",
+            "axis_band",
+            "boundary_flag",
+            "scene_key",
+            "intent_cluster",
+            "memory_state",
+            "adaptive_state",
+            "cross_assessment_key",
+            "tone_mode",
+            "access_tier",
+            "locale_scope",
+            "evidence_ref"
+        ],
+        "section_family_count": 15,
+        "section_family_keys": [
+            "overview",
+            "trait_overview",
+            "traits.why_this_type",
+            "growth.summary",
+            "growth.stability_confidence",
+            "traits.adjacent_type_contrast",
+            "growth.next_actions",
+            "growth.watchouts",
+            "career.summary",
+            "career.next_step",
+            "career.work_experiments",
+            "relationships.summary",
+            "relationships.try_this_week",
+            "recommendation.surface",
+            "cta.surface"
+        ]
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/manifest.json
@@ -2,14 +2,15 @@
     "schema": "fap.content.compiled.manifest.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "source_version": "v0.3",
-    "generated_at": "2026-03-20T07:04:26+00:00",
-    "checksum": "c1113779f607ddae20487e074c1cf47c744e09e3e16b761baec6f13b25da5da6",
+    "generated_at": "2026-03-22T12:22:44+00:00",
+    "checksum": "beaf385f206107737f15b00abd21385645bf84715e768624c8908c7fadf1387b",
     "files": [
         "cards.normalized.json",
         "cards.tag_index.json",
         "rules.normalized.json",
         "sections.spec.json",
         "variables.used.json",
+        "inventory.spec.json",
         "governance.spec.json"
     ]
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/rules.normalized.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/rules.normalized.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.rules.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-02-21T04:27:39+00:00",
+    "generated_at": "2026-03-22T12:22:44+00:00",
     "rules": [
         {
             "id": "cards_drop_badge_01",

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/sections.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/sections.spec.json
@@ -2,7 +2,7 @@
     "schema": "fap.report.section_policies.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-02-21T04:27:39+00:00",
+    "generated_at": "2026-03-22T12:22:44+00:00",
     "items": {
         "traits": {
             "min_cards": 3,

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/variables.used.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/variables.used.json
@@ -2,6 +2,6 @@
     "schema": "fap.content.compiled.variables.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-02-21T04:27:39+00:00",
+    "generated_at": "2026-03-22T12:22:44+00:00",
     "variables": []
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/manifest.json
@@ -43,6 +43,7 @@
         "rules": "fap.report.rules.v1",
         "section_policies": "fap.report.section_policies.v1",
         "dynamic_sections": "fap.mbti.dynamic_sections.v1",
+        "inventory": "fap.mbti.content_inventory.v1",
         "content_governance": "fap.mbti.content_governance.v1",
         "overrides_unified": "fap.report.overrides.v1",
         "meta": "fap.landing.meta.v1"
@@ -197,6 +198,9 @@
         ],
         "dynamic_sections": [
             "report_dynamic_sections.json"
+        ],
+        "inventory": [
+            "mbti_content_inventory.json"
         ],
         "content_governance": [
             "report_content_governance.json"

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/mbti_content_inventory.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/mbti_content_inventory.json
@@ -1,0 +1,721 @@
+{
+  "schema": "fap.mbti.content_inventory.v1",
+  "inventory_contract_version": 1,
+  "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
+  "cultural_context": "CN_MAINLAND.zh-CN",
+  "inventory_fingerprint": "mbti_content_inventory_v1.cn-mainland.zh-CN.2026-03",
+  "governance_profile": "mbti_content_inventory.v1",
+  "fragment_families": [
+    {
+      "key": "explainability_fragment",
+      "label": "Explainability fragment",
+      "description": "Why-this-type, contrast, and stability explanation blocks.",
+      "layer_scope": [
+        "boundary",
+        "explainability"
+      ],
+      "allowed_section_keys": [
+        "overview",
+        "trait_overview",
+        "traits.why_this_type",
+        "growth.stability_confidence",
+        "traits.adjacent_type_contrast"
+      ],
+      "block_kinds": [
+        "why_this_type",
+        "adjacent_type_contrast",
+        "stability_explanation"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "axis_band",
+        "boundary_flag",
+        "scene_key",
+        "tone_mode",
+        "access_tier",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "boundary_fragment",
+      "label": "Boundary fragment",
+      "description": "Boundary-state and borderline-axis explanation blocks.",
+      "layer_scope": [
+        "boundary"
+      ],
+      "allowed_section_keys": [
+        "overview",
+        "trait_overview",
+        "traits.why_this_type",
+        "growth.stability_confidence",
+        "traits.adjacent_type_contrast",
+        "growth.watchouts"
+      ],
+      "block_kinds": [
+        "boundary",
+        "borderline_axis"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "axis_band",
+        "boundary_flag",
+        "scene_key",
+        "tone_mode",
+        "access_tier",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "stress_fragment",
+      "label": "Stress fragment",
+      "description": "Stress, overload, and stability-under-pressure materials.",
+      "layer_scope": [
+        "scene",
+        "boundary"
+      ],
+      "allowed_section_keys": [
+        "growth.stability_confidence",
+        "growth.watchouts"
+      ],
+      "block_kinds": [
+        "stress_recovery",
+        "watchout"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "axis_band",
+        "boundary_flag",
+        "scene_key",
+        "intent_cluster",
+        "memory_state",
+        "tone_mode",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "recovery_fragment",
+      "label": "Recovery fragment",
+      "description": "Recovery, reset, and revisit materials for the next pass.",
+      "layer_scope": [
+        "scene",
+        "action"
+      ],
+      "allowed_section_keys": [
+        "growth.next_actions",
+        "growth.watchouts",
+        "career.work_experiments",
+        "relationships.try_this_week"
+      ],
+      "block_kinds": [
+        "stress_recovery",
+        "weekly_experiment"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "intent_cluster",
+        "memory_state",
+        "adaptive_state",
+        "tone_mode",
+        "access_tier",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "scene_fragment",
+      "label": "Scene fragment",
+      "description": "Scene fingerprints and scene-specific summary blocks.",
+      "layer_scope": [
+        "scene"
+      ],
+      "allowed_section_keys": [
+        "overview",
+        "trait_overview",
+        "growth.summary",
+        "career.summary",
+        "relationships.summary",
+        "traits.why_this_type"
+      ],
+      "block_kinds": [
+        "scene"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "scene_key",
+        "intent_cluster",
+        "memory_state",
+        "tone_mode",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "work_fragment",
+      "label": "Work fragment",
+      "description": "Work style, work environment, and career bridge materials.",
+      "layer_scope": [
+        "scene",
+        "action"
+      ],
+      "allowed_section_keys": [
+        "career.summary",
+        "career.next_step",
+        "career.work_experiments"
+      ],
+      "block_kinds": [
+        "work_style",
+        "work_env",
+        "role_fit",
+        "collaboration_fit",
+        "career_next_step",
+        "work_experiment"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "scene_key",
+        "intent_cluster",
+        "adaptive_state",
+        "tone_mode",
+        "access_tier",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "relationship_fragment",
+      "label": "Relationship fragment",
+      "description": "Relationship and communication materials.",
+      "layer_scope": [
+        "scene",
+        "action"
+      ],
+      "allowed_section_keys": [
+        "relationships.summary",
+        "relationships.try_this_week"
+      ],
+      "block_kinds": [
+        "communication",
+        "relationship_practice"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "scene_key",
+        "intent_cluster",
+        "memory_state",
+        "tone_mode",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "action_fragment",
+      "label": "Action fragment",
+      "description": "Next action, experiment, and bridge steps.",
+      "layer_scope": [
+        "action"
+      ],
+      "allowed_section_keys": [
+        "growth.next_actions",
+        "career.next_step",
+        "career.work_experiments",
+        "relationships.try_this_week"
+      ],
+      "block_kinds": [
+        "next_action",
+        "weekly_experiment",
+        "work_experiment",
+        "relationship_practice"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "intent_cluster",
+        "memory_state",
+        "adaptive_state",
+        "tone_mode",
+        "access_tier",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "watchout_fragment",
+      "label": "Watchout fragment",
+      "description": "Watchout and resistance materials for same-type divergence.",
+      "layer_scope": [
+        "boundary",
+        "action"
+      ],
+      "allowed_section_keys": [
+        "growth.watchouts",
+        "growth.stability_confidence"
+      ],
+      "block_kinds": [
+        "watchout",
+        "boundary"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "boundary_flag",
+        "intent_cluster",
+        "memory_state",
+        "adaptive_state",
+        "tone_mode",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "recommendation_fragment",
+      "label": "Recommendation fragment",
+      "description": "Recommendation pool and reading-path materials.",
+      "layer_scope": [
+        "scene",
+        "action"
+      ],
+      "allowed_section_keys": [
+        "recommendation.surface",
+        "career.next_step"
+      ],
+      "block_kinds": [
+        "recommendation"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "intent_cluster",
+        "memory_state",
+        "adaptive_state",
+        "access_tier",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "cta_bundle_fragment",
+      "label": "CTA bundle fragment",
+      "description": "Primary CTA, secondary CTA, and funnel-copy bundles.",
+      "layer_scope": [
+        "action"
+      ],
+      "allowed_section_keys": [
+        "cta.surface",
+        "recommendation.surface"
+      ],
+      "block_kinds": [
+        "cta_bundle"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "intent_cluster",
+        "adaptive_state",
+        "access_tier",
+        "tone_mode",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "tone_fragment",
+      "label": "Tone fragment",
+      "description": "Tone and phrasing variants that shape how a block reads.",
+      "layer_scope": [
+        "skeleton",
+        "boundary",
+        "explainability",
+        "scene",
+        "action"
+      ],
+      "allowed_section_keys": [
+        "overview",
+        "trait_overview",
+        "traits.why_this_type",
+        "growth.stability_confidence",
+        "traits.adjacent_type_contrast",
+        "growth.next_actions",
+        "growth.watchouts",
+        "career.summary",
+        "career.next_step",
+        "career.work_experiments",
+        "relationships.summary",
+        "relationships.try_this_week",
+        "recommendation.surface",
+        "cta.surface"
+      ],
+      "block_kinds": [
+        "tone"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "tone_mode",
+        "access_tier",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "revisit_fragment",
+      "label": "Revisit fragment",
+      "description": "Memory-aware revisit and continuity materials.",
+      "layer_scope": [
+        "action",
+        "scene"
+      ],
+      "allowed_section_keys": [
+        "overview",
+        "growth.summary",
+        "growth.next_actions",
+        "career.summary",
+        "career.next_step",
+        "relationships.summary",
+        "relationships.try_this_week"
+      ],
+      "block_kinds": [
+        "revisit"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "memory_state",
+        "adaptive_state",
+        "intent_cluster",
+        "tone_mode",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    },
+    {
+      "key": "adaptive_response_fragment",
+      "label": "Adaptive response fragment",
+      "description": "Adaptive and self-healing response materials for follow-through.",
+      "layer_scope": [
+        "action",
+        "boundary"
+      ],
+      "allowed_section_keys": [
+        "growth.next_actions",
+        "growth.watchouts",
+        "career.next_step",
+        "career.work_experiments",
+        "relationships.try_this_week",
+        "cta.surface"
+      ],
+      "block_kinds": [
+        "adaptive_response"
+      ],
+      "selection_tags": [
+        "section_key",
+        "block_family",
+        "adaptive_state",
+        "memory_state",
+        "intent_cluster",
+        "tone_mode",
+        "access_tier",
+        "locale_scope",
+        "evidence_ref"
+      ]
+    }
+  ],
+  "selection_tag_schema": {
+    "section_key": {
+      "type": "string",
+      "values": [
+        "overview",
+        "trait_overview",
+        "traits.why_this_type",
+        "growth.summary",
+        "growth.stability_confidence",
+        "growth.next_actions",
+        "growth.watchouts",
+        "career.summary",
+        "career.next_step",
+        "career.work_experiments",
+        "relationships.summary",
+        "relationships.try_this_week",
+        "traits.adjacent_type_contrast",
+        "recommendation.surface",
+        "cta.surface"
+      ]
+    },
+    "block_family": {
+      "type": "string",
+      "values": [
+        "explainability_fragment",
+        "boundary_fragment",
+        "stress_fragment",
+        "recovery_fragment",
+        "scene_fragment",
+        "work_fragment",
+        "relationship_fragment",
+        "action_fragment",
+        "watchout_fragment",
+        "recommendation_fragment",
+        "cta_bundle_fragment",
+        "tone_fragment",
+        "revisit_fragment",
+        "adaptive_response_fragment"
+      ]
+    },
+    "axis_band": {
+      "type": "string",
+      "values": [
+        "EI",
+        "SN",
+        "TF",
+        "JP",
+        "AT"
+      ]
+    },
+    "boundary_flag": {
+      "type": "string",
+      "values": [
+        "core",
+        "borderline",
+        "boundary_buffered",
+        "contrast",
+        "resume"
+      ]
+    },
+    "scene_key": {
+      "type": "string",
+      "values": [
+        "overview",
+        "growth",
+        "work",
+        "decision",
+        "stress_recovery",
+        "relationship",
+        "communication"
+      ]
+    },
+    "intent_cluster": {
+      "type": "string",
+      "values": [
+        "clarity",
+        "stability",
+        "action",
+        "career",
+        "relationship",
+        "revisit",
+        "adaptive"
+      ]
+    },
+    "memory_state": {
+      "type": "string",
+      "values": [
+        "fresh",
+        "carryover",
+        "revisit",
+        "resumed",
+        "stale"
+      ]
+    },
+    "adaptive_state": {
+      "type": "string",
+      "values": [
+        "baseline",
+        "adaptive",
+        "self_healing",
+        "guardrail"
+      ]
+    },
+    "cross_assessment_key": {
+      "type": "string",
+      "values": [
+        "MBTI",
+        "BigFive",
+        "EQ60",
+        "ClinicalCombo",
+        "SDS20"
+      ]
+    },
+    "tone_mode": {
+      "type": "string",
+      "values": [
+        "neutral",
+        "warm",
+        "direct",
+        "reflective",
+        "pragmatic"
+      ]
+    },
+    "access_tier": {
+      "type": "string",
+      "values": [
+        "stable",
+        "experiment",
+        "commercial_overlay"
+      ]
+    },
+    "locale_scope": {
+      "type": "string",
+      "values": [
+        "CN_MAINLAND.zh-CN",
+        "GLOBAL.en"
+      ]
+    },
+    "evidence_ref": {
+      "type": "string",
+      "description": "Stable reference to authored evidence or compiled artifact sections."
+    }
+  },
+  "section_family_matrix": [
+    {
+      "section_key": "overview",
+      "primary_family": "scene_fragment",
+      "secondary_families": [
+        "explainability_fragment",
+        "revisit_fragment",
+        "tone_fragment"
+      ],
+      "content_goal": "Intro and same-type overview framing."
+    },
+    {
+      "section_key": "trait_overview",
+      "primary_family": "explainability_fragment",
+      "secondary_families": [
+        "boundary_fragment",
+        "scene_fragment",
+        "tone_fragment"
+      ],
+      "content_goal": "Trait-level intro with boundary-aware phrasing."
+    },
+    {
+      "section_key": "traits.why_this_type",
+      "primary_family": "explainability_fragment",
+      "secondary_families": [
+        "boundary_fragment",
+        "scene_fragment",
+        "tone_fragment"
+      ],
+      "content_goal": "Why this type and where it diverges from neighbors."
+    },
+    {
+      "section_key": "growth.summary",
+      "primary_family": "revisit_fragment",
+      "secondary_families": [
+        "stress_fragment",
+        "explainability_fragment",
+        "tone_fragment"
+      ],
+      "content_goal": "Growth summary with revisit-aware framing."
+    },
+    {
+      "section_key": "growth.stability_confidence",
+      "primary_family": "stress_fragment",
+      "secondary_families": [
+        "recovery_fragment",
+        "boundary_fragment",
+        "watchout_fragment"
+      ],
+      "content_goal": "Stability, pressure, and recovery framing."
+    },
+    {
+      "section_key": "traits.adjacent_type_contrast",
+      "primary_family": "explainability_fragment",
+      "secondary_families": [
+        "boundary_fragment",
+        "revisit_fragment"
+      ],
+      "content_goal": "Contrast with adjacent types and boundary states."
+    },
+    {
+      "section_key": "growth.next_actions",
+      "primary_family": "action_fragment",
+      "secondary_families": [
+        "recovery_fragment",
+        "revisit_fragment",
+        "adaptive_response_fragment"
+      ],
+      "content_goal": "Next actions with memory-aware follow-through."
+    },
+    {
+      "section_key": "growth.watchouts",
+      "primary_family": "watchout_fragment",
+      "secondary_families": [
+        "recovery_fragment",
+        "adaptive_response_fragment"
+      ],
+      "content_goal": "Watchouts, resistance, and recovery."
+    },
+    {
+      "section_key": "career.summary",
+      "primary_family": "work_fragment",
+      "secondary_families": [
+        "action_fragment",
+        "tone_fragment",
+        "recommendation_fragment"
+      ],
+      "content_goal": "Career overview and work style summary."
+    },
+    {
+      "section_key": "career.next_step",
+      "primary_family": "work_fragment",
+      "secondary_families": [
+        "action_fragment",
+        "revisit_fragment",
+        "adaptive_response_fragment"
+      ],
+      "content_goal": "Career bridge into the next concrete step."
+    },
+    {
+      "section_key": "career.work_experiments",
+      "primary_family": "work_fragment",
+      "secondary_families": [
+        "action_fragment",
+        "recovery_fragment"
+      ],
+      "content_goal": "Work experiments and adjustment loops."
+    },
+    {
+      "section_key": "relationships.summary",
+      "primary_family": "relationship_fragment",
+      "secondary_families": [
+        "action_fragment",
+        "tone_fragment"
+      ],
+      "content_goal": "Relationship and communication summary."
+    },
+    {
+      "section_key": "relationships.try_this_week",
+      "primary_family": "relationship_fragment",
+      "secondary_families": [
+        "action_fragment",
+        "recovery_fragment",
+        "adaptive_response_fragment"
+      ],
+      "content_goal": "Concrete relationship experiment for this week."
+    },
+    {
+      "section_key": "recommendation.surface",
+      "primary_family": "recommendation_fragment",
+      "secondary_families": [
+        "revisit_fragment",
+        "adaptive_response_fragment"
+      ],
+      "content_goal": "Recommendation pool and reading path."
+    },
+    {
+      "section_key": "cta.surface",
+      "primary_family": "cta_bundle_fragment",
+      "secondary_families": [
+        "adaptive_response_fragment",
+        "tone_fragment"
+      ],
+      "content_goal": "CTA bundle and funnel-copy surface."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR ships CE-1 for MBTI content inventory and taxonomy expansion.

It formalizes the MBTI content inventory as a backend-owned contract so future Explainability / Action / Recommendation / Tone / Adaptive expansions can build on a stable inventory, taxonomy, governance, compile, and control-plane visibility chain.

## What changed
- Added `mbti_content_inventory.json` to the MBTI pack source.
- Declared the inventory schema and asset in the pack manifest.
- Added a compiled inventory artifact: `compiled/inventory.spec.json`.
- Extended MBTI governance to lint and compile the inventory contract.
- Exposed a minimal `content_inventory_v1` summary in the content control plane.
- Added Ops visibility for the inventory contract.
- Added contract tests for inventory shape, compiled artifact integrity, lint/compile wiring, and control-plane visibility.

## Scope guardrails preserved
- No runtime personalization behavior changes.
- No same-type divergence / longitudinal memory / adaptive selection logic changes.
- No migration.
- No new dependency.
- No DB-as-runtime-truth behavior.
- No frontend changes required.
- No SEO / landing / answer changes.

## Validation
- `php artisan content:lint --pack=MBTI.cn-mainland.zh-CN.v0.3`
- `php artisan content:compile --pack=MBTI.cn-mainland.zh-CN.v0.3`
- `php artisan test --filter="MbtiContentInventoryContractTest|MbtiContentGovernanceContractTest|MbtiContentGovernanceSnapshotRegressionTest|ContentPackLintTest|ContentControlPlaneServiceTest"`
- `php artisan test --filter="ContentCompileServiceTest|ContentLintServiceTest|SelfCheckContractTest"`

## Notes
A broader MBTI/commercial flow test failed outside the CE-1 blast radius (`MbtiCompareInviteAttributionFlowTest`), with a pre-existing `CommerceController::isStubEnabled()` undefined-method error. The targeted CE-1 tests are green.
