### PR TITLE
fix(report): block public report IDOR by removing system fallback

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -313,7 +313,7 @@ class AttemptReadController extends Controller
         }
         $responseCodes = $this->resolveResponseScaleCodes($result);
         $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
-        $attempt = $this->resolveAttemptForReportRead($request, $orgId, $id, $scaleCode);
+        $attempt = $this->resolveAttemptForReportRead($request, $id, $scaleCode);
 
         $gate = $this->resolveReportGate(
             $orgId,
@@ -516,10 +516,8 @@ class AttemptReadController extends Controller
 
     private function resolveAttemptForReportRead(
         Request $request,
-        int $orgId,
         string $attemptId,
-        string $scaleCode,
-        bool $allowPublicSystemFallback = true
+        string $scaleCode
     ): Attempt
     {
         if ($this->isPublicReportScale($scaleCode)) {
@@ -528,13 +526,6 @@ class AttemptReadController extends Controller
 
             if ($attempt instanceof Attempt) {
                 return $attempt;
-            }
-
-            if ($allowPublicSystemFallback && $this->canFallbackToPublicReportSubject($actor)) {
-                $attempt = $this->reportSubjects->findAttemptForSystem(max(0, $orgId), $attemptId);
-                if ($attempt instanceof Attempt) {
-                    return $attempt;
-                }
             }
 
             throw new ApiProblemException(404, 'ATTEMPT_NOT_FOUND', 'attempt not found.');
@@ -555,7 +546,7 @@ class AttemptReadController extends Controller
             $responseCodes = $this->resolveResponseScaleCodes($result);
             $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
 
-            return $this->resolveAttemptForReportRead($request, $orgId, $attemptId, $scaleCode);
+            return $this->resolveAttemptForReportRead($request, $attemptId, $scaleCode);
         }
 
         $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
@@ -1293,12 +1284,6 @@ class AttemptReadController extends Controller
         return $this->isPublicResultScale($scaleCode);
     }
 
-    private function canFallbackToPublicReportSubject(ReportAccessActor $actor): bool
-    {
-        return $this->orgContext->contextKind() === OrgContext::KIND_PUBLIC
-            && ($actor->userId !== null || $actor->anonId !== null);
-    }
-
     private function resolveNormalizedScaleCode(array $responseCodes): string
     {
         $legacy = strtoupper(trim((string) ($responseCodes['scale_code_legacy'] ?? '')));
@@ -1358,7 +1343,7 @@ class AttemptReadController extends Controller
         $result = Result::where('org_id', $orgId)->where('attempt_id', $id)->firstOrFail();
         $responseCodes = $this->resolveResponseScaleCodes($result);
         $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
-        $attempt = $this->resolveAttemptForReportRead($request, $orgId, $id, $scaleCode, false);
+        $attempt = $this->resolveAttemptForReportRead($request, $id, $scaleCode);
 
         $gate = $this->reportGatekeeper->resolve(
             $orgId,

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -453,18 +453,6 @@ class ReportGatekeeper
 
         $attempt = $this->subjects->findAttemptForCurrentContext($attemptId, $actor);
         if (! $attempt instanceof Attempt) {
-            if ($this->canFallbackToPublicReportSubject($actor)) {
-                $subject = $this->subjects->findSubjectForSystem(max(0, $orgId), $attemptId);
-                if ($subject !== null && $this->isPublicReportScaleForSubject($subject->attempt, $subject->result)) {
-                    return [
-                        'ok' => true,
-                        'attempt' => $subject->attempt,
-                        'result' => $subject->result,
-                        'org_id' => $subject->orgId,
-                    ];
-                }
-            }
-
             return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
         }
 
@@ -491,19 +479,6 @@ class ReportGatekeeper
         $normalizedRole = strtolower(trim((string) $role));
 
         return $normalizedRole === 'system';
-    }
-
-    private function canFallbackToPublicReportSubject(ReportAccessActor $actor): bool
-    {
-        return $this->orgContext->contextKind() === OrgContext::KIND_PUBLIC
-            && ($actor->userId !== null || $actor->anonId !== null);
-    }
-
-    private function isPublicReportScaleForSubject(Attempt $attempt, Result $result): bool
-    {
-        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?: $result->scale_code ?: '')));
-
-        return in_array($scaleCode, self::PUBLIC_REPORT_READ_SCALES, true);
     }
 
     private function upsertSnapshotVariants(

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -173,9 +173,9 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         ];
 
         $json = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/report");
-        $json->assertStatus(200);
-        $json->assertJsonPath('ok', true);
-        $json->assertJsonPath('locked', true);
+        $json->assertStatus(404);
+        $json->assertJsonPath('error_code', 'ATTEMPT_NOT_FOUND');
+        $json->assertJsonPath('message', 'attempt not found.');
 
         $pdf = $this->withHeaders($headers)->get("/api/v0.3/attempts/{$attemptId}/report.pdf");
         $pdf->assertStatus(404);

