### PR TITLE
[codex] safe archive cohort planning

### DIFF
--- a/backend/app/Console/Commands/StorageArchiveReportArtifacts.php
+++ b/backend/app/Console/Commands/StorageArchiveReportArtifacts.php
@@ -14,6 +14,8 @@ final class StorageArchiveReportArtifacts extends Command
     protected $signature = 'storage:archive-report-artifacts
         {--dry-run : Build an archive plan for canonical report artifacts only}
         {--execute : Execute archive from an existing plan}
+        {--attempt-id=* : Narrow dry-run candidate selection to one or more attempt_ids}
+        {--limit= : Limit dry-run candidate selection after candidate collection}
         {--disk=s3 : Remote object storage disk that receives archived canonical artifacts}
         {--plan= : Absolute or storage-relative plan path required for execute mode}
         {--json : Emit the full payload as JSON}';
@@ -44,11 +46,21 @@ final class StorageArchiveReportArtifacts extends Command
             $this->ensureTargetDiskIsRemote($disk);
 
             if ($dryRun) {
-                $plan = $this->service->buildPlan($disk);
+                $plan = $this->service->buildPlan($disk, [
+                    'attempt_ids' => $this->normalizedAttemptIds(),
+                    'limit' => $this->normalizedLimit(),
+                    'generated_by_command' => 'storage:archive-report-artifacts',
+                ]);
                 $planPath = $this->persistPlan($plan);
                 $payload = $plan + ['plan' => $planPath];
 
                 return $this->emitPayload($payload);
+            }
+
+            if ($this->normalizedAttemptIds() !== [] || $this->option('limit') !== null) {
+                $this->error('--attempt-id and --limit are only supported with --dry-run.');
+
+                return self::FAILURE;
             }
 
             $planOption = trim((string) ($this->option('plan') ?? ''));
@@ -67,9 +79,10 @@ final class StorageArchiveReportArtifacts extends Command
                 return self::FAILURE;
             }
 
-            $plan['_meta'] = [
-                'plan_path' => $resolvedPlanPath,
-            ];
+            $plan['_meta'] = array_merge(
+                is_array($plan['_meta'] ?? null) ? $plan['_meta'] : [],
+                ['plan_path' => $resolvedPlanPath]
+            );
             $payload = $this->frontDoorEnabled()
                 ? $this->frontDoor->execute('archive_report_artifacts', $plan, fn (array $resolvedPlan): array => $this->service->executePlan($resolvedPlan))
                 : $this->service->executePlan($plan);
@@ -123,6 +136,14 @@ final class StorageArchiveReportArtifacts extends Command
         $this->line('target_disk='.(string) ($payload['target_disk'] ?? ''));
         $this->line('schema='.(string) ($payload['schema'] ?? ''));
         $this->line('plan='.(string) ($payload['plan'] ?? ''));
+        $this->line('selection_scope='.(string) data_get($payload, 'selection_scope', 'legacy_unscoped_plan'));
+        $requestedAttemptIds = data_get($payload, 'requested_attempt_ids', []);
+        if (! is_array($requestedAttemptIds)) {
+            $requestedAttemptIds = [];
+        }
+        $this->line('requested_attempt_ids='.implode(',', array_map(static fn (mixed $value): string => (string) $value, $requestedAttemptIds)));
+        $requestedLimit = data_get($payload, 'requested_limit');
+        $this->line('requested_limit='.(is_int($requestedLimit) ? (string) $requestedLimit : ''));
         $this->line('candidate_count='.(int) ($summary['candidate_count'] ?? 0));
         $this->line('copied_count='.(int) ($summary['copied_count'] ?? 0));
         $this->line('verified_count='.(int) ($summary['verified_count'] ?? 0));
