### PR TITLE
[codex] refresh EQ_60 and SDS_20 compiled packs

### DIFF
--- a/backend/content_packs/EQ_60/v1/compiled/golden_cases.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/golden_cases.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.golden_cases.compiled.v2",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-02-26T15:29:00.584325Z",
+    "generated_at": "2026-03-22T02:16:22.197064Z",
     "cases": [
         {
             "case_id": "EQ60_BALANCED_HIGH_ZH",

--- a/backend/content_packs/EQ_60/v1/compiled/landing.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/landing.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.landing.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-02-26T15:29:00.584296Z",
+    "generated_at": "2026-03-22T02:16:22.197034Z",
     "landing": {
         "zh-CN": {
             "title": "情商（EQ）测试",

--- a/backend/content_packs/EQ_60/v1/compiled/manifest.json
+++ b/backend/content_packs/EQ_60/v1/compiled/manifest.json
@@ -2,17 +2,17 @@
     "schema": "eq_60.compiled.manifest.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "compiled_at": "2026-02-26T15:29:00.588066Z",
-    "generated_at": "2026-02-26T15:29:00.588093Z",
+    "compiled_at": "2026-03-22T02:16:22.200177Z",
+    "generated_at": "2026-03-22T02:16:22.200200Z",
     "content_hash": "5dd364be4acc0e0004be44b468c86abf0464b2caa3f776db01102925cca7b795",
-    "compiled_hash": "90bab10d0a002f5ed6cca3e8aae0a773a2e789074613a7ef0723d9ea662f6205",
+    "compiled_hash": "6834580631926b3315261a47a7f7d0735ad491ebabb3ac5e4e468cbe335b38db",
     "hashes": {
-        "questions.compiled.json": "285005044698e183bfe95985e212f2cc9b2082b9271c0a44fee6c64af902f15f",
-        "options.compiled.json": "fe7faa9fca49a632d38b937cf28e3a60c956a69aea33c4b4a1e7d604952dbe14",
-        "policy.compiled.json": "e863debecb41a4fff35631de603412339442d64c5bd9f4ea98f855e26789e544",
-        "landing.compiled.json": "d8481b5aba5b1ad4a5e517e74c8fdcf9f4a8d7912f7411604145f863bb75cf0f",
-        "report.compiled.json": "46093f19f52790d91bce428067faa6403cd1189389c00616b086d4a4e0766a2a",
-        "golden_cases.compiled.json": "97dbb4f4bf7b2e56c57b0df4074524f30a40539c548151625d6a98cf6be342ac"
+        "questions.compiled.json": "3aafc26d15347212ed74367b190fa9184cc35f582246f0288608496a17594130",
+        "options.compiled.json": "d38e171d5dd82df0d70ca4be34aab286519873be203edad91edddb559a42b060",
+        "policy.compiled.json": "074a1f84397599f643a39c4f19705c5788b7721358f3c710fdcebe156897dcc1",
+        "landing.compiled.json": "22c0181bf1e978acae891b95962e2930b03a4384c9fbcdf449c8f6d838bef57f",
+        "report.compiled.json": "630a8a36d1d90fa9c2d62251fc4112bf3c76e0626a8232c7a6e11f11a658598a",
+        "golden_cases.compiled.json": "729ed87042152c118c18dba487c3cf04d2b7fbbe6a0aaef42b2eff600549e648"
     },
     "compiled_files": [
         "questions.compiled.json",

--- a/backend/content_packs/EQ_60/v1/compiled/options.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/options.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.options.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-02-26T15:29:00.584263Z",
+    "generated_at": "2026-03-22T02:16:22.197001Z",
     "codes": [
         "A",
         "B",

--- a/backend/content_packs/EQ_60/v1/compiled/policy.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/policy.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.policy.compiled.v2",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-02-26T15:29:00.584280Z",
+    "generated_at": "2026-03-22T02:16:22.197019Z",
     "policy": {
         "schema": "eq_60.policy.runtime.v2",
         "pack_id": "EQ_60",

--- a/backend/content_packs/EQ_60/v1/compiled/questions.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/questions.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.questions.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-02-26T15:29:00.584212Z",
+    "generated_at": "2026-03-22T02:16:22.196952Z",
     "dimension_codes": [
         "SA",
         "ER",

--- a/backend/content_packs/EQ_60/v1/compiled/report.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report.compiled.v2",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-02-26T15:29:00.584310Z",
+    "generated_at": "2026-03-22T02:16:22.197049Z",
     "layout": {
         "schema": "eq60.report_layout.v1",
         "conflict_rules": {

--- a/backend/content_packs/SDS_20/v1/compiled/golden_cases.compiled.json
+++ b/backend/content_packs/SDS_20/v1/compiled/golden_cases.compiled.json
@@ -2,7 +2,7 @@
     "schema": "sds_20.golden_cases.compiled.v1",
     "pack_id": "SDS_20",
     "pack_version": "v1",
-    "generated_at": "2026-02-22T11:14:48.029064Z",
+    "generated_at": "2026-03-22T16:33:55.209733Z",
     "cases": [
         {
             "case_id": "all_A",

--- a/backend/content_packs/SDS_20/v1/compiled/landing.compiled.json
+++ b/backend/content_packs/SDS_20/v1/compiled/landing.compiled.json
@@ -2,7 +2,7 @@
     "schema": "sds_20.landing.compiled.v1",
     "pack_id": "SDS_20",
     "pack_version": "v1",
-    "generated_at": "2026-02-22T11:14:48.029021Z",
+    "generated_at": "2026-03-22T16:33:55.209688Z",
     "landing": {
         "zh-CN": {
             "title": "抑郁测评[标准版]",

--- a/backend/content_packs/SDS_20/v1/compiled/manifest.json
+++ b/backend/content_packs/SDS_20/v1/compiled/manifest.json
@@ -2,18 +2,18 @@
     "schema": "sds_20.compiled.manifest.v1",
     "pack_id": "SDS_20",
     "pack_version": "v1",
-    "compiled_at": "2026-02-22T11:14:48.030172Z",
-    "generated_at": "2026-02-22T11:14:48.030213Z",
+    "compiled_at": "2026-03-22T16:33:55.211812Z",
+    "generated_at": "2026-03-22T16:33:55.211846Z",
     "content_hash": "a3c2a9d9bf25d20a8b2a3e131612353b1a0fc10ac4265b5330f7ff75b22556c1",
-    "compiled_hash": "457e82130a6cff7776ecf98b6cc5bb325fd9f6d9a159c155386a84c009b5ee5f",
+    "compiled_hash": "71746cc69e225cb7088b027f8f742b3a076f5302100a7506d03c8a43b9519e7b",
     "hashes": {
-        "questions.compiled.json": "88def8a344eb1cc3ba57f3b9115024bedaa196b874815de13f108fc8dfd4e92e",
-        "options.compiled.json": "fc21cb7bc9ce73a6103a4b3be6a215e785c4775c1b044fe5eb845aad228603a7",
-        "policy.compiled.json": "4a53a3d2435934a68d9fe01551ced3a37f1ac509ff7c314536e10da1e8a18296",
-        "landing.compiled.json": "1b9c98b8e3915f128b12af70d107feb0cfcd6e0af03f71dd80837e3c4f87ae0f",
-        "sources.compiled.json": "a99288717c5f1d780f8c09c3516e92c07d4df579fb68f6abf76e8613ec7c1717",
-        "report.compiled.json": "a7db9227684c0d8b7fe0630e5719e085d4079f26d9eb2d4345b1166a4c8cd3be",
-        "golden_cases.compiled.json": "7fa021f497cefe80009eb0c0952d0b000ace541a604dd0089b30c49327ef7f5f"
+        "questions.compiled.json": "71ff57d0737bdf7dadbadad27770a350156a06b3b02759e0c3d0b6d1e00989f6",
+        "options.compiled.json": "bd95899132216b237c81f3521a8d0da94b760261523ec5e1214381afa332f966",
+        "policy.compiled.json": "371277a523b348f310a18b0f3dd99ca372d1a7681d90fa07e8f2f92fa19379c5",
+        "landing.compiled.json": "126266a48de25e3bc9e4b62ab3ef798f35d9417abf4648487d89e68fc835ffbe",
+        "sources.compiled.json": "caba258489ec272e60e8f798530a8029f1344d8ab035f2a21f9f7e9df9f0d92b",
+        "report.compiled.json": "b786bbc4dffb378e20953fe932540ee5bb679ac0c467a18aa856334cc56235d4",
+        "golden_cases.compiled.json": "ce902efc8e81f7fb0a127cc586c4af60a5b1607cef264e9a234878ca10e91168"
     },
     "compiled_files": [
         "questions.compiled.json",

--- a/backend/content_packs/SDS_20/v1/compiled/options.compiled.json
+++ b/backend/content_packs/SDS_20/v1/compiled/options.compiled.json
@@ -2,7 +2,7 @@
     "schema": "sds_20.options.compiled.v1",
     "pack_id": "SDS_20",
     "pack_version": "v1",
-    "generated_at": "2026-02-22T11:14:48.028739Z",
+    "generated_at": "2026-03-22T16:33:55.208443Z",
     "set_code": "SDS_LIKERT4",
     "codes": [
         "A",

--- a/backend/content_packs/SDS_20/v1/compiled/policy.compiled.json
+++ b/backend/content_packs/SDS_20/v1/compiled/policy.compiled.json
@@ -2,7 +2,7 @@
     "schema": "sds_20.policy.compiled.v1",
     "pack_id": "SDS_20",
     "pack_version": "v1",
-    "generated_at": "2026-02-22T11:14:48.029006Z",
+    "generated_at": "2026-03-22T16:33:55.209671Z",
     "policy": {
         "engine_version": "v2.0_Factor_Logic",
         "scoring_spec_version": "v2.0_Factor_Logic",

--- a/backend/content_packs/SDS_20/v1/compiled/questions.compiled.json
+++ b/backend/content_packs/SDS_20/v1/compiled/questions.compiled.json
@@ -2,7 +2,7 @@
     "schema": "sds_20.questions.compiled.v1",
     "pack_id": "SDS_20",
     "pack_version": "v1",
-    "generated_at": "2026-02-22T11:14:48.028986Z",
+    "generated_at": "2026-03-22T16:33:55.209638Z",
     "question_index": {
         "1": {
             "direction": 1

--- a/backend/content_packs/SDS_20/v1/compiled/report.compiled.json
+++ b/backend/content_packs/SDS_20/v1/compiled/report.compiled.json
@@ -2,7 +2,7 @@
     "schema": "sds_20.report.compiled.v1",
     "pack_id": "SDS_20",
     "pack_version": "v1",
-    "generated_at": "2026-02-22T11:14:48.029050Z",
+    "generated_at": "2026-03-22T16:33:55.209719Z",
     "layout": {
         "sections": [
             {

--- a/backend/content_packs/SDS_20/v1/compiled/sources.compiled.json
+++ b/backend/content_packs/SDS_20/v1/compiled/sources.compiled.json
@@ -2,7 +2,7 @@
     "schema": "sds_20.sources.compiled.v1",
     "pack_id": "SDS_20",
     "pack_version": "v1",
-    "generated_at": "2026-02-22T11:14:48.029036Z",
+    "generated_at": "2026-03-22T16:33:55.209704Z",
     "sources": [
         {
             "source_id": "SDS_ZUNG_1965",


### PR DESCRIPTION
## Summary
This PR isolates the compiled output refresh for `EQ_60` and `SDS_20`.

## Included changes
- `backend/content_packs/EQ_60/v1/compiled/*`
- `backend/content_packs/SDS_20/v1/compiled/*`

## Notes
This PR intentionally excludes command changes and other content packs.
