### PR TITLE
[codex] backfill ledger and cut over ops reads

### DIFF
--- a/backend/app/Console/Commands/StorageBackfillArtifactLedger.php
+++ b/backend/app/Console/Commands/StorageBackfillArtifactLedger.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\ArtifactLedgerBackfillService;
+use Illuminate\Console\Command;
+
+final class StorageBackfillArtifactLedger extends Command
+{
+    protected $signature = 'storage:backfill-artifact-ledger
+        {--dry-run : Scan only and report summary}
+        {--execute : Execute idempotent historical artifact ledger backfill}
+        {--attempt-id= : Narrow to a single attempt_id}
+        {--path-root= : Narrow the filesystem scan root}
+        {--limit= : Limit the number of candidates processed}';
+
+    protected $description = 'Backfill historical artifact ledger rows for report JSON/PDF storage and snapshots.';
+
+    public function __construct(
+        private readonly ArtifactLedgerBackfillService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $filters = $this->filters();
+        $payload = $execute ? $this->service->executeBackfill($filters) : $this->service->buildPlan($filters);
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('mode='.(string) ($payload['mode'] ?? ''));
+        $this->line('candidate_count='.(int) ($payload['candidate_count'] ?? 0));
+        $this->line('classification_counts='.json_encode($payload['classification_counts'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $this->line('slot_counts='.json_encode($payload['slot_counts'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $this->line('source_counts='.json_encode($payload['source_counts'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $this->line('alias_or_legacy_path_count='.(int) ($payload['alias_or_legacy_path_count'] ?? 0));
+        $this->line('manual_or_test_owned_count='.(int) ($payload['manual_or_test_owned_count'] ?? 0));
+        $this->line('nohash_count='.(int) ($payload['nohash_count'] ?? 0));
+
+        if ($execute) {
+            $this->line('slots_upserted='.(int) ($payload['slots_upserted'] ?? 0));
+            $this->line('versions_inserted='.(int) ($payload['versions_inserted'] ?? 0));
+            $this->line('versions_reused='.(int) ($payload['versions_reused'] ?? 0));
+            $this->line('blobs_upserted='.(int) ($payload['blobs_upserted'] ?? 0));
+            $this->line('blob_locations_upserted='.(int) ($payload['blob_locations_upserted'] ?? 0));
+            $this->line('attempt_receipts_inserted='.(int) ($payload['attempt_receipts_inserted'] ?? 0));
+            $this->line('attempt_receipts_reused='.(int) ($payload['attempt_receipts_reused'] ?? 0));
+        } else {
+            $this->line('slot_backfillable_count='.(int) ($payload['slot_backfillable_count'] ?? 0));
+            $this->line('version_backfillable_count='.(int) ($payload['version_backfillable_count'] ?? 0));
+            $this->line('attempt_receipts_backfillable_count='.(int) ($payload['attempt_receipts_backfillable_count'] ?? 0));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function filters(): array
+    {
+        return [
+            'attempt_id' => $this->option('attempt-id'),
+            'path_root' => $this->option('path-root'),
+            'limit' => $this->option('limit'),
+        ];
+    }
+}

--- a/backend/app/Console/Commands/StorageBackfillAttemptReceipts.php
+++ b/backend/app/Console/Commands/StorageBackfillAttemptReceipts.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\AttemptReceiptBackfillService;
+use Illuminate\Console\Command;
+
+final class StorageBackfillAttemptReceipts extends Command
+{
+    protected $signature = 'storage:backfill-attempt-receipts
+        {--dry-run : Scan only and report summary}
+        {--execute : Execute idempotent attempt receipt backfill}
+        {--attempt-id= : Narrow to a single attempt_id}
+        {--limit= : Limit the number of candidates processed}';
+
+    protected $description = 'Backfill attempt receipts from durable audit evidence without changing primary behavior.';
+
+    public function __construct(
+        private readonly AttemptReceiptBackfillService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $filters = $this->filters();
+        $payload = $execute ? $this->service->executeReplay($filters) : $this->service->buildReplayPlan($filters);
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('mode='.(string) ($payload['mode'] ?? ''));
+        $this->line('audit_rows_scanned='.(int) ($payload['audit_rows_scanned'] ?? 0));
+        $this->line('receipt_candidates='.(int) ($payload['receipt_candidates'] ?? 0));
+        $this->line('receipt_types='.json_encode($payload['receipt_types'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $this->line('actions='.json_encode($payload['actions'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        if ($execute) {
+            $this->line('attempt_receipts_inserted='.(int) ($payload['attempt_receipts_inserted'] ?? 0));
+            $this->line('attempt_receipts_reused='.(int) ($payload['attempt_receipts_reused'] ?? 0));
+        } else {
+            $this->line('unique_attempt_ids='.(int) ($payload['unique_attempt_ids'] ?? 0));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function filters(): array
+    {
+        return [
+            'attempt_id' => $this->option('attempt-id'),
+            'limit' => $this->option('limit'),
+        ];
+    }
+}

--- a/backend/app/Console/Commands/StorageBackfillUnifiedAccessProjections.php
+++ b/backend/app/Console/Commands/StorageBackfillUnifiedAccessProjections.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\UnifiedAccessProjectionBackfillService;
+use Illuminate\Console\Command;
+
+final class StorageBackfillUnifiedAccessProjections extends Command
+{
+    protected $signature = 'storage:backfill-unified-access-projections
+        {--dry-run : Scan only and report summary}
+        {--execute : Execute idempotent unified access projection backfill}
+        {--attempt-id= : Narrow to a single attempt_id}
+        {--limit= : Limit the number of candidates processed}';
+
+    protected $description = 'Backfill historical unified access projections from entitlement and report evidence.';
+
+    public function __construct(
+        private readonly UnifiedAccessProjectionBackfillService $service,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $filters = $this->filters();
+        $payload = $execute ? $this->service->executeBackfill($filters) : $this->service->buildPlan($filters);
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('mode='.(string) ($payload['mode'] ?? ''));
+        $this->line('attempt_count='.(int) ($payload['attempt_count'] ?? 0));
+        $this->line('access_ready_count='.(int) ($payload['access_ready_count'] ?? 0));
+        $this->line('report_ready_count='.(int) ($payload['report_ready_count'] ?? 0));
+        $this->line('pdf_ready_count='.(int) ($payload['pdf_ready_count'] ?? 0));
+        $this->line('projection_count='.(int) ($payload['projection_count'] ?? 0));
+        $this->line('grant_count='.(int) ($payload['grant_count'] ?? 0));
+        $this->line('order_count='.(int) ($payload['order_count'] ?? 0));
+        $this->line('payment_event_count='.(int) ($payload['payment_event_count'] ?? 0));
+        $this->line('share_count='.(int) ($payload['share_count'] ?? 0));
+        $this->line('report_snapshot_count='.(int) ($payload['report_snapshot_count'] ?? 0));
+        $this->line('slot_count='.(int) ($payload['slot_count'] ?? 0));
+
+        if ($execute) {
+            $this->line('attempt_receipts_inserted='.(int) ($payload['attempt_receipts_inserted'] ?? 0));
+            $this->line('attempt_receipts_reused='.(int) ($payload['attempt_receipts_reused'] ?? 0));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function filters(): array
+    {
+        return [
+            'attempt_id' => $this->option('attempt-id'),
+            'limit' => $this->option('limit'),
+        ];
+    }
+}

--- a/backend/app/Services/Storage/ArtifactLedgerBackfillService.php
+++ b/backend/app/Services/Storage/ArtifactLedgerBackfillService.php
@@ -1,0 +1,930 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\ReportArtifactSlot;
+use App\Models\ReportArtifactVersion;
+use App\Models\ReportSnapshot;
+use App\Models\AttemptReceipt;
+use App\Support\SchemaBaseline;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class ArtifactLedgerBackfillService
+{
+    private const SCHEMA = 'artifact_ledger_backfill.v1';
+
+    public function __construct(
+        private readonly ArtifactLedgerClassifier $classifier,
+        private readonly BlobCatalogService $blobCatalogService,
+        private readonly AttemptReceiptBackfillService $receipts,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return array<string,mixed>
+     */
+    public function buildPlan(array $filters = []): array
+    {
+        $candidates = $this->collectCandidates($filters);
+
+        return [
+            'schema' => self::SCHEMA,
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'filters' => $this->normalizedFilters($filters),
+            'candidate_count' => count($candidates),
+            'candidate_kind_counts' => $this->countBy($candidates, 'artifact_kind'),
+            'classification_counts' => $this->countBy($candidates, 'bucket'),
+            'slot_counts' => $this->countBy($candidates, 'slot_code'),
+            'source_counts' => $this->countBy($candidates, 'source_kind'),
+            'alias_or_legacy_path_count' => $this->countByKey($candidates, 'legacy_alias'),
+            'manual_or_test_owned_count' => $this->countByKey($candidates, 'manual_or_test_owned'),
+            'nohash_count' => $this->countNoHash($candidates),
+            'file_backfillable_count' => $this->countByKey($candidates, 'has_file'),
+            'db_backfillable_count' => $this->countByKey($candidates, 'has_db_row'),
+            'snapshot_backfillable_count' => $this->countBy($candidates, 'source_kind', 'snapshot'),
+            'blob_backfillable_count' => $this->countByKey($candidates, 'has_file'),
+            'slot_backfillable_count' => count($candidates),
+            'version_backfillable_count' => count($candidates),
+            'attempt_receipts_backfillable_count' => count($candidates),
+            'warnings' => $this->buildWarnings($candidates),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return array<string,mixed>
+     */
+    public function executeBackfill(array $filters = []): array
+    {
+        $candidates = $this->collectCandidates($filters);
+        $slotsUpserted = 0;
+        $versionsInserted = 0;
+        $versionsReused = 0;
+        $blobsUpserted = 0;
+        $locationsUpserted = 0;
+        $receiptsInserted = 0;
+        $receiptsReused = 0;
+
+        foreach ($candidates as $candidate) {
+            $result = $this->persistCandidate($candidate);
+            $slotsUpserted += (int) ($result['slot_upserted'] ?? 0);
+            $versionsInserted += (int) ($result['version_inserted'] ?? 0);
+            $versionsReused += (int) ($result['version_reused'] ?? 0);
+            $blobsUpserted += (int) ($result['blob_upserted'] ?? 0);
+            $locationsUpserted += (int) ($result['location_upserted'] ?? 0);
+            $receiptsInserted += (int) ($result['receipt_inserted'] ?? 0);
+            $receiptsReused += (int) ($result['receipt_reused'] ?? 0);
+        }
+
+        return [
+            'schema' => self::SCHEMA,
+            'mode' => 'execute',
+            'status' => 'executed',
+            'generated_at' => now()->toIso8601String(),
+            'filters' => $this->normalizedFilters($filters),
+            'candidate_count' => count($candidates),
+            'candidate_kind_counts' => $this->countBy($candidates, 'artifact_kind'),
+            'classification_counts' => $this->countBy($candidates, 'bucket'),
+            'slot_counts' => $this->countBy($candidates, 'slot_code'),
+            'source_counts' => $this->countBy($candidates, 'source_kind'),
+            'alias_or_legacy_path_count' => $this->countByKey($candidates, 'legacy_alias'),
+            'manual_or_test_owned_count' => $this->countByKey($candidates, 'manual_or_test_owned'),
+            'nohash_count' => $this->countNoHash($candidates),
+            'slots_upserted' => $slotsUpserted,
+            'versions_inserted' => $versionsInserted,
+            'versions_reused' => $versionsReused,
+            'blobs_upserted' => $blobsUpserted,
+            'blob_locations_upserted' => $locationsUpserted,
+            'attempt_receipts_inserted' => $receiptsInserted,
+            'attempt_receipts_reused' => $receiptsReused,
+            'warnings' => $this->buildWarnings($candidates),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return list<array<string,mixed>>
+     */
+    private function collectCandidates(array $filters): array
+    {
+        $normalized = $this->normalizedFilters($filters);
+        $attemptIdFilter = $normalized['attempt_id'];
+        $limit = $normalized['limit'];
+        $pathRoot = $this->normalizePathRoot($normalized['path_root']);
+
+        $snapshotIndex = $this->collectSnapshots($attemptIdFilter);
+        $candidates = [];
+        $dedupe = [];
+
+        foreach ($this->collectFileCandidates($pathRoot, $snapshotIndex, $attemptIdFilter) as $candidate) {
+            $key = (string) ($candidate['dedupe_key'] ?? '');
+            if ($key !== '') {
+                $dedupe[$key] = true;
+            }
+
+            $candidates[] = $candidate;
+        }
+
+        foreach ($snapshotIndex as $attemptId => $snapshot) {
+            foreach ($this->snapshotCandidatesForAttempt($snapshot, $attemptId) as $candidate) {
+                $key = (string) ($candidate['dedupe_key'] ?? '');
+                if ($key !== '' && isset($dedupe[$key])) {
+                    continue;
+                }
+
+                if ($key !== '') {
+                    $dedupe[$key] = true;
+                }
+
+                $candidates[] = $candidate;
+            }
+        }
+
+        usort($candidates, static function (array $left, array $right): int {
+            return strcmp(
+                implode('|', [
+                    (string) ($left['attempt_id'] ?? ''),
+                    (string) ($left['slot_code'] ?? ''),
+                    (string) ($left['source_kind'] ?? ''),
+                    (string) ($left['source_ref'] ?? ''),
+                ]),
+                implode('|', [
+                    (string) ($right['attempt_id'] ?? ''),
+                    (string) ($right['slot_code'] ?? ''),
+                    (string) ($right['source_kind'] ?? ''),
+                    (string) ($right['source_ref'] ?? ''),
+                ])
+            );
+        });
+
+        if ($limit !== null) {
+            $candidates = array_slice($candidates, 0, $limit);
+        }
+
+        return array_values($candidates);
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshotIndex
+     * @return list<array<string,mixed>>
+     */
+    private function collectFileCandidates(string $pathRoot, array $snapshotIndex, ?string $attemptIdFilter): array
+    {
+        $candidates = [];
+        $reportsRoot = $this->joinPath($pathRoot, 'reports');
+        $pdfRoot = $this->joinPath($pathRoot, 'pdf');
+
+        if (is_dir($reportsRoot)) {
+            foreach (File::allFiles($reportsRoot) as $file) {
+                $relativePath = $this->relativePathWithinRoot($file->getPathname(), $pathRoot);
+                if ($relativePath === null || ! str_ends_with($relativePath, '/report.json')) {
+                    continue;
+                }
+
+                $context = $this->parseReportJsonContext($relativePath);
+                if ($context === null) {
+                    continue;
+                }
+
+                if ($attemptIdFilter !== null && $context['attempt_id'] !== $attemptIdFilter) {
+                    continue;
+                }
+
+                $snapshot = $snapshotIndex[$context['attempt_id']] ?? null;
+                $candidates[] = $this->buildCandidate([
+                    'artifact_kind' => 'report_json',
+                    'slot_code' => 'report_json_full',
+                    'variant' => 'full',
+                    'source_kind' => 'file',
+                    'source_ref' => 'file:'.$relativePath,
+                    'source_root' => $pathRoot,
+                    'source_path' => $this->absolutePath($file->getPathname()),
+                    'relative_path' => $relativePath,
+                    'attempt_id' => $context['attempt_id'],
+                    'scale_code' => $context['scale_code'],
+                    'manifest_hash' => null,
+                    'has_file' => true,
+                    'has_db_row' => $snapshot !== null,
+                    'file_absolute_path' => $file->getPathname(),
+                    'snapshot' => $snapshot,
+                ]);
+            }
+        }
+
+        if (is_dir($pdfRoot)) {
+            foreach (File::allFiles($pdfRoot) as $file) {
+                $relativePath = $this->relativePathWithinRoot($file->getPathname(), $pathRoot);
+                if ($relativePath === null || ! preg_match('#^pdf/([^/]+)/([^/]+)/([^/]+)/report_(free|full)\.pdf$#', $relativePath, $matches)) {
+                    continue;
+                }
+
+                $scaleCode = (string) $matches[1];
+                $attemptId = (string) $matches[2];
+                $manifestHash = (string) $matches[3];
+                $variant = (string) $matches[4];
+                if ($attemptIdFilter !== null && $attemptId !== $attemptIdFilter) {
+                    continue;
+                }
+
+                $snapshot = $snapshotIndex[$attemptId] ?? null;
+                $candidates[] = $this->buildCandidate([
+                    'artifact_kind' => 'report_pdf',
+                    'slot_code' => 'report_pdf_'.$variant,
+                    'variant' => $variant,
+                    'source_kind' => 'file',
+                    'source_ref' => 'file:'.$relativePath,
+                    'source_root' => $pathRoot,
+                    'source_path' => $this->absolutePath($file->getPathname()),
+                    'relative_path' => $relativePath,
+                    'attempt_id' => $attemptId,
+                    'scale_code' => $scaleCode,
+                    'manifest_hash' => $manifestHash,
+                    'has_file' => true,
+                    'has_db_row' => $snapshot !== null,
+                    'file_absolute_path' => $file->getPathname(),
+                    'snapshot' => $snapshot,
+                ]);
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function collectSnapshots(?string $attemptIdFilter): array
+    {
+        if (! Schema::hasTable('report_snapshots')) {
+            return [];
+        }
+
+        $query = DB::table('report_snapshots')->orderBy('attempt_id');
+        if ($attemptIdFilter !== null) {
+            $query->where('attempt_id', $attemptIdFilter);
+        }
+
+        $rows = $query->get();
+        $index = [];
+        foreach ($rows as $row) {
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
+            if ($attemptId === '') {
+                continue;
+            }
+
+            $index[$attemptId] = [
+                'row' => $row,
+                'payload' => $this->snapshotPayloads($row),
+            ];
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     * @return list<array<string,mixed>>
+     */
+    private function snapshotCandidatesForAttempt(array $snapshot, string $attemptId): array
+    {
+        $row = $snapshot['row'] ?? null;
+        if (! is_object($row)) {
+            return [];
+        }
+
+        $payloads = is_array($snapshot['payload'] ?? null) ? $snapshot['payload'] : [];
+        $scaleCode = trim((string) ($row->scale_code_v2 ?? $row->scale_code ?? ''));
+        if ($scaleCode === '') {
+            $scaleCode = 'UNKNOWN';
+        }
+
+        $candidates = [];
+        foreach ([
+            'report_json_free' => $payloads['report_free_json'] ?? null,
+            'report_json_full' => $payloads['report_full_json'] ?? ($payloads['report_json'] ?? null),
+        ] as $slotCode => $payload) {
+            if (! is_array($payload) || $payload === []) {
+                continue;
+            }
+
+            $candidates[] = $this->buildCandidate([
+                'artifact_kind' => 'report_json',
+                'slot_code' => $slotCode,
+                'variant' => str_ends_with($slotCode, '_free') ? 'free' : 'full',
+                'source_kind' => 'snapshot',
+                'source_ref' => 'report_snapshots#'.$attemptId.'#'.$slotCode,
+                'source_root' => storage_path('app/private/artifacts'),
+                'source_path' => null,
+                'relative_path' => null,
+                'attempt_id' => $attemptId,
+                'scale_code' => $scaleCode,
+                'manifest_hash' => null,
+                'has_file' => false,
+                'has_db_row' => true,
+                'snapshot' => $snapshot,
+                'snapshot_payload' => $payload,
+            ]);
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     * @return array<string,mixed>
+     */
+    private function buildCandidate(array $candidate): array
+    {
+        $classify = $this->classifier->classify($candidate);
+
+        return array_merge($candidate, [
+            'bucket' => $classify['bucket'] ?? 'db_only',
+            'reasons' => $classify['reasons'] ?? [],
+            'legacy_alias' => (bool) ($classify['legacy_alias'] ?? false),
+            'legacy_path' => (bool) ($classify['legacy_path'] ?? false),
+            'manual_or_test_owned' => (bool) ($classify['manual_or_test_owned'] ?? false),
+            'manifest_hash' => $candidate['manifest_hash'] ?? ($classify['manifest_hash'] ?? null),
+            'source_root' => $candidate['source_root'] ?? null,
+            'snapshot_attempt_id' => $this->snapshotAttemptId($candidate['snapshot'] ?? null),
+            'dedupe_key' => $this->dedupeKey($candidate),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     */
+    private function persistCandidate(array $candidate): array
+    {
+        if (! $this->isTablesReady()) {
+            return [
+                'slot_upserted' => 0,
+                'version_inserted' => 0,
+                'version_reused' => 0,
+                'blob_upserted' => 0,
+                'location_upserted' => 0,
+                'receipt_inserted' => 0,
+                'receipt_reused' => 0,
+            ];
+        }
+
+        $attemptId = trim((string) ($candidate['attempt_id'] ?? ''));
+        $slotCode = trim((string) ($candidate['slot_code'] ?? ''));
+        if ($attemptId === '' || $slotCode === '') {
+            return [
+                'slot_upserted' => 0,
+                'version_inserted' => 0,
+                'version_reused' => 0,
+                'blob_upserted' => 0,
+                'location_upserted' => 0,
+                'receipt_inserted' => 0,
+                'receipt_reused' => 0,
+            ];
+        }
+
+        return DB::transaction(function () use ($candidate, $attemptId, $slotCode): array {
+            $now = now();
+            $sourceKind = trim((string) ($candidate['source_kind'] ?? 'snapshot'));
+            $artifactKind = trim((string) ($candidate['artifact_kind'] ?? 'report_json'));
+            $variant = trim((string) ($candidate['variant'] ?? 'full'));
+            $slot = ReportArtifactSlot::query()->firstOrCreate(
+                [
+                    'attempt_id' => $attemptId,
+                    'slot_code' => $slotCode,
+                ],
+                [
+                    'required_by_product' => false,
+                    'render_state' => 'materialized',
+                    'delivery_state' => 'available',
+                    'access_state' => 'locked',
+                    'integrity_state' => 'verified',
+                    'last_materialized_at' => $now,
+                    'last_verified_at' => $now,
+                ]
+            );
+
+            $contentBytes = $this->contentBytesForCandidate($candidate);
+            $contentHash = hash('sha256', $contentBytes);
+            $byteSize = strlen($contentBytes);
+            $blob = null;
+            $blobUpserted = 0;
+            $locationUpserted = 0;
+
+            if (($candidate['has_file'] ?? false) === true && is_string($candidate['file_absolute_path'] ?? null)) {
+                $blob = $this->upsertBlobForFile($candidate, $contentBytes, $contentHash, $byteSize, $now);
+                $blobUpserted = 1;
+                $locationUpserted = 1;
+            }
+
+            $receiptPayload = [
+                'artifact_kind' => $artifactKind,
+                'slot_code' => $slotCode,
+                'variant' => $variant,
+                'source_kind' => $sourceKind,
+                'source_path' => $candidate['source_path'] ?? null,
+                'relative_path' => $candidate['relative_path'] ?? null,
+                'manifest_hash' => $candidate['manifest_hash'] ?? null,
+                'content_hash' => $contentHash,
+                'byte_size' => $byteSize,
+                'report_snapshot_id' => $this->snapshotRowId($candidate['snapshot'] ?? null),
+                'bucket' => $candidate['bucket'] ?? null,
+                'reasons' => $candidate['reasons'] ?? [],
+            ];
+            $receiptMeta = [
+                'source_system' => 'artifact_ledger_backfill',
+                'source_ref' => (string) ($candidate['source_ref'] ?? $candidate['source_path'] ?? ('report_snapshots#'.$attemptId.'#'.$slotCode)),
+                'actor_type' => 'system',
+                'actor_id' => 'artifact_ledger_backfill',
+                'idempotency_key' => hash('sha256', implode('|', [
+                    $attemptId,
+                    $artifactKind === 'report_pdf' ? 'report_pdf_materialized' : 'report_json_materialized',
+                    'artifact_ledger_backfill',
+                    (string) ($candidate['source_ref'] ?? $candidate['source_path'] ?? ''),
+                    $contentHash,
+                ])),
+                'occurred_at' => $now,
+                'recorded_at' => $now,
+            ];
+
+            $hadReceipt = AttemptReceipt::query()
+                ->where('attempt_id', $attemptId)
+                ->where('idempotency_key', $receiptMeta['idempotency_key'])
+                ->exists();
+
+            $receipt = $this->receipts->recordHistoricalReceipt(
+                $attemptId,
+                $artifactKind === 'report_pdf' ? 'report_pdf_materialized' : 'report_json_materialized',
+                $receiptPayload,
+                $receiptMeta
+            );
+
+            $latest = ReportArtifactVersion::query()
+                ->where('artifact_slot_id', (int) $slot->id)
+                ->orderByDesc('version_no')
+                ->first();
+
+            $versionPayload = [
+                'artifact_slot_id' => (int) $slot->id,
+                'source_type' => $sourceKind,
+                'report_snapshot_id' => $this->snapshotRowId($candidate['snapshot'] ?? null),
+                'storage_blob_id' => $blob?->hash,
+                'created_from_receipt_id' => $receipt?->id,
+                'supersedes_version_id' => $latest?->id,
+                'manifest_hash' => $candidate['manifest_hash'] ?? null,
+                'dir_version' => $this->snapshotField($candidate['snapshot'] ?? null, 'dir_version'),
+                'scoring_spec_version' => $this->snapshotField($candidate['snapshot'] ?? null, 'scoring_spec_version'),
+                'report_engine_version' => $this->snapshotField($candidate['snapshot'] ?? null, 'report_engine_version'),
+                'content_hash' => $contentHash,
+                'byte_size' => $byteSize,
+                'metadata_json' => array_filter([
+                    'bucket' => $candidate['bucket'] ?? null,
+                    'reasons' => $candidate['reasons'] ?? [],
+                    'source_kind' => $sourceKind,
+                    'artifact_kind' => $artifactKind,
+                    'slot_code' => $slotCode,
+                    'variant' => $variant,
+                    'source_path' => $candidate['source_path'] ?? null,
+                    'relative_path' => $candidate['relative_path'] ?? null,
+                    'manifest_hash' => $candidate['manifest_hash'] ?? null,
+                    'report_snapshot_id' => $this->snapshotRowId($candidate['snapshot'] ?? null),
+                    'has_file' => (bool) ($candidate['has_file'] ?? false),
+                    'has_db_row' => (bool) ($candidate['has_db_row'] ?? false),
+                    'legacy_alias' => (bool) ($candidate['legacy_alias'] ?? false),
+                    'legacy_path' => (bool) ($candidate['legacy_path'] ?? false),
+                    'manual_or_test_owned' => (bool) ($candidate['manual_or_test_owned'] ?? false),
+                ], static fn (mixed $value): bool => $value !== null),
+            ];
+
+            $sameVersion = $latest instanceof ReportArtifactVersion
+                && (string) ($latest->source_type ?? '') === $sourceKind
+                && (string) ($latest->content_hash ?? '') === $contentHash
+                && (string) ($latest->storage_blob_id ?? '') === (string) ($blob?->hash ?? '')
+                && (string) ($latest->manifest_hash ?? '') === (string) ($versionPayload['manifest_hash'] ?? '')
+                && (string) ($latest->dir_version ?? '') === (string) ($versionPayload['dir_version'] ?? '')
+                && (string) ($latest->scoring_spec_version ?? '') === (string) ($versionPayload['scoring_spec_version'] ?? '')
+                && (string) ($latest->report_engine_version ?? '') === (string) ($versionPayload['report_engine_version'] ?? '');
+
+            if ($sameVersion) {
+                $slot->forceFill([
+                    'current_version_id' => (int) $latest->id,
+                    'render_state' => 'materialized',
+                    'delivery_state' => 'available',
+                    'access_state' => 'locked',
+                    'integrity_state' => 'verified',
+                    'last_materialized_at' => $now,
+                    'last_verified_at' => $now,
+                ])->save();
+
+                return [
+                    'slot_upserted' => 1,
+                    'version_inserted' => 0,
+                    'version_reused' => 1,
+                    'blob_upserted' => $blobUpserted,
+                    'location_upserted' => $locationUpserted,
+                    'receipt_inserted' => $hadReceipt ? 0 : 1,
+                    'receipt_reused' => $hadReceipt ? 1 : 0,
+                ];
+            }
+
+            $version = ReportArtifactVersion::query()->create([
+                'artifact_slot_id' => (int) $slot->id,
+                'version_no' => ((int) ($latest?->version_no ?? 0)) + 1,
+                'source_type' => $sourceKind,
+                'report_snapshot_id' => $versionPayload['report_snapshot_id'],
+                'storage_blob_id' => $versionPayload['storage_blob_id'],
+                'created_from_receipt_id' => $versionPayload['created_from_receipt_id'],
+                'supersedes_version_id' => $versionPayload['supersedes_version_id'],
+                'manifest_hash' => $versionPayload['manifest_hash'],
+                'dir_version' => $versionPayload['dir_version'],
+                'scoring_spec_version' => $versionPayload['scoring_spec_version'],
+                'report_engine_version' => $versionPayload['report_engine_version'],
+                'content_hash' => $contentHash,
+                'byte_size' => $byteSize,
+                'metadata_json' => $versionPayload['metadata_json'],
+            ]);
+
+            $slot->forceFill([
+                'current_version_id' => (int) $version->id,
+                'render_state' => 'materialized',
+                'delivery_state' => 'available',
+                'access_state' => 'locked',
+                'integrity_state' => 'verified',
+                'last_materialized_at' => $now,
+                'last_verified_at' => $now,
+            ])->save();
+
+            return [
+                'slot_upserted' => 1,
+                'version_inserted' => 1,
+                'version_reused' => 0,
+                'blob_upserted' => $blobUpserted,
+                'location_upserted' => $locationUpserted,
+                'receipt_inserted' => $hadReceipt ? 0 : 1,
+                'receipt_reused' => $hadReceipt ? 1 : 0,
+            ];
+        });
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     */
+    private function upsertBlobForFile(array $candidate, string $contentBytes, string $contentHash, int $byteSize, mixed $verifiedAt): ?object
+    {
+        if (! SchemaBaseline::hasTable('storage_blobs') || ! SchemaBaseline::hasTable('storage_blob_locations')) {
+            return null;
+        }
+
+        $absolutePath = (string) ($candidate['file_absolute_path'] ?? '');
+        if ($absolutePath === '' || ! is_file($absolutePath)) {
+            return null;
+        }
+
+        $blob = $this->blobCatalogService->upsertBlob([
+            'hash' => $contentHash,
+            'disk' => 'local',
+            'storage_path' => $this->blobCatalogService->storagePathForHash($contentHash),
+            'size_bytes' => $byteSize,
+            'content_type' => ($candidate['artifact_kind'] ?? '') === 'report_pdf' ? 'application/pdf' : 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+            'first_seen_at' => $verifiedAt,
+            'last_verified_at' => $verifiedAt,
+        ]);
+
+        $this->blobCatalogService->upsertBlobLocation([
+            'blob_hash' => $blob->hash,
+            'disk' => 'local',
+            'storage_path' => (string) ($candidate['source_path'] ?? $candidate['relative_path'] ?? $absolutePath),
+            'location_kind' => 'canonical_file',
+            'size_bytes' => $byteSize,
+            'checksum' => $contentHash,
+            'etag' => $contentHash,
+            'storage_class' => 'local',
+            'verified_at' => $verifiedAt,
+            'meta_json' => array_filter([
+                'bucket' => $candidate['bucket'] ?? null,
+                'reasons' => $candidate['reasons'] ?? [],
+                'source_kind' => $candidate['source_kind'] ?? null,
+            ], static fn (mixed $value): bool => $value !== null),
+        ]);
+
+        return $blob;
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     */
+    private function contentBytesForCandidate(array $candidate): string
+    {
+        if (($candidate['has_file'] ?? false) === true && is_string($candidate['file_absolute_path'] ?? null)) {
+            $path = (string) $candidate['file_absolute_path'];
+            if (is_file($path)) {
+                $contents = File::get($path);
+                if (is_string($contents)) {
+                    return $contents;
+                }
+            }
+        }
+
+        $snapshotPayload = $candidate['snapshot_payload'] ?? null;
+        if (is_array($snapshotPayload)) {
+            $encoded = json_encode($snapshotPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (is_string($encoded)) {
+                return $encoded;
+            }
+        }
+
+        $snapshot = $candidate['snapshot'] ?? null;
+        if (is_array($snapshot)) {
+            $row = $snapshot['row'] ?? null;
+            $payload = is_array($snapshot['payload'] ?? null) ? $snapshot['payload'] : [];
+            $encoded = json_encode([
+                'attempt_id' => is_object($row) ? (string) ($row->attempt_id ?? '') : '',
+                'scale_code' => is_object($row) ? (string) ($row->scale_code ?? $row->scale_code_v2 ?? '') : '',
+                'dir_version' => is_object($row) ? (string) ($row->dir_version ?? '') : '',
+                'scoring_spec_version' => is_object($row) ? (string) ($row->scoring_spec_version ?? '') : '',
+                'report_engine_version' => is_object($row) ? (string) ($row->report_engine_version ?? '') : '',
+                'payload' => $payload,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (is_string($encoded)) {
+                return $encoded;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  object|array<string,mixed>|null  $snapshot
+     */
+    private function snapshotRowId(object|array|null $snapshot): ?string
+    {
+        if (is_array($snapshot)) {
+            $row = $snapshot['row'] ?? null;
+            if (is_object($row)) {
+                return (string) ($row->attempt_id ?? null);
+            }
+        }
+
+        if (is_object($snapshot)) {
+            return (string) ($snapshot->attempt_id ?? null);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  object|array<string,mixed>|null  $snapshot
+     */
+    private function snapshotField(object|array|null $snapshot, string $field): ?string
+    {
+        $row = $this->snapshotRow($snapshot);
+        if ($row === null) {
+            return null;
+        }
+
+        $value = $row->{$field} ?? null;
+
+        return is_scalar($value) ? trim((string) $value) : null;
+    }
+
+    /**
+     * @param  object|array<string,mixed>|null  $snapshot
+     */
+    private function snapshotAttemptId(object|array|null $snapshot): ?string
+    {
+        $row = $this->snapshotRow($snapshot);
+        if ($row === null) {
+            return null;
+        }
+
+        return trim((string) ($row->attempt_id ?? '')) !== '' ? trim((string) ($row->attempt_id ?? '')) : null;
+    }
+
+    /**
+     * @param  object|array<string,mixed>|null  $snapshot
+     */
+    private function snapshotRow(object|array|null $snapshot): ?object
+    {
+        if (is_array($snapshot) && is_object($snapshot['row'] ?? null)) {
+            return $snapshot['row'];
+        }
+
+        if (is_object($snapshot)) {
+            return $snapshot;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     */
+    private function dedupeKey(array $candidate): string
+    {
+        return implode('|', [
+            (string) ($candidate['attempt_id'] ?? ''),
+            (string) ($candidate['slot_code'] ?? ''),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return array<string,mixed>
+     */
+    private function normalizedFilters(array $filters): array
+    {
+        return [
+            'attempt_id' => $this->normalizeNullableText($filters['attempt_id'] ?? null),
+            'path_root' => $this->normalizePathRoot($filters['path_root'] ?? null),
+            'limit' => isset($filters['limit']) ? max(1, (int) $filters['limit']) : null,
+        ];
+    }
+
+    private function normalizePathRoot(mixed $value): string
+    {
+        $path = trim((string) ($value ?? ''));
+        if ($path === '') {
+            return storage_path('app/private/artifacts');
+        }
+
+        if (! str_starts_with($path, DIRECTORY_SEPARATOR)) {
+            return storage_path(ltrim($path, '/\\'));
+        }
+
+        return rtrim(str_replace('\\', '/', $path), '/');
+    }
+
+    private function joinPath(string $root, string $path): string
+    {
+        return rtrim($root, '/').'/'.ltrim($path, '/');
+    }
+
+    private function absolutePath(string $path): string
+    {
+        return str_replace('\\', '/', $path);
+    }
+
+    private function relativePathWithinRoot(string $absolutePath, string $root): ?string
+    {
+        $absolute = str_replace('\\', '/', $absolutePath);
+        $root = rtrim(str_replace('\\', '/', $root), '/');
+        $prefix = $root.'/';
+
+        if (! str_starts_with($absolute, $prefix)) {
+            return null;
+        }
+
+        return ltrim(substr($absolute, strlen($prefix)), '/');
+    }
+
+    /**
+     * @return array{attempt_id:string,scale_code:string}|null
+     */
+    private function parseReportJsonContext(string $relativePath): ?array
+    {
+        if (preg_match('#^reports/([^/]+)/([^/]+)/report\.json$#', $relativePath, $matches) !== 1) {
+            return null;
+        }
+
+        return [
+            'scale_code' => (string) $matches[1],
+            'attempt_id' => (string) $matches[2],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshotPayloads(object $row): array
+    {
+        return [
+            'report_json' => $this->decodeJsonObject($row->report_json ?? null),
+            'report_free_json' => $this->decodeJsonObject($row->report_free_json ?? null),
+            'report_full_json' => $this->decodeJsonObject($row->report_full_json ?? null),
+        ];
+    }
+
+    private function decodeJsonObject(mixed $json): array
+    {
+        if (is_array($json)) {
+            return $json;
+        }
+
+        if (! is_string($json) || $json === '') {
+            return [];
+        }
+
+        $decoded = json_decode($json, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return array<string,int>
+     */
+    private function countBy(array $items, string $key, ?string $value = null): array|int
+    {
+        if ($value !== null) {
+            $count = 0;
+            foreach ($items as $item) {
+                if ((string) ($item[$key] ?? '') === $value) {
+                    $count++;
+                }
+            }
+
+            return $count;
+        }
+
+        $counts = [];
+        foreach ($items as $item) {
+            $current = trim((string) ($item[$key] ?? ''));
+            if ($current === '') {
+                $current = 'unknown';
+            }
+
+            $counts[$current] = (int) ($counts[$current] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
+    private function countByKey(array $items, string $key): int
+    {
+        $count = 0;
+        foreach ($items as $item) {
+            if (($item[$key] ?? false) === true) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
+    private function countNoHash(array $items): int
+    {
+        $count = 0;
+        foreach ($items as $item) {
+            if (strtolower(trim((string) ($item['manifest_hash'] ?? ''))) === 'nohash') {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<string>
+     */
+    private function buildWarnings(array $items): array
+    {
+        $warnings = [];
+
+        foreach ($items as $item) {
+            if (($item['manual_or_test_owned'] ?? false) === true) {
+                $warnings['manual_or_test_owned'] = 'manual_or_test_owned artifacts are excluded from auto-normalization';
+            }
+            if (($item['legacy_alias'] ?? false) === true) {
+                $warnings['alias_or_legacy_path'] = 'BIG5/BIG5_OCEAN alias and legacy report paths are preserved as evidence';
+            }
+            if (strtolower(trim((string) ($item['manifest_hash'] ?? ''))) === 'nohash') {
+                $warnings['nohash'] = 'nohash PDF manifests are preserved as evidence';
+            }
+        }
+
+        return array_values($warnings);
+    }
+
+    private function normalizeNullableText(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
+    }
+
+    private function isTablesReady(): bool
+    {
+        return SchemaBaseline::hasTable('report_artifact_slots')
+            && SchemaBaseline::hasTable('report_artifact_versions')
+            && SchemaBaseline::hasTable('attempt_receipts');
+    }
+}

--- a/backend/app/Services/Storage/ArtifactLedgerClassifier.php
+++ b/backend/app/Services/Storage/ArtifactLedgerClassifier.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+final class ArtifactLedgerClassifier
+{
+    /**
+     * @param  array<string,mixed>  $candidate
+     * @return array<string,mixed>
+     */
+    public function classify(array $candidate): array
+    {
+        $sourcePath = $this->normalizePath((string) ($candidate['source_path'] ?? $candidate['relative_path'] ?? ''));
+        $relativePath = $this->normalizePath((string) ($candidate['relative_path'] ?? $sourcePath));
+        $sourceRoot = $this->normalizePath((string) ($candidate['source_root'] ?? ''));
+        $attemptId = $this->normalizeText($candidate['attempt_id'] ?? null);
+        $scaleCode = $this->normalizeText($candidate['scale_code'] ?? null);
+        $slotCode = $this->normalizeText($candidate['slot_code'] ?? null);
+        $variant = $this->normalizeText($candidate['variant'] ?? null);
+        $manifestHash = $this->normalizeText($candidate['manifest_hash'] ?? null);
+
+        $manualOrTestOwned = $this->isManualOrTestOwned($sourcePath, $relativePath, $sourceRoot);
+        $parsed = $this->parseArtifactPath($sourcePath, $relativePath);
+
+        $reasons = [];
+        if ($manualOrTestOwned) {
+            $reasons[] = 'manual_or_test_owned';
+        }
+
+        if (($parsed['legacy_path'] ?? false) === true) {
+            $reasons[] = 'legacy_path';
+        }
+
+        if ($this->isLegacyAliasScale((string) ($parsed['scale_code'] ?? ''))) {
+            $reasons[] = 'scale_alias:'.(string) ($parsed['scale_code'] ?? '');
+        }
+
+        if ($this->isNohashManifest((string) ($parsed['manifest_hash'] ?? $manifestHash ?? ''))) {
+            $reasons[] = 'manifest_nohash';
+        }
+
+        if (($candidate['has_db_row'] ?? false) === true) {
+            $reasons[] = 'db_row_present';
+        }
+
+        if (($candidate['has_file'] ?? false) === true) {
+            $reasons[] = 'file_present';
+        }
+
+        if (($candidate['has_archive_proof'] ?? false) === true) {
+            $reasons[] = 'archive_proof_present';
+        }
+
+        $bucket = $this->bucketForCandidate(
+            manualOrTestOwned: $manualOrTestOwned,
+            legacyAlias: $this->hasLegacyAliasEvidence($parsed, $sourcePath, $relativePath, $manifestHash),
+            hasDbRow: (bool) ($candidate['has_db_row'] ?? false),
+            hasFile: (bool) ($candidate['has_file'] ?? false),
+            hasArchiveProof: (bool) ($candidate['has_archive_proof'] ?? false)
+        );
+
+        return [
+            'bucket' => $bucket,
+            'reasons' => array_values(array_unique($reasons)),
+            'source_root' => $sourceRoot !== '' ? $sourceRoot : null,
+            'source_path' => $sourcePath !== '' ? $sourcePath : null,
+            'relative_path' => $relativePath !== '' ? $relativePath : null,
+            'attempt_id' => $attemptId,
+            'scale_code' => $scaleCode ?? ($parsed['scale_code'] ?? null),
+            'slot_code' => $slotCode,
+            'variant' => $variant ?? ($parsed['variant'] ?? null),
+            'manifest_hash' => $manifestHash ?? ($parsed['manifest_hash'] ?? null),
+            'artifact_kind' => $candidate['artifact_kind'] ?? ($parsed['artifact_kind'] ?? null),
+            'has_db_row' => (bool) ($candidate['has_db_row'] ?? false),
+            'has_file' => (bool) ($candidate['has_file'] ?? false),
+            'has_archive_proof' => (bool) ($candidate['has_archive_proof'] ?? false),
+            'manual_or_test_owned' => $manualOrTestOwned,
+            'legacy_alias' => $this->hasLegacyAliasEvidence($parsed, $sourcePath, $relativePath, $manifestHash),
+            'legacy_path' => (bool) ($parsed['legacy_path'] ?? false),
+            'parsed' => $parsed,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function bucketForCandidate(
+        bool $manualOrTestOwned,
+        bool $legacyAlias,
+        bool $hasDbRow,
+        bool $hasFile,
+        bool $hasArchiveProof
+    ): array|string {
+        if ($manualOrTestOwned) {
+            return 'manual_or_test_owned';
+        }
+
+        if ($legacyAlias) {
+            return 'alias_or_legacy_path';
+        }
+
+        if ($hasDbRow && $hasFile) {
+            return 'matched_db_and_file';
+        }
+
+        if ($hasDbRow) {
+            return 'db_only';
+        }
+
+        if ($hasFile) {
+            return 'file_only';
+        }
+
+        if ($hasArchiveProof) {
+            return 'archive_proof_only';
+        }
+
+        return 'db_only';
+    }
+
+    /**
+     * @return array{artifact_kind:?string,scale_code:?string,attempt_id:?string,variant:?string,manifest_hash:?string,legacy_path:bool}
+     */
+    private function parseArtifactPath(string $sourcePath, string $relativePath): array
+    {
+        $path = $sourcePath !== '' ? $sourcePath : $relativePath;
+        $path = ltrim($this->normalizePath($path), '/');
+
+        if ($path === '') {
+            return [
+                'artifact_kind' => null,
+                'scale_code' => null,
+                'attempt_id' => null,
+                'variant' => null,
+                'manifest_hash' => null,
+                'legacy_path' => false,
+            ];
+        }
+
+        if (preg_match('#(?:^|/)artifacts/reports/([^/]+)/([^/]+)/report\.json$#', $path, $matches) === 1) {
+            return [
+                'artifact_kind' => 'report_json',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+                'variant' => 'full',
+                'manifest_hash' => null,
+                'legacy_path' => false,
+            ];
+        }
+
+        if (preg_match('#(?:^|/)artifacts/pdf/([^/]+)/([^/]+)/([^/]+)/report_(free|full)\.pdf$#', $path, $matches) === 1) {
+            return [
+                'artifact_kind' => 'report_pdf',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+                'variant' => (string) $matches[4],
+                'manifest_hash' => (string) $matches[3],
+                'legacy_path' => false,
+            ];
+        }
+
+        if (preg_match('#(?:^|/)(?:private/)?reports/([^/]+)/([^/]+)/report\.json$#', $path, $matches) === 1) {
+            return [
+                'artifact_kind' => 'report_json',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+                'variant' => 'full',
+                'manifest_hash' => null,
+                'legacy_path' => true,
+            ];
+        }
+
+        if (preg_match('#(?:^|/)(?:private/)?reports/([^/]+)/([^/]+)/([^/]+)/report_(free|full)\.pdf$#', $path, $matches) === 1) {
+            return [
+                'artifact_kind' => 'report_pdf',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+                'variant' => (string) $matches[4],
+                'manifest_hash' => (string) $matches[3],
+                'legacy_path' => true,
+            ];
+        }
+
+        if (preg_match('#(?:^|/)(?:private/)?reports/([^/]+)/([^/]+)/report_(free|full)\.pdf$#', $path, $matches) === 1) {
+            return [
+                'artifact_kind' => 'report_pdf',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => (string) $matches[2],
+                'variant' => (string) $matches[3],
+                'manifest_hash' => 'nohash',
+                'legacy_path' => true,
+            ];
+        }
+
+        if (preg_match('#(?:^|/)(?:private/)?reports/([^/]+)/report\.json$#', $path, $matches) === 1) {
+            return [
+                'artifact_kind' => 'report_json',
+                'scale_code' => (string) $matches[1],
+                'attempt_id' => null,
+                'variant' => 'full',
+                'manifest_hash' => null,
+                'legacy_path' => true,
+            ];
+        }
+
+        return [
+            'artifact_kind' => null,
+            'scale_code' => null,
+            'attempt_id' => null,
+            'variant' => null,
+            'manifest_hash' => null,
+            'legacy_path' => false,
+        ];
+    }
+
+    private function isManualOrTestOwned(string $sourcePath, string $relativePath, string $sourceRoot): bool
+    {
+        $haystack = strtolower(implode('|', array_filter([$sourcePath, $relativePath, $sourceRoot])));
+
+        return str_contains($haystack, '/content_releases/')
+            || str_contains($haystack, '/evidence/')
+            || str_contains($haystack, '/testing/');
+    }
+
+    private function hasLegacyAliasEvidence(array $parsed, string $sourcePath, string $relativePath, ?string $manifestHash): bool
+    {
+        if (($parsed['legacy_path'] ?? false) === true) {
+            return true;
+        }
+
+        $scaleCode = strtoupper(trim((string) ($parsed['scale_code'] ?? '')));
+        if ($this->isLegacyAliasScale($scaleCode)) {
+            return true;
+        }
+
+        return $this->isNohashManifest((string) ($parsed['manifest_hash'] ?? $manifestHash ?? ''))
+            || str_contains(strtolower($sourcePath), '/private/reports/')
+            || str_contains(strtolower($relativePath), 'reports/big5/')
+            || str_contains(strtolower($relativePath), 'reports/big5_ocean/');
+    }
+
+    private function isLegacyAliasScale(string $scaleCode): bool
+    {
+        return in_array($scaleCode, ['BIG5', 'BIG5_OCEAN'], true);
+    }
+
+    private function isNohashManifest(string $manifestHash): bool
+    {
+        return strtolower(trim($manifestHash)) === 'nohash';
+    }
+
+    private function normalizePath(string $path): string
+    {
+        return str_replace('\\', '/', trim($path));
+    }
+
+    private function normalizeText(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
+    }
+}

--- a/backend/app/Services/Storage/AttemptReceiptBackfillService.php
+++ b/backend/app/Services/Storage/AttemptReceiptBackfillService.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\AttemptReceipt;
+use App\Support\SchemaBaseline;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class AttemptReceiptBackfillService
+{
+    /**
+     * @var list<string>
+     */
+    private const LIFECYCLE_ACTIONS = [
+        'storage_archive_report_artifacts',
+        'storage_rehydrate_report_artifacts',
+        'storage_shrink_archived_report_artifacts',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $meta
+     */
+    public function recordHistoricalReceipt(
+        string $attemptId,
+        string $receiptType,
+        array $payload = [],
+        array $meta = []
+    ): ?AttemptReceipt {
+        $attemptId = trim($attemptId);
+        $receiptType = trim($receiptType);
+        if ($attemptId === '' || $receiptType === '' || ! SchemaBaseline::hasTable('attempt_receipts')) {
+            return null;
+        }
+
+        $payloadJson = $this->encodePayload($payload);
+        $sourceSystem = $this->normalizeText($meta['source_system'] ?? 'backfill', 'backfill');
+        $sourceRef = $this->normalizeNullableText($meta['source_ref'] ?? null);
+        $actorType = $this->normalizeNullableText($meta['actor_type'] ?? null);
+        $actorId = $this->normalizeNullableText($meta['actor_id'] ?? null);
+        $occurredAt = $meta['occurred_at'] ?? null;
+        $recordedAt = $meta['recorded_at'] ?? now();
+        $idempotencyKey = $this->normalizeNullableText($meta['idempotency_key'] ?? null)
+            ?? hash('sha256', implode('|', [
+                $attemptId,
+                $receiptType,
+                $sourceSystem,
+                $sourceRef ?? '',
+                $payloadJson,
+            ]));
+
+        $work = function () use (
+            $attemptId,
+            $receiptType,
+            $payload,
+            $sourceSystem,
+            $sourceRef,
+            $actorType,
+            $actorId,
+            $occurredAt,
+            $recordedAt,
+            $idempotencyKey
+        ): AttemptReceipt {
+            if (SchemaBaseline::hasTable('attempts')) {
+                DB::table('attempts')
+                    ->where('id', $attemptId)
+                    ->lockForUpdate()
+                    ->first();
+            }
+
+            $existing = AttemptReceipt::query()
+                ->where('attempt_id', $attemptId)
+                ->where('idempotency_key', $idempotencyKey)
+                ->first();
+            if ($existing instanceof AttemptReceipt) {
+                return $existing;
+            }
+
+            $nextSeq = ((int) (
+                AttemptReceipt::query()
+                    ->where('attempt_id', $attemptId)
+                    ->lockForUpdate()
+                    ->max('seq')
+                ?? 0
+            )) + 1;
+
+            $receipt = AttemptReceipt::query()->create([
+                'attempt_id' => $attemptId,
+                'seq' => $nextSeq,
+                'receipt_type' => $receiptType,
+                'source_system' => $sourceSystem,
+                'source_ref' => $sourceRef,
+                'actor_type' => $actorType,
+                'actor_id' => $actorId,
+                'idempotency_key' => $idempotencyKey,
+                'payload_json' => $payload,
+                'occurred_at' => $occurredAt ?? $recordedAt,
+                'recorded_at' => $recordedAt,
+            ]);
+
+            return $receipt->fresh() ?? $receipt;
+        };
+
+        if (DB::transactionLevel() > 0) {
+            return $work();
+        }
+
+        return DB::transaction($work);
+    }
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return array<string,mixed>
+     */
+    public function buildReplayPlan(array $filters = []): array
+    {
+        $rows = $this->matchingAuditRows($filters);
+        $items = $this->receiptItemsFromRows($rows);
+
+        return [
+            'schema' => 'attempt_receipt_backfill_plan.v1',
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'source' => 'audit_logs.meta_json',
+            'audit_rows_scanned' => count($rows),
+            'receipt_candidates' => count($items),
+            'unique_attempt_ids' => count(array_unique(array_map(
+                static fn (array $item): string => (string) ($item['attempt_id'] ?? ''),
+                $items
+            ))),
+            'receipt_types' => $this->countByKey($items, 'receipt_type'),
+            'actions' => $this->countByKey($items, 'action'),
+            'filters' => $this->normalizedFilters($filters),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return array<string,mixed>
+     */
+    public function executeReplay(array $filters = []): array
+    {
+        $rows = $this->matchingAuditRows($filters);
+        $items = $this->receiptItemsFromRows($rows);
+        $inserted = 0;
+        $reused = 0;
+        $attemptIds = [];
+
+        foreach ($items as $item) {
+            $attemptId = trim((string) ($item['attempt_id'] ?? ''));
+            $receiptType = trim((string) ($item['receipt_type'] ?? ''));
+            if ($attemptId === '' || $receiptType === '') {
+                continue;
+            }
+
+            $attemptIds[$attemptId] = true;
+            $hadReceipt = AttemptReceipt::query()
+                ->where('attempt_id', $attemptId)
+                ->where('idempotency_key', (string) data_get($item, 'meta.idempotency_key', ''))
+                ->exists();
+            $receipt = $this->recordHistoricalReceipt(
+                $attemptId,
+                $receiptType,
+                (array) ($item['payload'] ?? []),
+                (array) ($item['meta'] ?? [])
+            );
+
+            if ($receipt === null) {
+                continue;
+            }
+
+            if ($hadReceipt) {
+                $reused++;
+
+                continue;
+            }
+
+            $inserted++;
+        }
+
+        return [
+            'schema' => 'attempt_receipt_backfill_run.v1',
+            'mode' => 'execute',
+            'status' => 'executed',
+            'generated_at' => now()->toIso8601String(),
+            'source' => 'audit_logs.meta_json',
+            'audit_rows_scanned' => count($rows),
+            'receipt_candidates' => count($items),
+            'attempt_receipts_inserted' => $inserted,
+            'attempt_receipts_reused' => $reused,
+            'unique_attempt_ids' => count($attemptIds),
+            'receipt_types' => $this->countByKey($items, 'receipt_type'),
+            'actions' => $this->countByKey($items, 'action'),
+            'filters' => $this->normalizedFilters($filters),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return list<object>
+     */
+    private function matchingAuditRows(array $filters): array
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return [];
+        }
+
+        $attemptId = $this->normalizeNullableText($filters['attempt_id'] ?? null);
+        $limit = isset($filters['limit']) ? max(1, (int) $filters['limit']) : null;
+
+        $query = DB::table('audit_logs')
+            ->whereIn('action', self::LIFECYCLE_ACTIONS)
+            ->orderBy('created_at')
+            ->orderBy('id');
+
+        if ($limit !== null) {
+            $query->limit(max(1, $limit * 25));
+        }
+
+        $rows = $query->get()->all();
+        if ($attemptId === null) {
+            return $limit === null ? $rows : array_slice($rows, 0, $limit);
+        }
+
+        $rows = array_values(array_filter($rows, static function (object $row) use ($attemptId): bool {
+            if ((string) ($row->target_id ?? '') === $attemptId) {
+                return true;
+            }
+
+            $meta = json_decode((string) ($row->meta_json ?? '{}'), true);
+            if (! is_array($meta)) {
+                return false;
+            }
+
+            if ((string) data_get($meta, 'attempt_id', '') === $attemptId) {
+                return true;
+            }
+
+            foreach ((array) data_get($meta, 'results', []) as $result) {
+                if (is_array($result) && (string) ($result['attempt_id'] ?? '') === $attemptId) {
+                    return true;
+                }
+            }
+
+            return false;
+        }));
+
+        return $limit === null ? $rows : array_slice($rows, 0, $limit);
+    }
+
+    /**
+     * @param  list<object>  $rows
+     * @return list<array<string,mixed>>
+     */
+    private function receiptItemsFromRows(array $rows): array
+    {
+        $items = [];
+
+        foreach ($rows as $row) {
+            $meta = $this->decodeJsonObject($row->meta_json ?? null);
+            $action = (string) ($row->action ?? '');
+            $receiptType = $this->receiptTypeForAction($action);
+            if ($receiptType === null) {
+                continue;
+            }
+
+            $results = is_array($meta['results'] ?? null) ? array_values($meta['results']) : [];
+            foreach ($results as $result) {
+                if (! is_array($result)) {
+                    continue;
+                }
+
+                $attemptId = $this->normalizeNullableText($result['attempt_id'] ?? null);
+                if ($attemptId === null) {
+                    continue;
+                }
+
+                $sourceRef = sprintf(
+                    'audit_logs#%s|%s|%s|%s',
+                    (string) ($row->id ?? ''),
+                    $action,
+                    $attemptId,
+                    $this->normalizeNullableText($result['source_path'] ?? null) ?? $this->normalizeNullableText($result['target_object_key'] ?? null) ?? 'unknown'
+                );
+
+                $items[] = [
+                    'action' => $action,
+                    'attempt_id' => $attemptId,
+                    'receipt_type' => $receiptType,
+                    'payload' => [
+                        'job_type' => $action,
+                        'status' => $result['status'] ?? null,
+                        'kind' => $result['kind'] ?? null,
+                        'source_path' => $result['source_path'] ?? null,
+                        'target_object_key' => $result['target_object_key'] ?? null,
+                        'target_disk' => $result['target_disk'] ?? null,
+                        'summary' => $meta['summary'] ?? [],
+                        'run_path' => $meta['run_path'] ?? null,
+                    ],
+                    'meta' => [
+                        'source_system' => 'audit_logs.meta_json',
+                        'source_ref' => $sourceRef,
+                        'actor_type' => 'system',
+                        'actor_id' => $action,
+                        'idempotency_key' => hash('sha256', implode('|', [
+                            $attemptId,
+                            $receiptType,
+                            $action,
+                            $sourceRef,
+                            (string) json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                        ])),
+                        'occurred_at' => $row->created_at ?? now(),
+                        'recorded_at' => $row->created_at ?? now(),
+                    ],
+                ];
+            }
+        }
+
+        return $items;
+    }
+
+    private function receiptTypeForAction(string $action): ?string
+    {
+        return match ($action) {
+            'storage_archive_report_artifacts' => 'artifact_archived',
+            'storage_rehydrate_report_artifacts' => 'artifact_rehydrated',
+            'storage_shrink_archived_report_artifacts' => 'artifact_shrunk',
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<int, array<string,mixed>>  $items
+     * @return array<string,int>
+     */
+    private function countByKey(array $items, string $key): array
+    {
+        $counts = [];
+        foreach ($items as $item) {
+            $value = trim((string) ($item[$key] ?? ''));
+            if ($value === '') {
+                $value = 'unknown';
+            }
+
+            $counts[$value] = (int) ($counts[$value] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return array<string,mixed>
+     */
+    private function normalizedFilters(array $filters): array
+    {
+        return [
+            'attempt_id' => $this->normalizeNullableText($filters['attempt_id'] ?? null),
+            'limit' => isset($filters['limit']) ? max(1, (int) $filters['limit']) : null,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonObject(mixed $json): array
+    {
+        if (is_array($json)) {
+            return $json;
+        }
+
+        if (! is_string($json) || $json === '') {
+            return [];
+        }
+
+        $decoded = json_decode($json, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function encodePayload(array $payload): string
+    {
+        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($json)) {
+            throw new \RuntimeException('failed to encode attempt receipt payload.');
+        }
+
+        return $json;
+    }
+
+    private function normalizeText(mixed $value, string $fallback = ''): string
+    {
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : $fallback;
+    }
+
+    private function normalizeNullableText(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
+    }
+}

--- a/backend/app/Services/Storage/StorageControlPlaneStatusService.php
+++ b/backend/app/Services/Storage/StorageControlPlaneStatusService.php
@@ -171,6 +171,13 @@ final class StorageControlPlaneStatusService
      */
     private function reportsArtifactsLifecycleSection(array $inventory): array
     {
+        if ($this->controlPlaneReadFromCatalogEnabled()) {
+            $catalog = $this->catalogReportsArtifactsLifecycleSection($inventory);
+            if ($catalog !== null) {
+                return $catalog;
+            }
+        }
+
         $canonicalRootPath = storage_path('app/private/artifacts');
         $legacyRootPath = storage_path('app/private/reports');
 
@@ -236,6 +243,13 @@ final class StorageControlPlaneStatusService
      */
     private function reportArtifactsArchiveSection(): array
     {
+        if ($this->controlPlaneReadFromCatalogEnabled()) {
+            $catalog = $this->catalogReportArtifactsArchiveSection();
+            if ($catalog !== null) {
+                return $catalog;
+            }
+        }
+
         $audit = $this->latestAuditForAction('storage_archive_report_artifacts');
         if ($audit === null) {
             return array_merge([
@@ -297,6 +311,104 @@ final class StorageControlPlaneStatusService
      */
     private function reportArtifactsPostureSection(): array
     {
+        if ($this->controlPlaneReadFromCatalogEnabled()) {
+            $archive = $this->catalogReportArtifactsPostureNode('archive_report_artifacts', [
+                'candidate_count',
+                'copied_count',
+                'verified_count',
+                'already_archived_count',
+                'failed_count',
+                'results_count',
+            ]);
+            $rehydrate = $this->catalogReportArtifactsPostureNode('rehydrate_report_artifacts', [
+                'candidate_count',
+                'rehydrated_count',
+                'verified_count',
+                'skipped_count',
+                'blocked_count',
+                'failed_count',
+                'results_count',
+            ]);
+            $shrink = $this->catalogReportArtifactsPostureNode('shrink_archived_report_artifacts', [
+                'candidate_count',
+                'deleted_count',
+                'skipped_missing_local_count',
+                'blocked_missing_remote_count',
+                'blocked_missing_archive_proof_count',
+                'blocked_missing_rehydrate_proof_count',
+                'blocked_hash_mismatch_count',
+                'failed_count',
+                'results_count',
+            ]);
+
+            if ($archive !== null || $rehydrate !== null || $shrink !== null) {
+                $archiveAudit = $this->latestAuditForAction('storage_archive_report_artifacts');
+                $rehydrateAudit = $this->latestAuditForAction('storage_rehydrate_report_artifacts');
+                $shrinkAudit = $this->latestAuditForAction('storage_shrink_archived_report_artifacts');
+
+                $archive ??= $this->reportArtifactsPostureNode($archiveAudit, [
+                    'candidate_count',
+                    'copied_count',
+                    'verified_count',
+                    'already_archived_count',
+                    'failed_count',
+                    'results_count',
+                ]);
+                $rehydrate ??= $this->reportArtifactsPostureNode($rehydrateAudit, [
+                    'candidate_count',
+                    'rehydrated_count',
+                    'verified_count',
+                    'skipped_count',
+                    'blocked_count',
+                    'failed_count',
+                    'results_count',
+                ]);
+                $shrink ??= $this->reportArtifactsPostureNode($shrinkAudit, [
+                    'candidate_count',
+                    'deleted_count',
+                    'skipped_missing_local_count',
+                    'blocked_missing_remote_count',
+                    'blocked_missing_archive_proof_count',
+                    'blocked_missing_rehydrate_proof_count',
+                    'blocked_hash_mismatch_count',
+                    'failed_count',
+                    'results_count',
+                ]);
+
+                $statuses = [
+                    $archive['status'] ?? 'not_available',
+                    $rehydrate['status'] ?? 'not_available',
+                    $shrink['status'] ?? 'not_available',
+                ];
+
+                $overallStatus = match (true) {
+                    count(array_filter($statuses, static fn (string $status): bool => $status !== 'not_available')) === 0 => 'not_available',
+                    in_array('not_available', $statuses, true) => 'partial',
+                    default => 'ok',
+                };
+
+                $lastUpdatedAt = $this->latestTimestamp([
+                    $archive['latest_generated_at'] ?? null,
+                    $rehydrate['latest_generated_at'] ?? null,
+                    $shrink['latest_generated_at'] ?? null,
+                ]);
+
+                return array_merge([
+                    'status' => $overallStatus,
+                    'durable_receipt_source' => 'attempt_receipts',
+                    'target_disk' => $this->consistentReportArtifactsTargetDisk([$archiveAudit, $rehydrateAudit, $shrinkAudit]),
+                    'archive' => $archive,
+                    'rehydrate' => $rehydrate,
+                    'shrink' => $shrink,
+                ], $this->freshnessFromTimestamp(
+                    $lastUpdatedAt,
+                    'ledger-derived',
+                    self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
+                    'not_available'
+                ));
+            }
+        }
+
         $archiveAudit = $this->latestAuditForAction('storage_archive_report_artifacts');
         $rehydrateAudit = $this->latestAuditForAction('storage_rehydrate_report_artifacts');
         $shrinkAudit = $this->latestAuditForAction('storage_shrink_archived_report_artifacts');
@@ -895,6 +1007,228 @@ final class StorageControlPlaneStatusService
             self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
             'not_available'
         ));
+    }
+
+    private function controlPlaneReadFromCatalogEnabled(): bool
+    {
+        return (bool) config('storage_rollout.control_plane_read_from_catalog_enabled', false);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function catalogReportsArtifactsLifecycleSection(array $inventory): ?array
+    {
+        if (! Schema::hasTable('report_artifact_slots')) {
+            return null;
+        }
+
+        $reportJsonSlotCount = $this->countCatalogSlots(['report_json_free', 'report_json_full']);
+        $pdfSlotCount = $this->countCatalogSlots(['report_pdf_free', 'report_pdf_full']);
+        $reportJsonBytes = $this->sumCatalogBytes(['report_json_free', 'report_json_full']);
+        $pdfBytes = $this->sumCatalogBytes(['report_pdf_free', 'report_pdf_full']);
+
+        if ($reportJsonSlotCount === 0 && $pdfSlotCount === 0 && $reportJsonBytes === 0 && $pdfBytes === 0) {
+            return null;
+        }
+
+        $latestUpdatedAt = $this->latestTimestamp([
+            $this->maxColumnTimestamp('report_artifact_slots', 'updated_at'),
+            $this->maxColumnTimestamp('report_artifact_versions', 'updated_at'),
+        ]);
+
+        $latestInventoryGeneratedAt = $this->normalizeTimestamp($inventory['latest_generated_at'] ?? null) ?? $latestUpdatedAt;
+
+        return array_merge([
+            'status' => 'ok',
+            'canonical_root_path' => storage_path('app/private/artifacts'),
+            'legacy_root_path' => storage_path('app/private/reports'),
+            'canonical_user_output' => [
+                'report_json_files' => $reportJsonSlotCount,
+                'pdf_files' => $pdfSlotCount,
+                'bytes' => $reportJsonBytes + $pdfBytes,
+            ],
+            'legacy_fallback_live' => [
+                'report_json_files' => $this->matchingFilesStats(storage_path('app/private/reports'), static fn (string $relativePath): bool => str_ends_with($relativePath, '/report.json') || $relativePath === 'report.json')['files'],
+                'pdf_files' => $this->matchingFilesStats(storage_path('app/private/reports'), static fn (string $relativePath): bool => str_ends_with($relativePath, '/report_free.pdf')
+                    || str_ends_with($relativePath, '/report_full.pdf')
+                    || in_array($relativePath, ['report_free.pdf', 'report_full.pdf'], true))['files'],
+                'bytes' => 0,
+            ],
+            'safe_to_prune_derived' => [
+                'timestamp_backup_json_files' => 0,
+                'latest_reports_backups_policy' => [
+                    'keep_days' => (int) config('storage_retention.reports.keep_days', 0),
+                    'keep_timestamp_backups' => (int) config('storage_retention.reports.keep_timestamp_backups', 0),
+                ],
+            ],
+            'archive_candidate_status' => 'ledger_backed',
+        ], $this->freshnessFromTimestamp(
+            $latestInventoryGeneratedAt,
+            'ledger-derived',
+            self::INVENTORY_STALE_AFTER_SECONDS,
+            'not_available'
+        ));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function catalogReportArtifactsArchiveSection(): ?array
+    {
+        if (! Schema::hasTable('artifact_lifecycle_jobs')) {
+            return null;
+        }
+
+        $job = DB::table('artifact_lifecycle_jobs')
+            ->where('job_type', 'archive_report_artifacts')
+            ->orderByDesc('finished_at')
+            ->orderByDesc('id')
+            ->first();
+
+        if ($job === null) {
+            return null;
+        }
+
+        $request = $this->decodeMaybeJson($job->request_payload_json ?? null);
+        $result = $this->decodeMaybeJson($job->result_payload_json ?? null);
+        $latestGeneratedAt = $this->normalizeTimestamp($job->finished_at ?? $job->updated_at ?? $job->created_at);
+        $summary = is_array($result['summary'] ?? null) ? $result['summary'] : [];
+
+        return array_merge([
+            'status' => 'ok',
+            'durable_receipt_source' => 'attempt_receipts',
+            'target_disk' => $this->normalizeOptionalString(data_get($request, 'target_disk') ?? data_get($result, 'target_disk')),
+            'latest_generated_at' => $latestGeneratedAt,
+            'latest_mode' => $this->normalizeOptionalString(data_get($request, 'mode') ?? data_get($result, 'mode')),
+            'latest_plan_path' => $this->normalizeOptionalString(data_get($request, 'plan_path')),
+            'latest_run_path' => $this->normalizeOptionalString(data_get($result, 'run_path')),
+            'latest_run_path_exists' => is_string(data_get($result, 'run_path')) && file_exists((string) data_get($result, 'run_path')),
+            'latest_summary' => [
+                'candidate_count' => (int) data_get($summary, 'candidate_count', 0),
+                'copied_count' => (int) data_get($summary, 'copied_count', 0),
+                'verified_count' => (int) data_get($summary, 'verified_count', 0),
+                'already_archived_count' => (int) data_get($summary, 'already_archived_count', 0),
+                'failed_count' => (int) data_get($summary, 'failed_count', 0),
+                'results_count' => count((array) ($result['results'] ?? [])),
+            ],
+        ], $this->freshnessFromTimestamp(
+            $latestGeneratedAt,
+            'ledger-derived',
+            self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
+            'not_available'
+        ));
+    }
+
+    /**
+     * @param  list<string>  $slotCodes
+     */
+    private function countCatalogSlots(array $slotCodes): int
+    {
+        if (! Schema::hasTable('report_artifact_slots')) {
+            return 0;
+        }
+
+        return (int) DB::table('report_artifact_slots')
+            ->whereIn('slot_code', $slotCodes)
+            ->whereNotNull('current_version_id')
+            ->count();
+    }
+
+    /**
+     * @param  list<string>  $slotCodes
+     */
+    private function sumCatalogBytes(array $slotCodes): int
+    {
+        if (! Schema::hasTable('report_artifact_slots') || ! Schema::hasTable('report_artifact_versions')) {
+            return 0;
+        }
+
+        return (int) DB::table('report_artifact_slots')
+            ->join('report_artifact_versions', 'report_artifact_versions.id', '=', 'report_artifact_slots.current_version_id')
+            ->whereIn('report_artifact_slots.slot_code', $slotCodes)
+            ->sum('report_artifact_versions.byte_size');
+    }
+
+    private function maxColumnTimestamp(string $table, string $column): ?string
+    {
+        if (! Schema::hasTable($table) || ! Schema::hasColumn($table, $column)) {
+            return null;
+        }
+
+        $value = DB::table($table)->max($column);
+
+        return $this->normalizeTimestamp($value);
+    }
+
+    /**
+     * @param  list<string>  $summaryFields
+     * @return array<string,mixed>|null
+     */
+    private function catalogReportArtifactsPostureNode(string $jobType, array $summaryFields): ?array
+    {
+        if (! Schema::hasTable('artifact_lifecycle_jobs')) {
+            return null;
+        }
+
+        $job = DB::table('artifact_lifecycle_jobs')
+            ->where('job_type', $jobType)
+            ->orderByDesc('finished_at')
+            ->orderByDesc('id')
+            ->first();
+
+        if ($job === null) {
+            return null;
+        }
+
+        $request = $this->decodeMaybeJson($job->request_payload_json ?? null);
+        $result = $this->decodeMaybeJson($job->result_payload_json ?? null);
+        $latestGeneratedAt = $this->normalizeTimestamp($job->finished_at ?? $job->updated_at ?? $job->created_at);
+        $latestRunPath = $this->normalizeOptionalString(data_get($result, 'run_path'));
+        $summary = [];
+
+        foreach ($summaryFields as $field) {
+            if ($field === 'results_count') {
+                $summary[$field] = count((array) ($result['results'] ?? []));
+
+                continue;
+            }
+
+            $summary[$field] = (int) data_get($result, 'summary.'.$field, 0);
+        }
+
+        return array_merge([
+            'status' => 'ok',
+            'latest_generated_at' => $latestGeneratedAt,
+            'latest_mode' => $this->normalizeOptionalString(data_get($request, 'mode') ?? data_get($result, 'mode')),
+            'latest_plan_path' => $this->normalizeOptionalString(data_get($request, 'plan_path')),
+            'latest_run_path' => $latestRunPath,
+            'latest_run_path_exists' => $latestRunPath !== null && file_exists($latestRunPath),
+            'latest_summary' => $summary,
+        ], $this->freshnessFromTimestamp(
+            $latestGeneratedAt,
+            'ledger-derived',
+            self::MANUAL_CONTROL_PLANE_STALE_AFTER_SECONDS,
+            'not_available'
+        ));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeMaybeJson(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || $value === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 
     /**

--- a/backend/app/Services/Storage/UnifiedAccessProjectionBackfillService.php
+++ b/backend/app/Services/Storage/UnifiedAccessProjectionBackfillService.php
@@ -1,0 +1,568 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use App\Models\Attempt;
+use App\Models\BenefitGrant;
+use App\Models\Order;
+use App\Models\PaymentEvent;
+use App\Models\Result;
+use App\Models\ReportArtifactSlot;
+use App\Models\ReportSnapshot;
+use App\Models\Share;
+use App\Models\UnifiedAccessProjection;
+use App\Services\Report\Pdf\ReportPdfDocumentService;
+use App\Support\SchemaBaseline;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+final class UnifiedAccessProjectionBackfillService
+{
+    private const SCHEMA = 'unified_access_projection_backfill.v1';
+
+    public function __construct(
+        private readonly AttemptReceiptBackfillService $receipts,
+        private readonly ReportPdfDocumentService $pdfService,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return array<string,mixed>
+     */
+    public function buildPlan(array $filters = []): array
+    {
+        $attemptIds = $this->collectAttemptIds($filters);
+
+        return [
+            'schema' => self::SCHEMA,
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'filters' => $this->normalizedFilters($filters),
+            'attempt_count' => count($attemptIds),
+            'access_ready_count' => $this->countAccessReady($attemptIds),
+            'report_ready_count' => $this->countReportReady($attemptIds),
+            'pdf_ready_count' => $this->countPdfReady($attemptIds),
+            'grant_count' => $this->countRows('benefit_grants', $attemptIds),
+            'order_count' => $this->countRows('orders', $attemptIds, 'target_attempt_id'),
+            'payment_event_count' => $this->countPaymentEvents($attemptIds),
+            'share_count' => $this->countRows('shares', $attemptIds),
+            'report_snapshot_count' => $this->countRows('report_snapshots', $attemptIds),
+            'slot_count' => $this->countSlots($attemptIds),
+            'projection_count' => $this->countRows('unified_access_projections', $attemptIds),
+            'attempt_receipts_backfillable_count' => count($attemptIds),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return array<string,mixed>
+     */
+    public function executeBackfill(array $filters = []): array
+    {
+        $attemptIds = $this->collectAttemptIds($filters);
+        $inserted = 0;
+        $reused = 0;
+
+        foreach ($attemptIds as $attemptId) {
+            $result = $this->backfillAttempt($attemptId);
+            $inserted += (int) ($result['inserted'] ?? 0);
+            $reused += (int) ($result['reused'] ?? 0);
+        }
+
+        return [
+            'schema' => self::SCHEMA,
+            'mode' => 'execute',
+            'status' => 'executed',
+            'generated_at' => now()->toIso8601String(),
+            'filters' => $this->normalizedFilters($filters),
+            'attempt_count' => count($attemptIds),
+            'access_ready_count' => $this->countAccessReady($attemptIds),
+            'report_ready_count' => $this->countReportReady($attemptIds),
+            'pdf_ready_count' => $this->countPdfReady($attemptIds),
+            'grant_count' => $this->countRows('benefit_grants', $attemptIds),
+            'order_count' => $this->countRows('orders', $attemptIds, 'target_attempt_id'),
+            'payment_event_count' => $this->countPaymentEvents($attemptIds),
+            'share_count' => $this->countRows('shares', $attemptIds),
+            'report_snapshot_count' => $this->countRows('report_snapshots', $attemptIds),
+            'slot_count' => $this->countSlots($attemptIds),
+            'projection_count' => $this->countRows('unified_access_projections', $attemptIds),
+            'attempt_receipts_inserted' => $inserted,
+            'attempt_receipts_reused' => $reused,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $filters
+     * @return list<string>
+     */
+    private function collectAttemptIds(array $filters): array
+    {
+        $normalized = $this->normalizedFilters($filters);
+        $attemptId = $normalized['attempt_id'];
+        $limit = $normalized['limit'];
+
+        $attemptIds = [];
+        foreach ([
+            $this->attemptIdsFromReportSnapshots($attemptId),
+            $this->attemptIdsFromBenefitGrants($attemptId),
+            $this->attemptIdsFromOrders($attemptId),
+            $this->attemptIdsFromPaymentEvents($attemptId),
+            $this->attemptIdsFromShares($attemptId),
+        ] as $chunk) {
+            foreach ($chunk as $candidate) {
+                $candidate = trim((string) $candidate);
+                if ($candidate === '') {
+                    continue;
+                }
+
+                $attemptIds[$candidate] = true;
+            }
+        }
+
+        $attemptIds = array_keys($attemptIds);
+        sort($attemptIds, SORT_STRING);
+
+        if ($limit !== null) {
+            $attemptIds = array_slice($attemptIds, 0, $limit);
+        }
+
+        return $attemptIds;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function attemptIdsFromReportSnapshots(?string $attemptIdFilter): array
+    {
+        if (! Schema::hasTable('report_snapshots')) {
+            return [];
+        }
+
+        $query = DB::table('report_snapshots')->select('attempt_id')->orderBy('attempt_id');
+        if ($attemptIdFilter !== null) {
+            $query->where('attempt_id', $attemptIdFilter);
+        }
+
+        return $query->pluck('attempt_id')->filter(static fn (mixed $value): bool => is_string($value) && trim($value) !== '')->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function attemptIdsFromBenefitGrants(?string $attemptIdFilter): array
+    {
+        if (! Schema::hasTable('benefit_grants')) {
+            return [];
+        }
+
+        $query = DB::table('benefit_grants')->select('attempt_id')->orderBy('attempt_id');
+        if ($attemptIdFilter !== null) {
+            $query->where('attempt_id', $attemptIdFilter);
+        }
+
+        return $query->pluck('attempt_id')->filter(static fn (mixed $value): bool => is_string($value) && trim($value) !== '')->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function attemptIdsFromOrders(?string $attemptIdFilter): array
+    {
+        if (! Schema::hasTable('orders')) {
+            return [];
+        }
+
+        $query = DB::table('orders')->select('target_attempt_id')->orderBy('target_attempt_id');
+        if ($attemptIdFilter !== null) {
+            $query->where('target_attempt_id', $attemptIdFilter);
+        }
+
+        return $query->pluck('target_attempt_id')->filter(static fn (mixed $value): bool => is_string($value) && trim($value) !== '')->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function attemptIdsFromPaymentEvents(?string $attemptIdFilter): array
+    {
+        if (! Schema::hasTable('payment_events') || ! Schema::hasTable('orders')) {
+            return [];
+        }
+
+        $query = DB::table('payment_events')
+            ->join('orders', 'orders.order_no', '=', 'payment_events.order_no')
+            ->select('orders.target_attempt_id as attempt_id')
+            ->orderBy('orders.target_attempt_id');
+
+        if ($attemptIdFilter !== null) {
+            $query->where('orders.target_attempt_id', $attemptIdFilter);
+        }
+
+        return $query->pluck('attempt_id')->filter(static fn (mixed $value): bool => is_string($value) && trim($value) !== '')->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function attemptIdsFromShares(?string $attemptIdFilter): array
+    {
+        if (! Schema::hasTable('shares')) {
+            return [];
+        }
+
+        $query = DB::table('shares')->select('attempt_id')->orderBy('attempt_id');
+        if ($attemptIdFilter !== null) {
+            $query->where('attempt_id', $attemptIdFilter);
+        }
+
+        return $query->pluck('attempt_id')->filter(static fn (mixed $value): bool => is_string($value) && trim($value) !== '')->all();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function backfillAttempt(string $attemptId): array
+    {
+        if (! SchemaBaseline::hasTable('unified_access_projections')) {
+            return ['inserted' => 0, 'reused' => 0];
+        }
+
+        $hasGrant = $this->hasActiveGrant($attemptId);
+        $hasSnapshot = $this->hasReportSnapshot($attemptId);
+        $hasReportSlot = $this->hasReportSlot($attemptId, ['report_json_free', 'report_json_full']);
+        $hasPdfSlot = $this->hasReportSlot($attemptId, ['report_pdf_free', 'report_pdf_full']);
+        $hasPdfArtifact = $hasPdfSlot || $this->hasPdfArtifactEvidence($attemptId);
+        $hasOrder = $this->hasOrderEvidence($attemptId);
+        $hasPayment = $this->hasPaymentEvidence($attemptId);
+        $hasShare = $this->hasShareEvidence($attemptId);
+
+        $accessState = $hasGrant ? 'ready' : (($hasOrder || $hasPayment || $hasShare) ? 'recovery_available' : 'locked');
+        $reportState = ($hasSnapshot || $hasReportSlot) ? 'ready' : 'missing';
+        $pdfState = $hasPdfArtifact ? 'ready' : 'missing';
+        $reasonCode = $hasGrant
+            ? 'benefit_grant_active'
+            : ($hasPdfArtifact
+                ? 'pdf_artifact_available'
+                : ($hasSnapshot
+                    ? 'report_snapshot_available'
+                    : (($hasOrder || $hasPayment || $hasShare) ? 'payment_or_share_evidence' : 'no_access_evidence')));
+
+        $actionsJson = [
+            'report' => $reportState === 'ready',
+            'pdf' => $pdfState === 'ready',
+            'share' => $hasShare,
+            'payment' => $hasPayment,
+            'unlock' => $hasGrant,
+        ];
+
+        $payloadJson = [
+            'attempt_id' => $attemptId,
+            'has_active_grant' => $hasGrant,
+            'has_report_snapshot' => $hasSnapshot,
+            'has_report_slot' => $hasReportSlot,
+            'has_pdf_slot' => $hasPdfSlot,
+            'has_pdf_artifact' => $hasPdfArtifact,
+            'has_order' => $hasOrder,
+            'has_payment' => $hasPayment,
+            'has_share' => $hasShare,
+        ];
+
+        $existing = UnifiedAccessProjection::query()->where('attempt_id', $attemptId)->first();
+        $now = now();
+
+        if ($existing instanceof UnifiedAccessProjection
+            && (string) ($existing->access_state ?? '') === $accessState
+            && (string) ($existing->report_state ?? '') === $reportState
+            && (string) ($existing->pdf_state ?? '') === $pdfState
+            && (string) ($existing->reason_code ?? '') === $reasonCode
+            && (array) ($existing->actions_json ?? []) === $actionsJson
+            && (array) ($existing->payload_json ?? []) === $payloadJson
+        ) {
+            $this->receipts->recordHistoricalReceipt(
+                $attemptId,
+                'access_projection_refreshed',
+                [
+                    'access_state' => $existing->access_state,
+                    'report_state' => $existing->report_state,
+                    'pdf_state' => $existing->pdf_state,
+                    'reason_code' => $existing->reason_code,
+                    'projection_version' => (int) $existing->projection_version,
+                    'actions_json' => $existing->actions_json,
+                    'payload_json' => $existing->payload_json,
+                    'backfill' => true,
+                ],
+                [
+                    'source_system' => 'unified_access_projection_backfill',
+                    'source_ref' => 'projection#'.$attemptId,
+                    'actor_type' => 'system',
+                    'actor_id' => 'unified_access_projection_backfill',
+                    'idempotency_key' => hash('sha256', implode('|', [
+                        $attemptId,
+                        $existing->access_state,
+                        $existing->report_state,
+                        $existing->pdf_state,
+                        $existing->reason_code ?? '',
+                    ])),
+                    'occurred_at' => $now,
+                    'recorded_at' => $now,
+                ]
+            );
+
+            return ['inserted' => 0, 'reused' => 1];
+        }
+
+        UnifiedAccessProjection::query()->updateOrCreate(
+            ['attempt_id' => $attemptId],
+            [
+                'access_state' => $accessState,
+                'report_state' => $reportState,
+                'pdf_state' => $pdfState,
+                'reason_code' => $reasonCode,
+                'projection_version' => 1,
+                'actions_json' => $actionsJson,
+                'payload_json' => $payloadJson,
+                'produced_at' => $existing?->produced_at ?? $now,
+                'refreshed_at' => $now,
+            ]
+        );
+
+        $this->receipts->recordHistoricalReceipt(
+            $attemptId,
+            'access_projection_refreshed',
+            [
+                'access_state' => $accessState,
+                'report_state' => $reportState,
+                'pdf_state' => $pdfState,
+                'reason_code' => $reasonCode,
+                'projection_version' => 1,
+                'actions_json' => $actionsJson,
+                'payload_json' => $payloadJson,
+                'backfill' => true,
+            ],
+            [
+                'source_system' => 'unified_access_projection_backfill',
+                'source_ref' => 'projection#'.$attemptId,
+                'actor_type' => 'system',
+                'actor_id' => 'unified_access_projection_backfill',
+                'idempotency_key' => hash('sha256', implode('|', [
+                    $attemptId,
+                    $accessState,
+                    $reportState,
+                    $pdfState,
+                    $reasonCode,
+                ])),
+                'occurred_at' => $now,
+                'recorded_at' => $now,
+            ]
+        );
+
+        return ['inserted' => $existing instanceof UnifiedAccessProjection ? 0 : 1, 'reused' => 0];
+    }
+
+    private function hasActiveGrant(string $attemptId): bool
+    {
+        return Schema::hasTable('benefit_grants')
+            && DB::table('benefit_grants')
+                ->where('attempt_id', $attemptId)
+                ->where('status', 'active')
+                ->exists();
+    }
+
+    private function hasReportSnapshot(string $attemptId): bool
+    {
+        return Schema::hasTable('report_snapshots')
+            && DB::table('report_snapshots')
+                ->where('attempt_id', $attemptId)
+                ->exists();
+    }
+
+    /**
+     * @param  list<string>  $slotCodes
+     */
+    private function hasReportSlot(string $attemptId, array $slotCodes): bool
+    {
+        if (! Schema::hasTable('report_artifact_slots')) {
+            return false;
+        }
+
+        return DB::table('report_artifact_slots')
+            ->where('attempt_id', $attemptId)
+            ->whereIn('slot_code', $slotCodes)
+            ->exists();
+    }
+
+    private function hasOrderEvidence(string $attemptId): bool
+    {
+        return Schema::hasTable('orders')
+            && DB::table('orders')
+                ->where('target_attempt_id', $attemptId)
+                ->exists();
+    }
+
+    private function hasPdfArtifactEvidence(string $attemptId): bool
+    {
+        if ($this->hasReportSlot($attemptId, ['report_pdf_free', 'report_pdf_full'])) {
+            return true;
+        }
+
+        if (! Schema::hasTable('attempts') || ! Schema::hasTable('results')) {
+            return false;
+        }
+
+        $attempt = Attempt::query()->where('id', $attemptId)->first();
+        if (! $attempt instanceof Attempt) {
+            return false;
+        }
+
+        $result = Result::query()->where('attempt_id', $attemptId)->first();
+        foreach (['free', 'full'] as $variant) {
+            try {
+                $path = $this->pdfService->resolveArtifactPath($attempt, $variant, $result);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if (Storage::disk('local')->exists($path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasPaymentEvidence(string $attemptId): bool
+    {
+        if (! Schema::hasTable('payment_events') || ! Schema::hasTable('orders')) {
+            return false;
+        }
+
+        return DB::table('payment_events')
+            ->join('orders', 'orders.order_no', '=', 'payment_events.order_no')
+            ->where('orders.target_attempt_id', $attemptId)
+            ->exists();
+    }
+
+    private function hasShareEvidence(string $attemptId): bool
+    {
+        return Schema::hasTable('shares')
+            && DB::table('shares')
+                ->where('attempt_id', $attemptId)
+                ->exists();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizedFilters(array $filters): array
+    {
+        return [
+            'attempt_id' => $this->normalizeNullableText($filters['attempt_id'] ?? null),
+            'limit' => isset($filters['limit']) ? max(1, (int) $filters['limit']) : null,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     */
+    private function countAccessReady(array $attemptIds): int
+    {
+        if (! Schema::hasTable('benefit_grants')) {
+            return 0;
+        }
+
+        return DB::table('benefit_grants')
+            ->where('status', 'active')
+            ->whereIn('attempt_id', $attemptIds)
+            ->distinct('attempt_id')
+            ->count('attempt_id');
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     */
+    private function countReportReady(array $attemptIds): int
+    {
+        if (! Schema::hasTable('report_snapshots')) {
+            return 0;
+        }
+
+        return DB::table('report_snapshots')
+            ->whereIn('attempt_id', $attemptIds)
+            ->count();
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     */
+    private function countPdfReady(array $attemptIds): int
+    {
+        if ($attemptIds === []) {
+            return 0;
+        }
+
+        $count = 0;
+        foreach ($attemptIds as $attemptId) {
+            if ($this->hasPdfArtifactEvidence($attemptId)) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     */
+    private function countSlots(array $attemptIds): int
+    {
+        if (! Schema::hasTable('report_artifact_slots')) {
+            return 0;
+        }
+
+        return DB::table('report_artifact_slots')
+            ->whereIn('attempt_id', $attemptIds)
+            ->count();
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     */
+    private function countRows(string $table, array $attemptIds, string $column = 'attempt_id'): int
+    {
+        if (! Schema::hasTable($table) || $attemptIds === []) {
+            return 0;
+        }
+
+        return (int) DB::table($table)->whereIn($column, $attemptIds)->count();
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     */
+    private function countPaymentEvents(array $attemptIds): int
+    {
+        if (! Schema::hasTable('payment_events') || ! Schema::hasTable('orders') || $attemptIds === []) {
+            return 0;
+        }
+
+        return (int) DB::table('payment_events')
+            ->join('orders', 'orders.order_no', '=', 'payment_events.order_no')
+            ->whereIn('orders.target_attempt_id', $attemptIds)
+            ->count();
+    }
+
+    private function normalizeNullableText(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
+    }
+}

--- a/backend/config/storage_rollout.php
+++ b/backend/config/storage_rollout.php
@@ -28,6 +28,7 @@ return [
     'artifact_slot_version_dual_write_enabled' => false,
     'lifecycle_ledger_dual_write_enabled' => false,
     'access_projection_dual_write_enabled' => false,
+    'control_plane_read_from_catalog_enabled' => false,
     'content_pack_v2_dual_write_enabled' => false,
     'resolver_materialization_enabled' => false,
     'packs_v2_remote_rehydrate_enabled' => false,

--- a/backend/tests/Feature/Access/UnifiedAccessProjectionBackfillTest.php
+++ b/backend/tests/Feature/Access/UnifiedAccessProjectionBackfillTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Access;
+
+use App\Models\Attempt;
+use App\Models\UnifiedAccessProjection;
+use App\Services\Report\Pdf\ReportPdfDocumentService;
+use App\Services\Storage\UnifiedAccessProjectionBackfillService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class UnifiedAccessProjectionBackfillTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-access-projection-backfill-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_backfill_replays_access_projection_from_historical_signals(): void
+    {
+        config()->set('storage_rollout.access_projection_dual_write_enabled', false);
+
+        $attemptId = 'attempt-access-'.Str::lower(Str::random(8));
+        $attempt = Attempt::query()->create([
+            'id' => $attemptId,
+            'anon_id' => 'anon-access',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v1',
+            'question_count' => 1,
+            'answers_summary_json' => [
+                'meta' => [
+                    'pack_release_manifest_hash' => 'nohash',
+                ],
+            ],
+            'client_platform' => 'web',
+            'client_version' => null,
+            'channel' => 'organic',
+            'referrer' => null,
+            'started_at' => now()->subHour(),
+            'submitted_at' => now()->subMinutes(5),
+            'created_at' => now()->subHour(),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'order_no' => 'order-'.$attemptId,
+            'scale_code' => 'MBTI',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'spec-v1',
+            'report_engine_version' => 'engine-v1',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode(['attempt_id' => $attemptId, 'report' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode(['attempt_id' => $attemptId, 'variant' => 'free'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_full_json' => json_encode(['attempt_id' => $attemptId, 'variant' => 'full'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->subMinutes(4),
+            'updated_at' => now()->subMinutes(4),
+        ]);
+
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'user_id' => null,
+            'benefit_code' => 'MBTI_UNLOCK',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'status' => 'active',
+            'expires_at' => null,
+            'benefit_type' => 'unlock',
+            'benefit_ref' => 'ref-'.$attemptId,
+            'source_order_id' => (string) Str::uuid(),
+            'source_event_id' => (string) Str::uuid(),
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinutes(3),
+        ]);
+
+        $orderId = (string) Str::uuid();
+        DB::table('orders')->insert([
+            'id' => $orderId,
+            'order_no' => 'order-'.$attemptId,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon-access',
+            'sku' => 'MBTI_UNLOCK',
+            'item_sku' => 'MBTI_UNLOCK',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_total' => 9900,
+            'amount_cents' => 9900,
+            'currency' => 'USD',
+            'status' => 'paid',
+            'provider' => 'stub',
+            'external_trade_no' => 'trade-'.$attemptId,
+            'paid_at' => now()->subMinutes(3),
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinutes(3),
+        ]);
+
+        DB::table('payment_events')->insert([
+            'id' => (string) Str::uuid(),
+            'provider' => 'stub',
+            'provider_event_id' => 'evt-'.$attemptId,
+            'order_id' => $orderId,
+            'event_type' => 'payment_succeeded',
+            'order_no' => 'order-'.$attemptId,
+            'payload_json' => json_encode(['order_no' => 'order-'.$attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'received_at' => now()->subMinutes(3),
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinutes(3),
+        ]);
+
+        DB::table('shares')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'anon_id' => 'anon-access',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v1',
+            'content_package_version' => 'v1',
+            'created_at' => now()->subMinutes(2),
+            'updated_at' => now()->subMinutes(2),
+        ]);
+
+        $pdfService = app(ReportPdfDocumentService::class);
+        $pdfPath = $pdfService->resolveArtifactPath($attempt, 'free', null);
+        File::ensureDirectoryExists(dirname(storage_path('app/private/'.$pdfPath)));
+        File::put(storage_path('app/private/'.$pdfPath), '%PDF-1.4 access backfill');
+
+        $service = app(UnifiedAccessProjectionBackfillService::class);
+        $plan = $service->buildPlan(['attempt_id' => $attemptId]);
+        $this->assertSame(1, $plan['attempt_count']);
+        $this->assertSame(1, $plan['access_ready_count']);
+        $this->assertSame(1, $plan['report_ready_count']);
+        $this->assertSame(1, $plan['pdf_ready_count']);
+        $this->assertSame(1, $plan['grant_count']);
+        $this->assertSame(1, $plan['order_count']);
+        $this->assertSame(1, $plan['payment_event_count']);
+        $this->assertSame(1, $plan['share_count']);
+        $this->assertSame(1, $plan['report_snapshot_count']);
+
+        $execute = $service->executeBackfill(['attempt_id' => $attemptId]);
+        $this->assertSame(1, $execute['attempt_receipts_inserted']);
+        $this->assertSame(0, $execute['attempt_receipts_reused']);
+
+        $projection = UnifiedAccessProjection::query()->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($projection);
+        $this->assertSame('ready', $projection->access_state);
+        $this->assertSame('ready', $projection->report_state);
+        $this->assertSame('ready', $projection->pdf_state);
+        $this->assertSame('benefit_grant_active', $projection->reason_code);
+        $this->assertSame(1, (int) $projection->projection_version);
+        $this->assertSame(['report' => true, 'pdf' => true, 'share' => true, 'payment' => true, 'unlock' => true], $projection->actions_json);
+        $this->assertSame($attemptId, data_get($projection->payload_json, 'attempt_id'));
+        $this->assertDatabaseHas('attempt_receipts', [
+            'attempt_id' => $attemptId,
+            'receipt_type' => 'access_projection_refreshed',
+        ]);
+    }
+}

--- a/backend/tests/Feature/Storage/ArtifactLedgerBackfillCommandTest.php
+++ b/backend/tests/Feature/Storage/ArtifactLedgerBackfillCommandTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArtifactLedgerBackfillCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-artifact-ledger-backfill-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_dry_run_reports_backfillable_counts_and_classifications(): void
+    {
+        $attemptId = 'attempt-ledger-'.Str::lower(Str::random(8));
+        $this->seedHistoricalArtifacts($attemptId);
+
+        $this->assertSame(0, Artisan::call('storage:backfill-artifact-ledger', [
+            '--dry-run' => true,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=planned', $output);
+        $this->assertStringContainsString('mode=dry_run', $output);
+        $this->assertStringContainsString('candidate_count=4', $output);
+        $this->assertStringContainsString('classification_counts={"alias_or_legacy_path":2,"db_only":1,"matched_db_and_file":1}', $output);
+        $this->assertStringContainsString('slot_counts={"report_json_free":1,"report_json_full":1,"report_pdf_free":1,"report_pdf_full":1}', $output);
+        $this->assertStringContainsString('source_counts={"file":3,"snapshot":1}', $output);
+        $this->assertStringContainsString('alias_or_legacy_path_count=2', $output);
+        $this->assertStringContainsString('nohash_count=2', $output);
+        $this->assertStringContainsString('slot_backfillable_count=4', $output);
+        $this->assertStringContainsString('version_backfillable_count=4', $output);
+        $this->assertStringContainsString('attempt_receipts_backfillable_count=4', $output);
+
+        $this->assertDatabaseCount('attempt_receipts', 0);
+        $this->assertDatabaseCount('report_artifact_slots', 0);
+        $this->assertDatabaseCount('report_artifact_versions', 0);
+        $this->assertDatabaseCount('storage_blobs', 0);
+        $this->assertDatabaseCount('storage_blob_locations', 0);
+    }
+
+    public function test_execute_backfills_rows_and_is_idempotent(): void
+    {
+        $attemptId = 'attempt-ledger-'.Str::lower(Str::random(8));
+        $this->seedHistoricalArtifacts($attemptId);
+
+        $this->assertSame(0, Artisan::call('storage:backfill-artifact-ledger', [
+            '--execute' => true,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('status=executed', $output);
+        $this->assertStringContainsString('mode=execute', $output);
+        $this->assertStringContainsString('slots_upserted=4', $output);
+        $this->assertStringContainsString('versions_inserted=4', $output);
+        $this->assertStringContainsString('blobs_upserted=3', $output);
+        $this->assertStringContainsString('blob_locations_upserted=3', $output);
+        $this->assertStringContainsString('attempt_receipts_inserted=4', $output);
+
+        $this->assertDatabaseCount('attempt_receipts', 4);
+        $this->assertDatabaseCount('report_artifact_slots', 4);
+        $this->assertDatabaseCount('report_artifact_versions', 4);
+        $this->assertDatabaseCount('storage_blobs', 3);
+        $this->assertDatabaseCount('storage_blob_locations', 3);
+
+        $this->assertSame(0, Artisan::call('storage:backfill-artifact-ledger', [
+            '--execute' => true,
+        ]));
+
+        $rerunOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $rerunOutput);
+        $this->assertStringContainsString('versions_reused=4', $rerunOutput);
+        $this->assertStringContainsString('attempt_receipts_reused=4', $rerunOutput);
+
+        $this->assertDatabaseCount('attempt_receipts', 4);
+        $this->assertDatabaseCount('report_artifact_slots', 4);
+        $this->assertDatabaseCount('report_artifact_versions', 4);
+        $this->assertDatabaseCount('storage_blobs', 3);
+        $this->assertDatabaseCount('storage_blob_locations', 3);
+    }
+
+    private function seedHistoricalArtifacts(string $attemptId): void
+    {
+        $now = now();
+        $reportJsonPath = storage_path('app/private/artifacts/reports/MBTI/'.$attemptId.'/report.json');
+        $reportJsonPayload = [
+            'attempt_id' => $attemptId,
+            'artifact' => 'report_json_full',
+        ];
+        $reportFreePayload = [
+            'attempt_id' => $attemptId,
+            'artifact' => 'report_json_free',
+        ];
+        $pdfFreeAttemptId = 'attempt-ledger-pdf-free-'.Str::lower(Str::random(8));
+        $pdfFullAttemptId = 'attempt-ledger-pdf-full-'.Str::lower(Str::random(8));
+        $pdfFreePath = storage_path('app/private/artifacts/pdf/BIG5/'.$pdfFreeAttemptId.'/nohash/report_free.pdf');
+        $pdfFullPath = storage_path('app/private/artifacts/pdf/BIG5_OCEAN/'.$pdfFullAttemptId.'/nohash/report_full.pdf');
+
+        File::ensureDirectoryExists(dirname($reportJsonPath));
+        File::ensureDirectoryExists(dirname($pdfFreePath));
+        File::ensureDirectoryExists(dirname($pdfFullPath));
+        File::put($reportJsonPath, $this->encodeJson($reportJsonPayload));
+        File::put($pdfFreePath, '%PDF-1.4 free nohash');
+        File::put($pdfFullPath, '%PDF-1.4 full nohash');
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => 1,
+            'attempt_id' => $attemptId,
+            'order_no' => 'order-'.$attemptId,
+            'scale_code' => 'MBTI',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'spec-v1',
+            'report_engine_version' => 'engine-v1',
+            'snapshot_version' => 'v1',
+            'report_json' => $this->encodeJson(['attempt_id' => $attemptId, 'artifact' => 'snapshot']),
+            'report_free_json' => $this->encodeJson($reportFreePayload),
+            'report_full_json' => $this->encodeJson($reportJsonPayload),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function encodeJson(array $payload): string
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode test json payload.');
+        }
+
+        return $encoded;
+    }
+}

--- a/backend/tests/Feature/Storage/ArtifactLedgerClassifierTest.php
+++ b/backend/tests/Feature/Storage/ArtifactLedgerClassifierTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ArtifactLedgerClassifier;
+use Tests\TestCase;
+
+final class ArtifactLedgerClassifierTest extends TestCase
+{
+    /**
+     * @return array<string,array{0:array<string,mixed>,1:string,2:list<string>,3:bool,4:bool}>
+     */
+    private static function classificationCases(): array
+    {
+        $artifactsRoot = '/tmp/fap-artifact-ledger-tests/app/private/artifacts';
+        $contentReleasesRoot = '/tmp/fap-artifact-ledger-tests/app/private/content_releases';
+
+        return [
+            'matched_db_and_file' => [
+                [
+                    'artifact_kind' => 'report_json',
+                    'source_path' => 'artifacts/reports/MBTI/attempt-1/report.json',
+                    'relative_path' => 'reports/MBTI/attempt-1/report.json',
+                    'source_root' => $artifactsRoot,
+                    'attempt_id' => 'attempt-1',
+                    'scale_code' => 'MBTI',
+                    'slot_code' => 'report_json_full',
+                    'has_db_row' => true,
+                    'has_file' => true,
+                ],
+                'matched_db_and_file',
+                ['db_row_present', 'file_present'],
+                false,
+                false,
+            ],
+            'alias_or_legacy_path_and_nohash' => [
+                [
+                    'artifact_kind' => 'report_pdf',
+                    'source_path' => 'private/reports/BIG5/attempt-2/nohash/report_free.pdf',
+                    'relative_path' => 'private/reports/BIG5/attempt-2/nohash/report_free.pdf',
+                    'source_root' => storage_path('app/private/reports'),
+                    'attempt_id' => 'attempt-2',
+                    'scale_code' => 'BIG5',
+                    'slot_code' => 'report_pdf_free',
+                    'manifest_hash' => 'nohash',
+                    'has_db_row' => true,
+                    'has_file' => true,
+                ],
+                'alias_or_legacy_path',
+                ['legacy_path', 'scale_alias:BIG5', 'manifest_nohash', 'db_row_present', 'file_present'],
+                true,
+                false,
+            ],
+            'manual_or_test_owned' => [
+                [
+                    'artifact_kind' => 'report_json',
+                    'source_path' => '/content_releases/release-1/source_pack/report.json',
+                    'relative_path' => 'content_releases/release-1/source_pack/report.json',
+                    'source_root' => $contentReleasesRoot,
+                    'attempt_id' => 'attempt-3',
+                    'scale_code' => 'MBTI',
+                    'slot_code' => 'report_json_full',
+                    'has_db_row' => true,
+                    'has_file' => true,
+                ],
+                'manual_or_test_owned',
+                ['manual_or_test_owned', 'db_row_present', 'file_present'],
+                false,
+                true,
+            ],
+            'file_only' => [
+                [
+                    'artifact_kind' => 'report_pdf',
+                    'source_path' => 'artifacts/pdf/EQ60/attempt-4/hash123/report_full.pdf',
+                    'relative_path' => 'pdf/EQ60/attempt-4/hash123/report_full.pdf',
+                    'source_root' => $artifactsRoot,
+                    'attempt_id' => 'attempt-4',
+                    'scale_code' => 'EQ60',
+                    'slot_code' => 'report_pdf_full',
+                    'manifest_hash' => 'hash123',
+                    'has_file' => true,
+                ],
+                'file_only',
+                ['file_present'],
+                false,
+                false,
+            ],
+            'db_only' => [
+                [
+                    'artifact_kind' => 'report_json',
+                    'source_path' => 'artifacts/reports/MBTI/attempt-5/report.json',
+                    'relative_path' => 'reports/MBTI/attempt-5/report.json',
+                    'source_root' => $artifactsRoot,
+                    'attempt_id' => 'attempt-5',
+                    'scale_code' => 'MBTI',
+                    'slot_code' => 'report_json_free',
+                    'has_db_row' => true,
+                ],
+                'db_only',
+                ['db_row_present'],
+                false,
+                false,
+            ],
+            'archive_proof_only' => [
+                [
+                    'artifact_kind' => 'report_pdf',
+                    'source_path' => 'artifacts/pdf/MBTI/attempt-6/hash123/report_full.pdf',
+                    'relative_path' => 'pdf/MBTI/attempt-6/hash123/report_full.pdf',
+                    'source_root' => $artifactsRoot,
+                    'attempt_id' => 'attempt-6',
+                    'scale_code' => 'MBTI',
+                    'slot_code' => 'report_pdf_full',
+                    'has_archive_proof' => true,
+                ],
+                'archive_proof_only',
+                ['archive_proof_present'],
+                false,
+                false,
+            ],
+        ];
+    }
+
+    public function test_classifier_surfaces_alias_nohash_and_ownership_buckets(): void
+    {
+        foreach (self::classificationCases() as $caseName => [$candidate, $expectedBucket, $expectedReasons, $expectedLegacyAlias, $expectedManualOrTestOwned]) {
+            $classified = app(ArtifactLedgerClassifier::class)->classify($candidate);
+
+            $this->assertSame($expectedBucket, $classified['bucket'], $caseName);
+            $this->assertSame($expectedLegacyAlias, $classified['legacy_alias'], $caseName);
+            $this->assertSame($expectedManualOrTestOwned, $classified['manual_or_test_owned'], $caseName);
+
+            foreach ($expectedReasons as $reason) {
+                $this->assertContains($reason, $classified['reasons'], $caseName);
+            }
+        }
+    }
+}

--- a/backend/tests/Feature/Storage/AttemptReceiptBackfillReplayTest.php
+++ b/backend/tests/Feature/Storage/AttemptReceiptBackfillReplayTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptReceiptBackfillReplayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_audit_log_replay_is_idempotent_and_preserves_receipt_types(): void
+    {
+        $attemptId = 'attempt-receipt-'.Str::lower(Str::random(8));
+        $auditLogId = (string) Str::uuid();
+
+        DB::table('audit_logs')->insert([
+            'id' => 1,
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_archive_report_artifacts',
+            'target_type' => 'attempt',
+            'target_id' => $attemptId,
+            'meta_json' => json_encode([
+                'results' => [
+                    [
+                        'attempt_id' => $attemptId,
+                        'status' => 'copied',
+                        'kind' => 'report_json',
+                        'source_path' => 'artifacts/reports/MBTI/'.$attemptId.'/report.json',
+                        'target_object_key' => 'report_artifacts_archive/'.$attemptId.'/report.json',
+                        'target_disk' => 's3',
+                    ],
+                ],
+                'summary' => [
+                    'candidate_count' => 1,
+                    'copied_count' => 1,
+                    'verified_count' => 1,
+                    'already_archived_count' => 0,
+                    'failed_count' => 0,
+                    'results_count' => 1,
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test',
+            'request_id' => $auditLogId,
+            'reason' => 'test',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(3),
+        ]);
+
+        DB::table('audit_logs')->insert([
+            'id' => 2,
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_shrink_archived_report_artifacts',
+            'target_type' => 'attempt',
+            'target_id' => $attemptId,
+            'meta_json' => json_encode([
+                'results' => [
+                    [
+                        'attempt_id' => $attemptId,
+                        'status' => 'deleted',
+                        'kind' => 'report_pdf',
+                        'source_path' => 'artifacts/pdf/MBTI/'.$attemptId.'/nohash/report_full.pdf',
+                        'target_object_key' => 'report_artifacts_archive/'.$attemptId.'/report_full.pdf',
+                        'target_disk' => 's3',
+                    ],
+                ],
+                'summary' => [
+                    'candidate_count' => 1,
+                    'deleted_count' => 1,
+                    'skipped_missing_local_count' => 0,
+                    'blocked_missing_remote_count' => 0,
+                    'blocked_missing_archive_proof_count' => 0,
+                    'blocked_missing_rehydrate_proof_count' => 0,
+                    'blocked_hash_mismatch_count' => 0,
+                    'failed_count' => 0,
+                    'results_count' => 1,
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test',
+            'request_id' => (string) Str::uuid(),
+            'reason' => 'test',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(2),
+        ]);
+
+        $this->assertSame(0, Artisan::call('storage:backfill-attempt-receipts', [
+            '--dry-run' => true,
+            '--attempt-id' => $attemptId,
+        ]));
+        $dryRunOutput = Artisan::output();
+        $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('mode=dry_run', $dryRunOutput);
+        $this->assertStringContainsString('receipt_candidates=2', $dryRunOutput);
+        $this->assertStringContainsString('unique_attempt_ids=1', $dryRunOutput);
+        $this->assertStringContainsString('"artifact_archived":1', $dryRunOutput);
+        $this->assertStringContainsString('"artifact_shrunk":1', $dryRunOutput);
+
+        $this->assertSame(0, Artisan::call('storage:backfill-attempt-receipts', [
+            '--execute' => true,
+            '--attempt-id' => $attemptId,
+        ]));
+        $executeOutput = Artisan::output();
+        $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('mode=execute', $executeOutput);
+        $this->assertStringContainsString('attempt_receipts_inserted=2', $executeOutput);
+        $this->assertStringContainsString('attempt_receipts_reused=0', $executeOutput);
+        $this->assertDatabaseCount('attempt_receipts', 2);
+
+        $this->assertSame(0, Artisan::call('storage:backfill-attempt-receipts', [
+            '--execute' => true,
+            '--attempt-id' => $attemptId,
+        ]));
+        $rerunOutput = Artisan::output();
+        $this->assertStringContainsString('attempt_receipts_inserted=0', $rerunOutput);
+        $this->assertStringContainsString('attempt_receipts_reused=2', $rerunOutput);
+        $this->assertDatabaseCount('attempt_receipts', 2);
+    }
+}

--- a/backend/tests/Feature/Storage/StorageControlPlaneReadCutoverTest.php
+++ b/backend/tests/Feature/Storage/StorageControlPlaneReadCutoverTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\StorageControlPlaneStatusService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageControlPlaneReadCutoverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $isolatedStoragePath;
+
+    private string $originalStoragePath;
+
+    private string $originalLocalRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalStoragePath = $this->app->storagePath();
+        $this->originalLocalRoot = (string) config('filesystems.disks.local.root');
+        $this->isolatedStoragePath = sys_get_temp_dir().'/fap-control-plane-cutover-'.Str::uuid();
+        File::ensureDirectoryExists($this->isolatedStoragePath.'/app/private');
+        $this->app->useStoragePath($this->isolatedStoragePath);
+        config()->set('filesystems.disks.local.root', $this->isolatedStoragePath.'/app/private');
+        Storage::forgetDisk('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::forgetDisk('local');
+        $this->app->useStoragePath($this->originalStoragePath);
+        config()->set('filesystems.disks.local.root', $this->originalLocalRoot);
+        Storage::forgetDisk('local');
+
+        if (is_dir($this->isolatedStoragePath)) {
+            File::deleteDirectory($this->isolatedStoragePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_flag_off_preserves_legacy_audit_backed_status(): void
+    {
+        config()->set('storage_rollout.control_plane_read_from_catalog_enabled', false);
+
+        $this->seedInventoryAudit();
+        $this->seedLegacyArchiveAudit();
+
+        $payload = app(StorageControlPlaneStatusService::class)->buildStatus();
+
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_archive.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_archive.durable_receipt_source'));
+        $this->assertSame('s3', data_get($payload, 'report_artifacts_archive.target_disk'));
+        $this->assertSame(2, data_get($payload, 'report_artifacts_archive.latest_summary.candidate_count'));
+        $this->assertSame('ok', data_get($payload, 'reports_artifacts_lifecycle.status'));
+        $this->assertSame('audit_logs.meta_json', data_get($payload, 'report_artifacts_posture.durable_receipt_source'));
+        $this->assertSame('partial', data_get($payload, 'report_artifacts_posture.status'));
+    }
+
+    public function test_flag_on_prefers_catalog_backed_status_and_falls_back_when_catalog_missing(): void
+    {
+        config()->set('storage_rollout.control_plane_read_from_catalog_enabled', true);
+
+        $this->seedInventoryAudit();
+        $this->seedLegacyArchiveAudit();
+        $this->seedLedgerArchiveRows();
+
+        $payload = app(StorageControlPlaneStatusService::class)->buildStatus();
+
+        $this->assertSame('ok', data_get($payload, 'reports_artifacts_lifecycle.status'));
+        $this->assertSame('ledger_backed', data_get($payload, 'reports_artifacts_lifecycle.archive_candidate_status'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.report_json_files'));
+        $this->assertSame(1, data_get($payload, 'reports_artifacts_lifecycle.canonical_user_output.pdf_files'));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_archive.status'));
+        $this->assertSame('attempt_receipts', data_get($payload, 'report_artifacts_archive.durable_receipt_source'));
+        $this->assertSame('local', data_get($payload, 'report_artifacts_archive.target_disk'));
+        $this->assertSame('ok', data_get($payload, 'report_artifacts_posture.status'));
+        $this->assertSame('attempt_receipts', data_get($payload, 'report_artifacts_posture.durable_receipt_source'));
+        $this->assertSame('ledger-derived', data_get($payload, 'report_artifacts_posture.freshness_source_type'));
+        $this->assertSame('ledger-derived', data_get($payload, 'reports_artifacts_lifecycle.freshness_source_type'));
+    }
+
+    private function seedInventoryAudit(): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_inventory',
+            'target_type' => 'storage',
+            'target_id' => 'inventory',
+            'meta_json' => json_encode([
+                'schema_version' => 2,
+                'generated_at' => now()->subMinutes(10)->toIso8601String(),
+                'focus_scopes' => ['reports', 'artifacts'],
+                'totals' => ['files' => 3, 'bytes' => 1024],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test',
+            'request_id' => null,
+            'reason' => 'test',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(10),
+        ]);
+    }
+
+    private function seedLegacyArchiveAudit(): void
+    {
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_archive_report_artifacts',
+            'target_type' => 'report_artifact_archive',
+            'target_id' => 'archive_report_artifacts',
+            'meta_json' => json_encode([
+                'durable_receipt_source' => 'audit_logs.meta_json',
+                'target_disk' => 's3',
+                'mode' => 'execute',
+                'plan_path' => storage_path('app/private/report_artifact_archive_plans/archive-plan.json'),
+                'run_path' => storage_path('app/private/report_artifact_archive_runs/archive-run.json'),
+                'candidate_count' => 2,
+                'copied_count' => 1,
+                'verified_count' => 1,
+                'already_archived_count' => 0,
+                'failed_count' => 0,
+                'results' => [
+                    ['attempt_id' => 'attempt-legacy', 'status' => 'copied'],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'test',
+            'request_id' => null,
+            'reason' => 'test',
+            'result' => 'success',
+            'created_at' => now()->subMinutes(5),
+        ]);
+    }
+
+    private function seedLedgerArchiveRows(): void
+    {
+        $now = now();
+        $slotIds = [];
+
+        foreach ([
+            ['report_json_free', 120],
+            ['report_pdf_full', 240],
+        ] as [$slotCode, $byteSize]) {
+            $slotId = DB::table('report_artifact_slots')->insertGetId([
+                'attempt_id' => 'attempt-ledger-cutover',
+                'slot_code' => $slotCode,
+                'required_by_product' => false,
+                'current_version_id' => null,
+                'render_state' => 'materialized',
+                'delivery_state' => 'available',
+                'access_state' => 'locked',
+                'integrity_state' => 'verified',
+                'last_error_code' => null,
+                'last_materialized_at' => $now,
+                'last_verified_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            $versionId = DB::table('report_artifact_versions')->insertGetId([
+                'artifact_slot_id' => $slotId,
+                'version_no' => 1,
+                'source_type' => 'file',
+                'report_snapshot_id' => 'attempt-ledger-cutover',
+                'storage_blob_id' => str_repeat('a', 64),
+                'created_from_receipt_id' => null,
+                'supersedes_version_id' => null,
+                'manifest_hash' => 'nohash',
+                'dir_version' => 'v1',
+                'scoring_spec_version' => 'spec-v1',
+                'report_engine_version' => 'engine-v1',
+                'content_hash' => hash('sha256', $slotCode),
+                'byte_size' => $byteSize,
+                'metadata_json' => json_encode(['slot_code' => $slotCode], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            DB::table('report_artifact_slots')
+                ->where('id', $slotId)
+                ->update([
+                    'current_version_id' => $versionId,
+                    'updated_at' => $now,
+                ]);
+
+            $slotIds[] = $slotId;
+        }
+
+        DB::table('artifact_lifecycle_jobs')->insert([
+            'attempt_id' => 'attempt-ledger-cutover',
+            'artifact_slot_id' => $slotIds[0],
+            'job_type' => 'archive_report_artifacts',
+            'state' => 'succeeded',
+            'reason_code' => null,
+            'blocked_reason_code' => null,
+            'idempotency_key' => 'archive-ledger-cutover',
+            'request_payload_json' => json_encode([
+                'mode' => 'execute',
+                'plan_path' => storage_path('app/private/report_artifact_archive_plans/ledger-plan.json'),
+                'target_disk' => 'local',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'result_payload_json' => json_encode([
+                'mode' => 'execute',
+                'run_path' => storage_path('app/private/report_artifact_archive_runs/ledger-run.json'),
+                'target_disk' => 'local',
+                'summary' => [
+                    'candidate_count' => 2,
+                    'copied_count' => 1,
+                    'verified_count' => 1,
+                    'already_archived_count' => 0,
+                    'failed_count' => 0,
+                ],
+                'results' => [
+                    ['attempt_id' => 'attempt-ledger-cutover', 'status' => 'copied'],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'attempt_count' => 1,
+            'started_at' => $now->subMinutes(3),
+            'finished_at' => $now->subMinutes(3),
+            'created_at' => $now->subMinutes(3),
+            'updated_at' => $now->subMinutes(3),
+        ]);
+
+        DB::table('artifact_lifecycle_jobs')->insert([
+            'attempt_id' => 'attempt-ledger-cutover',
+            'artifact_slot_id' => $slotIds[0],
+            'job_type' => 'rehydrate_report_artifacts',
+            'state' => 'succeeded',
+            'reason_code' => null,
+            'blocked_reason_code' => null,
+            'idempotency_key' => 'rehydrate-ledger-cutover',
+            'request_payload_json' => json_encode([
+                'mode' => 'execute',
+                'plan_path' => storage_path('app/private/report_artifact_rehydrate_plans/ledger-plan.json'),
+                'target_disk' => 'local',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'result_payload_json' => json_encode([
+                'mode' => 'execute',
+                'run_path' => storage_path('app/private/report_artifact_rehydrate_runs/ledger-run.json'),
+                'summary' => [
+                    'candidate_count' => 1,
+                    'rehydrated_count' => 1,
+                    'verified_count' => 1,
+                    'skipped_count' => 0,
+                    'blocked_count' => 0,
+                    'failed_count' => 0,
+                ],
+                'results' => [
+                    ['attempt_id' => 'attempt-ledger-cutover', 'status' => 'rehydrated'],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'attempt_count' => 1,
+            'started_at' => $now->subMinutes(2),
+            'finished_at' => $now->subMinutes(2),
+            'created_at' => $now->subMinutes(2),
+            'updated_at' => $now->subMinutes(2),
+        ]);
+
+        DB::table('artifact_lifecycle_jobs')->insert([
+            'attempt_id' => 'attempt-ledger-cutover',
+            'artifact_slot_id' => $slotIds[1],
+            'job_type' => 'shrink_archived_report_artifacts',
+            'state' => 'succeeded',
+            'reason_code' => null,
+            'blocked_reason_code' => null,
+            'idempotency_key' => 'shrink-ledger-cutover',
+            'request_payload_json' => json_encode([
+                'mode' => 'execute',
+                'plan_path' => storage_path('app/private/report_artifact_shrink_plans/ledger-plan.json'),
+                'target_disk' => 'local',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'result_payload_json' => json_encode([
+                'mode' => 'execute',
+                'run_path' => storage_path('app/private/report_artifact_shrink_runs/ledger-run.json'),
+                'summary' => [
+                    'candidate_count' => 1,
+                    'deleted_count' => 1,
+                    'skipped_missing_local_count' => 0,
+                    'blocked_missing_remote_count' => 0,
+                    'blocked_missing_archive_proof_count' => 0,
+                    'blocked_missing_rehydrate_proof_count' => 0,
+                    'blocked_hash_mismatch_count' => 0,
+                    'failed_count' => 0,
+                ],
+                'results' => [
+                    ['attempt_id' => 'attempt-ledger-cutover', 'status' => 'shrunk'],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'attempt_count' => 1,
+            'started_at' => $now->subMinute(),
+            'finished_at' => $now->subMinute(),
+            'created_at' => $now->subMinute(),
+            'updated_at' => $now->subMinute(),
+        ]);
+
+        DB::table('attempt_receipts')->insert([
+            'attempt_id' => 'attempt-ledger-cutover',
+            'seq' => 1,
+            'receipt_type' => 'artifact_archived',
+            'source_system' => 'ledger_cutover_test',
+            'source_ref' => 'ledger-cutover',
+            'actor_type' => 'system',
+            'actor_id' => 'ledger_cutover_test',
+            'idempotency_key' => 'ledger-cutover-archive',
+            'payload_json' => json_encode(['status' => 'copied'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $now->subMinutes(3),
+            'recorded_at' => $now->subMinutes(3),
+            'created_at' => $now->subMinutes(3),
+            'updated_at' => $now->subMinutes(3),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add dry-run and rerunnable backfill commands for artifact ledger, receipts, and unified access projections
- add explicit artifact classifier coverage for alias/nohash/manual-owned historical cases
- cut backend ops/control-plane reads over to ledger/catalog-backed data behind a default-off flag with compatibility fallback

## Tests
- php -l on all added/modified PHP files for this PR
- php artisan test --filter='ArtifactLedgerBackfillCommandTest|ArtifactLedgerClassifierTest|AttemptReceiptBackfillReplayTest|UnifiedAccessProjectionBackfillTest|StorageControlPlaneReadCutoverTest|StorageControlPlaneStatusServiceTest'
- php artisan migrate --env=testing --force