### PR TITLE
[codex] tighten mbti content source-of-truth

### DIFF
--- a/backend/app/Services/Content/ContentPathAliasResolver.php
+++ b/backend/app/Services/Content/ContentPathAliasResolver.php
@@ -11,6 +11,8 @@ final class ContentPathAliasResolver
 {
     /**
      * Resolve backend content_packs root directory for a legacy pack id.
+     * This is a compat alias bridge only. Current runtime canonical truth must come from
+     * content_packs config / primary resolvers, not from alias selection side effects.
      * Default behavior remains legacy-first, with safe fallback if mapped path does not exist.
      */
     public function resolveBackendPackRoot(string $legacyPackId): string
@@ -42,6 +44,7 @@ final class ContentPathAliasResolver
      * Modes:
      * - legacy/dual: prefer legacy path, fallback mapped path.
      * - v2: prefer mapped path, fallback legacy path.
+     * This does not redefine which dir is canonical for runtime reads.
      */
     public function resolveBackendPublishSourceDir(string $legacyPackId, string $version): string
     {

--- a/backend/app/Services/ContentPackResolver.php
+++ b/backend/app/Services/ContentPackResolver.php
@@ -76,8 +76,15 @@ final class ContentPackResolver
                 }
             }
 
-            $picked = $matches[count($matches) - 1];
-            $trace['picked'] = ['reason' => $cand['reason'], 'key' => $key, 'pack_id' => $picked['pack_id']];
+            $picked = $this->pickPreferredPayload($matches, $scale);
+            if ($picked !== null) {
+                $trace['picked'] = [
+                    'reason' => $cand['reason'] . ':preferred_match',
+                    'key' => $key,
+                    'pack_id' => $picked['pack_id'],
+                    'dir_version' => $picked['dir_version'] ?? null,
+                ];
+            }
             break;
         }
 
@@ -174,10 +181,119 @@ final class ContentPackResolver
                 $this->indexByKey[$key] = [];
             }
             $this->indexByKey[$key][] = $payload;
-            $this->byPackId[$packId] = $payload;
+
+            if (!isset($this->byPackId[$packId])) {
+                $this->byPackId[$packId] = $payload;
+                continue;
+            }
+
+            $current = $this->byPackId[$packId];
+            $this->byPackId[$packId] = $this->comparePayloadPreference($payload, $current, $scale) < 0
+                ? $payload
+                : $current;
         }
 
         $this->built = true;
+    }
+
+    private function pickPreferredPayload(array $matches, string $scale): ?array
+    {
+        $preferred = null;
+
+        foreach ($matches as $candidate) {
+            if (!is_array($candidate)) {
+                continue;
+            }
+
+            if ($preferred === null || $this->comparePayloadPreference($candidate, $preferred, $scale) < 0) {
+                $preferred = $candidate;
+            }
+        }
+
+        return $preferred;
+    }
+
+    private function comparePayloadPreference(array $candidate, array $current, string $scale): int
+    {
+        $candidateScore = $this->payloadPreferenceScore($candidate, $scale);
+        $currentScore = $this->payloadPreferenceScore($current, $scale);
+
+        if ($candidateScore !== $currentScore) {
+            return $candidateScore <=> $currentScore;
+        }
+
+        $candidateDir = (string) ($candidate['dir_version'] ?? '');
+        $currentDir = (string) ($current['dir_version'] ?? '');
+        if ($candidateDir !== $currentDir) {
+            return strcmp($candidateDir, $currentDir);
+        }
+
+        $candidateBase = (string) ($candidate['base_dir'] ?? '');
+        $currentBase = (string) ($current['base_dir'] ?? '');
+        if ($candidateBase !== $currentBase) {
+            return strcmp($candidateBase, $currentBase);
+        }
+
+        return strcmp((string) ($candidate['pack_id'] ?? ''), (string) ($current['pack_id'] ?? ''));
+    }
+
+    private function payloadPreferenceScore(array $payload, string $scale): int
+    {
+        $score = 100;
+        $dirVersion = trim((string) ($payload['dir_version'] ?? ''));
+        $scale = strtoupper(trim($scale));
+
+        $canonicalDir = $this->canonicalDirVersionForScale($scale);
+        if ($canonicalDir !== null && $dirVersion === $canonicalDir) {
+            return 0;
+        }
+
+        $compatDirs = $this->compatAliasDirVersionsForScale($scale);
+        if ($dirVersion !== '' && in_array($dirVersion, $compatDirs, true)) {
+            $score += 50;
+        }
+
+        $defaultDir = trim((string) config('content_packs.default_dir_version', ''));
+        if ($defaultDir !== '' && $dirVersion === $defaultDir) {
+            $score -= 10;
+        }
+
+        return $score;
+    }
+
+    private function canonicalDirVersionForScale(string $scale): ?string
+    {
+        $map = (array) config('content_packs.canonical_dir_versions', []);
+        $value = trim((string) ($map[$scale] ?? ''));
+
+        if ($value !== '') {
+            return $value;
+        }
+
+        if ($scale === 'MBTI') {
+            $fallback = trim((string) config('content_packs.default_dir_version', ''));
+
+            return $fallback !== '' ? $fallback : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function compatAliasDirVersionsForScale(string $scale): array
+    {
+        $map = (array) config('content_packs.compat_alias_dir_versions', []);
+        $raw = $map[$scale] ?? [];
+        if (!is_array($raw)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn ($value): string => trim((string) $value),
+            $raw
+        ), static fn (string $value): bool => $value !== ''));
     }
 
     private function makeKey(string $scale, string $region, string $locale, string $version): string

