### PR TITLE
[codex] add safe shrink cohort planning seam

### DIFF
--- a/backend/app/Console/Commands/StorageShrinkArchivedReportArtifacts.php
+++ b/backend/app/Console/Commands/StorageShrinkArchivedReportArtifacts.php
@@ -14,6 +14,8 @@ final class StorageShrinkArchivedReportArtifacts extends Command
     protected $signature = 'storage:shrink-archived-report-artifacts
         {--dry-run : Build a shrink plan for archived and rehydratable local canonical report artifacts}
         {--execute : Execute shrink from an existing plan}
+        {--attempt-id=* : Narrow dry-run candidate selection to one or more attempt_ids}
+        {--limit= : Limit dry-run candidate selection after proof/block evaluation}
         {--disk=s3 : Remote object storage disk that still holds archived canonical artifacts}
         {--plan= : Absolute or storage-relative plan path required for execute mode}
         {--json : Emit the full payload as JSON}';
@@ -44,11 +46,21 @@ final class StorageShrinkArchivedReportArtifacts extends Command
             $this->ensureTargetDiskIsRemote($disk);
 
             if ($dryRun) {
-                $plan = $this->service->buildPlan($disk);
+                $plan = $this->service->buildPlan($disk, [
+                    'attempt_ids' => $this->normalizedAttemptIds(),
+                    'limit' => $this->normalizedLimit(),
+                    'generated_by_command' => 'storage:shrink-archived-report-artifacts',
+                ]);
                 $planPath = $this->persistPlan($plan);
                 $payload = $plan + ['plan' => $planPath];
 
                 return $this->emitPayload($payload);
+            }
+
+            if ($this->normalizedAttemptIds() !== [] || $this->option('limit') !== null) {
+                $this->error('--attempt-id and --limit are only supported with --dry-run.');
+
+                return self::FAILURE;
             }
 
             $planOption = trim((string) ($this->option('plan') ?? ''));
@@ -67,9 +79,10 @@ final class StorageShrinkArchivedReportArtifacts extends Command
                 return self::FAILURE;
             }
 
-            $plan['_meta'] = [
-                'plan_path' => $resolvedPlanPath,
-            ];
+            $plan['_meta'] = array_merge(
+                is_array($plan['_meta'] ?? null) ? $plan['_meta'] : [],
+                ['plan_path' => $resolvedPlanPath]
+            );
             $payload = $this->frontDoorEnabled()
                 ? $this->frontDoor->execute('shrink_archived_report_artifacts', $plan, fn (array $resolvedPlan): array => $this->service->executePlan($resolvedPlan))
                 : $this->service->executePlan($plan);
@@ -123,6 +136,14 @@ final class StorageShrinkArchivedReportArtifacts extends Command
         $this->line('target_disk='.(string) ($payload['target_disk'] ?? ''));
         $this->line('schema='.(string) ($payload['schema'] ?? ''));
         $this->line('plan='.(string) ($payload['plan'] ?? ''));
+        $this->line('selection_scope='.(string) data_get($payload, 'selection_scope', 'legacy_unscoped_plan'));
+        $requestedAttemptIds = data_get($payload, 'requested_attempt_ids', []);
+        if (! is_array($requestedAttemptIds)) {
+            $requestedAttemptIds = [];
+        }
+        $this->line('requested_attempt_ids='.implode(',', array_map(static fn (mixed $value): string => (string) $value, $requestedAttemptIds)));
+        $requestedLimit = data_get($payload, 'requested_limit');
+        $this->line('requested_limit='.(is_int($requestedLimit) ? (string) $requestedLimit : ''));
         $this->line('candidate_count='.(int) ($summary['candidate_count'] ?? 0));
         $this->line('deleted_count='.(int) ($summary['deleted_count'] ?? 0));
         $this->line('skipped_missing_local_count='.(int) ($summary['skipped_missing_local_count'] ?? 0));
@@ -197,5 +218,41 @@ final class StorageShrinkArchivedReportArtifacts extends Command
     private function frontDoorEnabled(): bool
     {
         return (bool) config('storage_rollout.lifecycle_front_door_enabled', false);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizedAttemptIds(): array
+    {
+        $values = $this->option('attempt-id');
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $attemptIds = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            $values
+        ), static fn (string $value): bool => $value !== ''));
+
+        $attemptIds = array_values(array_unique($attemptIds));
+        sort($attemptIds);
+
+        return $attemptIds;
+    }
+
+    private function normalizedLimit(): ?int
+    {
+        $raw = $this->option('limit');
+        if ($raw === null || trim((string) $raw) === '') {
+            return null;
+        }
+
+        $limit = trim((string) $raw);
+        if (! ctype_digit($limit) || (int) $limit <= 0) {
+            throw new \RuntimeException('--limit must be a positive integer.');
+        }
+
+        return (int) $limit;
     }
 }

