### PR TITLE
[codex] currentize mbti quality write path

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmitScoreService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitScoreService.php
@@ -2,7 +2,9 @@
 
 namespace App\Services\Attempts;
 
+use App\Services\Assessment\ScoreResult;
 use App\Exceptions\Api\ApiProblemException;
+use App\Services\Psychometrics\MbtiQualityEvaluator;
 
 class AttemptSubmitScoreService
 {
@@ -48,6 +50,27 @@ class AttemptSubmitScoreService
         $modelSelection = is_array($scored['model_selection'] ?? null)
             ? $scored['model_selection']
             : [];
+
+        if (
+            $scaleCode === 'MBTI'
+            && $scoreResult instanceof ScoreResult
+            && $contentPackageVersion !== ''
+        ) {
+            // Current MBTI quality truth starts here and is persisted through results.result_json.
+            $quality = app(MbtiQualityEvaluator::class)->evaluate(
+                (string) ($canonicalized['region'] ?? ''),
+                (string) ($canonicalized['locale'] ?? ''),
+                $contentPackageVersion,
+                $dirVersion,
+                $mergedAnswers
+            );
+
+            if ($quality !== []) {
+                $normed = is_array($scoreResult->normedJson ?? null) ? $scoreResult->normedJson : [];
+                $normed['quality'] = $quality;
+                $scoreResult->normedJson = $normed;
+            }
+        }
 
         $commercial = $registryRow['commercial_json'] ?? null;
         if (is_string($commercial)) {

--- a/backend/app/Services/Attempts/AttemptSubmitTxService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitTxService.php
@@ -372,6 +372,14 @@ class AttemptSubmitTxService
             if (in_array($scaleCode, ['BIG5_OCEAN', 'SDS_20', 'EQ_60'], true) && is_array($resultJson['normed_json'] ?? null)) {
                 $resultJson = array_merge($resultJson, $resultJson['normed_json']);
             }
+            if (
+                $scaleCode === 'MBTI'
+                &&
+                ! is_array($resultJson['quality'] ?? null)
+                && is_array($resultJson['normed_json']['quality'] ?? null)
+            ) {
+                $resultJson['quality'] = $resultJson['normed_json']['quality'];
+            }
             if (is_array($resultJson['quality'] ?? null)) {
                 $resultJson['quality']['client_duration_ms'] = $durationMs;
             }
@@ -428,6 +436,24 @@ class AttemptSubmitTxService
             } else {
                 $resultData['id'] = (string) Str::uuid();
                 $result = Result::create($resultData);
+            }
+
+            // attempt_quality remains a compat mirror for ops/legacy readers, not the current truth.
+            if ($scaleCode === 'MBTI' && \App\Support\SchemaBaseline::hasTable('attempt_quality')) {
+                $quality = is_array($resultJson['quality'] ?? null) ? $resultJson['quality'] : null;
+                if (is_array($quality)) {
+                    $checks = $quality['checks'] ?? null;
+                    DB::table('attempt_quality')->updateOrInsert(
+                        ['attempt_id' => $attemptId],
+                        [
+                            'checks_json' => is_array($checks)
+                                ? json_encode($checks, JSON_UNESCAPED_SLASHES)
+                                : json_encode([], JSON_UNESCAPED_SLASHES),
+                            'grade' => strtoupper(trim((string) ($quality['grade'] ?? $quality['level'] ?? 'A'))),
+                            'created_at' => now(),
+                        ]
+                    );
+                }
             }
 
             $responsePayload = $this->core->buildSubmitPayload($locked, $result, true);

--- a/backend/app/Services/Psychometrics/MbtiQualityEvaluator.php
+++ b/backend/app/Services/Psychometrics/MbtiQualityEvaluator.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Psychometrics;
+
+use App\Services\ContentPackResolver;
+
+final class MbtiQualityEvaluator
+{
+    public function __construct(
+        private readonly ContentPackResolver $resolver,
+        private readonly QualityChecker $checker,
+    ) {}
+
+    /**
+     * @param  list<array<string,mixed>>  $answers
+     * @return array<string,mixed>
+     */
+    public function evaluate(
+        string $region,
+        string $locale,
+        string $contentPackageVersion,
+        string $dirVersion,
+        array $answers,
+    ): array {
+        $resolvedVersion = trim($contentPackageVersion) !== ''
+            ? trim($contentPackageVersion)
+            : trim($dirVersion);
+
+        if ($resolvedVersion === '') {
+            return [];
+        }
+
+        try {
+            $resolved = $this->resolver->resolve('MBTI', $region, $locale, $resolvedVersion, $dirVersion);
+        } catch (\Throwable) {
+            return [];
+        }
+
+        $loader = $resolved->loaders['readJson'] ?? null;
+        if (! is_callable($loader)) {
+            return [];
+        }
+
+        $scoringSpec = $loader('scoring_spec.json');
+        $qualitySpec = $loader('quality_checks.json');
+        if (! is_array($scoringSpec) || ! is_array($qualitySpec)) {
+            return [];
+        }
+
+        $quality = $this->checker->check($answers, $scoringSpec, $qualitySpec);
+        $grade = strtoupper(trim((string) ($quality['grade'] ?? '')));
+        if (! in_array($grade, ['A', 'B', 'C', 'D'], true)) {
+            $grade = 'A';
+        }
+
+        $checks = is_array($quality['checks'] ?? null) ? $quality['checks'] : [];
+
+        return [
+            'level' => $grade,
+            'grade' => $grade,
+            'flags' => $this->deriveFlags($checks),
+            'checks' => $checks,
+        ];
+    }
+
+    /**
+     * @param  list<mixed>  $checks
+     * @return list<string>
+     */
+    private function deriveFlags(array $checks): array
+    {
+        $flags = [];
+
+        foreach ($checks as $check) {
+            if (! is_array($check) || (($check['passed'] ?? true) === true)) {
+                continue;
+            }
+
+            $type = trim((string) ($check['type'] ?? ''));
+            $flag = match ($type) {
+                'min_answer_count' => 'INCOMPLETE_ANSWERS',
+                'max_same_option_ratio' => 'STRAIGHTLINING',
+                'reverse_pair_mismatch_ratio' => 'INCONSISTENT',
+                default => '',
+            };
+
+            if ($flag !== '') {
+                $flags[$flag] = true;
+            }
+        }
+
+        return array_keys($flags);
+    }
+}

--- a/backend/tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php
+++ b/backend/tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiQualityCurrentSubmitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    /**
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function mbtiAnswers(): array
+    {
+        $packRoot = rtrim((string) config('content_packs.root'), DIRECTORY_SEPARATOR);
+        $dirVersion = trim((string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'));
+        $questionsPath = $packRoot . DIRECTORY_SEPARATOR . 'default/CN_MAINLAND/zh-CN/' . $dirVersion . DIRECTORY_SEPARATOR . 'questions.json';
+
+        $decoded = json_decode((string) file_get_contents($questionsPath), true);
+        $items = is_array($decoded['items'] ?? null) ? $decoded['items'] : [];
+
+        $answers = [];
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            $code = trim((string) ($options[0]['code'] ?? 'A'));
+            if ($questionId === '' || $code === '') {
+                continue;
+            }
+
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => $code,
+            ];
+        }
+
+        return $answers;
+    }
+
+    public function test_mbti_current_submit_writes_quality_truth_and_attempt_quality_mirror(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+
+        $anonId = 'mbti-quality-current-anon';
+        $anonToken = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'anon_id' => $anonId,
+        ]);
+
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $answers = $this->mbtiAnswers();
+        $this->assertCount(144, $answers);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $anonToken,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 180000,
+        ]);
+
+        $submit->assertStatus(200);
+        $submit->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+        ]);
+
+        $quality = $submit->json('result.quality');
+        $this->assertIsArray($quality);
+        $this->assertContains((string) ($quality['level'] ?? ''), ['A', 'B', 'C', 'D']);
+        $this->assertSame(
+            (string) ($quality['level'] ?? ''),
+            (string) ($quality['grade'] ?? '')
+        );
+        $this->assertIsArray($quality['checks'] ?? null);
+        $this->assertNotEmpty($quality['checks'] ?? []);
+
+        $result = Result::query()->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($result);
+        $resultJson = is_array($result?->result_json ?? null) ? $result->result_json : [];
+        $this->assertSame((string) ($quality['level'] ?? ''), (string) data_get($resultJson, 'quality.level'));
+        $this->assertSame((string) ($quality['grade'] ?? ''), (string) data_get($resultJson, 'quality.grade'));
+        $this->assertIsArray(data_get($resultJson, 'normed_json.quality'));
+
+        $mirror = DB::table('attempt_quality')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($mirror);
+        $this->assertSame((string) ($quality['grade'] ?? ''), (string) ($mirror->grade ?? ''));
+
+        $resultRead = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $anonToken,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $resultRead->assertStatus(200);
+        $this->assertSame((string) ($quality['level'] ?? ''), (string) $resultRead->json('result.quality.level'));
+        $this->assertSame((string) ($quality['grade'] ?? ''), (string) $resultRead->json('result.quality.grade'));
+    }
+}


### PR DESCRIPTION
## Summary

This PR currentizes MBTI quality writing in the v0.3 submit pipeline.

Before this change, MBTI current submit could complete successfully, but it did not produce a stable quality source of truth on the current path. The only confirmed MBTI quality write path lived in the legacy lifecycle, which meant current read-side consumers such as gate/result analytics had a generic quality channel available but no guaranteed MBTI quality payload to consume.

This PR keeps the scope narrow and only fixes that gap.

## Problem

MBTI current submit used the refactored pipeline:

`AttemptSubmitService -> guard -> canonicalize -> score -> tx -> postCommit`

But unlike BIG5 / SDS / EQ / clinical flows, MBTI did not emit a quality payload from the current scoring path, and `AttemptSubmitTxService` had no MBTI-specific persistence step for quality.

As a result:

- `results.result_json.quality` was not guaranteed for MBTI current submit
- `attempt_quality` remained the only confirmed MBTI quality writer
- existing generic read-side code could read quality if present, but MBTI current submit did not reliably supply it

## Root Cause

The MBTI scorer/driver path returned axis scores and type information only. The canonical MBTI pack already contained `scoring_spec.json.reverse_pairs` and `quality_checks.json`, and the backend already had `QualityChecker`, but that logic was only wired into `LegacyMbtiAttemptLifecycleService`.

The current pipeline had the ingredients, but no current hook.

## Fix

The change adds a small current-path MBTI quality evaluator and wires it into the current submit flow.

- Add `MbtiQualityEvaluator` to resolve the canonical MBTI pack, read `scoring_spec.json` and `quality_checks.json`, and compute MBTI quality by reusing `QualityChecker`
- Call that evaluator from `AttemptSubmitScoreService` only for `MBTI`
- Attach the computed payload to `ScoreResult->normedJson['quality']`
- In `AttemptSubmitTxService`, promote MBTI `normed_json.quality` to top-level `result_json.quality` so `results.result_json.quality` becomes the current source of truth
- Keep writing `attempt_quality`, but only as a compat mirror for legacy/ops readers

This stays intentionally narrow:

- no frontend changes
- no content resolver changes
- no legacy lifecycle removal
- no report builder refactor
- no cross-scale quality redesign

## Validation

Targeted checks run:

- `php -l` on all changed PHP files
- `php artisan test tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php tests/Feature/V0_3/AttemptsStartSubmitTest.php --filter='mbti_current_submit_writes_quality_truth_and_attempt_quality_mirror|simple_score_start_submit_result|mbti_report_locked_true_without_entitlement'`

Results:

- 3 tests passed
- 39 assertions

## Notes

`attempt_quality` is still written after this PR, but it is no longer the only confirmed MBTI quality writer. The current truth now lives in `results.result_json.quality`, and the mirror remains for compatibility with existing readers.