@@ -193,5 +214,41 @@ final class StorageArchiveReportArtifacts extends Command
     private function frontDoorEnabled(): bool
     {
         return (bool) config('storage_rollout.lifecycle_front_door_enabled', false);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizedAttemptIds(): array
+    {
+        $values = $this->option('attempt-id');
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $attemptIds = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            $values
+        ), static fn (string $value): bool => $value !== ''));
+
+        $attemptIds = array_values(array_unique($attemptIds));
+        sort($attemptIds);
+
+        return $attemptIds;
+    }
+
+    private function normalizedLimit(): ?int
+    {
+        $raw = $this->option('limit');
+        if ($raw === null || trim((string) $raw) === '') {
+            return null;
+        }
+
+        $limit = trim((string) $raw);
+        if (! ctype_digit($limit) || (int) $limit <= 0) {
+            throw new \RuntimeException('--limit must be a positive integer.');
+        }
+
+        return (int) $limit;
     }
 }

--- a/backend/app/Services/Storage/ReportArtifactsArchiveService.php
+++ b/backend/app/Services/Storage/ReportArtifactsArchiveService.php
@@ -29,10 +29,14 @@ final class ReportArtifactsArchiveService
     /**
      * @return array<string,mixed>
      */
-    public function buildPlan(string $targetDisk): array
+    public function buildPlan(string $targetDisk, array $selection = []): array
     {
         $targetDisk = $this->normalizeDisk($targetDisk);
-        $candidates = $this->collectCandidates($targetDisk);
+        $selectionMeta = $this->selectionMeta($selection);
+        $candidates = $this->collectCandidates($targetDisk, $selectionMeta['requested_attempt_ids']);
+        if ($selectionMeta['requested_limit'] !== null) {
+            $candidates = array_slice($candidates, 0, $selectionMeta['requested_limit']);
+        }
         $summary = $this->buildSummary($candidates);
 
         $payload = [
@@ -42,6 +46,11 @@ final class ReportArtifactsArchiveService
             'generated_at' => now()->toIso8601String(),
             'disk' => $targetDisk,
             'target_disk' => $targetDisk,
+            'selection_scope' => $selectionMeta['selection_scope'],
+            'requested_attempt_ids' => $selectionMeta['requested_attempt_ids'],
+            'requested_limit' => $selectionMeta['requested_limit'],
+            'generated_by_command' => $selectionMeta['generated_by_command'],
+            'candidate_count' => $summary['candidate_count'],
             'summary' => $summary + [
                 'copied_count' => 0,
                 'verified_count' => 0,
@@ -69,6 +78,7 @@ final class ReportArtifactsArchiveService
         $this->assertPlanSchema($plan);
 
         $targetDisk = $this->normalizeDisk((string) ($plan['target_disk'] ?? $plan['disk'] ?? ''));
+        $selectionMeta = $this->selectionMetaFromPlan($plan);
         $candidates = is_array($plan['candidates'] ?? null) ? array_values($plan['candidates']) : [];
         $results = [];
         $summary = [
@@ -120,6 +130,11 @@ final class ReportArtifactsArchiveService
             'target_disk' => $targetDisk,
             'plan' => trim((string) data_get($plan, '_meta.plan_path', '')),
             'plan_path' => trim((string) data_get($plan, '_meta.plan_path', '')),
+            'selection_scope' => $selectionMeta['selection_scope'],
+            'requested_attempt_ids' => $selectionMeta['requested_attempt_ids'],
+            'requested_limit' => $selectionMeta['requested_limit'],
+            'generated_by_command' => $selectionMeta['generated_by_command'],
+            'candidate_count' => $summary['candidate_count'],
             'summary' => $summary,
             'results' => $results,
         ];
@@ -141,7 +156,7 @@ final class ReportArtifactsArchiveService
     /**
      * @return list<array<string,mixed>>
      */
-    private function collectCandidates(string $targetDisk): array
+    private function collectCandidates(string $targetDisk, array $requestedAttemptIds = []): array
     {
         $artifactsRoot = storage_path('app/private/artifacts');
         if (! is_dir($artifactsRoot)) {
@@ -159,6 +174,11 @@ final class ReportArtifactsArchiveService
             foreach (File::allFiles($root) as $file) {
                 $candidate = $this->candidateFromFile($file, $artifactsRoot, $targetDisk);
                 if ($candidate === null) {
+                    continue;
+                }
+
+                if ($requestedAttemptIds !== []
+                    && ! in_array((string) ($candidate['attempt_id'] ?? ''), $requestedAttemptIds, true)) {
                     continue;
                 }
 
@@ -534,6 +554,10 @@ final class ReportArtifactsArchiveService
                 'plan' => $planPath,
                 'plan_path' => $planPath,
                 'run_path' => $runPath,
+                'selection_scope' => $payload['selection_scope'] ?? 'legacy_unscoped_plan',
+                'requested_attempt_ids' => array_values(is_array($payload['requested_attempt_ids'] ?? null) ? $payload['requested_attempt_ids'] : []),
+                'requested_limit' => $payload['requested_limit'] ?? null,
+                'generated_by_command' => $payload['generated_by_command'] ?? null,
                 'candidate_count' => (int) ($summary['candidate_count'] ?? 0),
                 'copied_count' => (int) ($summary['copied_count'] ?? 0),
                 'verified_count' => (int) ($summary['verified_count'] ?? 0),
@@ -572,6 +596,93 @@ final class ReportArtifactsArchiveService
         if ((string) ($plan['schema'] ?? '') !== self::PLAN_SCHEMA) {
             throw new \RuntimeException('report artifact archive plan schema mismatch.');
         }
+    }
+
+    /**
+     * @param  array<string,mixed>  $selection
+     * @return array{
+     *     selection_scope:string,
+     *     requested_attempt_ids:list<string>,
+     *     requested_limit:int|null,
+     *     generated_by_command:string
+     * }
+     */
+    private function selectionMeta(array $selection): array
+    {
+        $requestedAttemptIds = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            is_array($selection['attempt_ids'] ?? null) ? $selection['attempt_ids'] : []
+        ), static fn (string $value): bool => $value !== ''));
+        $requestedAttemptIds = array_values(array_unique($requestedAttemptIds));
+        sort($requestedAttemptIds);
+
+        $requestedLimit = $this->normalizeSelectionLimit($selection['limit'] ?? null);
+
+        $selectionScope = 'full_scan';
+        if ($requestedAttemptIds !== [] && $requestedLimit !== null) {
+            $selectionScope = 'attempt_scoped_limited';
+        } elseif ($requestedAttemptIds !== []) {
+            $selectionScope = 'attempt_scoped';
+        } elseif ($requestedLimit !== null) {
+            $selectionScope = 'limit_scoped';
+        }
+
+        return [
+            'selection_scope' => $selectionScope,
+            'requested_attempt_ids' => $requestedAttemptIds,
+            'requested_limit' => $requestedLimit,
+            'generated_by_command' => trim((string) ($selection['generated_by_command'] ?? 'storage:archive-report-artifacts')),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array{
+     *     selection_scope:string,
+     *     requested_attempt_ids:list<string>,
+     *     requested_limit:int|null,
+     *     generated_by_command:string|null
+     * }
+     */
+    private function selectionMetaFromPlan(array $plan): array
+    {
+        $requestedAttemptIds = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            is_array($plan['requested_attempt_ids'] ?? null) ? $plan['requested_attempt_ids'] : []
+        ), static fn (string $value): bool => $value !== ''));
+        $requestedAttemptIds = array_values(array_unique($requestedAttemptIds));
+        sort($requestedAttemptIds);
+
+        $selectionScope = trim((string) ($plan['selection_scope'] ?? ''));
+        if ($selectionScope === '') {
+            $selectionScope = 'legacy_unscoped_plan';
+        }
+
+        $generatedByCommand = trim((string) ($plan['generated_by_command'] ?? ''));
+
+        return [
+            'selection_scope' => $selectionScope,
+            'requested_attempt_ids' => $requestedAttemptIds,
+            'requested_limit' => $this->normalizeSelectionLimit($plan['requested_limit'] ?? null),
+            'generated_by_command' => $generatedByCommand !== '' ? $generatedByCommand : null,
+        ];
+    }
+
+    private function normalizeSelectionLimit(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (is_string($value) && ctype_digit($value) && (int) $value > 0) {
+            return (int) $value;
+        }
+
+        return null;
     }
 
     private function normalizeDisk(string $disk): string

--- a/backend/tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php
@@ -74,6 +74,14 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         $this->artisan('storage:archive-report-artifacts --execute --disk=s3')
             ->expectsOutputToContain('--execute requires --plan.')
             ->assertExitCode(1);
+
+        $this->artisan('storage:archive-report-artifacts --execute --disk=s3 --plan=fake-plan.json --attempt-id=attempt-1')
+            ->expectsOutputToContain('--attempt-id and --limit are only supported with --dry-run.')
+            ->assertExitCode(1);
+
+        $this->artisan('storage:archive-report-artifacts --dry-run --disk=s3 --limit=0')
+            ->expectsOutputToContain('--limit must be a positive integer.')
+            ->assertExitCode(1);
     }
 
     public function test_command_dry_run_execute_json_and_partial_failure_are_visible(): void