--- a/backend/app/Services/Report/Composer/ReportPayloadAssemblerOverridesTrait.php
+++ b/backend/app/Services/Report/Composer/ReportPayloadAssemblerOverridesTrait.php
@@ -205,6 +205,7 @@ trait ReportPayloadAssemblerOverridesTrait
             }
         }
 
+        // Compat fallback only: current main path is pack chain -> manifest-declared overrides docs.
         if (empty($docs) && is_callable($ctx['loadReportAssetJson'] ?? null)) {
             $raw = ($ctx['loadReportAssetJson'])($legacyContentPackageDir, 'report_overrides.json');
             if (is_object($raw)) {

--- a/backend/app/Services/Report/Composer/ReportPayloadAssemblerPackDocsTrait.php
+++ b/backend/app/Services/Report/Composer/ReportPayloadAssemblerPackDocsTrait.php
@@ -85,6 +85,7 @@ trait ReportPayloadAssemblerPackDocsTrait
             }
         }
 
+        // Compat fallback only: current main path is pack chain -> manifest-declared assets.
         if (is_callable($ctx['loadReportAssetJson'] ?? null)) {
             $raw = ($ctx['loadReportAssetJson'])($legacyContentPackageDir, $wantedBasename);
 

--- a/backend/app/Services/Report/Composer/ReportPayloadAssemblerProfilesTrait.php
+++ b/backend/app/Services/Report/Composer/ReportPayloadAssemblerProfilesTrait.php
@@ -65,6 +65,7 @@ trait ReportPayloadAssemblerProfilesTrait
             return $picked;
         }
 
