### PR TITLE
[codex] Fix public rich report read

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -514,13 +514,27 @@ class AttemptReadController extends Controller
         ]);
     }
 
-    private function resolveAttemptForReportRead(Request $request, int $orgId, string $attemptId, string $scaleCode): Attempt
+    private function resolveAttemptForReportRead(
+        Request $request,
+        int $orgId,
+        string $attemptId,
+        string $scaleCode,
+        bool $allowPublicSystemFallback = true
+    ): Attempt
     {
         if ($this->isPublicReportScale($scaleCode)) {
-            $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
+            $actor = $this->reportActor($request);
+            $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $actor);
 
             if ($attempt instanceof Attempt) {
                 return $attempt;
+            }
+
+            if ($allowPublicSystemFallback && $this->canFallbackToPublicReportSubject($actor)) {
+                $attempt = $this->reportSubjects->findAttemptForSystem(max(0, $orgId), $attemptId);
+                if ($attempt instanceof Attempt) {
+                    return $attempt;
+                }
             }
 
             throw new ApiProblemException(404, 'ATTEMPT_NOT_FOUND', 'attempt not found.');
@@ -1279,6 +1293,12 @@ class AttemptReadController extends Controller
         return $this->isPublicResultScale($scaleCode);
     }
 
+    private function canFallbackToPublicReportSubject(ReportAccessActor $actor): bool
+    {
+        return $this->orgContext->contextKind() === OrgContext::KIND_PUBLIC
+            && ($actor->userId !== null || $actor->anonId !== null);
+    }
+
     private function resolveNormalizedScaleCode(array $responseCodes): string
     {
         $legacy = strtoupper(trim((string) ($responseCodes['scale_code_legacy'] ?? '')));
@@ -1338,7 +1358,7 @@ class AttemptReadController extends Controller
         $result = Result::where('org_id', $orgId)->where('attempt_id', $id)->firstOrFail();
         $responseCodes = $this->resolveResponseScaleCodes($result);
         $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
-        $attempt = $this->resolveAttemptForReportRead($request, $orgId, $id, $scaleCode);
+        $attempt = $this->resolveAttemptForReportRead($request, $orgId, $id, $scaleCode, false);
 
         $gate = $this->reportGatekeeper->resolve(
             $orgId,

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -24,6 +24,8 @@ class ReportGatekeeper
 {
     use ReportGatekeeperTeaserTrait;
 
+    private const PUBLIC_REPORT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60'];
+
     private const SNAPSHOT_RETRY_AFTER_SECONDS = 3;
 
     public function __construct(
@@ -451,6 +453,18 @@ class ReportGatekeeper
 
         $attempt = $this->subjects->findAttemptForCurrentContext($attemptId, $actor);
         if (! $attempt instanceof Attempt) {
+            if ($this->canFallbackToPublicReportSubject($actor)) {
+                $subject = $this->subjects->findSubjectForSystem(max(0, $orgId), $attemptId);
+                if ($subject !== null && $this->isPublicReportScaleForSubject($subject->attempt, $subject->result)) {
+                    return [
+                        'ok' => true,
+                        'attempt' => $subject->attempt,
+                        'result' => $subject->result,
+                        'org_id' => $subject->orgId,
+                    ];
+                }
+            }
+
             return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
         }
 
@@ -477,6 +491,19 @@ class ReportGatekeeper
         $normalizedRole = strtolower(trim((string) $role));
 
         return $normalizedRole === 'system';
+    }
+
+    private function canFallbackToPublicReportSubject(ReportAccessActor $actor): bool
+    {
+        return $this->orgContext->contextKind() === OrgContext::KIND_PUBLIC
+            && ($actor->userId !== null || $actor->anonId !== null);
+    }
+
+    private function isPublicReportScaleForSubject(Attempt $attempt, Result $result): bool
+    {
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?: $result->scale_code ?: '')));
+
+        return in_array($scaleCode, self::PUBLIC_REPORT_READ_SCALES, true);
     }
 
     private function upsertSnapshotVariants(

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -153,4 +153,31 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $pdf->assertHeader('X-Report-Scale', 'MBTI');
         $pdf->assertHeader('X-Report-Locked', 'true');
     }
+
+    public function test_public_mbti_report_pdf_still_requires_matching_attempt_subject(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+        Storage::fake('local');
+
+        $attemptId = (string) Str::uuid();
+        $ownerAnonId = 'anon_mbti_pdf_owner';
+        $viewerAnonId = 'anon_mbti_pdf_viewer';
+        $token = $this->issueAnonToken($viewerAnonId);
+        $this->createAttempt($attemptId, 'MBTI', $ownerAnonId);
+        $this->createResult($attemptId);
+
+        $headers = [
+            'X-Anon-Id' => $viewerAnonId,
+            'Authorization' => 'Bearer '.$token,
+        ];
+
+        $json = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/report");
+        $json->assertStatus(200);
+        $json->assertJsonPath('ok', true);
+        $json->assertJsonPath('locked', true);
+
+        $pdf = $this->withHeaders($headers)->get("/api/v0.3/attempts/{$attemptId}/report.pdf");
+        $pdf->assertStatus(404);
+    }
 }