--- a/backend/app/Services/Storage/ReportArtifactsShrinkService.php
+++ b/backend/app/Services/Storage/ReportArtifactsShrinkService.php
@@ -40,10 +40,11 @@ final class ReportArtifactsShrinkService
     /**
      * @return array<string,mixed>
      */
-    public function buildPlan(string $targetDisk): array
+    public function buildPlan(string $targetDisk, array $selection = []): array
     {
         $targetDisk = $this->normalizeDisk($targetDisk);
-        $localFiles = $this->collectLocalCanonicalFiles();
+        $selectionMeta = $this->selectionMeta($selection);
+        $localFiles = $this->collectLocalCanonicalFiles($selectionMeta['requested_attempt_ids']);
         $archiveProofsByPath = $this->collectArchiveProofsByPath($targetDisk);
 
         $candidates = [];
@@ -104,6 +105,11 @@ final class ReportArtifactsShrinkService
         usort($candidates, static fn (array $left, array $right): int => strcmp((string) ($left['local_path'] ?? ''), (string) ($right['local_path'] ?? '')));
         usort($blocked, static fn (array $left, array $right): int => strcmp((string) ($left['local_path'] ?? ''), (string) ($right['local_path'] ?? '')));
 
+        if ($selectionMeta['requested_limit'] !== null) {
+            $candidates = array_slice($candidates, 0, $selectionMeta['requested_limit']);
+            $summary['candidate_count'] = count($candidates);
+        }
+
         $payload = [
             'schema' => self::PLAN_SCHEMA,
             'mode' => 'dry_run',
@@ -111,6 +117,11 @@ final class ReportArtifactsShrinkService
             'generated_at' => now()->toIso8601String(),
             'disk' => $targetDisk,
             'target_disk' => $targetDisk,
+            'selection_scope' => $selectionMeta['selection_scope'],
+            'requested_attempt_ids' => $selectionMeta['requested_attempt_ids'],
+            'requested_limit' => $selectionMeta['requested_limit'],
+            'generated_by_command' => $selectionMeta['generated_by_command'],
+            'candidate_count' => $summary['candidate_count'],
             'summary' => $summary,
             'candidates' => $candidates,
             'blocked' => $blocked,
@@ -130,6 +141,7 @@ final class ReportArtifactsShrinkService
         $this->assertPlanSchema($plan);
 
         $targetDisk = $this->normalizeDisk((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+        $selectionMeta = $this->selectionMetaFromPlan($plan);
         $candidates = is_array($plan['candidates'] ?? null) ? array_values($plan['candidates']) : [];
         $summary = [
             'candidate_count' => count($candidates),
@@ -211,6 +223,11 @@ final class ReportArtifactsShrinkService
             'target_disk' => $targetDisk,
             'plan' => trim((string) data_get($plan, '_meta.plan_path', '')),
             'plan_path' => trim((string) data_get($plan, '_meta.plan_path', '')),
+            'selection_scope' => $selectionMeta['selection_scope'],
+            'requested_attempt_ids' => $selectionMeta['requested_attempt_ids'],
+            'requested_limit' => $selectionMeta['requested_limit'],
+            'generated_by_command' => $selectionMeta['generated_by_command'],
+            'candidate_count' => $summary['candidate_count'],
             'summary' => $summary,
             'results' => $results,
         ];
@@ -232,7 +249,7 @@ final class ReportArtifactsShrinkService
     /**
      * @return list<array<string,mixed>>
      */
-    private function collectLocalCanonicalFiles(): array
+    private function collectLocalCanonicalFiles(array $requestedAttemptIds = []): array
     {
         $artifactsRoot = storage_path('app/private/artifacts');
         if (! is_dir($artifactsRoot)) {
@@ -250,6 +267,10 @@ final class ReportArtifactsShrinkService
             foreach (File::allFiles($root) as $file) {
                 $candidate = $this->localCanonicalFileFromSplFile($file, $artifactsRoot);
                 if ($candidate === null) {
+                    continue;
+                }
+
+                if ($requestedAttemptIds !== [] && ! in_array((string) ($candidate['attempt_id'] ?? ''), $requestedAttemptIds, true)) {
                     continue;
                 }
 
@@ -712,6 +733,11 @@ final class ReportArtifactsShrinkService
                 'failed_count' => $failedCount,
                 'results_count' => count($results),
                 'durable_receipt_source' => 'audit_logs.meta_json',
+                'selection_scope' => $payload['selection_scope'] ?? 'legacy_unscoped_plan',
+                'requested_attempt_ids' => array_values(is_array($payload['requested_attempt_ids'] ?? null) ? $payload['requested_attempt_ids'] : []),
+                'requested_limit' => $payload['requested_limit'] ?? null,
+                'generated_by_command' => $payload['generated_by_command'] ?? null,
+                'candidate_count' => (int) ($payload['candidate_count'] ?? $summary['candidate_count'] ?? 0),
                 'summary' => $summary,
                 'results' => $results,
             ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
@@ -892,5 +918,90 @@ final class ReportArtifactsShrinkService
         $timestamp = trim((string) $value);
 
         return $timestamp === '' ? null : $timestamp;
+    }
+
+    /**
+     * @param  array<string,mixed>  $selection
+     * @return array{
+     *     selection_scope:string,
+     *     requested_attempt_ids:list<string>,
+     *     requested_limit:int|null,
+     *     generated_by_command:string
+     * }
+     */
+    private function selectionMeta(array $selection): array
+    {
+        $requestedAttemptIds = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            is_array($selection['attempt_ids'] ?? null) ? $selection['attempt_ids'] : []
+        ), static fn (string $value): bool => $value !== ''));
+        $requestedAttemptIds = array_values(array_unique($requestedAttemptIds));
+        sort($requestedAttemptIds);
+
+        $requestedLimit = $this->normalizePlanLimit($selection['limit'] ?? null);
+        $selectionScope = match (true) {
+            $requestedAttemptIds !== [] && $requestedLimit !== null => 'attempt_scoped_limited',
+            $requestedAttemptIds !== [] => 'attempt_scoped',
+            $requestedLimit !== null => 'limit_scoped',
+            default => 'full_scan',
+        };
+
+        return [
+            'selection_scope' => $selectionScope,
+            'requested_attempt_ids' => $requestedAttemptIds,
+            'requested_limit' => $requestedLimit,
+            'generated_by_command' => trim((string) ($selection['generated_by_command'] ?? 'storage:shrink-archived-report-artifacts')),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array{
+     *     selection_scope:string,
+     *     requested_attempt_ids:list<string>,
+     *     requested_limit:int|null,
+     *     generated_by_command:string|null
+     * }
+     */
+    private function selectionMetaFromPlan(array $plan): array
+    {
+        $requestedAttemptIds = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            is_array($plan['requested_attempt_ids'] ?? null) ? $plan['requested_attempt_ids'] : []
+        ), static fn (string $value): bool => $value !== ''));
+        $requestedAttemptIds = array_values(array_unique($requestedAttemptIds));
+        sort($requestedAttemptIds);
+
+        $selectionScope = trim((string) ($plan['selection_scope'] ?? ''));
+        if ($selectionScope === '') {
+            $selectionScope = 'legacy_unscoped_plan';
+        }
+
+        $generatedByCommand = trim((string) ($plan['generated_by_command'] ?? ''));
+
+        return [
+            'selection_scope' => $selectionScope,
+            'requested_attempt_ids' => $requestedAttemptIds,
+            'requested_limit' => $this->normalizePlanLimit($plan['requested_limit'] ?? null),
+            'generated_by_command' => $generatedByCommand !== '' ? $generatedByCommand : null,
+        ];
+    }
+
+    private function normalizePlanLimit(mixed $value): ?int
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (! ctype_digit($normalized) || (int) $normalized <= 0) {
+            throw new \RuntimeException('shrink plan limit must be a positive integer.');
+        }
+
+        return (int) $normalized;
     }
 }