--- a/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
@@ -142,7 +142,7 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
         ]);
     }
 
-    public function test_public_mbti_report_can_be_read_with_mismatched_but_bound_public_identity(): void
+    public function test_public_mbti_report_requires_matching_attempt_subject(): void
     {
         $this->seedScales();
         config()->set('fap.features.report_snapshot_strict_v2', false);
@@ -160,16 +160,13 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
         ])
             ->getJson("/api/v0.3/attempts/{$attemptId}/report");
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('locked', true);
-        $response->assertJsonPath('variant', 'free');
-        $response->assertJsonPath('meta.scale_code_legacy', 'MBTI');
-        $this->assertIsArray($response->json('report'));
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'ATTEMPT_NOT_FOUND');
+        $response->assertJsonPath('message', 'attempt not found.');
         $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
     }
 
-    public function test_public_mbti_report_access_can_be_read_with_mismatched_but_bound_public_identity(): void
+    public function test_public_mbti_report_access_requires_matching_attempt_subject(): void
     {
         $this->seedScales();
 
@@ -185,16 +182,9 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
             'Authorization' => 'Bearer '.$token,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('attempt_id', $attemptId);
-        $response->assertJsonPath('access_state', 'locked');
-        $response->assertJsonPath('report_state', 'ready');
-        $response->assertJsonPath('pdf_state', 'missing');
-        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
-        $response->assertJsonPath('actions.pdf_href', null);
-        $response->assertJsonPath('actions.history_href', '/history/mbti');
-        $response->assertJsonPath('actions.lookup_href', '/orders/lookup');
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'ATTEMPT_NOT_FOUND');
+        $response->assertJsonPath('message', 'attempt not found.');
     }
 
     public function test_public_mbti_report_rejects_orphan_result_with_explicit_attempt_not_found_contract(): void


### PR DESCRIPTION
### Motivation
- A public-context system fallback allowed loading attempts/results by org+attempt ID without verifying that the requesting actor owns the attempt, enabling an IDOR leak for public report scales.
- The change closes the authorization gap by ensuring public report reads require actor-scoped ownership resolution and do not fall back to system lookups.

### Description
- Modified files (no additions): `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`, `backend/app/Services/Report/ReportGatekeeper.php`, `backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php`, and `backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php`.
- Controller change: removed the public-context system fallback in `AttemptReadController::resolveAttemptForReportRead` so public report reads only use actor-scoped lookup and return `ATTEMPT_NOT_FOUND` when actor does not own the attempt (replacement region: `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php` L517-L539).
```php
// File: backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
// Replacement range: lines ~517-539
private function resolveAttemptForReportRead(
    Request $request,
    string $attemptId,
    string $scaleCode
): Attempt
{
    if ($this->isPublicReportScale($scaleCode)) {
        $actor = $this->reportActor($request);
        $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $actor);

        if ($attempt instanceof Attempt) {
            return $attempt;
        }

        throw new ApiProblemException(404, 'ATTEMPT_NOT_FOUND', 'attempt not found.');
    }

    $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
    if ($attempt instanceof Attempt) {
        return $attempt;
    }

    throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
}
```
- Service change: removed matching public fallback in `ReportGatekeeper::resolveSubject` so service-side report resolution also enforces actor-scoped ownership (replacement region: `backend/app/Services/Report/ReportGatekeeper.php` L454-L470).
```php
// File: backend/app/Services/Report/ReportGatekeeper.php
// Replacement range: lines ~454-470
$attempt = $this->subjects->findAttemptForCurrentContext($attemptId, $actor);
if (! $attempt instanceof Attempt) {
    return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
}
```
- Tests updated: changed expectations to require matching attempt subject for public MBTI reads/access/pdf parity; updated `backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php` and `backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php` to assert `404` with `ATTEMPT_NOT_FOUND` when anon identity mismatches (exact modified ranges shown in repo diff).

### Testing
- Syntax checks: `php -l` on modified controller/service/tests passed with no syntax errors.
- PHPUnit: `php artisan test --filter=AttemptPublicReportReadHotfixTest` and `php artisan test --filter=AttemptPublicReportPdfParityTest` could not be executed in this environment due to missing Composer dependencies (`backend/vendor/autoload.php`), so runtime tests were not run here.
- CLI verification steps you can run locally in `backend/` to validate the change: `php artisan route:list`, `php artisan migrate`, `php artisan test --filter=AttemptPublicReportReadHotfixTest`, `php artisan test --filter=AttemptPublicReportPdfParityTest`, `curl -i http://127.0.0.1:8000/api/v0.3/attempts/<attempt-id>/report`, and `bash scripts/ci_verify_mbti.sh`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c22882cc4883309f57843e0a89f064)