--- a/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
@@ -142,19 +142,20 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
         ]);
     }
 
-    public function test_public_mbti_report_can_be_read_without_attempt_ownership(): void
+    public function test_public_mbti_report_can_be_read_with_mismatched_but_bound_public_identity(): void
     {
         $this->seedScales();
         config()->set('fap.features.report_snapshot_strict_v2', false);
 
         $attemptId = (string) Str::uuid();
-        $anonId = 'anon_mbti_owner';
-        $token = $this->issueAnonToken($anonId);
-        $this->createAttempt($attemptId, 'MBTI', $anonId);
+        $ownerAnonId = 'anon_mbti_owner';
+        $viewerAnonId = 'anon_mbti_viewer';
+        $token = $this->issueAnonToken($viewerAnonId);
+        $this->createAttempt($attemptId, 'MBTI', $ownerAnonId);
         $this->createResult($attemptId, 'MBTI');
 
         $response = $this->withHeaders([
-            'X-Anon-Id' => $anonId,
+            'X-Anon-Id' => $viewerAnonId,
             'Authorization' => 'Bearer '.$token,
         ])
             ->getJson("/api/v0.3/attempts/{$attemptId}/report");
@@ -166,6 +167,34 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
         $response->assertJsonPath('meta.scale_code_legacy', 'MBTI');
         $this->assertIsArray($response->json('report'));
         $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
+    }
+
+    public function test_public_mbti_report_access_can_be_read_with_mismatched_but_bound_public_identity(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $ownerAnonId = 'anon_access_owner';
+        $viewerAnonId = 'anon_access_viewer';
+        $token = $this->issueAnonToken($viewerAnonId);
+        $this->createAttempt($attemptId, 'MBTI', $ownerAnonId);
+        $this->createResult($attemptId, 'MBTI');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $viewerAnonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'locked');
+        $response->assertJsonPath('report_state', 'ready');
+        $response->assertJsonPath('pdf_state', 'missing');
+        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+        $response->assertJsonPath('actions.pdf_href', null);
+        $response->assertJsonPath('actions.history_href', '/history/mbti');
+        $response->assertJsonPath('actions.lookup_href', '/orders/lookup');
     }
 
     public function test_public_mbti_report_rejects_orphan_result_with_explicit_attempt_not_found_contract(): void


### PR DESCRIPTION
## Summary

This PR fixes the backend root cause behind production cases where `/api/v0.3/attempts/{id}/result` returned `200`, but `/api/v0.3/attempts/{id}/report-access` and `/api/v0.3/attempts/{id}/report` returned `404 ATTEMPT_NOT_FOUND` for the same public MBTI attempt.

From a user perspective, those attempts already had a real computed result row, but the richer report envelope remained unreachable. The frontend could only fall back to a thin basic result view. After this change, public rich JSON report reads can recover when the request comes from a bound public identity that does not match the original attempt subject, while keeping stricter boundaries in place for PDF delivery.

## Root Cause

The public read path had an internal split:

- `/result` tolerated a missing current-context subject for public scales and could still return the result payload when a `results` row existed.
- `/report-access` and `/report` still required `findAttemptForCurrentContext(...)` to succeed.
- `ReportGatekeeper` repeated the same current-context requirement even after the controller layer.

That meant the system could legitimately know that an attempt/result existed, while still failing to resolve the richer report subject and returning `ATTEMPT_NOT_FOUND`.

## Fix

This PR adds a narrow fallback only for public rich JSON report reads:

- `AttemptReadController` now allows public `report` / `report-access` resolution to fall back to a system-level subject lookup when the caller is in the public realm and already has a bound identity (`userId` or `anonId`).
- `ReportGatekeeper` now mirrors that same fallback so the gate and the controller do not disagree.
- The fallback is restricted to public report scales only (`MBTI`, `BIG5_OCEAN`, `IQ_RAVEN`, `EQ_60`).
- `report.pdf` explicitly does **not** use this fallback and still requires the original ownership chain.

This keeps the richer free/locked JSON report available for public result attempts without silently broadening PDF access.

## Validation

I ran the backend regression coverage directly against the affected contracts:

- `php artisan test tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php`
- `php artisan test tests/Feature/V0_3/AttemptReportAccessReadTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php`

The updated tests now prove:

- public MBTI JSON report can be read with a mismatched but bound public identity
- public MBTI `report-access` can be read in the same scenario
- orphan results still return `ATTEMPT_NOT_FOUND`
- SDS-20 still keeps the existing stricter ownership boundary
- PDF still requires the matching attempt subject even when JSON report can fall back

## Scope Guardrails

This PR does not relax tenant access, does not change non-public scales, and does not broaden PDF/download access. It is intentionally limited to public rich JSON report resolution and its direct regression coverage.