--- a/backend/tests/Feature/Storage/StorageShrinkArchivedReportArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageShrinkArchivedReportArtifactsCommandTest.php
@@ -74,31 +74,19 @@ final class StorageShrinkArchivedReportArtifactsCommandTest extends TestCase
         $this->artisan('storage:shrink-archived-report-artifacts --execute --disk=s3')
             ->expectsOutputToContain('--execute requires --plan.')
             ->assertExitCode(1);
+
+        $this->artisan('storage:shrink-archived-report-artifacts --execute --disk=s3 --plan=fake-plan.json --attempt-id=attempt-1')
+            ->expectsOutputToContain('--attempt-id and --limit are only supported with --dry-run.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:shrink-archived-report-artifacts --dry-run --disk=s3 --limit=0')
+            ->expectsOutputToContain('--limit must be a positive integer.')
+            ->assertExitCode(1);
     }
 
     public function test_command_dry_run_execute_json_and_skipped_missing_local_are_visible(): void
     {
-        $reportBytes = json_encode(['attempt' => 'command-shrink'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-        $this->assertIsString($reportBytes);
-        $reportPath = 'artifacts/reports/MBTI/command-shrink/report.json';
-        Storage::disk('local')->put($reportPath, $reportBytes);
-        Storage::disk('s3')->put('report_artifacts_archive/reports/MBTI/command-shrink/report.json', $reportBytes);
-
-        $this->seedArchiveAudit([
-            [
-                'status' => 'copied',
-                'kind' => 'report_json',
-                'source_path' => $reportPath,
-                'target_disk' => 's3',
-                'target_object_key' => 'report_artifacts_archive/reports/MBTI/command-shrink/report.json',
-                'source_sha256' => hash('sha256', $reportBytes),
-                'source_bytes' => strlen($reportBytes),
-                'target_bytes' => strlen($reportBytes),
-                'scale_code' => 'MBTI',
-                'attempt_id' => 'command-shrink',
-                'verified_at' => now()->toIso8601String(),
-            ],
-        ]);
+        $this->seedCanonicalArchivedArtifact('command-shrink');
 
         $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
             '--dry-run' => true,
@@ -106,6 +94,9 @@ final class StorageShrinkArchivedReportArtifactsCommandTest extends TestCase
         ]));
         $dryRunOutput = Artisan::output();
         $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('selection_scope=full_scan', $dryRunOutput);
