### PR TITLE
[codex] declare explicit artifact model table names

### DIFF
--- a/backend/app/Models/ArtifactLifecycleEvent.php
+++ b/backend/app/Models/ArtifactLifecycleEvent.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class ArtifactLifecycleEvent extends Model
 {
+    protected $table = 'artifact_lifecycle_events';
+
     protected $fillable = [
         'job_id',
         'attempt_id',

--- a/backend/app/Models/ArtifactLifecycleJob.php
+++ b/backend/app/Models/ArtifactLifecycleJob.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class ArtifactLifecycleJob extends Model
 {
+    protected $table = 'artifact_lifecycle_jobs';
+
     protected $fillable = [
         'attempt_id',
         'artifact_slot_id',

--- a/backend/app/Models/ArtifactReconcileCase.php
+++ b/backend/app/Models/ArtifactReconcileCase.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class ArtifactReconcileCase extends Model
 {
+    protected $table = 'artifact_reconcile_cases';
+
     protected $fillable = [
         'attempt_id',
         'slot_code',

--- a/backend/app/Models/AttemptReceipt.php
+++ b/backend/app/Models/AttemptReceipt.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class AttemptReceipt extends Model
 {
+    protected $table = 'attempt_receipts';
+
     protected $fillable = [
         'attempt_id',
         'seq',

--- a/backend/app/Models/ReportArtifactPosture.php
+++ b/backend/app/Models/ReportArtifactPosture.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class ReportArtifactPosture extends Model
 {
+    protected $table = 'report_artifact_postures';
+
     protected $fillable = [
         'attempt_id',
         'slot_code',

--- a/backend/app/Models/ReportArtifactSlot.php
+++ b/backend/app/Models/ReportArtifactSlot.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class ReportArtifactSlot extends Model
 {
+    protected $table = 'report_artifact_slots';
+
     protected $fillable = [
         'attempt_id',
         'slot_code',

--- a/backend/app/Models/ReportArtifactVersion.php
+++ b/backend/app/Models/ReportArtifactVersion.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class ReportArtifactVersion extends Model
 {
+    protected $table = 'report_artifact_versions';
+
     protected $fillable = [
         'artifact_slot_id',
         'version_no',

--- a/backend/app/Models/UnifiedAccessProjection.php
+++ b/backend/app/Models/UnifiedAccessProjection.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class UnifiedAccessProjection extends Model
 {
+    protected $table = 'unified_access_projections';
+
     protected $fillable = [
         'attempt_id',
         'access_state',


### PR DESCRIPTION
## Summary
This PR isolates the model-layer fix for the artifact control-plane tables by declaring explicit Eloquent table names on the eight new artifact and projection models.

## Problem
These models rely on pluralization-sensitive table names such as `attempt_receipts`, `artifact_lifecycle_jobs`, and `unified_access_projections`. Leaving them implicit makes the mapping fragile and harder to reason about when these models are used by later control-plane and lifecycle work.

## Fix
Each of the following models now declares its table name explicitly:
- `AttemptReceipt`
- `ArtifactLifecycleJob`
- `ArtifactLifecycleEvent`
- `ArtifactReconcileCase`
- `ReportArtifactSlot`
- `ReportArtifactVersion`
- `ReportArtifactPosture`
- `UnifiedAccessProjection`

This keeps the change narrow and avoids mixing it with unrelated compiled content or command changes already present in the worktree.

## Validation
No runtime logic was changed in this branch. This PR isolates the existing model mapping fix only.
