### PR TITLE
[codex] schema foundation for artifact control-plane

### DIFF
--- a/backend/app/Models/ArtifactLifecycleEvent.php
+++ b/backend/app/Models/ArtifactLifecycleEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ArtifactLifecycleEvent extends Model
+{
+    protected $fillable = [
+        'job_id',
+        'attempt_id',
+        'artifact_slot_id',
+        'event_type',
+        'from_state',
+        'to_state',
+        'reason_code',
+        'payload_json',
+        'occurred_at',
+    ];
+
+    protected $casts = [
+        'job_id' => 'integer',
+        'artifact_slot_id' => 'integer',
+        'payload_json' => 'array',
+        'occurred_at' => 'datetime',
+    ];
+}

--- a/backend/app/Models/ArtifactLifecycleJob.php
+++ b/backend/app/Models/ArtifactLifecycleJob.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ArtifactLifecycleJob extends Model
+{
+    protected $fillable = [
+        'attempt_id',
+        'artifact_slot_id',
+        'job_type',
+        'state',
+        'reason_code',
+        'blocked_reason_code',
+        'idempotency_key',
+        'request_payload_json',
+        'result_payload_json',
+        'attempt_count',
+        'started_at',
+        'finished_at',
+    ];
+
+    protected $casts = [
+        'artifact_slot_id' => 'integer',
+        'attempt_count' => 'integer',
+        'request_payload_json' => 'array',
+        'result_payload_json' => 'array',
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
+    ];
+}

--- a/backend/app/Models/ArtifactReconcileCase.php
+++ b/backend/app/Models/ArtifactReconcileCase.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ArtifactReconcileCase extends Model
+{
+    protected $fillable = [
+        'attempt_id',
+        'slot_code',
+        'case_type',
+        'status',
+        'suspected_cause',
+        'opened_by',
+        'assigned_to',
+        'resolution_code',
+        'resolution_notes',
+        'payload_json',
+        'opened_at',
+        'resolved_at',
+    ];
+
+    protected $casts = [
+        'opened_by' => 'integer',
+        'assigned_to' => 'integer',
+        'payload_json' => 'array',
+        'opened_at' => 'datetime',
+        'resolved_at' => 'datetime',
+    ];
+}

--- a/backend/app/Models/AttemptReceipt.php
+++ b/backend/app/Models/AttemptReceipt.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AttemptReceipt extends Model
+{
+    protected $fillable = [
+        'attempt_id',
+        'seq',
+        'receipt_type',
+        'source_system',
+        'source_ref',
+        'actor_type',
+        'actor_id',
+        'idempotency_key',
+        'payload_json',
+        'occurred_at',
+        'recorded_at',
+    ];
+
+    protected $casts = [
+        'seq' => 'integer',
+        'payload_json' => 'array',
+        'occurred_at' => 'datetime',
+        'recorded_at' => 'datetime',
+    ];
+}

--- a/backend/app/Models/ReportArtifactPosture.php
+++ b/backend/app/Models/ReportArtifactPosture.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ReportArtifactPosture extends Model
+{
+    protected $fillable = [
+        'attempt_id',
+        'slot_code',
+        'current_version_id',
+        'active_job_id',
+        'render_state',
+        'delivery_state',
+        'access_state',
+        'integrity_state',
+        'attention_state',
+        'blocked_reason_code',
+        'payload_json',
+        'projection_fresh_at',
+    ];
+
+    protected $casts = [
+        'current_version_id' => 'integer',
+        'active_job_id' => 'integer',
+        'payload_json' => 'array',
+        'projection_fresh_at' => 'datetime',
+    ];
+}

--- a/backend/app/Models/ReportArtifactSlot.php
+++ b/backend/app/Models/ReportArtifactSlot.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ReportArtifactSlot extends Model
+{
+    protected $fillable = [
+        'attempt_id',
+        'slot_code',
+        'required_by_product',
+        'current_version_id',
+        'render_state',
+        'delivery_state',
+        'access_state',
+        'integrity_state',
+        'last_error_code',
+        'last_materialized_at',
+        'last_verified_at',
+    ];
+
+    protected $casts = [
+        'required_by_product' => 'boolean',
+        'current_version_id' => 'integer',
+        'last_materialized_at' => 'datetime',
+        'last_verified_at' => 'datetime',
+    ];
+}

