### PR TITLE
fix(compliance): block DSAR subjects outside org membership

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ComplianceDsarController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ComplianceDsarController.php
@@ -47,6 +47,10 @@ final class ComplianceDsarController extends Controller
         $subjectUserId = (int) $payload['subject_user_id'];
         $mode = (string) ($payload['mode'] ?? 'hybrid_anonymize');
         $reason = isset($payload['reason']) ? trim((string) $payload['reason']) : null;
+        if (! $this->subjectBelongsToOrg($orgId, $subjectUserId)) {
+            return $this->invalidSubject();
+        }
+
         $initialPayload = [
             'ip' => $request->ip(),
             'user_agent' => (string) $request->userAgent(),
@@ -455,6 +459,37 @@ final class ComplianceDsarController extends Controller
             'error_code' => 'DSAR_REQUEST_NOT_FOUND',
             'message' => 'dsar request not found.',
         ], 404);
+    }
+
+    private function invalidSubject(): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'INVALID_SUBJECT',
+            'message' => 'subject user is not in current organization.',
+        ], 422);
+    }
+
+    private function subjectBelongsToOrg(int $orgId, int $subjectUserId): bool
+    {
+        if (! SchemaBaseline::hasTable('organization_members')) {
+            return false;
+        }
+
+        if (! SchemaBaseline::hasColumn('organization_members', 'org_id')
+            || ! SchemaBaseline::hasColumn('organization_members', 'user_id')) {
+            return false;
+        }
+
+        $query = DB::table('organization_members')
+            ->where('org_id', $orgId)
+            ->where('user_id', $subjectUserId);
+
+        if (SchemaBaseline::hasColumn('organization_members', 'is_active')) {
+            $query->where('is_active', 1);
+        }
+
+        return $query->exists();
     }
 
     private function appendStatusTransitionAudit(

--- a/backend/tests/Feature/Compliance/DsarRequestApiTest.php
+++ b/backend/tests/Feature/Compliance/DsarRequestApiTest.php
@@ -342,6 +342,40 @@ final class DsarRequestApiTest extends TestCase
         $this->assertSame('RuntimeException', (string) ($terminalContext['exception_class'] ?? ''));
     }
 