@@ -95,6 +103,9 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         ]));
         $dryRunOutput = Artisan::output();
         $this->assertStringContainsString('status=planned', $dryRunOutput);
+        $this->assertStringContainsString('selection_scope=full_scan', $dryRunOutput);
+        $this->assertStringContainsString('requested_attempt_ids=', $dryRunOutput);
+        $this->assertStringContainsString('requested_limit=', $dryRunOutput);
         $this->assertStringContainsString('candidate_count=2', $dryRunOutput);
         $this->assertStringContainsString('copied_count=0', $dryRunOutput);
         $this->assertStringContainsString('already_archived_count=0', $dryRunOutput);
@@ -113,6 +124,9 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         $this->assertIsArray($dryRunMeta);
         $this->assertSame('dry_run', $dryRunMeta['mode'] ?? null);
         $this->assertSame('audit_logs.meta_json', $dryRunMeta['durable_receipt_source'] ?? null);
+        $this->assertSame('full_scan', $dryRunMeta['selection_scope'] ?? null);
+        $this->assertSame([], $dryRunMeta['requested_attempt_ids'] ?? null);
+        $this->assertNull($dryRunMeta['requested_limit'] ?? null);
         $this->assertSame(2, $dryRunMeta['candidate_count'] ?? null);
         $this->assertSame(0, $dryRunMeta['results_count'] ?? null);
 