+        $this->assertStringContainsString('requested_attempt_ids=', $dryRunOutput);
+        $this->assertStringContainsString('requested_limit=', $dryRunOutput);
         $this->assertStringContainsString('candidate_count=1', $dryRunOutput);
         $this->assertStringContainsString('deleted_count=0', $dryRunOutput);
         $this->assertStringContainsString('blocked_missing_archive_proof_count=0', $dryRunOutput);
@@ -121,9 +112,10 @@ final class StorageShrinkArchivedReportArtifactsCommandTest extends TestCase
         ]));
         $executeOutput = Artisan::output();
         $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('selection_scope=full_scan', $executeOutput);
         $this->assertStringContainsString('deleted_count=1', $executeOutput);
         $this->assertStringContainsString('run_path=', $executeOutput);
-        $this->assertFalse(Storage::disk('local')->exists($reportPath));
+        $this->assertFalse(Storage::disk('local')->exists('artifacts/reports/MBTI/command-shrink/report.json'));
 
         $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
             '--execute' => true,
@@ -144,6 +136,9 @@ final class StorageShrinkArchivedReportArtifactsCommandTest extends TestCase
         $this->assertIsArray($jsonPayload);
         $this->assertSame('storage_shrink_archived_report_artifacts_plan.v1', $jsonPayload['schema'] ?? null);
         $this->assertSame(0, data_get($jsonPayload, 'summary.candidate_count'));
+        $this->assertSame('full_scan', $jsonPayload['selection_scope'] ?? null);
+        $this->assertSame([], $jsonPayload['requested_attempt_ids'] ?? null);
+        $this->assertNull($jsonPayload['requested_limit'] ?? null);
 
         $audit = DB::table('audit_logs')
             ->where('action', 'storage_shrink_archived_report_artifacts')
@@ -155,6 +150,190 @@ final class StorageShrinkArchivedReportArtifactsCommandTest extends TestCase
         $this->assertIsArray($meta);
         $this->assertSame('dry_run', $meta['mode'] ?? null);
         $this->assertSame('audit_logs.meta_json', $meta['durable_receipt_source'] ?? null);
