### PR TITLE
fix(v0.3-result): enforce ownership checks for result reads

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -23,7 +23,6 @@ class AttemptReadController extends Controller
 {
     use ResolvesAttemptOwnership;
 
-    private const PUBLIC_RESULT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60'];
 
     private const SENSITIVE_RESULT_READ_SCALES = ['SDS_20', 'CLINICAL_COMBO_68'];
 
@@ -77,7 +76,7 @@ class AttemptReadController extends Controller
 
         $responseCodes = $this->resolveResponseScaleCodes($result);
         $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
-        $attempt = $this->resolveAttemptForResultRead($request, $orgId, $id, $scaleCode);
+        $attempt = $this->resolveAttemptForResultRead($request, $id);
         $attemptId = $this->resolveAttemptId($result, $attempt, $id);
         $packId = $this->preferredStringField($result, $attempt, 'pack_id');
         $dirVersion = $this->preferredStringField($result, $attempt, 'dir_version');
@@ -347,15 +346,8 @@ class AttemptReadController extends Controller
         return $payload;
     }
 
-    private function resolveAttemptForResultRead(Request $request, int $orgId, string $attemptId, string $scaleCode): ?Attempt
+    private function resolveAttemptForResultRead(Request $request, string $attemptId): ?Attempt
     {
-        if ($this->isPublicResultScale($scaleCode)) {
-            return Attempt::withoutGlobalScopes()
-                ->where('org_id', $orgId)
-                ->where('id', $attemptId)
-                ->first();
-        }
-
         $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
         if ($attempt instanceof Attempt) {
             return $attempt;
@@ -364,10 +356,6 @@ class AttemptReadController extends Controller
         throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
     }
 
-    private function isPublicResultScale(string $scaleCode): bool
-    {
-        return in_array($scaleCode, self::PUBLIC_RESULT_READ_SCALES, true);
-    }
 
     private function resolveNormalizedScaleCode(array $responseCodes): string
     {

--- a/backend/tests/Feature/V0_3/AttemptPublicResultReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicResultReadHotfixTest.php
@@ -126,7 +126,7 @@ final class AttemptPublicResultReadHotfixTest extends TestCase
         $response->assertJsonPath('meta.scale_code_legacy', 'BIG5_OCEAN');
     }
 
-    public function test_public_orphan_result_can_be_read_without_attempt_row(): void
+    public function test_public_orphan_result_read_requires_owned_attempt(): void
     {
         $this->seedScales();
 
@@ -152,16 +152,8 @@ final class AttemptPublicResultReadHotfixTest extends TestCase
         $response = $this->withHeader('X-Anon-Id', 'anon_orphan_probe')
             ->getJson("/api/v0.3/attempts/{$attemptId}/result");
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('attempt_id', $attemptId);
-        $response->assertJsonPath('type_code', 'IQ-RESULT');
-        $response->assertJsonPath('meta.scale_code_legacy', 'IQ_RAVEN');
-        $response->assertJsonPath('meta.pack_id', 'IQ_RAVEN.result-pack');
-        $response->assertJsonPath('meta.dir_version', 'IQ_RAVEN.result-dir');
-        $response->assertJsonPath('meta.content_package_version', 'result-only-v1');
-        $response->assertJsonPath('meta.scoring_spec_version', 'result-only-score-v1');
-        $response->assertJsonPath('meta.report_engine_version', 'v2.1');
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
     }
 
     public function test_sds20_anonymous_result_read_is_still_rejected(): void


### PR DESCRIPTION
### Motivation
- A recent change allowed reading certain public-scale results by loading the `Result` first and then using a public-scale path that bypassed `ownedAttemptQuery`, introducing an IDOR-style authorization bypass for MBTI/BIG5/IQ/EQ scales.
- The goal is to ensure result reads always validate anon/user ownership and tenant scope so callers cannot read orphaned results by knowing an attempt UUID.

### Description
- Changed files: `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php` (modified) and `backend/tests/Feature/V0_3/AttemptPublicResultReadHotfixTest.php` (modified).
- Replace the call in `result(Request $request, string $id)` so it invokes `resolveAttemptForResultRead($request, $id)` instead of the prior signature that accepted org/scale and used a public bypass; exact replacement (around the `result()` call site):

`$attempt = $this->resolveAttemptForResultRead($request, $orgId, $id, $scaleCode);`

is replaced with:

`$attempt = $this->resolveAttemptForResultRead($request, $id);`

- Replace the helper `resolveAttemptForResultRead` to always use `ownedAttemptQuery(...)` and remove the public-scale bypass; exact replacement (helper region):

Old

`private function resolveAttemptForResultRead(Request $request, int $orgId, string $attemptId, string $scaleCode): ?Attempt
{
    if ($this->isPublicResultScale($scaleCode)) {
        return Attempt::withoutGlobalScopes()
            ->where('org_id', $orgId)
            ->where('id', $attemptId)
            ->first();
    }

    $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
    if ($attempt instanceof Attempt) {
        return $attempt;
    }

    throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
}`

New

`private function resolveAttemptForResultRead(Request $request, string $attemptId): ?Attempt
{
    $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
    if ($attempt instanceof Attempt) {
        return $attempt;
    }

    throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
}`

- Update test `AttemptPublicResultReadHotfixTest.php` to assert an orphan public result is rejected, replacing the former success assertions with `404` plus `error_code` check (exact test change around the orphan case):

Old assertions replaced with:

`$response->assertStatus(404);
$response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');`

### Testing
- Ran PHP linting on modified files with `php -l` and both `AttemptReadController.php` and `AttemptPublicResultReadHotfixTest.php` reported "No syntax errors detected".
- Attempted to run full acceptance commands but `php artisan` commands (`php artisan route:list` and `php artisan migrate`) and the CI verify script failed because `vendor/autoload.php` is missing in this environment due to inability to complete `composer install` (network/git fetch errors), so full automated test suite could not be executed here.
- Minimal acceptance commands to run in CI or a developer environment (when dependencies are available) are: `cd backend && php artisan route:list`, `cd backend && php artisan migrate`, `curl -i http://127.0.0.1:8000/api/v0.3/attempts/<attempt-id>/result`, and `cd backend && bash scripts/ci_verify_mbti.sh`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad423008b483309837305b1230c16c)