### PR TITLE
[codex] refresh MBTI-CN compiled pack

### DIFF
--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.normalized.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.normalized.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.cards.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T16:52:00+00:00",
+    "generated_at": "2026-03-22T17:07:16+00:00",
     "sections": {
         "career": {
             "items": [

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.tag_index.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/cards.tag_index.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.tag_index.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T16:52:00+00:00",
+    "generated_at": "2026-03-22T17:07:16+00:00",
     "sections": {
         "career": {
             "axis:AT:A": [

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/governance.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/governance.spec.json
@@ -2,7 +2,7 @@
     "schema": "fap.mbti.content_governance.compiled.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T16:52:00+00:00",
+    "generated_at": "2026-03-22T17:07:16+00:00",
     "required_layers": [
         "skeleton",
         "intensity",

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/inventory.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/inventory.spec.json
@@ -2,7 +2,7 @@
     "schema": "fap.mbti.content_inventory.compiled.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T16:52:00+00:00",
+    "generated_at": "2026-03-22T17:07:16+00:00",
     "inventory_contract_version": 1,
     "inventory_fingerprint": "mbti_content_inventory_v1.cn-mainland.zh-CN.2026-03-ce6",
     "governance_profile": "mbti_content_inventory.v1",

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/manifest.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.manifest.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "source_version": "v0.3",
-    "generated_at": "2026-03-22T16:52:00+00:00",
+    "generated_at": "2026-03-22T17:07:16+00:00",
     "checksum": "c9b10f44ed528de90ed9dfa7373af0109ae751c7321294d2fdc66da4359784c5",
     "files": [
         "cards.normalized.json",

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/rules.normalized.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/rules.normalized.json
@@ -2,7 +2,7 @@
     "schema": "fap.content.compiled.rules.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T16:52:00+00:00",
+    "generated_at": "2026-03-22T17:07:16+00:00",
     "rules": [
         {
             "id": "cards_drop_badge_01",

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/sections.spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/sections.spec.json
@@ -2,7 +2,7 @@
     "schema": "fap.report.section_policies.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T16:52:00+00:00",
+    "generated_at": "2026-03-22T17:07:16+00:00",
     "items": {
         "traits": {
             "min_cards": 3,

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/variables.used.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/variables.used.json
@@ -2,6 +2,6 @@
     "schema": "fap.content.compiled.variables.v1",
     "pack_id": "MBTI.cn-mainland.zh-CN.v0.3",
     "version": "v0.3",
-    "generated_at": "2026-03-22T16:52:00+00:00",
+    "generated_at": "2026-03-22T17:07:16+00:00",
     "variables": []
 }


### PR DESCRIPTION
## Summary
This PR isolates the compiled output refresh for `MBTI-CN-v0.3` under the default content package tree.

## Included changes
- `content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/compiled/*`

## Notes
This PR intentionally excludes backend content pack outputs and command changes.