+    public function test_owner_cannot_create_dsar_for_user_outside_org_membership(): void
+    {
+        Queue::fake();
+
+        $orgId = 703;
+        $ownerUserId = 70301;
+        $outsideUserId = 70302;
+
+        $this->seedUser($ownerUserId, "owner_{$ownerUserId}@example.test", '+8613900007031');
+        $this->seedUser($outsideUserId, "outside_{$outsideUserId}@example.test", '+8613900007032');
+        $this->seedOrgWithOwnerMembership($orgId, $ownerUserId);
+
+        $ownerToken = $this->issueToken($ownerUserId, $orgId, 'owner', 'anon_owner_dsar_703');
+
+        $headers = [
+            'Authorization' => 'Bearer '.$ownerToken,
+            'X-Org-Id' => (string) $orgId,
+        ];
+
+        $response = $this->withHeaders($headers)->postJson('/api/v0.3/compliance/dsar/requests', [
+            'subject_user_id' => $outsideUserId,
+            'mode' => 'hybrid_anonymize',
+            'reason' => 'cross tenant probe',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'INVALID_SUBJECT')
+            ->assertJsonPath('message', 'subject user is not in current organization.');
+
+        Queue::assertNothingPushed();
+        $this->assertSame(0, DB::table('dsar_requests')->count());
+    }
+
     private function seedUser(int $userId, string $email, string $phoneE164): void
     {
         DB::table('users')->insert([


### PR DESCRIPTION
### Motivation
- A raw DSAR creation path accepted any `subject_user_id` integer and later invoked lifecycle operations that update/delete global `users`, `sessions`, `email_outbox` and tokens without verifying membership, enabling cross-tenant destructive actions. The change prevents an org actor from targeting users that are not members of their org.

### Description
- Modified files: `backend/app/Http/Controllers/API/V0_3/ComplianceDsarController.php` (modified) and `backend/tests/Feature/Compliance/DsarRequestApiTest.php` (modified). No new files added.
- Added an early membership guard in `ComplianceDsarController::store` which returns a 422 `INVALID_SUBJECT` response when the `subject_user_id` is not an active member of the caller org, preventing creation/dispatch of DSARs for cross-tenant users.
- Implemented `subjectBelongsToOrg()` lookup against the `organization_members` table using `SchemaBaseline` checks and an `is_active` filter when present, and added `invalidSubject()` response helper keeping the API shape consistent (`ok/error_code/message`).
- Added a feature test `test_owner_cannot_create_dsar_for_user_outside_org_membership` that verifies the rejection, ensures no queue job is pushed and no `dsar_requests` row is created.

Copy-paste blocks (exact insertions/replacements):

1) Insert in `ComplianceDsarController::store()` immediately after the `$reason` assignment (present near line where `$subjectUserId`/`$mode`/`$reason` are defined):
```php
if (! $this->subjectBelongsToOrg($orgId, $subjectUserId)) {
    return $this->invalidSubject();
}
```

2) Add helper methods (placed near other private response helpers, e.g. after `requestNotFound()`):
```php
private function invalidSubject(): JsonResponse
{
    return response()->json([
        'ok' => false,
        'error_code' => 'INVALID_SUBJECT',
        'message' => 'subject user is not in current organization.',
    ], 422);
}

private function subjectBelongsToOrg(int $orgId, int $subjectUserId): bool
{
    if (! SchemaBaseline::hasTable('organization_members')) {
        return false;
    }

    if (! SchemaBaseline::hasColumn('organization_members', 'org_id')
        || ! SchemaBaseline::hasColumn('organization_members', 'user_id')) {
        return false;
    }

    $query = DB::table('organization_members')
        ->where('org_id', $orgId)
        ->where('user_id', $subjectUserId);

    if (SchemaBaseline::hasColumn('organization_members', 'is_active')) {
        $query->where('is_active', 1);
    }

    return $query->exists();
}
```

3) New test method inserted in `backend/tests/Feature/Compliance/DsarRequestApiTest.php` (placed near other DSAR tests):
```php
public function test_owner_cannot_create_dsar_for_user_outside_org_membership(): void
{
    Queue::fake();

    $orgId = 703;
    $ownerUserId = 70301;
    $outsideUserId = 70302;

    $this->seedUser($ownerUserId, "owner_{$ownerUserId}@example.test", '+8613900007031');
    $this->seedUser($outsideUserId, "outside_{$outsideUserId}@example.test", '+8613900007032');
    $this->seedOrgWithOwnerMembership($orgId, $ownerUserId);

    $ownerToken = $this->issueToken($ownerUserId, $orgId, 'owner', 'anon_owner_dsar_703');

    $headers = [
        'Authorization' => 'Bearer '.$ownerToken,
        'X-Org-Id' => (string) $orgId,
    ];

    $response = $this->withHeaders($headers)->postJson('/api/v0.3/compliance/dsar/requests', [
        'subject_user_id' => $outsideUserId,
        'mode' => 'hybrid_anonymize',
        'reason' => 'cross tenant probe',
    ]);

    $response->assertStatus(422)
        ->assertJsonPath('ok', false)
        ->assertJsonPath('error_code', 'INVALID_SUBJECT')
        ->assertJsonPath('message', 'subject user is not in current organization.');

    Queue::assertNothingPushed();
    $this->assertSame(0, DB::table('dsar_requests')->count());
}
```

### Testing
- Minimal acceptance commands (run in `backend/`): `php artisan route:list`, `php artisan migrate`, `curl` request to the endpoint, and `bash scripts/ci_verify_mbti.sh`.
- Attempted automated commands in this environment:
  - `cd backend && php artisan route:list` — failed due to missing `vendor/autoload.php` in the container; runtime not available here.
  - `cd backend && php artisan migrate` — failed due to missing `vendor/autoload.php` in the container.
  - `curl -i -X POST http://127.0.0.1:8000/api/v0.3/compliance/dsar/requests -H 'Content-Type: application/json' -d '{"subject_user_id":1,"mode":"hybrid_anonymize"}'` — failed to connect (local server not running in this environment).
  - `cd backend && bash scripts/ci_verify_mbti.sh` — attempted and failed early for the same missing `vendor/autoload.php` reason.
- Unit/feature test added: `backend/tests/Feature/Compliance/DsarRequestApiTest.php::test_owner_cannot_create_dsar_for_user_outside_org_membership` validates the intended protection; it should be executed as part of the test suite (`cd backend && composer test` / `phpunit`) in a fully bootstrapped dev environment.

Notes: change is intentionally minimal and only affects DSAR request creation path (pre-dispatch) to block cross-tenant targeting; it preserves the existing lifecycle flow and audit behavior for valid subjects. Follow-up hardening (e.g. double-check in job execution path) can be added later if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abc958d83c8330a55ee307ea24e588)