### PR TITLE
fix(auth): block numeric anon_id in guest token issuance

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AuthGuestController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AuthGuestController.php
@@ -83,6 +83,10 @@ final class AuthGuestController extends Controller
             return null;
         }
 
+        if (preg_match('/^\d+$/', $anonId) === 1) {
+            return null;
+        }
+
         $lower = mb_strtolower($anonId, 'UTF-8');
         foreach (['todo', 'placeholder', 'fixme', 'tbd', '填这里'] as $bad) {
             if (mb_strpos($lower, $bad) !== false) {

--- a/backend/tests/Feature/V0_3/AuthGuestTokenTest.php
+++ b/backend/tests/Feature/V0_3/AuthGuestTokenTest.php
@@ -68,6 +68,30 @@ final class AuthGuestTokenTest extends TestCase
         $this->assertMatchesRegularExpression('/^anon_[0-9a-fA-F-]{36}$/', $anonId);
     }
 
+
+    public function test_guest_token_does_not_use_numeric_body_anon_id(): void
+    {
+        $response = $this->postJson('/api/v0.3/auth/guest', [
+            'anon_id' => '1',
+        ]);
+
+        $response->assertStatus(200)->assertJson([
+            'ok' => true,
+        ]);
+
+        $anonId = (string) $response->json('anon_id');
+        $this->assertMatchesRegularExpression('/^anon_[0-9a-fA-F-]{36}$/', $anonId);
+
+        $token = (string) $response->json('fm_token');
+        $authRow = DB::table('auth_tokens')
+            ->where('token_hash', hash('sha256', $token))
+            ->first();
+
+        $this->assertNotNull($authRow);
+        $this->assertNull($authRow->user_id);
+        $this->assertSame($anonId, (string) ($authRow->anon_id ?? ''));
+    }
+
     public function test_guest_token_rejects_invalid_anon_id_payload(): void
     {
         $response = $this->postJson('/api/v0.3/auth/guest', [


### PR DESCRIPTION
### Motivation
- Prevent a critical auth bypass where a numeric `anon_id` supplied to the public `/api/v0.3/auth/guest` endpoint was persisted as a real `user_id` and allowed attackers to mint tokens impersonating arbitrary users.

### Description
- Modified `backend/app/Http/Controllers/API/V0_3/AuthGuestController.php` to reject purely numeric `anon_id` values inside `normalizeAnonId()` so transport/body-supplied numeric IDs cannot flow into `FmTokenService::issueForUser()`.
- Added a focused feature test `backend/tests/Feature/V0_3/AuthGuestTokenTest.php` that posts `anon_id: "1"` and asserts the API generates a safe `anon_*` id and that `auth_tokens.user_id` remains `null` for the issued token.

Changed files (Modified only):
- `backend/app/Http/Controllers/API/V0_3/AuthGuestController.php`
- `backend/tests/Feature/V0_3/AuthGuestTokenTest.php`

Copy-paste exact insertion (in `normalizeAnonId()`), inserted after the block:
```php
if ($anonId === '' || strlen($anonId) > 128) {
    return null;
}
```
Inserted block:
```php
if (preg_match('/^\d+$/', $anonId) === 1) {
    return null;
}
```

Inserted test (placed before `test_guest_token_rejects_invalid_anon_id_payload()`):
```php
public function test_guest_token_does_not_use_numeric_body_anon_id(): void
{
    $response = $this->postJson('/api/v0.3/auth/guest', [
        'anon_id' => '1',
    ]);

    $response->assertStatus(200)->assertJson([
        'ok' => true,
    ]);

    $anonId = (string) $response->json('anon_id');
    $this->assertMatchesRegularExpression('/^anon_[0-9a-fA-F-]{36}$/', $anonId);

    $token = (string) $response->json('fm_token');
    $authRow = DB::table('auth_tokens')
        ->where('token_hash', hash('sha256', $token))
        ->first();

    $this->assertNotNull($authRow);
    $this->assertNull($authRow->user_id);
    $this->assertSame($anonId, (string) ($authRow->anon_id ?? ''));
}
```

Minimal acceptance commands (run from repo root where appropriate):
- `php -l backend/app/Http/Controllers/API/V0_3/AuthGuestController.php`
- `php -l backend/tests/Feature/V0_3/AuthGuestTokenTest.php`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `curl -i -sS -X POST http://127.0.0.1:8000/api/v0.3/auth/guest -H 'Content-Type: application/json' -d '{"anon_id":"1"}'`
- `cd backend && bash scripts/ci_verify_mbti.sh`

### Testing
- Ran `php -l` checks on the modified files and they succeeded (no syntax errors). 
- Committed the change and added the new feature test file; unit/feature test run attempts were blocked because `composer install` could not complete in this environment (network errors / missing `vendor/autoload.php`), so automated test runs (`php artisan route:list`, `php artisan migrate`, `bash scripts/ci_verify_mbti.sh`) could not be executed here. 
- The newly added test exercises the regression (numeric `anon_id`) and should pass in CI once dependencies are available and `phpunit` / `bash scripts/ci_verify_mbti.sh` are run in the normal environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abcab7b98c8330b483e1429f523a6d)