+        // Compat fallback only: current main path is pack chain -> type_profiles asset.
         if (is_callable($ctx['loadTypeProfile'] ?? null)) {
             $p = ($ctx['loadTypeProfile'])($legacyContentPackageDir, $typeCode);
             if (is_array($p)) {
@@ -105,6 +106,7 @@ trait ReportPayloadAssemblerProfilesTrait
             return $picked;
         }
 
+        // Compat fallback only: current main path is pack chain -> identity asset.
         if (is_callable($ctx['loadReportAssetItems'] ?? null)) {
             $map = ($ctx['loadReportAssetItems'])($legacyContentPackageDir, 'report_identity_cards.json', 'type_code');
             if (is_object($map)) {
@@ -167,6 +169,7 @@ trait ReportPayloadAssemblerProfilesTrait
             $card['code'] = $card['code'] ?? $role;
         }
 
+        // Compat fallback only: current main path is pack chain -> roles asset.
         if (!$card && is_callable($ctx['buildRoleCard'] ?? null)) {
             $x = ($ctx['buildRoleCard'])($legacyContentPackageDir, $typeCode);
             if (is_array($x)) {
@@ -203,6 +206,7 @@ trait ReportPayloadAssemblerProfilesTrait
             $card['code'] = $card['code'] ?? $st;
         }
 
+        // Compat fallback only: current main path is pack chain -> strategies asset.
         if (!$card && is_callable($ctx['buildStrategyCard'] ?? null)) {
             $x = ($ctx['buildStrategyCard'])($legacyContentPackageDir, $typeCode);
             if (is_array($x)) {
@@ -268,6 +272,7 @@ trait ReportPayloadAssemblerProfilesTrait
             }
         }
 
+        // Compat fallback only: current main path is pack chain -> borderline asset.
         if (is_callable($ctx['buildBorderlineNote'] ?? null)) {
             $x = ($ctx['buildBorderlineNote'])($scoresPct, $legacyContentPackageDir);
             if (is_array($x)) {

--- a/backend/config/content.php
+++ b/backend/config/content.php
@@ -2,6 +2,7 @@
 
 // file: backend/config/content.php
 // 本文件为 legacy/兼容桥接，内容包定位以 config/content_packs.php 为单一真相源。
+// MBTI current canonical dir 也以 content_packs.canonical_dir_versions.MBTI 为准。
 
 return [
     /**
@@ -26,10 +27,11 @@ return [
      * "No default content_package_version configured for scale=default."
      */
     'default_versions' => [
-        // ✅ 线上默认 scale=default 时用这个
+        // ✅ 线上默认 scale=default 时用当前 canonical MBTI dir
         'default' => env('FAP_DEFAULT_DIR_VERSION', 'MBTI-CN-v0.3'),
 
         // ✅ 可选：兼容旧路径/旧调用（如果历史上有人传 scale=MBTI）
+        // 这里仍然指向 current canonical，而不是 compat alias dir。
         'MBTI' => env('FAP_DEFAULT_DIR_VERSION', 'MBTI-CN-v0.3'),
     ],
 

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -37,6 +37,19 @@ return [
     // default_dir_version 对应目录名（MBTI-CN-v0.3）
     'default_dir_version' => env('FAP_DEFAULT_DIR_VERSION', 'MBTI-CN-v0.3'),
 
+    // MBTI content source-of-truth:
+    // - canonical_dir_versions: current runtime canonical dirs
+    // - compat_alias_dir_versions: compat-only aliases that may still be resolved explicitly
+    // Canonical truth is defined here, not by scale_identity dir_version v1/v2 naming.
+    'canonical_dir_versions' => [
+        'MBTI' => env('FAP_DEFAULT_DIR_VERSION', 'MBTI-CN-v0.3'),
+    ],
+    'compat_alias_dir_versions' => [
+        'MBTI' => [
+            'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3',
+        ],
+    ],
+
     // ✅ 默认 region/locale 也钉死到 CN_MAINLAND/zh-CN（仍保留 fallback 机制）
     'default_region' => env('FAP_DEFAULT_REGION', 'CN_MAINLAND'),
     'default_locale' => env('FAP_DEFAULT_LOCALE', 'zh-CN'),

--- a/backend/config/scale_identity.php
+++ b/backend/config/scale_identity.php
@@ -23,6 +23,8 @@ return [
     // Content path read mode and publish mode.
     // content_path_mode: legacy|dual_prefer_old|dual_prefer_new|v2
     // content_publish_mode: legacy|dual|v2
+    // Note: for MBTI, current canonical dir is still defined by
+    // content_packs.canonical_dir_versions.MBTI. The v2 maps below are compat identity/path aliases.
     'content_path_mode' => env('FAP_CONTENT_PATH_MODE', 'legacy'),
     'content_publish_mode' => env('FAP_CONTENT_PUBLISH_MODE', 'legacy'),
 
@@ -72,6 +74,8 @@ return [
         'EQ_60' => 'EQ_60',
     ],
 
+    // v2 pack/dir maps are compat aliases for dual-code/read-path migration.
+    // They do not redefine the current runtime canonical MBTI content source.
     'pack_id_map_v2' => [
         'MBTI' => 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3',
         'BIG5_OCEAN' => 'BIG_FIVE_OCEAN_MODEL',

--- a/backend/tests/Unit/Services/ContentPackResolverCanonicalPreferenceTest.php
+++ b/backend/tests/Unit/Services/ContentPackResolverCanonicalPreferenceTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\ContentPackResolver;
+use Illuminate\Support\Facades\File;
+use ReflectionClass;
+use Tests\TestCase;
+
+final class ContentPackResolverCanonicalPreferenceTest extends TestCase
+{
+    public function test_mbti_without_dir_version_prefers_canonical_even_when_alias_is_last_match(): void
+    {
+        config()->set('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        config()->set('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+        config()->set('content_packs.canonical_dir_versions', [
+            'MBTI' => 'MBTI-CN-v0.3',
+        ]);
+        config()->set('content_packs.compat_alias_dir_versions', [
+            'MBTI' => ['MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3'],
+        ]);
+
+        $resolver = new ContentPackResolver();
+
+        $canonical = $this->makePayload('MBTI-CN-v0.3', '/tmp/canonical');
+        $compat = $this->makePayload('MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3', '/tmp/compat');
+
+        $this->injectResolverState($resolver, [$compat, $canonical]);
+        $pickedWithCompatFirst = $resolver->resolve('MBTI', 'CN_MAINLAND', 'zh-CN', 'v0.3');
+        $this->assertSame('/tmp/canonical', $pickedWithCompatFirst->baseDir);
+        $this->assertSame('MBTI-CN-v0.3', (string) ($pickedWithCompatFirst->trace['picked']['dir_version'] ?? ''));
+
+        $this->injectResolverState($resolver, [$canonical, $compat]);
+        $pickedWithCompatLast = $resolver->resolve('MBTI', 'CN_MAINLAND', 'zh-CN', 'v0.3');
+        $this->assertSame('/tmp/canonical', $pickedWithCompatLast->baseDir);
+        $this->assertSame('MBTI-CN-v0.3', (string) ($pickedWithCompatLast->trace['picked']['dir_version'] ?? ''));
+    }
+
+    public function test_mbti_with_explicit_dir_version_still_hits_exact_match(): void
+    {
+        config()->set('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        config()->set('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+        config()->set('content_packs.canonical_dir_versions', [
+            'MBTI' => 'MBTI-CN-v0.3',
+        ]);
+        config()->set('content_packs.compat_alias_dir_versions', [
+            'MBTI' => ['MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3'],
+        ]);
+
+        $resolver = new ContentPackResolver();
+
+        $canonical = $this->makePayload('MBTI-CN-v0.3', '/tmp/canonical');
+        $compat = $this->makePayload('MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3', '/tmp/compat');
+
+        $this->injectResolverState($resolver, [$compat, $canonical]);
+
+        $pickedCanonical = $resolver->resolve('MBTI', 'CN_MAINLAND', 'zh-CN', 'v0.3', 'MBTI-CN-v0.3');
+        $this->assertSame('/tmp/canonical', $pickedCanonical->baseDir);
+
+        $pickedCompat = $resolver->resolve(
+            'MBTI',
+            'CN_MAINLAND',
+            'zh-CN',
+            'v0.3',
+            'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3'
+        );
+        $this->assertSame('/tmp/compat', $pickedCompat->baseDir);
+    }
+
+    public function test_default_pack_id_fallback_uses_canonical_mbti_dir_when_duplicate_pack_ids_exist(): void
+    {
+        $root = sys_get_temp_dir() . '/mbti_content_pack_pref_' . uniqid('', true);
+        $canonicalDir = $root . '/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3';
+        $compatDir = $root . '/default/CN_MAINLAND/zh-CN/MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3';
+
+        File::ensureDirectoryExists($canonicalDir);
+        File::ensureDirectoryExists($compatDir);
+
+        file_put_contents($canonicalDir . '/manifest.json', json_encode([
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'scale_code' => 'MBTI',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'content_package_version' => 'v0.3',
+            'fallback' => [],
+        ], JSON_UNESCAPED_UNICODE));
+
+        file_put_contents($compatDir . '/manifest.json', json_encode([
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'scale_code' => 'MBTI',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'content_package_version' => 'v0.3',
+            'fallback' => [],
+        ], JSON_UNESCAPED_UNICODE));
+
+        try {
+            config()->set('content_packs.root', $root);
+            config()->set('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+            config()->set('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+            config()->set('content_packs.default_region', 'CN_MAINLAND');
+            config()->set('content_packs.default_locale', 'zh-CN');
+            config()->set('content_packs.canonical_dir_versions', [
+                'MBTI' => 'MBTI-CN-v0.3',
+            ]);
+            config()->set('content_packs.compat_alias_dir_versions', [
+                'MBTI' => ['MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3'],
+            ]);
+
+            $resolver = new ContentPackResolver();
+            $picked = $resolver->resolve('MBTI', 'UNKNOWN_REGION', 'fr-FR', 'v9.9');
+
+            $this->assertSame($canonicalDir, $picked->baseDir);
+            $this->assertSame('default_pack_id', (string) ($picked->trace['picked']['reason'] ?? ''));
+        } finally {
+            File::deleteDirectory($root);
+        }
+    }
+
+    /**
+     * @return array{
+     *   pack_id:string,
+     *   manifest_path:string,
+     *   base_dir:string,
+     *   dir_version:string,
+     *   manifest:array<string,mixed>,
+     *   scale:string,
+     *   region:string,
+     *   locale:string,
+     *   version:string
+     * }
+     */
+    private function makePayload(string $dirVersion, string $baseDir): array
+    {
+        return [
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'manifest_path' => $baseDir.'/manifest.json',
+            'base_dir' => $baseDir,
+            'dir_version' => $dirVersion,
+            'manifest' => [
+                'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'scale_code' => 'MBTI',
+                'region' => 'CN_MAINLAND',
+                'locale' => 'zh-CN',
+                'content_package_version' => 'v0.3',
+                'fallback' => [],
+            ],
+            'scale' => 'MBTI',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'version' => 'v0.3',
+        ];
+    }
+
+    /**
+     * @param list<array<string,mixed>> $matches
+     */
+    private function injectResolverState(ContentPackResolver $resolver, array $matches): void
+    {
+        $reflection = new ReflectionClass($resolver);
+
+        $indexByKey = $reflection->getProperty('indexByKey');
+        $indexByKey->setAccessible(true);
+        $indexByKey->setValue($resolver, [
+            'MBTI|CN_MAINLAND|zh-CN|v0.3' => $matches,
+        ]);
+
+        $byPackId = $reflection->getProperty('byPackId');
+        $byPackId->setAccessible(true);
+        $byPackId->setValue($resolver, [
+            'MBTI.cn-mainland.zh-CN.v0.3' => $matches[0],
+        ]);
+
+        $built = $reflection->getProperty('built');
+        $built->setAccessible(true);
+        $built->setValue($resolver, true);
+    }
+}


### PR DESCRIPTION
## Summary
This PR tightens MBTI content source-of-truth boundaries without changing scorer semantics, report contracts, frontend behavior, quality handling, or legacy lifecycle behavior.

The current runtime canonical MBTI pack remains `MBTI-CN-v0.3`. The parallel `MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3` directory is kept as a compat alias, but runtime selection is now explicit and deterministic instead of depending on duplicate manifest scan order.

## Problem
The backend previously had three overlapping sources of ambiguity:

1. config and scale identity metadata exposed old/new MBTI directories without explicitly stating which one was current canonical and which one was compat
2. `App\\Services\\ContentPackResolver` could encounter duplicate MBTI manifests with the same `scale/region/locale/content_package_version` and would fall through to the last scanned match when `dirVersion` was omitted
3. report assembler pack-doc fallbacks were still present but not clearly labeled as compat-only, which made the main path vs fallback path boundary harder to read

This did not change frontend contracts, but it left backend runtime truth implicit.

## Fix
The PR keeps behavior narrow and backend-only:

- declares MBTI canonical and compat alias roles explicitly in `config/content_packs.php`
- clarifies in `config/content.php` and `config/scale_identity.php` that MBTI canonical truth comes from `content_packs`, while v2 identity/path mappings remain compat metadata
- updates `App\\Services\\ContentPackResolver` to apply deterministic MBTI preference rules when `dirVersion` is omitted
- preserves explicit `dirVersion` exact-match behavior
- makes duplicate `pack_id` indexing deterministic with the same preference logic so `default_pack_id` fallback also lands on canonical MBTI
- marks report assembler callback/legacy asset branches as compat fallback only, without removing them or changing report output semantics
- leaves `ContentPathAliasResolver` behavior unchanged, but clarifies in code comments that it is a compat bridge rather than the canonical truth owner

## Scope Boundaries
This PR intentionally does not:

- change frontend code
- change MBTI scoring logic
- change report/result contracts
- change quality or `quality_checks.json`
- remove legacy MBTI lifecycle or legacy builders
- change PDF, paywall, snapshot, Big5, or clinical behavior

## Validation
Targeted checks run:

- `php artisan test tests/Unit/Services/ContentPackResolverCanonicalPreferenceTest.php tests/Unit/Services/ContentPackResolverParityTest.php tests/Unit/Services/Content/ContentPathAliasResolverTest.php tests/Unit/Services/ContentPackResolverCacheTest.php`
- `php -l app/Services/ContentPackResolver.php`
- `php -l app/Services/Content/ContentPathAliasResolver.php`
- `php -l app/Services/Report/Composer/ReportPayloadAssemblerPackDocsTrait.php`
- `php -l app/Services/Report/Composer/ReportPayloadAssemblerProfilesTrait.php`
- `php -l app/Services/Report/Composer/ReportPayloadAssemblerOverridesTrait.php`
- `php -l tests/Unit/Services/ContentPackResolverCanonicalPreferenceTest.php`

The new tests specifically verify:

- MBTI without `dirVersion` prefers canonical even if compat alias ordering changes
- explicit canonical `dirVersion` still resolves canonical
- explicit compat alias `dirVersion` still resolves compat
- `default_pack_id` fallback also resolves canonical when duplicate MBTI pack IDs exist
