### PR TITLE
fix(attempts): prevent cross-tenant access to org_id=0 attempts

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -149,14 +149,13 @@ class AttemptSubmitService
         ?string $actorAnonId
     ): Builder {
         $orgId = $ctx->orgId() ?? 0;
-        $orgIds = $orgId === 0 ? [0] : [$orgId, 0];
 
         // ✅ 强制走写库 + 去掉全局 scopes
-        // ✅ whereIn(org_id, [$orgId, 0])：兼容历史 attempt 写成 org_id=0
+        // ✅ 仅允许当前 org，避免跨租户访问 org_id=0 历史数据
         $query = Attempt::onWriteConnection()
             ->withoutGlobalScopes()
             ->where('id', $attemptId)
-            ->whereIn('org_id', $orgIds);
+            ->where('org_id', $orgId);
 
         $role = (string) ($ctx->role() ?? '');
         if (in_array($role, ['owner', 'admin'], true)) {


### PR DESCRIPTION
### Motivation
- Fix an access-control weakening where admin/owner callers could access attempts stored with `org_id=0` across tenants by bypassing tenant isolation in the ownership query.

### Description
- Modified file: `backend/app/Services/Attempts/AttemptSubmitService.php` to scope the submit/ownership query to the caller's current org only.

Exact replacement range: `backend/app/Services/Attempts/AttemptSubmitService.php` lines 151-158 (replace the previous `whereIn(org_id, ...)` block with the following):

```php
        $orgId = $ctx->orgId() ?? 0;

        // ✅ 强制走写库 + 去掉全局 scopes
        // ✅ 仅允许当前 org，避免跨租户访问 org_id=0 历史数据
        $query = Attempt::onWriteConnection()
            ->withoutGlobalScopes()
            ->where('id', $attemptId)
            ->where('org_id', $orgId);
```

### Testing
- Automated checks attempted: `php artisan route:list`, `php artisan migrate --force`, `bash backend/scripts/ci_verify_mbti.sh`, `composer install`, and a sample `curl` request were executed and the change was validated by code inspection and `git diff`.

Minimal acceptance commands set (run in `backend/`):
- `php artisan route:list` (failed: `vendor/autoload.php` missing in the environment)
- `php artisan migrate --force` (failed: `vendor/autoload.php` missing in the environment)
- `curl -i http://127.0.0.1:8000/api/v0.2/me/attempts` (failed: local server not running)
- `bash backend/scripts/ci_verify_mbti.sh` (failed early: `vendor/autoload.php` missing)

Notes: `composer install` was attempted to enable the above commands but the environment blocked dependency fetch (network/proxy `CONNECT tunnel failed, response 403`), so runtime verification could not be completed here; the fix is intentionally minimal and limited to the ownership query to close the reported cross-tenant access vector while preserving the surrounding logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abc491da3c83309afaff55f3338f65)