### PR TITLE
fix(storage): scope DSAR artifact purge to canonical paths to prevent cross-attempt deletions

### DIFF
--- a/backend/app/Services/Storage/ArtifactPurgeService.php
+++ b/backend/app/Services/Storage/ArtifactPurgeService.php
@@ -141,12 +141,7 @@ final class ArtifactPurgeService
 
         if (SchemaBaseline::hasTable('storage_blob_locations')) {
             $locationRows = StorageBlobLocation::query()
-                ->where(function ($query) use ($canonicalPaths, $blobHashes): void {
-                    $query->whereIn('storage_path', array_values($canonicalPaths));
-                    if ($blobHashes !== []) {
-                        $query->orWhereIn('blob_hash', array_keys($blobHashes));
-                    }
-                })
+                ->whereIn('storage_path', array_values($canonicalPaths))
                 ->get(['id', 'blob_hash', 'disk', 'storage_path', 'location_kind', 'meta_json']);
 
             foreach ($locationRows as $locationRow) {
@@ -224,8 +219,6 @@ final class ArtifactPurgeService
             $locationsQuery = StorageBlobLocation::query();
             if ($locationIds !== []) {
                 $locationsQuery->whereIn('id', $locationIds);
-            } elseif ($blobHashes !== []) {
-                $locationsQuery->whereIn('blob_hash', $blobHashes);
             } else {
                 $locationsQuery->whereRaw('1 = 0');
             }

--- a/backend/tests/Feature/Compliance/DsarArtifactFullPurgeTest.php
+++ b/backend/tests/Feature/Compliance/DsarArtifactFullPurgeTest.php
@@ -267,4 +267,226 @@ final class DsarArtifactFullPurgeTest extends TestCase
         $this->assertIsArray($requestResult);
         $this->assertSame('no_residual_found', (string) data_get($requestResult, 'artifact_residual_audit.state'));
     }
+
+    public function test_full_artifact_purge_does_not_delete_other_attempt_locations_with_same_blob_hash(): void
+    {
+        Storage::fake('local');
+        Storage::fake('s3');
+        config()->set('storage_rollout.retention_policy_engine_enabled', true);
+        config()->set('storage_rollout.lifecycle_front_door_enabled', true);
+        config()->set('storage_rollout.dsar_artifact_purge_enabled', true);
+
+        DB::table('retention_policies')->insert([
+            'code' => 'dsar_full_purge_default',
+            'subject_scope' => 'attempt',
+            'artifact_scope' => 'report_artifact_domain',
+            'archive_after_days' => null,
+            'shrink_after_days' => null,
+            'purge_after_days' => 0,
+            'delete_behavior' => 'purge_all',
+            'delete_remote_archive' => true,
+            'active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $orgId = 919;
+        $attemptId = (string) Str::uuid();
+        $otherAttemptId = (string) Str::uuid();
+        $manifestHash = 'purgehashv1';
+        $sharedReportBytes = '{"artifact":"shared-report"}';
+        $sharedHash = hash('sha256', $sharedReportBytes);
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => 'anon_purge_full',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => [
+                'stage' => 'seed',
+                'meta' => [
+                    'pack_release_manifest_hash' => $manifestHash,
+                ],
+            ],
+            'started_at' => now()->subMinutes(5),
+            'submitted_at' => now(),
+        ]);
+        Attempt::create([
+            'id' => $otherAttemptId,
+            'org_id' => $orgId + 1,
+            'anon_id' => 'anon_purge_other',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => [
+                'stage' => 'seed',
+                'meta' => [
+                    'pack_release_manifest_hash' => $manifestHash,
+                ],
+            ],
+            'started_at' => now()->subMinutes(6),
+            'submitted_at' => now()->subMinute(),
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => ['EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20]],
+            'scores_pct' => ['EI' => 50],
+            'axis_states' => ['EI' => 'clear'],
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId + 1,
+            'attempt_id' => $otherAttemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => ['EI' => ['a' => 11, 'b' => 9, 'neutral' => 0, 'sum' => 2, 'total' => 20]],
+            'scores_pct' => ['EI' => 55],
+            'axis_states' => ['EI' => 'clear'],
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        /** @var ArtifactStore $artifactStore */
+        $artifactStore = app(ArtifactStore::class);
+        $targetReportPath = $artifactStore->reportCanonicalPath('MBTI', $attemptId);
+        $otherReportPath = $artifactStore->reportCanonicalPath('MBTI', $otherAttemptId);
+        Storage::disk('local')->put($targetReportPath, $sharedReportBytes);
+        Storage::disk('local')->put($otherReportPath, $sharedReportBytes);
+
+        DB::table('storage_blobs')->insert([
+            'hash' => $sharedHash,
+            'disk' => 'local',
+            'storage_path' => 'blobs/'.$sharedHash,
+            'size_bytes' => strlen($sharedReportBytes),
+            'content_type' => 'application/json',
+            'encoding' => 'identity',
+            'ref_count' => 0,
+            'first_seen_at' => now(),
+            'last_verified_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('storage_blob_locations')->insert([
+            [
+                'blob_hash' => $sharedHash,
+                'disk' => 'local',
+                'storage_path' => $targetReportPath,
+                'location_kind' => 'canonical_file',
+                'size_bytes' => strlen($sharedReportBytes),
+                'verified_at' => now(),
+                'meta_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'blob_hash' => $sharedHash,
+                'disk' => 'local',
+                'storage_path' => $otherReportPath,
+                'location_kind' => 'canonical_file',
+                'size_bytes' => strlen($sharedReportBytes),
+                'verified_at' => now(),
+                'meta_json' => json_encode(['attempt_id' => $otherAttemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $targetJsonSlotId = DB::table('report_artifact_slots')->insertGetId([
+            'attempt_id' => $attemptId,
+            'slot_code' => 'report_json_full',
+            'required_by_product' => true,
+            'current_version_id' => null,
+            'render_state' => 'materialized',
+            'delivery_state' => 'available',
+            'access_state' => 'ready',
+            'integrity_state' => 'verified',
+            'last_materialized_at' => now(),
+            'last_verified_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $otherJsonSlotId = DB::table('report_artifact_slots')->insertGetId([
+            'attempt_id' => $otherAttemptId,
+            'slot_code' => 'report_json_full',
+            'required_by_product' => true,
+            'current_version_id' => null,
+            'render_state' => 'materialized',
+            'delivery_state' => 'available',
+            'access_state' => 'ready',
+            'integrity_state' => 'verified',
+            'last_materialized_at' => now(),
+            'last_verified_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('report_artifact_versions')->insert([
+            [
+                'artifact_slot_id' => $targetJsonSlotId,
+                'version_no' => 1,
+                'source_type' => 'report_json',
+                'storage_blob_id' => $sharedHash,
+                'manifest_hash' => $manifestHash,
+                'content_hash' => $sharedHash,
+                'byte_size' => strlen($sharedReportBytes),
+                'metadata_json' => json_encode(['source' => 'phpunit'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'artifact_slot_id' => $otherJsonSlotId,
+                'version_no' => 1,
+                'source_type' => 'report_json',
+                'storage_blob_id' => $sharedHash,
+                'manifest_hash' => $manifestHash,
+                'content_hash' => $sharedHash,
+                'byte_size' => strlen($sharedReportBytes),
+                'metadata_json' => json_encode(['source' => 'phpunit'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        /** @var AttemptDataLifecycleService $service */
+        $service = app(AttemptDataLifecycleService::class);
+        $result = $service->purgeAttempt($attemptId, $orgId, [
+            'reason' => 'user_request',
+            'scale_code' => 'MBTI',
+            'actor_user_id' => 9001,
+            'request_id' => 'req-full-purge',
+            'task_id' => 'task-full-purge',
+            'reference_id' => 'ref-full-purge',
+        ]);
+
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+        $this->assertFalse(Storage::disk('local')->exists($targetReportPath));
+        $this->assertTrue(Storage::disk('local')->exists($otherReportPath));
+        $this->assertDatabaseMissing('storage_blob_locations', [
+            'storage_path' => $targetReportPath,
+        ]);
+        $this->assertDatabaseHas('storage_blob_locations', [
+            'storage_path' => $otherReportPath,
+        ]);
+        $this->assertDatabaseHas('storage_blobs', [
+            'hash' => $sharedHash,
+        ]);
+    }
 }


### PR DESCRIPTION
### Motivation

- The purge flow previously expanded `storage_blob_locations` by `blob_hash`, collecting locations that may belong to other attempts/orgs and enabling cross-tenant deletions when blobs are shared.  
- The intent is to ensure a user-requested attempt purge only affects that attempt's canonical artifact locations and explicitly discovered catalog location IDs.  
- This change minimizes the purge surface by removing blob-hash based location discovery and requiring explicit location IDs discovered from canonical paths.

### Description

- Modified files (Modified only): `backend/app/Services/Storage/ArtifactPurgeService.php`, `backend/tests/Feature/Compliance/DsarArtifactFullPurgeTest.php`.
- Key code changes: restricted discovery of `storage_blob_locations` in `describeAttemptArtifacts()` to only match canonical `storage_path`s and removed the `blob_hash` fallback query in `executePurge()` so purge only acts on explicit `catalog_location_ids` discovered for the attempt.  
- Added a regression feature test `test_full_artifact_purge_does_not_delete_other_attempt_locations_with_same_blob_hash()` which verifies that purging one attempt does not delete another attempt's files/locations even when blob hashes are identical.

- Copy-paste blocks (exact replacement/insertion ranges):

  - File: `backend/app/Services/Storage/ArtifactPurgeService.php` — replacement in `describeAttemptArtifacts()` (original block replaced to remove OR on `blob_hash`):

```php
// Replaced block (search around describeAttemptArtifacts -> storage_blob_locations query)
if (SchemaBaseline::hasTable('storage_blob_locations')) {
    $locationRows = StorageBlobLocation::query()
        ->whereIn('storage_path', array_values($canonicalPaths))
        ->get(['id', 'blob_hash', 'disk', 'storage_path', 'location_kind', 'meta_json']);

    foreach ($locationRows as $locationRow) {
        $locationIds[] = (int) $locationRow->id;
        $hash = trim((string) ($locationRow->blob_hash ?? ''));
        if ($hash !== '') {
            $blobHashes[$hash] = true;
        }
    }
}
```

  - File: `backend/app/Services/Storage/ArtifactPurgeService.php` — replacement in `executePurge()` (removed blob-hash fallback so only explicit `id` list is allowed):

```php
// Replaced block (around building locationsQuery in executePurge)
if (SchemaBaseline::hasTable('storage_blob_locations')) {
    $locationsQuery = StorageBlobLocation::query();
    if ($locationIds !== []) {
        $locationsQuery->whereIn('id', $locationIds);
    } else {
        $locationsQuery->whereRaw('1 = 0');
    }

    $locations = $locationsQuery->get();
    // ... process $locations as before (delete storage objects and rows)
}
```

  - File: `backend/tests/Feature/Compliance/DsarArtifactFullPurgeTest.php` — insertion (exact insertion position: appended a new test function after the existing `test_full_artifact_purge_removes_canonical_and_cataloged_artifacts_when_flag_is_enabled()`):

```php
public function test_full_artifact_purge_does_not_delete_other_attempt_locations_with_same_blob_hash(): void
{
    Storage::fake('local');
    Storage::fake('s3');
    config()->set('storage_rollout.retention_policy_engine_enabled', true);
    config()->set('storage_rollout.lifecycle_front_door_enabled', true);
    config()->set('storage_rollout.dsar_artifact_purge_enabled', true);

    DB::table('retention_policies')->insert([
        'code' => 'dsar_full_purge_default',
        'subject_scope' => 'attempt',
        'artifact_scope' => 'report_artifact_domain',
        'archive_after_days' => null,
        'shrink_after_days' => null,
        'purge_after_days' => 0,
        'delete_behavior' => 'purge_all',
        'delete_remote_archive' => true,
        'active' => true,
        'created_at' => now(),
        'updated_at' => now(),
    ]);

    $orgId = 919;
    $attemptId = (string) Str::uuid();
    $otherAttemptId = (string) Str::uuid();
    $manifestHash = 'purgehashv1';
    $sharedReportBytes = '{"artifact":"shared-report"}';
    $sharedHash = hash('sha256', $sharedReportBytes);

    Attempt::create([ /* target attempt data */ ]);
    Attempt::create([ /* other attempt data */ ]);

    Result::create([ /* result for target attempt */ ]);
    Result::create([ /* result for other attempt */ ]);

    $artifactStore = app(ArtifactStore::class);
    $targetReportPath = $artifactStore->reportCanonicalPath('MBTI', $attemptId);
    $otherReportPath = $artifactStore->reportCanonicalPath('MBTI', $otherAttemptId);
    Storage::disk('local')->put($targetReportPath, $sharedReportBytes);
    Storage::disk('local')->put($otherReportPath, $sharedReportBytes);

    DB::table('storage_blobs')->insert([ /* single shared blob row */ ]);
    DB::table('storage_blob_locations')->insert([ /* two locations: target and other */ ]);

    // create slots & versions for both attempts referencing the same blob hash
    DB::table('report_artifact_slots')->insertGetId([ /* ... */ ]);
    DB::table('report_artifact_versions')->insert([ /* ... */ ]);

    $service = app(AttemptDataLifecycleService::class);
    $result = $service->purgeAttempt($attemptId, $orgId, [ /* context */ ]);

    $this->assertTrue((bool) ($result['ok'] ?? false));
    $this->assertFalse(Storage::disk('local')->exists($targetReportPath));
    $this->assertTrue(Storage::disk('local')->exists($otherReportPath));
    $this->assertDatabaseMissing('storage_blob_locations', ['storage_path' => $targetReportPath]);
    $this->assertDatabaseHas('storage_blob_locations', ['storage_path' => $otherReportPath]);
    $this->assertDatabaseHas('storage_blobs', ['hash' => $sharedHash]);
}
```

### Testing

- Automated tests attempted: `php artisan test --filter=DsarArtifactFullPurgeTest` was attempted but blocked due to missing vendor autoload (see next bullet).  
- Dependency install: `cd backend && composer install --no-interaction --prefer-dist` failed in this environment due to network/proxy errors when cloning/downloading packages (GitHub access returned 403 / tunnel failures), so test execution and framework commands were not runnable here.  
- CI verification: `cd backend && bash scripts/ci_verify_mbti.sh` was attempted and also failed because `vendor/autoload.php` was not present after dependency install failed.

Minimal acceptance / verification commands (run locally or in CI after dependencies are installable):

- `cd backend && composer install --no-interaction --prefer-dist`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --force`
- `cd backend && php artisan test --filter=DsarArtifactFullPurgeTest`
- `cd backend && curl -i http://127.0.0.1:8000/api/health`
- `cd backend && bash scripts/ci_verify_mbti.sh`

All automated test runs in this environment were blocked by the inability to install Composer dependencies; the change includes a new regression test which should pass once dependencies can be installed and the test suite executed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2282eec588330903bd2e002b24626)