@@ -123,6 +137,9 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         ]));
         $executeOutput = Artisan::output();
         $this->assertStringContainsString('status=executed', $executeOutput);
+        $this->assertStringContainsString('selection_scope=full_scan', $executeOutput);
+        $this->assertStringContainsString('requested_attempt_ids=', $executeOutput);
+        $this->assertStringContainsString('requested_limit=', $executeOutput);
         $this->assertStringContainsString('candidate_count=2', $executeOutput);
         $this->assertStringContainsString('copied_count=2', $executeOutput);
         $this->assertStringContainsString('verified_count=2', $executeOutput);
@@ -138,6 +155,9 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         $this->assertIsArray($executeMeta);
         $this->assertSame('execute', $executeMeta['mode'] ?? null);
         $this->assertSame($planPath, $executeMeta['plan_path'] ?? null);
+        $this->assertSame('full_scan', $executeMeta['selection_scope'] ?? null);
+        $this->assertSame([], $executeMeta['requested_attempt_ids'] ?? null);
+        $this->assertNull($executeMeta['requested_limit'] ?? null);
         $this->assertSame(2, $executeMeta['verified_count'] ?? null);
         $this->assertSame(2, $executeMeta['results_count'] ?? null);
 
@@ -155,6 +175,9 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         $jsonPayload = json_decode(Artisan::output(), true);
         $this->assertIsArray($jsonPayload);
         $this->assertSame('storage_archive_report_artifacts_plan.v1', $jsonPayload['schema'] ?? null);
+        $this->assertSame('full_scan', $jsonPayload['selection_scope'] ?? null);
+        $this->assertSame([], $jsonPayload['requested_attempt_ids'] ?? null);
+        $this->assertNull($jsonPayload['requested_limit'] ?? null);
         $this->assertSame(2, data_get($jsonPayload, 'summary.candidate_count'));
 
         $secondPlanPath = storage_path('app/private/report_artifact_archive_plans/failure.json');
