### PR TITLE
[codex] expose report access projection

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -183,6 +183,9 @@ Route::prefix('v0.3')->middleware([
         Route::get('/attempts/{id}/report', [AttemptReadController::class, 'report'])
             ->middleware('uuid:id')
             ->name('api.v0_3.attempts.report');
+        Route::get('/attempts/{id}/report-access', [AttemptReadController::class, 'reportAccess'])
+            ->middleware('uuid:id')
+            ->name('api.v0_3.attempts.report_access');
         Route::get('/attempts/{id}/report.pdf', [AttemptReadController::class, 'reportPdf'])
             ->middleware('uuid:id')
             ->name('api.v0_3.attempts.report_pdf');

--- a/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+++ b/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptReportAccessReadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createAttempt(string $attemptId, string $anonId): void
+    {
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'attempt-v1',
+            'scoring_spec_version' => 'attempt-score-v1',
+        ]);
+    }
+
+    private function createResult(string $attemptId): void
+    {
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [],
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'result-v1',
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => 'result-score-v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+    }
+
+    public function test_it_reads_consumer_report_access_projection_without_changing_report_contracts(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_reader';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createResult($attemptId);
+
+        DB::table('unified_access_projections')->insert([
+            'attempt_id' => $attemptId,
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'ready',
+            'reason_code' => 'entitlement_granted',
+            'projection_version' => 1,
+            'actions_json' => json_encode(['report' => true, 'pdf' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_json' => json_encode(['attempt_id' => $attemptId, 'has_active_grant' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'produced_at' => now(),
+            'refreshed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'ready');
+        $response->assertJsonPath('report_state', 'ready');
+        $response->assertJsonPath('pdf_state', 'ready');
+        $response->assertJsonPath('reason_code', 'entitlement_granted');
+        $response->assertJsonPath('projection_version', 1);
+        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+        $response->assertJsonPath('actions.pdf_href', "/api/v0.3/attempts/{$attemptId}/report.pdf");
+        $response->assertJsonPath('actions.history_href', '/history/mbti');
+        $response->assertJsonPath('actions.lookup_href', '/orders/lookup');
+        $response->assertJsonPath('payload.has_active_grant', true);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds the minimal backend read-only surfacing needed for the frontend access-projection cutover.

The frontend now needs a stable consumer-facing projection source instead of reconstructing access from report endpoints, order delivery payloads, and legacy URL fields. The backend already writes unified access projections, but it did not expose a narrow read surface for consumers.

This PR adds that thin additive surface without changing any existing user-facing report or PDF APIs.

## Root cause
The control-plane and write-side work is already in place, but frontend consumers still lacked a stable way to read projection state directly. Without a dedicated read seam, the frontend would have to keep merging legacy fields and remain an owner of access semantics.

## What changed
- added an additive `GET /api/v0.3/attempts/{id}/report-access` route
- covered the endpoint with a focused feature test in `AttemptReportAccessReadTest`
- kept existing report and PDF endpoints unchanged
- did not change schema, writes, backfill, lifecycle execution, or response contracts on existing endpoints

## User impact
This is intentionally a thin backend support PR. It does not alter current user-facing report behavior on its own, but it gives the frontend a stable projection read surface so access decisions can move out of legacy field merging.

## Validation
- `php artisan test --filter=AttemptReportAccessReadTest`
