### PR TITLE
[codex] Ship CE-2 MBTI explainability and stability content expansion

### DIFF
--- a/backend/app/Services/Mbti/MbtiAdaptiveSelectionService.php
+++ b/backend/app/Services/Mbti/MbtiAdaptiveSelectionService.php
@@ -670,7 +670,7 @@ final class MbtiAdaptiveSelectionService
                 default => ['work_experiment', 'identity', 'axis_strength'],
             },
             'traits.why_this_type' => match ($selectionMode) {
-                'adaptive_clarify_boundary' => ['why_this_type', 'boundary', 'axis_strength'],
+                'adaptive_clarify_boundary' => ['why_this_type', 'misunderstanding_fix', 'boundary', 'axis_strength'],
                 default => ['why_this_type', 'identity', 'axis_strength'],
             },
             default => [],

--- a/backend/app/Services/Mbti/MbtiIntraTypeProfileService.php
+++ b/backend/app/Services/Mbti/MbtiIntraTypeProfileService.php
@@ -740,12 +740,12 @@ final class MbtiIntraTypeProfileService
     {
         return match ($sectionKey) {
             'traits.why_this_type' => match ($selectionMode) {
-                'explain_boundary' => ['why_this_type', 'boundary', 'axis_strength', 'identity'],
+                'explain_boundary' => ['why_this_type', 'misunderstanding_fix', 'boundary', 'axis_strength', 'identity'],
                 default => ['why_this_type', 'identity', 'axis_strength'],
             },
             'growth.stability_confidence' => match ($selectionMode) {
-                'boundary_buffered' => ['stability_explanation', 'boundary'],
-                default => ['stability_explanation'],
+                'boundary_buffered' => ['stability_explanation', 'stability_reframe', 'stress_recovery', 'boundary'],
+                default => ['stability_explanation', 'stability_reframe'],
             },
             'growth.next_actions' => match ($selectionMode) {
                 'action_career_bridge' => ['next_action', 'axis_strength', 'boundary'],
@@ -783,7 +783,7 @@ final class MbtiIntraTypeProfileService
     private function maxBlocksForSection(string $sectionKey, string $selectionMode): int
     {
         return match ($sectionKey) {
-            'growth.stability_confidence' => $selectionMode === 'stability_core' ? 1 : 2,
+            'growth.stability_confidence' => $selectionMode === 'stability_core' ? 2 : 3,
             'traits.adjacent_type_contrast' => $selectionMode === 'contrast_neighbor' ? 2 : 3,
             default => 3,
         };

--- a/backend/app/Services/Mbti/MbtiLongitudinalMemoryService.php
+++ b/backend/app/Services/Mbti/MbtiLongitudinalMemoryService.php
@@ -713,8 +713,8 @@ final class MbtiLongitudinalMemoryService
     private function preferredKindsForMode(string $sectionKey, string $selectionMode): array
     {
         return match ($sectionKey) {
-            'traits.why_this_type' => ['why_this_type', 'boundary', 'identity'],
-            'growth.stability_confidence' => ['stability_explanation', 'boundary'],
+            'traits.why_this_type' => ['why_this_type', 'misunderstanding_fix', 'boundary', 'identity'],
+            'growth.stability_confidence' => ['stability_explanation', 'stability_reframe', 'stress_recovery', 'boundary'],
             'growth.next_actions' => $selectionMode === 'memory.action_refine'
                 ? ['next_action', 'boundary', 'identity']
                 : ['next_action', 'identity', 'axis_strength'],
@@ -729,7 +729,7 @@ final class MbtiLongitudinalMemoryService
     private function maxBlocksForSection(string $sectionKey, string $selectionMode): int
     {
         return match ($sectionKey) {
-            'growth.stability_confidence' => 2,
+            'growth.stability_confidence' => 3,
             'traits.why_this_type' => $selectionMode === 'memory.explainability_resume' ? 3 : 2,
             default => 3,
         };

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -189,9 +189,11 @@ final class MbtiResultPersonalizationService
         'stress_recovery' => '压力恢复场景',
         'communication' => '沟通协作场景',
         'why_this_type' => '为什么是这个类型',
+        'misunderstanding_fix' => '误读修正',
         'borderline_axis' => '边界轴解释',
         'adjacent_type_contrast' => '相邻类型对照',
         'stability_explanation' => '稳定性解释',
+        'stability_reframe' => '稳定性重释',
     ];
 
     /**
@@ -217,9 +219,11 @@ final class MbtiResultPersonalizationService
         'stress_recovery' => 'Stress recovery scene',
         'communication' => 'Communication scene',
         'why_this_type' => 'Why-this-type explanation',
+        'misunderstanding_fix' => 'Misread correction',
         'borderline_axis' => 'Borderline-axis explanation',
         'adjacent_type_contrast' => 'Adjacent-type contrast',
         'stability_explanation' => 'Stability explanation',
+        'stability_reframe' => 'Stability reframe',
     ];
 
     /**
@@ -542,6 +546,42 @@ final class MbtiResultPersonalizationService
         'context_sensitive' => 'Your result is not vague; it is context-sensitive because several axes sit close to the middle at once. {{dominant_axis_label}} and {{dominant_side_label}} still decide the main type, but {{close_axis_label}} strongly affects which nearby type you can resemble in different situations.',
     ];
 
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private const DEFAULT_MISUNDERSTANDING_FIX_TEMPLATES = [
+        'why_this_type' => [
+            'boundary' => '别人之所以会误读你，往往不是因为主类型不成立，而是{{close_axis_label}}和{{identity_clause}}让你在外显风格上保留了更多弹性。你看起来不像刻板印象里的{{dominant_side_label}}，但主判断还是会回到{{dominant_side_label}}。',
+            'clear' => '你会被误读成别的样子，常常是因为{{close_axis_label}}仍会在不同情境里借用另一侧节奏；但主类型成立的真正原因，是{{dominant_axis_label}}上的{{dominant_side_label}}已经形成稳定拉力。{{identity_clause}}',
+            'strong' => '你会被误读成别的样子，通常是因为{{dominant_axis_label}}上的{{dominant_side_label}}已经很强，但{{close_axis_label}}仍会让外显节奏带着一点另一侧的影子。主类型成立，不代表表达方式只有一种。{{identity_clause}}',
+            'very_strong' => '你会被误读成别的样子，更多是因为{{dominant_axis_label}}上的{{dominant_side_label}}太强，以至于别人会把你的局部切换当成整体变化。{{close_axis_label}}解释的是外显波动，不是主类型失效。{{identity_clause}}',
+        ],
+        'adjacent_type_contrast' => [
+            'boundary' => '最容易把你看成{{neighbor_type}}，是因为{{axis_label}}离中线太近，外显风格会借用{{opposite_side_label}}的节奏；但真正的差异在于你最终仍会回到{{side_label}}做主判断。{{identity_clause}}',
+            'clear' => '最容易把你看成{{neighbor_type}}，通常不是因为结果错了，而是{{axis_label}}上的{{side_label}}还没有把外显节奏完全锁死，所以你看起来会借一点{{opposite_side_label}}的影子。真正拉开差异的是最后你仍然会回到{{side_label}}来收尾。{{identity_clause}}',
+            'strong' => '如果只看最接近边界的外显部分，别人最容易把你看成{{neighbor_type}}。原因不是你“测错了”，而是{{axis_label}}上的{{side_label}}会在表达上短暂借用{{opposite_side_label}}的节奏。真正区分你们的，不是表面像不像，而是你最终仍会回到{{side_label}}来做主判断和收尾。{{identity_clause}}',
+            'very_strong' => '你最容易被看成{{neighbor_type}}的时刻，往往来自{{axis_label}}上的{{side_label}}已经很强，却仍保留了足够的近边界弹性，让外显风格偶尔像{{opposite_side_label}}。但真正决定你是谁的，仍然是最后回到{{side_label}}的那一步。{{identity_clause}}',
+        ],
+    ];
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private const DEFAULT_MISUNDERSTANDING_FIX_TEMPLATES_EN = [
+        'why_this_type' => [
+            'boundary' => 'People misread you not because the core type is invalid, but because {{close_axis_label}} and {{identity_clause}} keep more elasticity in your surface style. You do not look like a stereotype of {{dominant_side_label}}, but your final judgment still returns there.',
+            'clear' => 'You can be misread because {{close_axis_label}} still borrows the rhythm of the opposite side across contexts; the real reason the core type stands is that {{dominant_axis_label}} and {{dominant_side_label}} already create a stable pull. {{identity_clause}}',
+            'strong' => 'You can be misread because {{dominant_axis_label}} and {{dominant_side_label}} are already strong, while {{close_axis_label}} still lets your surface rhythm borrow some of the opposite side. The core type still stands, but expression does not collapse into one shape.',
+            'very_strong' => 'You can be misread because {{dominant_axis_label}} and {{dominant_side_label}} are so strong that people treat local switching as a full type change. {{close_axis_label}} explains surface fluctuation, not a failed core type. {{identity_clause}}',
+        ],
+        'adjacent_type_contrast' => [
+            'boundary' => 'The easiest mistake is to read you as {{neighbor_type}}, because {{axis_label}} sits close enough to the middle that your surface style borrows the rhythm of {{opposite_side_label}}; the real difference is that you still return to {{side_label}} for final judgment. {{identity_clause}}',
+            'clear' => 'The easiest mistake is to read you as {{neighbor_type}}, usually not because the result is wrong but because the {{side_label}} on {{axis_label}} has not fully locked your surface rhythm, so you can look like you are borrowing a bit of {{opposite_side_label}}. The real split is that you still return to {{side_label}} to close the loop. {{identity_clause}}',
+            'strong' => 'If someone only looks at your closest-boundary surface, they are most likely to read you as {{neighbor_type}}. That is not because the result is wrong; it is because the {{side_label}} on {{axis_label}} may borrow the rhythm of {{opposite_side_label}} in expression. The real difference is that you still return to {{side_label}} for judgment and closure. {{identity_clause}}',
+            'very_strong' => 'The moments when you are most likely to be read as {{neighbor_type}} come from a strong {{side_label}} on {{axis_label}} that still keeps enough near-boundary elasticity to look a bit like {{opposite_side_label}}. What still decides who you are, though, is the final return to {{side_label}}. {{identity_clause}}',
+        ],
+    ];
+
     private const DEFAULT_CLOSE_CALL_AXIS_TEMPLATE = '在{{axis_label}}上，你最后仍偏向{{side_label}}，但和另一侧只拉开了{{delta}}个点差。也就是说，这条轴更像“近身拉扯”而不是绝对定型：熟悉情境下你常会先用{{side_label}}，而高压、误解或角色变化时，{{opposite_side_label}}会很快进场补位。';
 
     private const DEFAULT_CLOSE_CALL_AXIS_TEMPLATE_EN = 'On {{axis_label}}, you still end up leaning toward {{side_label}}, but the margin is only {{delta}} points. This axis behaves more like a live tension than a fixed identity: in familiar situations you may start with {{side_label}}, while pressure, misunderstanding, or role shifts can quickly pull in {{opposite_side_label}} as a correction.';
@@ -566,6 +606,42 @@ final class MbtiResultPersonalizationService
         'stable' => 'This result is comparatively stable overall. The core type should not rewrite itself under ordinary context shifts; the real thing to watch is when {{close_axis_label}} needs deliberate room for the opposite side.',
         'mixed' => 'This result is best read as a clear type with local context shifts. You are not unstable; a few axes simply change entry points across task, relationship, and pressure conditions.',
         'context_sensitive' => 'This result is best read as context-sensitive stability rather than simple stability or simple wavering. The main type still holds, but several near-boundary axes make your switching pattern more visible across situations.',
+    ];
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private const DEFAULT_STABILITY_REFRAME_TEMPLATES = [
+        'stable' => [
+            'zh-CN' => '稳定性不是“一直一样”，而是你在{{close_axis_label}}附近仍能保持主类型的回弹能力。{{identity_clause}}',
+            'en' => 'Stability is not “staying the same”; it is the ability to bounce back to the core type even around {{close_axis_label}}. {{identity_clause}}',
+        ],
+        'mixed' => [
+            'zh-CN' => '你的稳定更像“可校准”：主类型会保留，但压力一上来，你会在{{close_axis_label}}和{{identity_clause}}之间重新分配注意力与恢复资源。',
+            'en' => 'Your stability is more like something you can recalibrate: the core type remains, but under pressure you redistribute attention and recovery resources between {{close_axis_label}} and {{identity_clause}}.',
+        ],
+        'context_sensitive' => [
+            'zh-CN' => '你是情境敏感型稳定：不是不稳，而是面对不同压力源时会切换不同的恢复入口。最重要的是把这种切换看成可复用的恢复机制，而不是自我怀疑。{{identity_clause}}',
+            'en' => 'You are context-sensitive in a stable way: not unstable, but switching recovery entry points as different pressure sources appear. The key is to treat that switching as a reusable recovery mechanism, not as self-doubt. {{identity_clause}}',
+        ],
+    ];
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private const DEFAULT_STABILITY_REFRAME_TEMPLATES_EN = [
+        'stable' => [
+            'zh-CN' => '稳定性不是“一直一样”，而是你在{{close_axis_label}}附近仍能保持主类型的回弹能力。{{identity_clause}}',
+            'en' => 'Stability is not “staying the same”; it is the ability to bounce back to the core type even around {{close_axis_label}}. {{identity_clause}}',
+        ],
+        'mixed' => [
+            'zh-CN' => '你的稳定更像“可校准”：主类型会保留，但压力一上来，你会在{{close_axis_label}}和{{identity_clause}}之间重新分配注意力与恢复资源。',
+            'en' => 'Your stability is more like something you can recalibrate: the core type remains, but under pressure you redistribute attention and recovery resources between {{close_axis_label}} and {{identity_clause}}.',
+        ],
+        'context_sensitive' => [
+            'zh-CN' => '你是情境敏感型稳定：不是不稳，而是面对不同压力源时会切换不同的恢复入口。最重要的是把这种切换看成可复用的恢复机制，而不是自我怀疑。{{identity_clause}}',
+            'en' => 'You are context-sensitive in a stable way: not unstable, but switching recovery entry points as different pressure sources appear. The key is to treat that switching as a reusable recovery mechanism, not as self-doubt. {{identity_clause}}',
+        ],
     ];
 
     public function __construct(
@@ -1492,6 +1568,29 @@ final class MbtiResultPersonalizationService
                 ];
             }
 
+            $misunderstandingFixText = $this->resolveMisunderstandingFixText(
+                $doc,
+                $locale,
+                $sectionKey,
+                (string) ($primaryAxis['band'] ?? 'clear'),
+                $primaryAxis,
+                $supportAxis,
+                $identity,
+                $closeCallAxes,
+                $neighborTypeKeys
+            );
+            if ($misunderstandingFixText !== '') {
+                $blockId = sprintf('%s.misunderstanding_fix.%s', $sectionKey, strtolower((string) ($primaryAxis['axis'] ?? 'axis')));
+                $selectedBlocks[] = $blockId;
+                $blocks[] = [
+                    'id' => $blockId,
+                    'kind' => 'misunderstanding_fix',
+                    'label' => $this->blockLabel('misunderstanding_fix', $doc, $locale),
+                    'text' => $misunderstandingFixText,
+                    'contrast_key' => $contrastKey,
+                ];
+            }
+
             if ($identityText !== '') {
                 $blockId = sprintf('%s.identity.%s', $sectionKey, strtolower($identity));
                 $selectedBlocks[] = $blockId;
@@ -1579,6 +1678,29 @@ final class MbtiResultPersonalizationService
                 ];
             }
 
+            $misunderstandingFixText = $this->resolveMisunderstandingFixText(
+                $doc,
+                $locale,
+                $sectionKey,
+                (string) ($primaryAxis['band'] ?? 'clear'),
+                $primaryAxis,
+                $supportAxis,
+                $identity,
+                $closeCallAxes,
+                $neighborTypeKeys
+            );
+            if ($misunderstandingFixText !== '') {
+                $blockId = sprintf('%s.misunderstanding_fix.%s', $sectionKey, strtolower((string) ($neighborTypeKeys[0] ?? ($primaryAxis['axis'] ?? 'axis'))));
+                $selectedBlocks[] = $blockId;
+                $blocks[] = [
+                    'id' => $blockId,
+                    'kind' => 'misunderstanding_fix',
+                    'label' => $this->blockLabel('misunderstanding_fix', $doc, $locale),
+                    'text' => $misunderstandingFixText,
+                    'contrast_key' => $contrastKey,
+                ];
+            }
+
             if ($identityText !== '') {
                 $blockId = sprintf('%s.identity.%s', $sectionKey, strtolower($identity));
                 $selectedBlocks[] = $blockId;
@@ -1613,6 +1735,37 @@ final class MbtiResultPersonalizationService
                     'label' => $this->blockLabel('stability_explanation', $doc, $locale),
                     'text' => $stabilityText,
                     'contrast_key' => $contrastKey,
+                ];
+            }
+
+            $stabilityReframeText = $this->resolveStabilityReframeText(
+                $doc,
+                $locale,
+                $stabilityBucket,
+                $primaryCloseAxis ?? $primaryAxis,
+                $identity
+            );
+            if ($stabilityReframeText !== '') {
+                $blockId = sprintf('%s.stability_reframe.%s', $sectionKey, $stabilityBucket);
+                $selectedBlocks[] = $blockId;
+                $blocks[] = [
+                    'id' => $blockId,
+                    'kind' => 'stability_reframe',
+                    'label' => $this->blockLabel('stability_reframe', $doc, $locale),
+                    'text' => $stabilityReframeText,
+                    'contrast_key' => $contrastKey,
+                ];
+            }
+
+            $stressRecoveryText = $this->resolveSceneText($doc, 'stress_recovery', $locale, $primaryCloseAxis ?? $primaryAxis);
+            if ($stressRecoveryText !== '') {
+                $blockId = sprintf('%s.stress_recovery.%s', $sectionKey, $primaryCloseAxis['axis'] ?? $primaryAxis['axis'] ?? 'axis');
+                $selectedBlocks[] = $blockId;
+                $blocks[] = [
+                    'id' => $blockId,
+                    'kind' => 'stress_recovery',
+                    'label' => $this->blockLabel('stress_recovery', $doc, $locale),
+                    'text' => $stressRecoveryText,
                 ];
             }
 
@@ -2127,6 +2280,47 @@ final class MbtiResultPersonalizationService
         ]);
     }
 
+    /**
+     * @param  list<string>  $neighborTypeKeys
+     * @param  list<array<string, mixed>>  $closeCallAxes
+     */
+    private function resolveMisunderstandingFixText(
+        array $doc,
+        string $locale,
+        string $sectionKey,
+        string $band,
+        array $primaryAxis,
+        ?array $supportAxis,
+        string $identity,
+        array $closeCallAxes,
+        array $neighborTypeKeys
+    ): string {
+        $templateKey = $sectionKey === 'traits.adjacent_type_contrast'
+            ? 'adjacent_type_contrast'
+            : 'why_this_type';
+
+        $template = $this->resolveTemplate(
+            data_get($doc, 'misunderstanding_fix_templates.'.$templateKey.'.'.trim($band)),
+            $locale,
+            $locale === 'zh-CN'
+                ? (self::DEFAULT_MISUNDERSTANDING_FIX_TEMPLATES[$templateKey][$band] ?? self::DEFAULT_MISUNDERSTANDING_FIX_TEMPLATES[$templateKey]['clear'])
+                : (self::DEFAULT_MISUNDERSTANDING_FIX_TEMPLATES_EN[$templateKey][$band] ?? self::DEFAULT_MISUNDERSTANDING_FIX_TEMPLATES_EN[$templateKey]['clear'])
+        );
+
+        $closeAxis = is_array($closeCallAxes[0] ?? null) ? $closeCallAxes[0] : $supportAxis;
+
+        return $this->renderTemplate($template, [
+            'dominant_axis_label' => trim((string) ($primaryAxis['axis_label'] ?? '')),
+            'dominant_side_label' => trim((string) ($primaryAxis['side_label'] ?? '')),
+            'axis_label' => trim((string) ($closeAxis['axis_label'] ?? ($primaryAxis['axis_label'] ?? ''))),
+            'side_label' => trim((string) ($closeAxis['side_label'] ?? ($primaryAxis['side_label'] ?? ''))),
+            'opposite_side_label' => trim((string) ($closeAxis['opposite_side_label'] ?? ($primaryAxis['opposite_side_label'] ?? ''))),
+            'close_axis_label' => trim((string) ($closeAxis['axis_label'] ?? ($locale === 'zh-CN' ? '最接近边界的那条轴' : 'the closest-call axis'))),
+            'neighbor_type' => trim((string) ($neighborTypeKeys[0] ?? ($locale === 'zh-CN' ? '相邻类型' : 'a nearby type'))),
+            'identity_clause' => $this->shortIdentityClause($identity, $locale),
+        ]);
+    }
+
     private function resolveStabilityExplanationText(
         array $doc,
         string $locale,
@@ -2140,6 +2334,27 @@ final class MbtiResultPersonalizationService
             $locale === 'zh-CN'
                 ? (self::DEFAULT_STABILITY_EXPLANATION_TEMPLATES[$bucket] ?? self::DEFAULT_STABILITY_EXPLANATION_TEMPLATES['mixed'])
                 : (self::DEFAULT_STABILITY_EXPLANATION_TEMPLATES_EN[$bucket] ?? self::DEFAULT_STABILITY_EXPLANATION_TEMPLATES_EN['mixed'])
+        );
+
+        return $this->renderTemplate($template, [
+            'close_axis_label' => trim((string) ($closeAxis['axis_label'] ?? ($locale === 'zh-CN' ? '最接近边界的那条轴' : 'the closest-call axis'))),
+            'identity_clause' => $this->shortIdentityClause($identity, $locale),
+        ]);
+    }
+
+    private function resolveStabilityReframeText(
+        array $doc,
+        string $locale,
+        string $bucket,
+        ?array $closeAxis,
+        string $identity
+    ): string {
+        $template = $this->resolveTemplate(
+            data_get($doc, 'stability_reframe_templates.'.$bucket),
+            $locale,
+            $locale === 'zh-CN'
+                ? (self::DEFAULT_STABILITY_REFRAME_TEMPLATES[$bucket][$locale] ?? self::DEFAULT_STABILITY_REFRAME_TEMPLATES['mixed'][$locale])
+                : (self::DEFAULT_STABILITY_REFRAME_TEMPLATES_EN[$bucket][$locale] ?? self::DEFAULT_STABILITY_REFRAME_TEMPLATES_EN['mixed'][$locale])
         );
 
         return $this->renderTemplate($template, [

--- a/backend/tests/Feature/Content/MbtiContentInventoryContractTest.php
+++ b/backend/tests/Feature/Content/MbtiContentInventoryContractTest.php
@@ -58,6 +58,13 @@ final class MbtiContentInventoryContractTest extends TestCase
             static fn (array $family): string => trim((string) ($family['key'] ?? '')),
             $families
         )));
+        $familyIndex = [];
+        foreach ($families as $family) {
+            $familyKey = trim((string) ($family['key'] ?? ''));
+            if ($familyKey !== '') {
+                $familyIndex[$familyKey] = $family;
+            }
+        }
 
         $this->assertEqualsCanonicalizing([
             'explainability_fragment',
@@ -75,6 +82,8 @@ final class MbtiContentInventoryContractTest extends TestCase
             'revisit_fragment',
             'adaptive_response_fragment',
         ], $familyKeys);
+        $this->assertContains('misunderstanding_fix', data_get($familyIndex, 'explainability_fragment.block_kinds', []));
+        $this->assertContains('stability_reframe', data_get($familyIndex, 'explainability_fragment.block_kinds', []));
 
         $selectionTagSchema = is_array($inventory['selection_tag_schema'] ?? null) ? $inventory['selection_tag_schema'] : [];
         foreach ([
@@ -128,6 +137,7 @@ final class MbtiContentInventoryContractTest extends TestCase
 
         $this->assertSame('scene_fragment', $matrixIndex['overview']['primary_family'] ?? null);
         $this->assertSame('explainability_fragment', $matrixIndex['traits.why_this_type']['primary_family'] ?? null);
+        $this->assertContains('explainability_fragment', $matrixIndex['growth.stability_confidence']['secondary_families'] ?? []);
         $this->assertSame('action_fragment', $matrixIndex['growth.next_actions']['primary_family'] ?? null);
         $this->assertSame('cta_bundle_fragment', $matrixIndex['cta.surface']['primary_family'] ?? null);
     }

--- a/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php
@@ -350,6 +350,14 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
             'traits.why_this_type:EI.E.clear:identity.T:boundary.JP',
             $clear['variant_keys']['traits.why_this_type'] ?? null
         );
+        $this->assertEqualsCanonicalizing(
+            [
+                'traits.why_this_type.why_this_type.ei',
+                'traits.why_this_type.misunderstanding_fix.ei',
+                'traits.why_this_type.axis_strength.EI.E.clear',
+            ],
+            $clear['sections']['traits.why_this_type']['selected_blocks'] ?? null
+        );
         $this->assertSame(
             'traits.close_call_axes:JP.J.boundary:identity.T:boundary.JP',
             $clear['variant_keys']['traits.close_call_axes'] ?? null
@@ -358,9 +366,25 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
             'traits.adjacent_type_contrast:JP.J.boundary:identity.T:neighbor.ENFJ',
             $clear['variant_keys']['traits.adjacent_type_contrast'] ?? null
         );
+        $this->assertEqualsCanonicalizing(
+            [
+                'traits.adjacent_type_contrast.adjacent_type_contrast.jp',
+                'traits.adjacent_type_contrast.identity.t',
+                'traits.adjacent_type_contrast.misunderstanding_fix.enfj',
+            ],
+            $clear['sections']['traits.adjacent_type_contrast']['selected_blocks'] ?? null
+        );
         $this->assertSame(
             'growth.stability_confidence:stability.context_sensitive:identity.T:boundary.JP',
             $clear['variant_keys']['growth.stability_confidence'] ?? null
+        );
+        $this->assertSame(
+            [
+                'growth.stability_confidence.stability.context_sensitive',
+                'growth.stability_confidence.stability_reframe.context_sensitive',
+                'growth.stability_confidence.stress_recovery.JP',
+            ],
+            $clear['sections']['growth.stability_confidence']['selected_blocks'] ?? null
         );
         $this->assertSame(
             'traits.why_this_type:dominant.EI.E.clear',
@@ -471,6 +495,10 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
             $clear['sections']['traits.why_this_type']['blocks'][1]['kind'] ?? null
         );
         $this->assertSame(
+            'misunderstanding_fix',
+            $clear['sections']['traits.why_this_type']['blocks'][2]['kind'] ?? null
+        );
+        $this->assertSame(
             'borderline_axis',
             $clear['sections']['traits.close_call_axes']['blocks'][0]['kind'] ?? null
         );
@@ -481,6 +509,14 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
         $this->assertSame(
             'stability_explanation',
             $clear['sections']['growth.stability_confidence']['blocks'][0]['kind'] ?? null
+        );
+        $this->assertSame(
+            'stability_reframe',
+            $clear['sections']['growth.stability_confidence']['blocks'][1]['kind'] ?? null
+        );
+        $this->assertSame(
+            'stress_recovery',
+            $clear['sections']['growth.stability_confidence']['blocks'][2]['kind'] ?? null
         );
         $this->assertSame(
             'next_action',
@@ -503,6 +539,10 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
             (string) ($clear['sections']['traits.why_this_type']['blocks'][1]['text'] ?? '')
         );
         $this->assertStringContainsString(
+            '误读',
+            (string) ($clear['sections']['traits.why_this_type']['blocks'][2]['text'] ?? '')
+        );
+        $this->assertStringContainsString(
             '只拉开了7个点差',
             (string) ($clear['sections']['traits.close_call_axes']['blocks'][0]['text'] ?? '')
         );
@@ -511,8 +551,20 @@ final class MbtiResultPersonalizationServiceTest extends TestCase
             (string) ($clear['sections']['traits.adjacent_type_contrast']['blocks'][0]['text'] ?? '')
         );
         $this->assertStringContainsString(
+            '回到',
+            (string) ($clear['sections']['traits.adjacent_type_contrast']['blocks'][1]['text'] ?? '')
+        );
+        $this->assertStringContainsString(
             '情境敏感型稳定',
             (string) ($clear['sections']['growth.stability_confidence']['blocks'][0]['text'] ?? '')
+        );
+        $this->assertStringContainsString(
+            '恢复入口',
+            (string) ($clear['sections']['growth.stability_confidence']['blocks'][1]['text'] ?? '')
+        );
+        $this->assertStringContainsString(
+            '自救方式',
+            (string) ($clear['sections']['growth.stability_confidence']['blocks'][2]['text'] ?? '')
         );
         $this->assertStringContainsString(
             '压力升高时',

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.normalized.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.normalized.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.cards.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T12:22:44+00:00",
+    "generated_at": "2026-03-22T13:13:53+00:00",
     "sections": {
         "career": {
             "items": [

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.tag_index.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.tag_index.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.tag_index.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T12:22:44+00:00",
+    "generated_at": "2026-03-22T13:13:53+00:00",
     "sections": {
         "career": {
             "axis:AT:A": [

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/governance.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/governance.spec.json
@@ -2,7 +2,7 @@
     "schema": "fap.mbti.content_governance.compiled.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T12:22:44+00:00",
+    "generated_at": "2026-03-22T13:13:53+00:00",
     "required_layers": [
         "skeleton",
         "intensity",
@@ -37,8 +37,10 @@
                 "description": "Why-this-type, adjacent contrast, and stability explanation content.",
                 "block_kinds": [
                     "why_this_type",
+                    "misunderstanding_fix",
                     "adjacent_type_contrast",
-                    "stability_explanation"
+                    "stability_explanation",
+                    "stability_reframe"
                 ]
             },
             "intensity": {
@@ -82,11 +84,13 @@
             "communication": "scene",
             "decision": "scene",
             "identity": "skeleton",
+            "misunderstanding_fix": "explainability",
             "next_action": "action",
             "relationship_practice": "action",
             "role_fit": "scene",
             "scene": "scene",
             "stability_explanation": "explainability",
+            "stability_reframe": "explainability",
             "stress_recovery": "scene",
             "type_skeleton": "skeleton",
             "watchout": "action",

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/inventory.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/inventory.spec.json
@@ -2,7 +2,7 @@
     "schema": "fap.mbti.content_inventory.compiled.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T12:22:44+00:00",
+    "generated_at": "2026-03-22T13:13:53+00:00",
     "inventory_contract_version": 1,
     "inventory_fingerprint": "mbti_content_inventory_v1.cn-mainland.zh-CN.2026-03",
     "governance_profile": "mbti_content_inventory.v1",
@@ -24,8 +24,10 @@
             ],
             "block_kinds": [
                 "why_this_type",
+                "misunderstanding_fix",
                 "adjacent_type_contrast",
-                "stability_explanation"
+                "stability_explanation",
+                "stability_reframe"
             ],
             "selection_tags": [
                 "section_key",
@@ -618,6 +620,7 @@
             "section_key": "growth.stability_confidence",
             "primary_family": "stress_fragment",
             "secondary_families": [
+                "explainability_fragment",
                 "recovery_fragment",
                 "boundary_fragment",
                 "watchout_fragment"

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/manifest.json
@@ -2,8 +2,8 @@
     "schema": "fap.content.compiled.manifest.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "source_version": "v0.3",
-    "generated_at": "2026-03-22T12:22:44+00:00",
-    "checksum": "beaf385f206107737f15b00abd21385645bf84715e768624c8908c7fadf1387b",
+    "generated_at": "2026-03-22T13:13:53+00:00",
+    "checksum": "85f4dfc3ff665849cfc92f8b4b39888c79f3cd5c9a11d33bf9d98b437a1fa5d8",
     "files": [
         "cards.normalized.json",
         "cards.tag_index.json",

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/rules.normalized.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/rules.normalized.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.rules.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T12:22:44+00:00",
+    "generated_at": "2026-03-22T13:13:53+00:00",
     "rules": [
         {
             "id": "cards_drop_badge_01",

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/sections.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/sections.spec.json
@@ -2,7 +2,7 @@
     "schema": "fap.report.section_policies.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T12:22:44+00:00",
+    "generated_at": "2026-03-22T13:13:53+00:00",
     "items": {
         "traits": {
             "min_cards": 3,

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/variables.used.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/variables.used.json
@@ -2,6 +2,6 @@
     "schema": "fap.content.compiled.variables.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T12:22:44+00:00",
+    "generated_at": "2026-03-22T13:13:53+00:00",
     "variables": []
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/mbti_content_inventory.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/mbti_content_inventory.json
@@ -23,8 +23,10 @@
       ],
       "block_kinds": [
         "why_this_type",
+        "misunderstanding_fix",
         "adjacent_type_contrast",
-        "stability_explanation"
+        "stability_explanation",
+        "stability_reframe"
       ],
       "selection_tags": [
         "section_key",
@@ -617,6 +619,7 @@
       "section_key": "growth.stability_confidence",
       "primary_family": "stress_fragment",
       "secondary_families": [
+        "explainability_fragment",
         "recovery_fragment",
         "boundary_fragment",
         "watchout_fragment"

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_content_governance.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_content_governance.json
@@ -87,8 +87,10 @@
         "description": "Why-this-type, adjacent contrast, and stability explanation content.",
         "block_kinds": [
           "why_this_type",
+          "misunderstanding_fix",
           "adjacent_type_contrast",
-          "stability_explanation"
+          "stability_explanation",
+          "stability_reframe"
         ]
       },
       "action": {

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/report_dynamic_sections.json
@@ -22,9 +22,11 @@
       "stress_recovery": "压力恢复场景",
       "communication": "沟通协作场景",
       "why_this_type": "为什么是这个类型",
+      "misunderstanding_fix": "误读修正",
       "borderline_axis": "边界轴解释",
       "adjacent_type_contrast": "相邻类型对照",
-      "stability_explanation": "稳定性解释"
+      "stability_explanation": "稳定性解释",
+      "stability_reframe": "稳定性重释"
     },
         "band": {
             "boundary": "边界带",
@@ -155,6 +157,44 @@
         "strong": "主类型之所以成立，是因为{{dominant_axis_label}}上的{{dominant_side_label}}偏好已经足够鲜明，会自然拉高你的默认判断和表达节奏。真正让你显得不像标准模板的，是{{close_axis_label}}这种近边界轴。{{identity_clause}}",
         "very_strong": "主类型之所以成立，是因为{{dominant_axis_label}}上的{{dominant_side_label}}几乎已经成为默认底层模式。别人通常很快就能识别这一点，而{{close_axis_label}}只会在更具体的情境里改变你看起来像谁。{{identity_clause}}"
     },
+    "misunderstanding_fix_templates": {
+        "why_this_type": {
+            "boundary": {
+                "zh-CN": "别人之所以会误读你，往往不是因为主类型不成立，而是{{close_axis_label}}和{{identity_clause}}让你在外显风格上保留了更多弹性。你看起来不像刻板印象里的{{dominant_side_label}}，但主判断还是会回到{{dominant_side_label}}。",
+                "en": "People misread you not because the core type is invalid, but because {{close_axis_label}} and {{identity_clause}} keep more elasticity in your surface style. You do not look like a stereotype of {{dominant_side_label}}, but your final judgment still returns there."
+            },
+            "clear": {
+                "zh-CN": "你会被误读成别的样子，常常是因为{{close_axis_label}}仍会在不同情境里借用另一侧节奏；但主类型成立的真正原因，是{{dominant_axis_label}}上的{{dominant_side_label}}已经形成稳定拉力。{{identity_clause}}",
+                "en": "You can be misread because {{close_axis_label}} still borrows the rhythm of the opposite side across contexts; the real reason the core type stands is that {{dominant_axis_label}} and {{dominant_side_label}} already create a stable pull. {{identity_clause}}"
+            },
+            "strong": {
+                "zh-CN": "你会被误读成别的样子，通常是因为{{dominant_axis_label}}上的{{dominant_side_label}}已经很强，但{{close_axis_label}}仍会让外显节奏带着一点另一侧的影子。主类型成立，不代表表达方式只有一种。{{identity_clause}}",
+                "en": "You can be misread because {{dominant_axis_label}} and {{dominant_side_label}} are already strong, while {{close_axis_label}} still lets your surface rhythm borrow some of the opposite side. The core type still stands, but expression does not collapse into one shape."
+            },
+            "very_strong": {
+                "zh-CN": "你会被误读成别的样子，更多是因为{{dominant_axis_label}}上的{{dominant_side_label}}太强，以至于别人会把你的局部切换当成整体变化。{{close_axis_label}}解释的是外显波动，不是主类型失效。{{identity_clause}}",
+                "en": "You can be misread because {{dominant_axis_label}} and {{dominant_side_label}} are so strong that people treat local switching as a full type change. {{close_axis_label}} explains surface fluctuation, not a failed core type. {{identity_clause}}"
+            }
+        },
+        "adjacent_type_contrast": {
+            "boundary": {
+                "zh-CN": "最容易把你看成{{neighbor_type}}，是因为{{axis_label}}离中线太近，外显风格会借用{{opposite_side_label}}的节奏；但真正的差异在于你最终仍会回到{{side_label}}做主判断。{{identity_clause}}",
+                "en": "The easiest mistake is to read you as {{neighbor_type}}, because {{axis_label}} sits close enough to the middle that your surface style borrows the rhythm of {{opposite_side_label}}; the real difference is that you still return to {{side_label}} for final judgment. {{identity_clause}}"
+            },
+            "clear": {
+                "zh-CN": "最容易把你看成{{neighbor_type}}，通常不是因为结果错了，而是{{axis_label}}上的{{side_label}}还没有把外显节奏完全锁死，所以你看起来会借一点{{opposite_side_label}}的影子。真正拉开差异的是最后你仍然会回到{{side_label}}来收尾。{{identity_clause}}",
+                "en": "The easiest mistake is to read you as {{neighbor_type}}, usually not because the result is wrong but because the {{side_label}} on {{axis_label}} has not fully locked your surface rhythm, so you can look like you are borrowing a bit of {{opposite_side_label}}. The real split is that you still return to {{side_label}} to close the loop. {{identity_clause}}"
+            },
+            "strong": {
+                "zh-CN": "如果只看最接近边界的外显部分，别人最容易把你看成{{neighbor_type}}。原因不是你“测错了”，而是{{axis_label}}上的{{side_label}}会在表达上短暂借用{{opposite_side_label}}的节奏。真正区分你们的，不是表面像不像，而是你最终仍会回到{{side_label}}来做主判断和收尾。{{identity_clause}}",
+                "en": "If someone only looks at your closest-boundary surface, they are most likely to read you as {{neighbor_type}}. That is not because the result is wrong; it is because the {{side_label}} on {{axis_label}} may borrow the rhythm of {{opposite_side_label}} in expression. The real difference is that you still return to {{side_label}} for judgment and closure. {{identity_clause}}"
+            },
+            "very_strong": {
+                "zh-CN": "你最容易被看成{{neighbor_type}}的时刻，往往来自{{axis_label}}上的{{side_label}}已经很强，却仍保留了足够的近边界弹性，让外显风格偶尔像{{opposite_side_label}}。但真正决定你是谁的，仍然是最后回到{{side_label}}的那一步。{{identity_clause}}",
+                "en": "The moments when you are most likely to be read as {{neighbor_type}} come from a strong {{side_label}} on {{axis_label}} that still keeps enough near-boundary elasticity to look a bit like {{opposite_side_label}}. What still decides who you are, though, is the final return to {{side_label}}. {{identity_clause}}"
+            }
+        }
+    },
     "close_call_axis_templates": {
         "default": "在{{axis_label}}上，你最后仍偏向{{side_label}}，但和另一侧只拉开了{{delta}}个点差。也就是说，这条轴更像“近身拉扯”而不是绝对定型：熟悉情境下你常会先用{{side_label}}，而高压、误解或角色变化时，{{opposite_side_label}}会很快进场补位。"
     },
@@ -165,6 +205,20 @@
         "stable": "这一份结果整体比较稳定。主类型不会因为普通情境波动就频繁改写，真正需要留意的，是在{{close_axis_label}}上什么时候需要主动给另一侧留一点空间。",
         "mixed": "这一份结果整体属于“主类型明确，但局部会随场景切换”。你不是不稳定，而是有几条轴会根据任务、人际和压力负荷切换表达入口。{{identity_clause}}",
         "context_sensitive": "这一份结果最需要读成“情境敏感型稳定”，而不是简单稳定或简单摇摆。主类型仍然成立，但近边界轴太多时，你在不同场景里会更明显地表现出不同的切换模式。{{identity_clause}}"
+    },
+    "stability_reframe_templates": {
+        "stable": {
+            "zh-CN": "稳定性不是“一直一样”，而是你在{{close_axis_label}}附近仍能保持主类型的回弹能力。{{identity_clause}}",
+            "en": "Stability is not “staying the same”; it is the ability to bounce back to the core type even around {{close_axis_label}}. {{identity_clause}}"
+        },
+        "mixed": {
+            "zh-CN": "你的稳定更像“可校准”：主类型会保留，但压力一上来，你会在{{close_axis_label}}和{{identity_clause}}之间重新分配注意力与恢复资源。",
+            "en": "Your stability is more like something you can recalibrate: the core type remains, but under pressure you redistribute attention and recovery resources between {{close_axis_label}} and {{identity_clause}}."
+        },
+        "context_sensitive": {
+            "zh-CN": "你是情境敏感型稳定：不是不稳，而是面对不同压力源时会切换不同的恢复入口。最重要的是把这种切换看成可复用的恢复机制，而不是自我怀疑。{{identity_clause}}",
+            "en": "You are context-sensitive in a stable way: not unstable, but switching recovery entry points as different pressure sources appear. The key is to treat that switching as a reusable recovery mechanism, not as self-doubt. {{identity_clause}}"
+        }
     },
     "action_plan_summary_templates": {
         "stable": "接下来最值得做的，不是继续解释自己，而是把{{growth_hint}}、{{relationship_hint}}和{{work_hint}}分别变成一个小动作。因为你的结果整体较稳定，重点是把高匹配动作重复出来。",


### PR DESCRIPTION
## Summary
This PR ships CE-2: MBTI explainability and stability content expansion.

It deepens the most user-visible same-type divergence surface in the MBTI result page by adding backend-owned content for explainability, misunderstanding correction, stability framing, and stress recovery, without changing runtime truth, scoring logic, or the overall personalization algorithm.

## What changed
- Added new MBTI content blocks for:
  - `misunderstanding_fix`
  - `stability_reframe`
- Expanded the explainability and stability content inventory and governance contract.
- Updated runtime selection so first-wave explainability/stability sections can actually consume the new block families.
- Kept the algorithmic core intact:
  - same-type divergence stays backend-owned
  - longitudinal memory stays backend-owned
  - adaptive selection stays backend-owned
- Added and updated contract tests to prove the new content blocks are selected by runtime and survive compile/lint/governance checks.

## Scope guardrails preserved
- No migration
- No new dependency
- No auth changes
- No DB runtime truth
- No SEO / landing / GEO changes
- No recommendation pool / CTA bundle / tone runtime expansion
- No frontend IA changes
- No task-external dirty files included

## Validation
- `php artisan content:lint --pack=MBTI.cn-mainland.zh-CN.v0.3`
- `php artisan content:compile --pack=MBTI.cn-mainland.zh-CN.v0.3`
- `php artisan test --filter="MbtiResultPersonalizationServiceTest|MbtiReadPathParityContractTest|MbtiResultTelemetryContractTest|MbtiContentInventoryContractTest|MbtiContentGovernanceContractTest|ContentPackLintTest|MbtiPhase2AssemblerIntegrationTest"`

Result: `20 passed`, `1256 assertions`