--- a/backend/app/Models/ReportArtifactVersion.php
+++ b/backend/app/Models/ReportArtifactVersion.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ReportArtifactVersion extends Model
+{
+    protected $fillable = [
+        'artifact_slot_id',
+        'version_no',
+        'source_type',
+        'report_snapshot_id',
+        'storage_blob_id',
+        'created_from_receipt_id',
+        'supersedes_version_id',
+        'manifest_hash',
+        'dir_version',
+        'scoring_spec_version',
+        'report_engine_version',
+        'content_hash',
+        'byte_size',
+        'metadata_json',
+    ];
+
+    protected $casts = [
+        'artifact_slot_id' => 'integer',
+        'version_no' => 'integer',
+        'created_from_receipt_id' => 'integer',
+        'supersedes_version_id' => 'integer',
+        'byte_size' => 'integer',
+        'metadata_json' => 'array',
+    ];
+}

--- a/backend/app/Models/UnifiedAccessProjection.php
+++ b/backend/app/Models/UnifiedAccessProjection.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UnifiedAccessProjection extends Model
+{
+    protected $fillable = [
+        'attempt_id',
+        'access_state',
+        'report_state',
+        'pdf_state',
+        'reason_code',
+        'projection_version',
+        'actions_json',
+        'payload_json',
+        'produced_at',
+        'refreshed_at',
+    ];
+
+    protected $casts = [
+        'projection_version' => 'integer',
+        'actions_json' => 'array',
+        'payload_json' => 'array',
+        'produced_at' => 'datetime',
+        'refreshed_at' => 'datetime',
+    ];
+}