@@ -170,5 +193,163 @@ final class StorageArchiveReportArtifactsCommandTest extends TestCase
         $failureOutput = Artisan::output();
         $this->assertStringContainsString('status=partial_failure', $failureOutput);
         $this->assertStringContainsString('failed_count=1', $failureOutput);
+    }
+
+    public function test_command_can_build_attempt_scoped_dry_run_plan(): void
+    {
+        $this->seedCanonicalReportArtifact('attempt-b');
+        $this->seedCanonicalReportArtifact('attempt-a');
+
+        $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--attempt-id' => ['attempt-b', 'attempt-a'],
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('attempt_scoped', $payload['selection_scope'] ?? null);
+        $this->assertSame(['attempt-a', 'attempt-b'], $payload['requested_attempt_ids'] ?? null);
+        $this->assertNull($payload['requested_limit'] ?? null);
+        $this->assertSame(2, $payload['candidate_count'] ?? null);
+        $this->assertSame(2, data_get($payload, 'summary.candidate_count'));
+        $this->assertSame(['attempt-a', 'attempt-b'], array_column((array) ($payload['candidates'] ?? []), 'attempt_id'));
+    }
+
+    public function test_command_can_build_limit_scoped_plan(): void
+    {
+        $this->seedCanonicalReportArtifact('limit-b');
+        $this->seedCanonicalReportArtifact('limit-a');
+
+        $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--limit' => '1',
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('limit_scoped', $payload['selection_scope'] ?? null);
+        $this->assertSame([], $payload['requested_attempt_ids'] ?? null);
+        $this->assertSame(1, $payload['requested_limit'] ?? null);
+        $this->assertSame(1, $payload['candidate_count'] ?? null);
+        $this->assertSame(1, data_get($payload, 'summary.candidate_count'));
+        $this->assertSame('limit-a', data_get($payload, 'candidates.0.attempt_id'));
+    }
+
+    public function test_command_combines_attempt_filter_before_limit(): void
+    {
+        $this->seedCanonicalReportArtifact('combo-b');
+        $this->seedCanonicalReportArtifact('combo-a');
+        $this->seedCanonicalReportArtifact('combo-c');
+
+        $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--attempt-id' => ['combo-c', 'combo-a'],
+            '--limit' => '1',
+            '--json' => true,
+        ]));
+
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('attempt_scoped_limited', $payload['selection_scope'] ?? null);
+        $this->assertSame(['combo-a', 'combo-c'], $payload['requested_attempt_ids'] ?? null);
+        $this->assertSame(1, $payload['requested_limit'] ?? null);
+        $this->assertSame(1, $payload['candidate_count'] ?? null);
+        $this->assertSame('combo-a', data_get($payload, 'candidates.0.attempt_id'));
+    }
+
+    public function test_command_execute_marks_legacy_plan_as_unscoped_for_compatibility(): void
+    {
+        $this->seedCanonicalReportArtifact('legacy-plan-attempt');
+        $planPath = storage_path('app/private/report_artifact_archive_plans/legacy-plan.json');
+        File::ensureDirectoryExists(dirname($planPath));
+        File::put($planPath, json_encode([
+            'schema' => 'storage_archive_report_artifacts_plan.v1',
+            'mode' => 'dry_run',
+            'status' => 'planned',
+            'generated_at' => now()->toIso8601String(),
+            'disk' => 's3',
+            'target_disk' => 's3',
+            'summary' => [
+                'candidate_count' => 1,
+                'candidate_bytes' => strlen('{"attempt":"legacy-plan-attempt"}'),
+                'kind_counts' => ['report_json' => 1],
+                'copied_count' => 0,
+                'verified_count' => 0,
+                'already_archived_count' => 0,
+                'failed_count' => 0,
+            ],
+            'candidates' => [[
+                'kind' => 'report_json',
+                'source_path' => 'artifacts/reports/MBTI/legacy-plan-attempt/report.json',
+                'relative_path' => 'reports/MBTI/legacy-plan-attempt/report.json',
+                'target_disk' => 's3',
+                'target_object_key' => 'report_artifacts_archive/reports/MBTI/legacy-plan-attempt/report.json',
+                'bytes' => strlen('{"attempt":"legacy-plan-attempt"}'),
+                'sha256' => hash('sha256', '{"attempt":"legacy-plan-attempt"}'),
+                'scale_code' => 'MBTI',
+                'attempt_id' => 'legacy-plan-attempt',
+            ]],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+
+        $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('selection_scope=legacy_unscoped_plan', $output);
+        $this->assertStringContainsString('requested_attempt_ids=', $output);
+        $this->assertStringContainsString('requested_limit=', $output);
+    }
+
+    public function test_command_execute_surfaces_scoped_plan_metadata_for_auditability(): void
+    {
+        $this->seedCanonicalReportArtifact('scoped-plan-attempt');
+
+        $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
+            '--dry-run' => true,
+            '--disk' => 's3',
+            '--attempt-id' => ['scoped-plan-attempt'],
+        ]));
+        preg_match('/^plan=(.+)$/m', Artisan::output(), $matches);
+        $planPath = trim((string) ($matches[1] ?? ''));
+        $this->assertFileExists($planPath);
+
+        $this->assertSame(0, Artisan::call('storage:archive-report-artifacts', [
+            '--execute' => true,
+            '--disk' => 's3',
+            '--plan' => $planPath,
+        ]));
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('selection_scope=attempt_scoped', $output);
+        $this->assertStringContainsString('requested_attempt_ids=scoped-plan-attempt', $output);
+        $this->assertStringContainsString('requested_limit=', $output);
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_archive_report_artifacts')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $meta = json_decode((string) $audit->meta_json, true);
+        $this->assertIsArray($meta);
+        $this->assertSame('attempt_scoped', $meta['selection_scope'] ?? null);
+        $this->assertSame(['scoped-plan-attempt'], $meta['requested_attempt_ids'] ?? null);
+        $this->assertNull($meta['requested_limit'] ?? null);
+    }
+
+    private function seedCanonicalReportArtifact(string $attemptId): void
+    {
+        Storage::disk('local')->put(
+            'artifacts/reports/MBTI/'.$attemptId.'/report.json',
+            json_encode(['attempt' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        );
     }
 }


### PR DESCRIPTION
## Summary
This change adds a supported scoped planning seam to `storage:archive-report-artifacts` so operators can generate very small archive dry-run plans for 1-5 attempts without hand-editing plan files.

The command now accepts `--attempt-id=*` and `--limit=` in dry-run mode only. Those selectors are applied during plan generation, not during execute, so the destructive path remains plan-file-scoped. `--attempt-id` is applied first and `--limit` is applied to the filtered candidate set.

## Problem
Archive proof bootstrap was still blocked operationally because the archive command only generated full-scan plans. That meant there was no supported operator flow for producing a tiny first cohort plan, even though execute already required a plan file.

## Root cause
The archive command and archive service lacked a scoped candidate-selection seam and did not persist selection metadata into the plan or execute audit trail. As a result, plan generation was all-or-nothing, and execute could not surface whether a plan was scoped or legacy/unscoped.

## Fix
The archive command now:
- accepts `--attempt-id=*` and `--limit=` for dry-run only
- rejects those options in execute mode so no new direct destructive shortcut is introduced
- prints selection metadata in human-readable output

The archive service now:
- accepts selection inputs in `buildPlan()`
- filters candidates at plan-generation time
- records stable plan metadata: `selection_scope`, `requested_attempt_ids`, `requested_limit`, `generated_by_command`, `generated_at`, and `candidate_count`
- preserves backward compatibility for legacy plans by surfacing `legacy_unscoped_plan` when metadata is absent

## Validation
- `php -l app/Console/Commands/StorageArchiveReportArtifacts.php`
- `php -l app/Services/Storage/ReportArtifactsArchiveService.php`
- `php -l tests/Feature/Storage/StorageArchiveReportArtifactsCommandTest.php`
- `php artisan test --filter='StorageArchiveReportArtifactsCommandTest|LifecycleFrontDoorCommandTest|ReportArtifactsArchiveServiceTest'`
