### PR TITLE
fix(big5-ops): block path traversal in publish and rollback inputs

### DIFF
--- a/backend/app/Console/Commands/PacksPublish.php
+++ b/backend/app/Console/Commands/PacksPublish.php
@@ -56,6 +56,11 @@ final class PacksPublish extends Command
             return 1;
         }
 
+        if (! $this->isSafePathSegment($packId) || ! $this->isSafeVersion($version) || ! $this->isSafePathSegment($region) || ! $this->isSafePathSegment($locale) || ! $this->isSafePathSegment($dirAlias)) {
+            $this->error('invalid --pack/--pack-version/--region/--locale/--dir_alias value.');
+            return 1;
+        }
+
         $sourceContext = $pathAliasResolver->resolveBackendPublishSourceContext($packId, $version);
         $sourceDir = trim((string) ($sourceContext['selected_path'] ?? ''));
         $sourceSelection = strtolower(trim((string) ($sourceContext['selected_source'] ?? 'legacy')));
@@ -245,6 +250,16 @@ final class PacksPublish extends Command
             : 'norms:big5:drift-check';
     }
 
+
+    private function isSafePathSegment(string $value): bool
+    {
+        return (bool) preg_match('/\A(?!\.\.)[A-Za-z0-9_-]+\z/', $value);
+    }
+
+    private function isSafeVersion(string $value): bool
+    {
+        return (bool) preg_match('/\A(?!\.\.)[A-Za-z0-9._-]+\z/', $value);
+    }
     private function resolveLocalSourceType(string $sourceSelection): string
     {
         $selection = strtolower(trim($sourceSelection));

--- a/backend/app/Console/Commands/PacksRollback.php
+++ b/backend/app/Console/Commands/PacksRollback.php
@@ -40,6 +40,11 @@ final class PacksRollback extends Command
             return 1;
         }
 
+        if (! $this->isSafePathSegment($region) || ! $this->isSafePathSegment($locale) || ! $this->isSafePathSegment($dirAlias)) {
+            $this->error('invalid --region/--locale/--dir_alias value.');
+            return 1;
+        }
+
         $result = $publisher->rollback(
             $region,
             $locale,
@@ -73,6 +78,12 @@ final class PacksRollback extends Command
         }
 
         return $status === 'success' ? 0 : 1;
+    }
+
+
+    private function isSafePathSegment(string $value): bool
+    {
+        return (bool) preg_match('/\A(?!\.\.)[A-Za-z0-9_-]+\z/', $value);
     }
 
     private function isTruthy(mixed $value): bool

--- a/backend/app/Http/Requests/V0_3/BigFiveOpsRequest.php
+++ b/backend/app/Http/Requests/V0_3/BigFiveOpsRequest.php
@@ -16,17 +16,17 @@ final class BigFiveOpsRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'region' => ['sometimes', 'string', 'max:64'],
-            'locale' => ['sometimes', 'string', 'max:32'],
+            'region' => ['sometimes', 'string', 'max:64', 'regex:/\A(?!\.\.)[A-Za-z0-9_-]+\z/'],
+            'locale' => ['sometimes', 'string', 'max:32', 'regex:/\A(?!\.\.)[A-Za-z0-9_-]+\z/'],
             'action' => ['sometimes', 'string', 'max:64'],
             'release_action' => ['sometimes', 'string', 'max:64'],
             'result' => ['sometimes', 'string', 'max:32'],
             'release_id' => ['sometimes', 'string', 'max:128'],
             'limit' => ['sometimes', 'integer', 'min:1', 'max:100'],
 
-            'dir_alias' => ['sometimes', 'string', 'max:128'],
-            'pack' => ['sometimes', 'string', 'max:128'],
-            'pack_version' => ['sometimes', 'string', 'max:128'],
+            'dir_alias' => ['sometimes', 'string', 'max:128', 'regex:/\A(?!\.\.)[A-Za-z0-9_-]+\z/'],
+            'pack' => ['sometimes', 'string', 'max:128', 'regex:/\A(?!\.\.)[A-Za-z0-9_-]+\z/'],
+            'pack_version' => ['sometimes', 'string', 'max:128', 'regex:/\A(?!\.\.)[A-Za-z0-9._-]+\z/'],
             'probe' => ['sometimes', 'boolean'],
             'skip_drift' => ['sometimes', 'boolean'],
             'base_url' => ['sometimes', 'string', 'max:512'],

--- a/backend/tests/Feature/Ops/BigFiveOpsWriteEndpointsTest.php
+++ b/backend/tests/Feature/Ops/BigFiveOpsWriteEndpointsTest.php
@@ -118,6 +118,31 @@ final class BigFiveOpsWriteEndpointsTest extends TestCase
         $this->assertSame('success', (string) ($rollbackAudit->result ?? ''));
     }
 