--- a/backend/database/migrations/2026_03_22_090000_create_attempt_receipts_table.php
+++ b/backend/database/migrations/2026_03_22_090000_create_attempt_receipts_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('attempt_receipts')) {
+            return;
+        }
+
+        Schema::create('attempt_receipts', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('attempt_id', 64);
+            $table->unsignedInteger('seq');
+            $table->string('receipt_type', 64);
+            $table->string('source_system', 64);
+            $table->string('source_ref', 255)->nullable();
+            $table->string('actor_type', 64)->nullable();
+            $table->string('actor_id', 64)->nullable();
+            $table->string('idempotency_key', 128)->nullable();
+            $table->json('payload_json')->nullable();
+            $table->timestamp('occurred_at')->nullable();
+            $table->timestamp('recorded_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['attempt_id', 'seq'], 'attempt_receipts_attempt_seq_unique');
+            $table->index('receipt_type', 'attempt_receipts_receipt_type_idx');
+            $table->index('idempotency_key', 'attempt_receipts_idempotency_key_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_22_090100_create_artifact_lifecycle_jobs_table.php
+++ b/backend/database/migrations/2026_03_22_090100_create_artifact_lifecycle_jobs_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('artifact_lifecycle_jobs')) {
+            return;
+        }
+
+        Schema::create('artifact_lifecycle_jobs', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('attempt_id', 64)->nullable();
+            $table->unsignedBigInteger('artifact_slot_id')->nullable();
+            $table->string('job_type', 64);
+            $table->string('state', 64)->default('queued');
+            $table->string('reason_code', 128)->nullable();
+            $table->string('blocked_reason_code', 128)->nullable();
+            $table->string('idempotency_key', 128)->nullable();
+            $table->json('request_payload_json')->nullable();
+            $table->json('result_payload_json')->nullable();
+            $table->unsignedInteger('attempt_count')->default(0);
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('finished_at')->nullable();
+            $table->timestamps();
+
+            $table->index('attempt_id', 'artifact_lifecycle_jobs_attempt_id_idx');
+            $table->index('artifact_slot_id', 'artifact_lifecycle_jobs_artifact_slot_id_idx');
+            $table->index('job_type', 'artifact_lifecycle_jobs_job_type_idx');
+            $table->index('state', 'artifact_lifecycle_jobs_state_idx');
+            $table->index('idempotency_key', 'artifact_lifecycle_jobs_idempotency_key_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_22_090200_create_artifact_lifecycle_events_table.php
+++ b/backend/database/migrations/2026_03_22_090200_create_artifact_lifecycle_events_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('artifact_lifecycle_events')) {
+            return;
+        }
+
+        Schema::create('artifact_lifecycle_events', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('job_id')->nullable();
+            $table->string('attempt_id', 64)->nullable();
+            $table->unsignedBigInteger('artifact_slot_id')->nullable();
+            $table->string('event_type', 64);
+            $table->string('from_state', 64)->nullable();
+            $table->string('to_state', 64)->nullable();
+            $table->string('reason_code', 128)->nullable();
+            $table->json('payload_json')->nullable();
+            $table->timestamp('occurred_at')->nullable();
+            $table->timestamps();
+
+            $table->index('job_id', 'artifact_lifecycle_events_job_id_idx');
+            $table->index('attempt_id', 'artifact_lifecycle_events_attempt_id_idx');
+            $table->index('artifact_slot_id', 'artifact_lifecycle_events_artifact_slot_id_idx');
+            $table->index('event_type', 'artifact_lifecycle_events_event_type_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_22_090300_create_report_artifact_slots_table.php
+++ b/backend/database/migrations/2026_03_22_090300_create_report_artifact_slots_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('report_artifact_slots')) {
+            return;
+        }
+
+        Schema::create('report_artifact_slots', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('attempt_id', 64);
+            $table->string('slot_code', 64);
+            $table->boolean('required_by_product')->default(false);
+            $table->unsignedBigInteger('current_version_id')->nullable();
+            $table->string('render_state', 64)->default('pending');
+            $table->string('delivery_state', 64)->default('unavailable');
+            $table->string('access_state', 64)->default('locked');
+            $table->string('integrity_state', 64)->default('unknown');
+            $table->string('last_error_code', 128)->nullable();
+            $table->timestamp('last_materialized_at')->nullable();
+            $table->timestamp('last_verified_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['attempt_id', 'slot_code'], 'report_artifact_slots_attempt_slot_unique');
+            $table->index('attempt_id', 'report_artifact_slots_attempt_id_idx');
+            $table->index('current_version_id', 'report_artifact_slots_current_version_id_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_22_090400_create_report_artifact_versions_table.php
+++ b/backend/database/migrations/2026_03_22_090400_create_report_artifact_versions_table.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('report_artifact_versions')) {
+            return;
+        }
+
+        Schema::create('report_artifact_versions', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('artifact_slot_id');
+            $table->unsignedInteger('version_no');
+            $table->string('source_type', 64);
+            $table->string('report_snapshot_id', 64)->nullable();
+            $table->char('storage_blob_id', 64)->nullable();
+            $table->unsignedBigInteger('created_from_receipt_id')->nullable();
+            $table->unsignedBigInteger('supersedes_version_id')->nullable();
+            $table->string('manifest_hash', 128)->nullable();
+            $table->string('dir_version', 128)->nullable();
+            $table->string('scoring_spec_version', 64)->nullable();
+            $table->string('report_engine_version', 64)->nullable();
+            $table->string('content_hash', 128)->nullable();
+            $table->unsignedBigInteger('byte_size')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+
+            $table->unique(['artifact_slot_id', 'version_no'], 'report_artifact_versions_slot_version_unique');
+            $table->index('artifact_slot_id', 'report_artifact_versions_artifact_slot_id_idx');
+            $table->index('source_type', 'report_artifact_versions_source_type_idx');
+            $table->index('report_snapshot_id', 'report_artifact_versions_report_snapshot_id_idx');
+            $table->index('storage_blob_id', 'report_artifact_versions_storage_blob_id_idx');
+            $table->index('created_from_receipt_id', 'report_artifact_versions_created_from_receipt_id_idx');
+            $table->index('supersedes_version_id', 'report_artifact_versions_supersedes_version_id_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_22_090500_create_unified_access_projections_table.php
+++ b/backend/database/migrations/2026_03_22_090500_create_unified_access_projections_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('unified_access_projections')) {
+            return;
+        }
+
+        Schema::create('unified_access_projections', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('attempt_id', 64);
+            $table->string('access_state', 64);
+            $table->string('report_state', 64);
+            $table->string('pdf_state', 64);
+            $table->string('reason_code', 128)->nullable();
+            $table->unsignedInteger('projection_version')->default(1);
+            $table->json('actions_json')->nullable();
+            $table->json('payload_json')->nullable();
+            $table->timestamp('produced_at')->nullable();
+            $table->timestamp('refreshed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['attempt_id'], 'unified_access_projections_attempt_id_unique');
+            $table->index('attempt_id', 'unified_access_projections_attempt_id_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_22_090600_create_report_artifact_postures_table.php
+++ b/backend/database/migrations/2026_03_22_090600_create_report_artifact_postures_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('report_artifact_postures')) {
+            return;
+        }
+
+        Schema::create('report_artifact_postures', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('attempt_id', 64);
+            $table->string('slot_code', 64);
+            $table->unsignedBigInteger('current_version_id')->nullable();
+            $table->unsignedBigInteger('active_job_id')->nullable();
+            $table->string('render_state', 64)->default('pending');
+            $table->string('delivery_state', 64)->default('unavailable');
+            $table->string('access_state', 64)->default('locked');
+            $table->string('integrity_state', 64)->default('unknown');
+            $table->string('attention_state', 64)->default('normal');
+            $table->string('blocked_reason_code', 128)->nullable();
+            $table->json('payload_json')->nullable();
+            $table->timestamp('projection_fresh_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['attempt_id', 'slot_code'], 'report_artifact_postures_attempt_slot_unique');
+            $table->index('attempt_id', 'report_artifact_postures_attempt_id_idx');
+            $table->index('current_version_id', 'report_artifact_postures_current_version_id_idx');
+            $table->index('active_job_id', 'report_artifact_postures_active_job_id_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_22_090700_create_artifact_reconcile_cases_table.php
+++ b/backend/database/migrations/2026_03_22_090700_create_artifact_reconcile_cases_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('artifact_reconcile_cases')) {
+            return;
+        }
+
+        Schema::create('artifact_reconcile_cases', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('attempt_id', 64)->nullable();
+            $table->string('slot_code', 64)->nullable();
+            $table->string('case_type', 64);
+            $table->string('status', 64)->default('open');
+            $table->string('suspected_cause', 128)->nullable();
+            $table->unsignedBigInteger('opened_by')->nullable();
+            $table->unsignedBigInteger('assigned_to')->nullable();
+            $table->string('resolution_code', 128)->nullable();
+            $table->text('resolution_notes')->nullable();
+            $table->json('payload_json')->nullable();
+            $table->timestamp('opened_at')->nullable();
+            $table->timestamp('resolved_at')->nullable();
+            $table->timestamps();
+
+            $table->index('attempt_id', 'artifact_reconcile_cases_attempt_id_idx');
+            $table->index('case_type', 'artifact_reconcile_cases_case_type_idx');
+            $table->index('status', 'artifact_reconcile_cases_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Storage/ArtifactSchemaFoundationMigrationTest.php
+++ b/backend/tests/Feature/Storage/ArtifactSchemaFoundationMigrationTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class ArtifactSchemaFoundationMigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('tableProvider')]
+    public function test_new_schema_tables_expose_expected_columns_and_indexes(
+        string $table,
+        array $columns,
+        array $indexes
+    ): void {
+        $this->assertTrue(Schema::hasTable($table), sprintf('Table %s should exist', $table));
+
+        foreach ($columns as $column) {
+            $this->assertTrue(
+                Schema::hasColumn($table, $column),
+                sprintf('Table %s should have column %s', $table, $column)
+            );
+        }
+
+        foreach ($indexes as $index) {
+            $this->assertTrue(
+                SchemaIndex::indexExists($table, $index),
+                sprintf('Table %s should have index %s', $table, $index)
+            );
+        }
+    }
+
+    public static function tableProvider(): array
+    {
+        return [
+            'attempt_receipts' => [
+                'attempt_receipts',
+                [
+                    'id',
+                    'attempt_id',
+                    'seq',
+                    'receipt_type',
+                    'source_system',
+                    'source_ref',
+                    'actor_type',
+                    'actor_id',
+                    'idempotency_key',
+                    'payload_json',
+                    'occurred_at',
+                    'recorded_at',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'attempt_receipts_attempt_seq_unique',
+                    'attempt_receipts_receipt_type_idx',
+                    'attempt_receipts_idempotency_key_idx',
+                ],
+            ],
+            'artifact_lifecycle_jobs' => [
+                'artifact_lifecycle_jobs',
+                [
+                    'id',
+                    'attempt_id',
+                    'artifact_slot_id',
+                    'job_type',
+                    'state',
+                    'reason_code',
+                    'blocked_reason_code',
+                    'idempotency_key',
+                    'request_payload_json',
+                    'result_payload_json',
+                    'attempt_count',
+                    'started_at',
+                    'finished_at',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'artifact_lifecycle_jobs_attempt_id_idx',
+                    'artifact_lifecycle_jobs_artifact_slot_id_idx',
+                    'artifact_lifecycle_jobs_job_type_idx',
+                    'artifact_lifecycle_jobs_state_idx',
+                    'artifact_lifecycle_jobs_idempotency_key_idx',
+                ],
+            ],
+            'artifact_lifecycle_events' => [
+                'artifact_lifecycle_events',
+                [
+                    'id',
+                    'job_id',
+                    'attempt_id',
+                    'artifact_slot_id',
+                    'event_type',
+                    'from_state',
+                    'to_state',
+                    'reason_code',
+                    'payload_json',
+                    'occurred_at',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'artifact_lifecycle_events_job_id_idx',
+                    'artifact_lifecycle_events_attempt_id_idx',
+                    'artifact_lifecycle_events_artifact_slot_id_idx',
+                    'artifact_lifecycle_events_event_type_idx',
+                ],
+            ],
+            'report_artifact_slots' => [
+                'report_artifact_slots',
+                [
+                    'id',
+                    'attempt_id',
+                    'slot_code',
+                    'required_by_product',
+                    'current_version_id',
+                    'render_state',
+                    'delivery_state',
+                    'access_state',
+                    'integrity_state',
+                    'last_error_code',
+                    'last_materialized_at',
+                    'last_verified_at',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'report_artifact_slots_attempt_slot_unique',
+                    'report_artifact_slots_attempt_id_idx',
+                    'report_artifact_slots_current_version_id_idx',
+                ],
+            ],
+            'report_artifact_versions' => [
+                'report_artifact_versions',
+                [
+                    'id',
+                    'artifact_slot_id',
+                    'version_no',
+                    'source_type',
+                    'report_snapshot_id',
+                    'storage_blob_id',
+                    'created_from_receipt_id',
+                    'supersedes_version_id',
+                    'manifest_hash',
+                    'dir_version',
+                    'scoring_spec_version',
+                    'report_engine_version',
+                    'content_hash',
+                    'byte_size',
+                    'metadata_json',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'report_artifact_versions_slot_version_unique',
+                    'report_artifact_versions_artifact_slot_id_idx',
+                    'report_artifact_versions_source_type_idx',
+                    'report_artifact_versions_report_snapshot_id_idx',
+                    'report_artifact_versions_storage_blob_id_idx',
+                    'report_artifact_versions_created_from_receipt_id_idx',
+                    'report_artifact_versions_supersedes_version_id_idx',
+                ],
+            ],
+            'unified_access_projections' => [
+                'unified_access_projections',
+                [
+                    'id',
+                    'attempt_id',
+                    'access_state',
+                    'report_state',
+                    'pdf_state',
+                    'reason_code',
+                    'projection_version',
+                    'actions_json',
+                    'payload_json',
+                    'produced_at',
+                    'refreshed_at',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'unified_access_projections_attempt_id_unique',
+                    'unified_access_projections_attempt_id_idx',
+                ],
+            ],
+            'report_artifact_postures' => [
+                'report_artifact_postures',
+                [
+                    'id',
+                    'attempt_id',
+                    'slot_code',
+                    'current_version_id',
+                    'active_job_id',
+                    'render_state',
+                    'delivery_state',
+                    'access_state',
+                    'integrity_state',
+                    'attention_state',
+                    'blocked_reason_code',
+                    'payload_json',
+                    'projection_fresh_at',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'report_artifact_postures_attempt_slot_unique',
+                    'report_artifact_postures_attempt_id_idx',
+                    'report_artifact_postures_current_version_id_idx',
+                    'report_artifact_postures_active_job_id_idx',
+                ],
+            ],
+            'artifact_reconcile_cases' => [
+                'artifact_reconcile_cases',
+                [
+                    'id',
+                    'attempt_id',
+                    'slot_code',
+                    'case_type',
+                    'status',
+                    'suspected_cause',
+                    'opened_by',
+                    'assigned_to',
+                    'resolution_code',
+                    'resolution_notes',
+                    'payload_json',
+                    'opened_at',
+                    'resolved_at',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'artifact_reconcile_cases_attempt_id_idx',
+                    'artifact_reconcile_cases_case_type_idx',
+                    'artifact_reconcile_cases_status_idx',
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds the schema foundation for the artifact control-plane path without changing runtime behavior.

It introduces eight new tables: `attempt_receipts`, `artifact_lifecycle_jobs`, `artifact_lifecycle_events`, `report_artifact_slots`, `report_artifact_versions`, `unified_access_projections`, `report_artifact_postures`, and `artifact_reconcile_cases`. The schemas are intentionally conservative: nullable where later phases will backfill, string-based state columns, explicit indexes for the expected lookup paths, and no production FKs that would risk type conflicts with existing legacy tables.

The PR also adds minimal Eloquent models for each table so later phases can wire dual-write and projection logic against stable names and casts. No controller, service, job, command, route, frontend, or report generation code was changed.

A focused schema regression test now verifies that the new tables and key columns/indexes exist after migration. Validation performed:
- `php -l` on all new migrations, models, and the new test
- `php artisan test --filter=ArtifactSchemaFoundationMigrationTest`
- `php artisan migrate --env=testing --force`

This is strictly a schema foundation PR. Dual-write, backfill, read cutover, frontend cutover, retention, legal-hold, and purge work are intentionally left for later phases.