+        $this->assertSame('full_scan', $meta['selection_scope'] ?? null);
+    }
+
+    public function test_command_can_build_attempt_scoped_dry_run_plan(): void
+    {
+        $this->seedCanonicalArchivedArtifact('attempt-b');
+        $this->seedCanonicalArchivedArtifact('attempt-a');
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--attempt-id' => ['attempt-b', 'attempt-a'],
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('attempt_scoped', $payload['selection_scope'] ?? null);
+        $this->assertSame(['attempt-a', 'attempt-b'], $payload['requested_attempt_ids'] ?? null);
+        $this->assertNull($payload['requested_limit'] ?? null);
+        $this->assertSame(2, $payload['candidate_count'] ?? null);
+        $this->assertSame(2, data_get($payload, 'summary.candidate_count'));
+        $this->assertSame(['attempt-a', 'attempt-b'], array_column((array) ($payload['candidates'] ?? []), 'attempt_id'));
+    }
+
+    public function test_command_can_build_limit_scoped_plan_without_hiding_blocked_summary(): void
+    {
+        $this->seedCanonicalArchivedArtifact('limit-a');
+        $this->seedCanonicalArchivedArtifact('limit-b');
+        Storage::disk('local')->put('artifacts/reports/MBTI/blocked-missing-proof/report.json', '{"attempt":"blocked-missing-proof"}');
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--limit' => '1',
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('limit_scoped', $payload['selection_scope'] ?? null);
+        $this->assertSame([], $payload['requested_attempt_ids'] ?? null);
+        $this->assertSame(1, $payload['requested_limit'] ?? null);
+        $this->assertSame(1, $payload['candidate_count'] ?? null);
+        $this->assertSame(1, data_get($payload, 'summary.candidate_count'));
+        $this->assertSame(1, data_get($payload, 'summary.blocked_missing_archive_proof_count'));
+        $this->assertSame('limit-a', data_get($payload, 'candidates.0.attempt_id'));
+    }
+
+    public function test_command_combines_attempt_filter_before_limit(): void
+    {
+        $this->seedCanonicalArchivedArtifact('combo-a');
+        $this->seedCanonicalArchivedArtifact('combo-b');
+        $this->seedCanonicalArchivedArtifact('combo-c');
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--attempt-id' => ['combo-c', 'combo-a'],
+            '--limit' => '1',
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('attempt_scoped_limited', $payload['selection_scope'] ?? null);
+        $this->assertSame(['combo-a', 'combo-c'], $payload['requested_attempt_ids'] ?? null);
+        $this->assertSame(1, $payload['requested_limit'] ?? null);
+        $this->assertSame(1, $payload['candidate_count'] ?? null);
+        $this->assertSame(1, data_get($payload, 'summary.candidate_count'));
+        $this->assertSame('combo-a', data_get($payload, 'candidates.0.attempt_id'));
+    }
+
+    public function test_command_execute_marks_legacy_plan_as_unscoped_for_compatibility(): void
+    {
+        $this->seedCanonicalArchivedArtifact('legacy-plan-attempt');
+        $planPath = storage_path('app/private/report_artifact_shrink_plans/legacy-plan.json');
+        File::ensureDirectoryExists(dirname($planPath));
+        File::put($planPath, json_encode([
+            'schema' => 'storage_shrink_archived_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'disk' => 's3',
+            'target_disk' => 's3',
+            'summary' => [
+                'candidate_count' => 1,
+                'deleted_count' => 0,
+                'skipped_missing_local_count' => 0,
+                'blocked_legal_hold_count' => 0,
+                'blocked_missing_remote_count' => 0,
+                'blocked_missing_archive_proof_count' => 0,
+                'blocked_missing_rehydrate_proof_count' => 0,
+                'blocked_hash_mismatch_count' => 0,
+                'failed_count' => 0,
+            ],
+            'candidates' => [[
+                'kind' => 'report_json',
+                'local_path' => 'artifacts/reports/MBTI/legacy-plan-attempt/report.json',
+                'target_disk' => 's3',
+                'target_object_key' => 'report_artifacts_archive/reports/MBTI/legacy-plan-attempt/report.json',
+                'source_sha256' => hash('sha256', '{"attempt":"legacy-plan-attempt"}'),
+                'source_bytes' => strlen('{"attempt":"legacy-plan-attempt"}'),
+                'archive_audit_id' => 1,
+                'rehydrate_ready' => true,
+                'archived_status' => 'copied',
+                'scale_code' => 'MBTI',
+                'attempt_id' => 'legacy-plan-attempt',
+            ]],
+            'blocked' => [],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('selection_scope=legacy_unscoped_plan', $output);
+        $this->assertStringContainsString('requested_attempt_ids=', $output);
+        $this->assertStringContainsString('requested_limit=', $output);
+    }
+
+    public function test_command_execute_surfaces_scoped_plan_metadata_for_auditability(): void
+    {
+        $this->seedCanonicalArchivedArtifact('scoped-plan-attempt');
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--attempt-id' => ['scoped-plan-attempt'],
+        ]));
+        preg_match('/^plan=(.+)$/m', Artisan::output(), $matches);
+        $planPath = trim((string) ($matches[1] ?? ''));
+        $this->assertFileExists($planPath);
+
+        $this->assertSame(0, Artisan::call('storage:shrink-archived-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('selection_scope=attempt_scoped', $output);
+        $this->assertStringContainsString('requested_attempt_ids=scoped-plan-attempt', $output);
+        $this->assertStringContainsString('requested_limit=', $output);
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_shrink_archived_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $meta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($meta);
+        $this->assertSame('attempt_scoped', $meta['selection_scope'] ?? null);
+        $this->assertSame(['scoped-plan-attempt'], $meta['requested_attempt_ids'] ?? null);
+        $this->assertNull($meta['requested_limit'] ?? null);
+    }
+
+    private function seedCanonicalArchivedArtifact(string $attemptId): void
+    {
+        $reportBytes = json_encode(['attempt' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($reportBytes);
+        $reportPath = 'artifacts/reports/MBTI/'.$attemptId.'/report.json';
+        Storage::disk('local')->put($reportPath, $reportBytes);
+        Storage::disk('s3')->put('report_artifacts_archive/reports/MBTI/'.$attemptId.'/report.json', $reportBytes);
+
+        $this->seedArchiveAudit([
+            [
+                'status' => 'copied',
+                'kind' => 'report_json',
+                'source_path' => $reportPath,
+                'target_disk' => 's3',
+                'target_object_key' => 'report_artifacts_archive/reports/MBTI/'.$attemptId.'/report.json',
+                'source_sha256' => hash('sha256', $reportBytes),
+                'source_bytes' => strlen($reportBytes),
+                'target_bytes' => strlen($reportBytes),
+                'scale_code' => 'MBTI',
+                'attempt_id' => $attemptId,
+                'verified_at' => now()->toIso8601String(),
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Summary
This change adds a supported small-cohort planning seam to `storage:shrink-archived-report-artifacts` without changing the destructive owner model.

The command now supports dry-run-only planning filters via `--attempt-id=*` and `--limit=`. These filters apply only while generating the shrink plan. Real execution still requires `--execute --plan=...`, so the destructive path remains plan-file-scoped.

## Why
Before this change, shrink execute was already safe only through a plan file, but dry-run could only generate a full-scan plan. That left first-cohort deletion blocked because operators had no supported way to generate a 1-5 attempt shrink plan for manual signoff.

## What changed
- Added `--attempt-id=*` and `--limit=` to `storage:shrink-archived-report-artifacts` for dry-run only.
- Rejected `--attempt-id` / `--limit` when `--execute` is used, so no direct destructive shortcut was introduced.
- Extended shrink plan generation to accept filtered attempt ids and an optional candidate limit.
- Preserved the existing proof and blocking rules: legal hold, archive proof, rehydrate proof, remote object presence, and hash match are unchanged.
- Added stable plan/run metadata for auditability:
  - `selection_scope`
  - `requested_attempt_ids`
  - `requested_limit`
  - `generated_by_command`
  - `generated_at`
  - `candidate_count`
- Kept old plans compatible. If metadata is missing, execute marks the plan as `legacy_unscoped_plan` instead of breaking.

## Validation
- `php -l app/Console/Commands/StorageShrinkArchivedReportArtifacts.php`
- `php -l app/Services/Storage/ReportArtifactsShrinkService.php`
- `php -l tests/Feature/Storage/StorageShrinkArchivedReportArtifactsCommandTest.php`
- `php artisan test --filter='StorageShrinkArchivedReportArtifactsCommandTest|LifecycleFrontDoorCommandTest|LifecycleFrontDoorFlagsOffCompatibilityTest|RetentionPolicyLegalHoldTest'`

All targeted checks passed.