+
+    public function test_publish_rejects_path_traversal_inputs(): void
+    {
+        $owner = $this->createUserWithToken('ops-write-validate@big5.test');
+        $orgId = $this->createOrgForToken($owner['token']);
+
+        $headers = [
+            'Authorization' => 'Bearer '.$owner['token'],
+            'X-Org-Id' => (string) $orgId,
+        ];
+
+        $response = $this->withHeaders($headers)->postJson('/api/v0.3/orgs/'.$orgId.'/big5/releases/publish', [
+            'pack' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'dir_alias' => '../../tmp',
+            'probe' => false,
+            'skip_drift' => true,
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['dir_alias']);
+    }
+
     public function test_owner_can_run_norms_write_operations_via_ops_endpoints(): void
     {
         $owner = $this->createUserWithToken('ops-norms-owner@big5.test');


### PR DESCRIPTION
### Motivation

- Prevent path traversal / arbitrary filesystem writes triggered by org-admin-facing publish/rollback endpoints by sanitizing user-controlled path segments before they reach filesystem operations.

### Description

- Modified files: `backend/app/Http/Requests/V0_3/BigFiveOpsRequest.php`, `backend/app/Console/Commands/PacksPublish.php`, `backend/app/Console/Commands/PacksRollback.php`, and `backend/tests/Feature/Ops/BigFiveOpsWriteEndpointsTest.php`.
- Request-level hardening: replaced loose string rules for `region`, `locale`, `dir_alias`, `pack`, and `pack_version` with allowlist regexes that disallow `..` and path separators (exact replacement in `rules()` array in `BigFiveOpsRequest`).
- Command-level defense-in-depth: added pre-checks in `packs:publish` and `packs:rollback` to reject unsafe `--pack/--pack-version/--region/--locale/--dir_alias` values, plus helper validators `isSafePathSegment()` and `isSafeVersion()` in the command classes.
- Test: added `test_publish_rejects_path_traversal_inputs()` to assert `dir_alias='../../tmp'` is rejected with a `422` validation error.

Copy-paste blocks (exact replacements/insertions):

1) `backend/app/Http/Requests/V0_3/BigFiveOpsRequest.php` — replacement in `rules()` for the named fields:

'region' => ['sometimes', 'string', 'max:64', 'regex:/\A(?!\.\.)[A-Za-z0-9_-]+\z/'],
'locale' => ['sometimes', 'string', 'max:32', 'regex:/\A(?!\.\.)[A-Za-z0-9_-]+\z/'],
...
'dir_alias' => ['sometimes', 'string', 'max:128', 'regex:/\A(?!\.\.)[A-Za-z0-9_-]+\z/'],
'pack' => ['sometimes', 'string', 'max:128', 'regex:/\A(?!\.\.)[A-Za-z0-9_-]+\z/'],
'pack_version' => ['sometimes', 'string', 'max:128', 'regex:/\A(?!\.\.)[A-Za-z0-9._-]+\z/'],

2) `backend/app/Console/Commands/PacksPublish.php` — insert after the required-empty check:

if (! $this->isSafePathSegment($packId) || ! $this->isSafeVersion($version) || ! $this->isSafePathSegment($region) || ! $this->isSafePathSegment($locale) || ! $this->isSafePathSegment($dirAlias)) {
    $this->error('invalid --pack/--pack-version/--region/--locale/--dir_alias value.');
    return 1;
}

and helper methods added near the end of the class:

private function isSafePathSegment(string $value): bool
{
    return (bool) preg_match('/\A(?!\.\.)[A-Za-z0-9_-]+\z/', $value);
}

private function isSafeVersion(string $value): bool
{
    return (bool) preg_match('/\A(?!\.\.)[A-Za-z0-9._-]+\z/', $value);
}

3) `backend/app/Console/Commands/PacksRollback.php` — insert after required-empty check:

if (! $this->isSafePathSegment($region) || ! $this->isSafePathSegment($locale) || ! $this->isSafePathSegment($dirAlias)) {
    $this->error('invalid --region/--locale/--dir_alias value.');
    return 1;
}

and add helper:

private function isSafePathSegment(string $value): bool
{
    return (bool) preg_match('/\A(?!\.\.)[A-Za-z0-9_-]+\z/', $value);
}

4) `backend/tests/Feature/Ops/BigFiveOpsWriteEndpointsTest.php` — inserted test before norms tests that posts `dir_alias = '../../tmp'` and asserts `422` + validation error for `dir_alias`.

### Testing

- Fast checks performed: ran `php -l` on modified PHP files and saw no syntax errors for `BigFiveOpsRequest.php`, `PacksPublish.php`, `PacksRollback.php`, and the updated feature test, all succeeded.
- Feature/unit run status: attempted to run `composer install`, `php artisan` and the repo's CI script but dependency fetch failed due to network/GitHub access in this environment (Composer downloads hit network 403/connection errors), so `vendor/autoload.php` is missing and `php artisan route:list` / `php artisan migrate` / `bash scripts/ci_verify_mbti.sh` / PHPUnit could not be executed here.
- Automated checks executed locally in this environment (and results): `php -l` checks passed (success), `composer install` failed (network), `php artisan` commands blocked due to missing vendor (blocked), `curl` against local server not run because app not running (blocked).

Minimal acceptance commands to run in CI or a dev environment with working network and dependencies:

- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `cd backend && ./vendor/bin/phpunit --filter BigFiveOpsWriteEndpointsTest`
- `cd backend && curl -i -X POST http://127.0.0.1:8000/api/v0.3/orgs/{org_id}/big5/releases/publish -H 'Content-Type: application/json' -d '{"pack":"BIG5_OCEAN","pack_version":"v1","region":"CN_MAINLAND","locale":"zh-CN","dir_alias":"../../tmp","probe":false,"skip_drift":true}'`
- `cd backend && bash scripts/ci_verify_mbti.sh`

All changes are confined to `backend/` and implement minimal, incremental hardening and a test to demonstrate validation rejection; full CI/verify should be run in an environment where Composer can fetch dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abd0959cc08330b25896caad04dc59)