### PR TITLE
fix(webhook): skip post-commit side effects for duplicate events

### DIFF
--- a/backend/app/Services/Commerce/Webhook/WebhookPostCommitService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookPostCommitService.php
@@ -22,7 +22,7 @@ class WebhookPostCommitService
             : null;
         $postCommitOutcome = null;
 
-        if (($result['ok'] ?? false) && is_array($postCommitCtx)) {
+        if (($result['ok'] ?? false) && ! ($result['duplicate'] ?? false) && is_array($postCommitCtx)) {
             $postCommitOutcome = $this->core->runWebhookPostCommitSideEffects($postCommitCtx);
 
             if (($postCommitOutcome['ok'] ?? false) === true) {

--- a/backend/tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php
@@ -140,6 +140,76 @@ final class PaymentWebhookProcessorAtomicityTest extends TestCase
         $this->assertSame(1, DB::table('benefit_wallet_ledgers')->where('reason', 'topup')->count());
     }
 
+    public function test_settled_credit_pack_new_event_id_does_not_retopup_wallet(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+
+        $orderNo = 'ord_atomic_credit_dup';
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => null,
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => null,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 4990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_CREDIT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+
+        $first = $this->postSignedBillingWebhook([
+            'provider_event_id' => 'evt_atomic_credit_dup_1',
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_atomic_credit_dup_1',
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+        ], [
+            'X-Org-Id' => '0',
+        ]);
+        $first->assertStatus(200);
+        $first->assertJson([
+            'ok' => true,
+            'order_no' => $orderNo,
+            'provider_event_id' => 'evt_atomic_credit_dup_1',
+        ]);
+
+        $second = $this->postSignedBillingWebhook([
+            'provider_event_id' => 'evt_atomic_credit_dup_2',
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_atomic_credit_dup_2',
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+        ], [
+            'X-Org-Id' => '0',
+        ]);
+        $second->assertStatus(200);
+        $second->assertJson([
+            'ok' => true,
+            'duplicate' => true,
+            'order_no' => $orderNo,
+            'provider_event_id' => 'evt_atomic_credit_dup_2',
+        ]);
+
+        $this->assertSame(1, DB::table('benefit_wallet_ledgers')->where('reason', 'topup')->count());
+        $this->assertSame(2, DB::table('payment_events')->where('provider', 'billing')->whereIn('provider_event_id', ['evt_atomic_credit_dup_1', 'evt_atomic_credit_dup_2'])->count());
+    }
+
     public function test_report_unlock_split_replay_converges_without_duplicate_side_effects(): void
     {
         (new Pr19CommerceSeeder)->run();


### PR DESCRIPTION
### Motivation
- A logic regression allowed post-commit side effects to run whenever a `post_commit_ctx` existed, even for already-settled orders that returned `{ok: true, duplicate: true}`, enabling duplicate wallet top-ups or entitlement grants when providers emit multiple success event types or replay events with new IDs.  
- The intent is to prevent duplicate post-commit side effects while preserving existing transaction / duplicate-detection semantics and minimal surface area of change.  

### Description
- Modified `WebhookPostCommitService::handle` to only run `runWebhookPostCommitSideEffects` when the result is successful and not marked as a duplicate by adding a `!($result['duplicate'] ?? false)` check.  
- Added a focused regression test `test_settled_credit_pack_new_event_id_does_not_retopup_wallet` to `PaymentWebhookProcessorAtomicityTest.php` which verifies a settled `credit_pack` order does not cause a second wallet top-up when a second webhook with a different `provider_event_id` arrives.  

A) Changed files list (Modified)
- Modified: `backend/app/Services/Commerce/Webhook/WebhookPostCommitService.php`
- Modified: `backend/tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php`

B) Copy-paste blocks (exact replacement / insertion)

1) Exact replacement (one-line) — File: `backend/app/Services/Commerce/Webhook/WebhookPostCommitService.php` (inside `handle(array $ctx): array`)
Replace this line:
```php
if (($result['ok'] ?? false) && is_array($postCommitCtx)) {
```
with:
```php
if (($result['ok'] ?? false) && ! ($result['duplicate'] ?? false) && is_array($postCommitCtx)) {
```

2) Exact insertion — File: `backend/tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php`
Insert the following test method immediately before the existing `test_report_unlock_split_replay_converges_without_duplicate_side_effects` method (i.e. inserted before the marker method header `public function test_report_unlock_split_replay_converges_without_duplicate_side_effects(): void`):
```php
public function test_settled_credit_pack_new_event_id_does_not_retopup_wallet(): void
{
    (new Pr19CommerceSeeder)->run();

    $orderNo = 'ord_atomic_credit_dup';
    DB::table('orders')->insert([
        'id' => (string) Str::uuid(),
        'order_no' => $orderNo,
        'org_id' => 0,
        'user_id' => null,
        'anon_id' => null,
        'sku' => 'MBTI_CREDIT',
        'quantity' => 1,
        'target_attempt_id' => null,
        'amount_cents' => 4990,
        'currency' => 'USD',
        'status' => 'created',
        'provider' => 'billing',
        'external_trade_no' => null,
        'paid_at' => null,
        'created_at' => now(),
        'updated_at' => now(),
        'amount_total' => 4990,
        'amount_refunded' => 0,
        'item_sku' => 'MBTI_CREDIT',
        'provider_order_id' => null,
        'device_id' => null,
        'request_id' => null,
        'created_ip' => null,
        'fulfilled_at' => null,
        'refunded_at' => null,
    ]);

    $first = $this->postSignedBillingWebhook([
        'provider_event_id' => 'evt_atomic_credit_dup_1',
        'order_no' => $orderNo,
        'external_trade_no' => 'trade_atomic_credit_dup_1',
        'amount_cents' => 4990,
        'currency' => 'USD',
    ], [
        'X-Org-Id' => '0',
    ]);
    $first->assertStatus(200);
    $first->assertJson([
        'ok' => true,
        'order_no' => $orderNo,
        'provider_event_id' => 'evt_atomic_credit_dup_1',
    ]);

    $second = $this->postSignedBillingWebhook([
        'provider_event_id' => 'evt_atomic_credit_dup_2',
        'order_no' => $orderNo,
        'external_trade_no' => 'trade_atomic_credit_dup_2',
        'amount_cents' => 4990,
        'currency' => 'USD',
    ], [
        'X-Org-Id' => '0',
    ]);
    $second->assertStatus(200);
    $second->assertJson([
        'ok' => true,
        'duplicate' => true,
        'order_no' => $orderNo,
        'provider_event_id' => 'evt_atomic_credit_dup_2',
    ]);

    $this->assertSame(1, DB::table('benefit_wallet_ledgers')->where('reason', 'topup')->count());
    $this->assertSame(2, DB::table('payment_events')->where('provider', 'billing')->whereIn('provider_event_id', ['evt_atomic_credit_dup_1', 'evt_atomic_credit_dup_2'])->count());
}
```

C) Minimal acceptance commands set
- `php -l backend/app/Services/Commerce/Webhook/WebhookPostCommitService.php`  (syntax check)
- `php -l backend/tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php`  (syntax check)
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --force`
- `curl -i http://127.0.0.1:8000/api/v0.2/health` (example health endpoint check)
- `cd backend && bash scripts/ci_verify_mbti.sh`

### Testing
- Ran `php -l` on the modified service and test files and both returned no syntax errors.  
- Attempted to run the CI/test matrix (`cd backend && php artisan test --filter=PaymentWebhookProcessorAtomicityTest` and `cd backend && bash scripts/ci_verify_mbti.sh`) but the environment could not install Composer dependencies (`vendor/autoload.php` missing and `composer install` failed due to network/GitHub fetch errors), so full PHPUnit/CI runs could not complete here.  
- The change is intentionally minimal and unit/integration test added should pass in a normal development or CI environment after `cd backend && composer install` and running the repository test suite and `bash scripts/ci_verify_mbti.sh` as required by repository policy.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abdb73bc708330b1e780951b2f7ff9)