### PR TITLE
[codex] Ship OP-1 unified order ledger and state normalization

### DIFF
--- a/backend/app/Filament/Ops/Resources/OrderResource.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource.php
@@ -98,6 +98,9 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('provider')
                     ->sortable(),
+                Tables\Columns\TextColumn::make('channel')
+                    ->badge()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('amount_cents')
                     ->label('Amount (cents)')
                     ->numeric()
@@ -109,6 +112,12 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                     ->formatStateUsing(fn (Order $record): string => $support->orderStatus($record)['label'])
                     ->badge()
                     ->color(fn (Order $record): string => $support->orderStatus($record)['state']),
+                Tables\Columns\TextColumn::make('payment_state')
+                    ->badge()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('grant_state')
+                    ->badge()
+                    ->toggleable(),
                 Tables\Columns\TextColumn::make('latest_payment_status')
                     ->label('Payment status')
                     ->state(fn (Order $record): string => $support->paymentStatus($record)['label'])
@@ -212,6 +221,12 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                     }),
                 Tables\Filters\SelectFilter::make('provider')
                     ->options(fn (): array => $support->distinctOrderOptions('provider')),
+                Tables\Filters\SelectFilter::make('channel')
+                    ->options(fn (): array => $support->distinctOrderOptions('channel')),
+                Tables\Filters\SelectFilter::make('payment_state')
+                    ->options(fn (): array => $support->distinctOrderOptions('payment_state')),
+                Tables\Filters\SelectFilter::make('grant_state')
+                    ->options(fn (): array => $support->distinctOrderOptions('grant_state')),
                 Tables\Filters\TernaryFilter::make('paid_success')
                     ->label('Paid success')
                     ->queries(

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API\V0_3;
 
 use App\Http\Controllers\Controller;
+use App\Models\Order;
 use App\Services\Commerce\Checkout\AlipayCheckoutService;
 use App\Services\Commerce\Checkout\LemonSqueezyCheckoutService;
 use App\Services\Commerce\Checkout\WechatPayCheckoutService;
@@ -68,6 +69,8 @@ class CommerceController extends Controller
             'email' => ['nullable', 'string', 'max:320'],
             'target_attempt_id' => ['nullable', 'string', 'max:64'],
             'provider' => ['nullable', 'string', 'max:32'],
+            'channel' => ['nullable', 'string', 'max:64'],
+            'provider_app' => ['nullable', 'string', 'max:128'],
             'idempotency_key' => ['nullable', 'string', 'max:128'],
             'org_id' => ['prohibited'],
             'user_id' => ['prohibited'],
@@ -102,7 +105,15 @@ class CommerceController extends Controller
             $provider,
             $idempotencyKey,
             $contactEmail,
-            $this->resolveRequestId($request)
+            $this->resolveRequestId($request),
+            [],
+            [],
+            $this->resolveOrderLedgerContext(
+                $request,
+                $payload,
+                $payload['target_attempt_id'] ?? null,
+                $provider
+            )
         );
 
         if (! ($result['ok'] ?? false)) {
@@ -152,8 +163,8 @@ class CommerceController extends Controller
         $order = $result['order'];
         $ownershipVerified = (bool) ($result['ownership_verified'] ?? true);
         $paymentRecoveryVerified = (bool) ($result['payment_recovery_verified'] ?? false);
-        $status = $this->normalizePublicOrderStatus((string) ($order->status ?? ''));
-        $message = $this->publicOrderMessage((string) ($order->status ?? ''));
+        $status = $this->resolvePublicOrderStatus($order);
+        $message = $this->publicOrderMessage($order);
         $delivery = $this->buildOrderDelivery($order);
         $paymentRecoveryToken = $paymentRecoveryVerified && $requestedPaymentRecoveryToken !== null
             ? $requestedPaymentRecoveryToken
@@ -169,6 +180,11 @@ class CommerceController extends Controller
             $status === 'pending' && ($request->boolean('include_payment_action') || $paymentRecoveryVerified),
             $paymentRecoveryToken
         );
+        if ($status === 'pending') {
+            $order = $this->orders->findOrderByOrderNo((string) ($order->order_no ?? ''), $orgId) ?? $order;
+            $status = $this->resolvePublicOrderStatus($order);
+            $message = $this->publicOrderMessage($order);
+        }
 
         $payload = [
             'ok' => true,
@@ -176,10 +192,13 @@ class CommerceController extends Controller
             'order_no' => $order->order_no ?? null,
             'attempt_id' => $delivery['attempt_id'],
             'status' => $status,
+            'payment_state' => $this->orders->resolvedPaymentState($order),
+            'grant_state' => $this->orders->resolvedGrantState($order),
             'message' => $message,
             'amount_cents' => $order->amount_cents ?? $order->amount_total ?? null,
             'currency' => $order->currency ?? null,
             'provider' => $payment['provider'],
+            'channel' => $order->channel ?? null,
             'payment_recovery_token' => $paymentRecoveryToken,
             'wait_url' => $recoveryUrls['wait_url'],
             'result_url' => $recoveryUrls['result_url'],
@@ -214,6 +233,8 @@ class CommerceController extends Controller
             'surface' => ['nullable', 'string', 'max:64'],
             'order_no' => ['nullable', 'string', 'max:64'],
             'provider' => ['nullable', 'string', 'max:32'],
+            'channel' => ['nullable', 'string', 'max:64'],
+            'provider_app' => ['nullable', 'string', 'max:128'],
             'idempotency_key' => ['nullable', 'string', 'max:128'],
             'share_id' => ['nullable', 'string', 'max:128'],
             'compare_invite_id' => ['nullable', 'string', 'max:128'],
@@ -278,17 +299,21 @@ class CommerceController extends Controller
                 $payment = $this->buildOrderPaymentPayload(
                     $request,
                     $order,
-                    $this->normalizePublicOrderStatus((string) ($order->status ?? '')) === 'pending',
+                    $this->resolvePublicOrderStatus($order) === 'pending',
                     $paymentRecoveryToken
                 );
+                $order = $this->orders->findOrderByOrderNo((string) ($order->order_no ?? $existingOrderNo), $orgId) ?? $order;
 
                 return response()->json([
                     'ok' => true,
                     'order_no' => $order->order_no ?? $existingOrderNo,
                     'attempt_id' => $order->target_attempt_id ?? null,
-                    'status' => $this->normalizePublicOrderStatus((string) ($order->status ?? '')),
-                    'message' => $this->publicOrderMessage((string) ($order->status ?? '')),
+                    'status' => $this->resolvePublicOrderStatus($order),
+                    'payment_state' => $this->orders->resolvedPaymentState($order),
+                    'grant_state' => $this->orders->resolvedGrantState($order),
+                    'message' => $this->publicOrderMessage($order),
                     'provider' => $payment['provider'] ?? $provider,
+                    'channel' => $order->channel ?? null,
                     'payment_recovery_token' => $paymentRecoveryToken,
                     'wait_url' => $recoveryUrls['wait_url'],
                     'result_url' => $recoveryUrls['result_url'],
@@ -317,6 +342,12 @@ class CommerceController extends Controller
 
         $idempotencyKey = $this->resolveIdempotencyKey($request, $payload);
         $attemptId = trim((string) ($payload['attempt_id'] ?? ''));
+        $ledgerContext = $this->resolveOrderLedgerContext(
+            $request,
+            $payload,
+            $attemptId !== '' ? $attemptId : null,
+            $provider
+        );
 
         $created = $this->orders->createOrder(
             $orgId,
@@ -330,7 +361,8 @@ class CommerceController extends Controller
             $contactEmail,
             $this->resolveRequestId($request),
             $attribution,
-            $emailCapture
+            $emailCapture,
+            $ledgerContext
         );
 
         if (! ($created['ok'] ?? false)) {
@@ -386,6 +418,12 @@ class CommerceController extends Controller
         }
 
         if ($order !== null) {
+            $this->orders->markPaymentPending(
+                (string) ($order->order_no ?? ''),
+                (int) ($order->org_id ?? $orgId),
+                $ledgerContext['channel'] ?? null,
+                $ledgerContext['provider_app'] ?? null
+            );
             $this->persistOrderPaymentPayload(
                 $order,
                 $this->resolvePaymentActionScene((string) $request->userAgent()),
@@ -420,7 +458,10 @@ class CommerceController extends Controller
             'attempt_id' => $attemptIdFromOrder !== '' ? $attemptIdFromOrder : null,
             'provider' => $provider,
             'status' => 'pending',
+            'payment_state' => 'pending',
+            'grant_state' => 'not_started',
             'message' => 'Order created, waiting for payment.',
+            'channel' => $ledgerContext['channel'] ?? null,
             'payment_recovery_token' => $paymentRecoveryToken,
             'wait_url' => $recoveryUrls['wait_url'],
             'result_url' => $recoveryUrls['result_url'],
@@ -469,7 +510,7 @@ class CommerceController extends Controller
         }
 
         $delivery = $this->buildOrderDelivery($order);
-        $status = $this->normalizePublicOrderStatus((string) ($order->status ?? ''));
+        $status = $this->resolvePublicOrderStatus($order);
         $paymentRecoveryToken = $status === 'pending'
             ? $this->orders->issuePaymentRecoveryToken($order)
             : null;
@@ -486,13 +527,20 @@ class CommerceController extends Controller
             $status === 'pending',
             $paymentRecoveryToken
         );
+        if ($status === 'pending') {
+            $order = $this->orders->findOrderByOrderNo((string) ($order->order_no ?? $orderNo), $orgId) ?? $order;
+            $status = $this->resolvePublicOrderStatus($order);
+        }
 
         $payload = [
             'ok' => true,
             'order_no' => $order->order_no ?? $orderNo,
             'status' => $status,
+            'payment_state' => $this->orders->resolvedPaymentState($order),
+            'grant_state' => $this->orders->resolvedGrantState($order),
             'attempt_id' => $delivery['attempt_id'],
             'provider' => $payment['provider'],
+            'channel' => $order->channel ?? null,
             'payment_recovery_token' => $paymentRecoveryToken,
             'wait_url' => $recoveryUrls['wait_url'],
             'result_url' => $recoveryUrls['result_url'],
@@ -658,6 +706,13 @@ class CommerceController extends Controller
         $scene = $this->resolvePaymentActionScene((string) $request->userAgent());
         $cached = $this->resolveCachedOrderPaymentPayload($order, $normalizedProvider, $scene);
         if ($cached !== null) {
+            $this->orders->markPaymentPending(
+                (string) ($order->order_no ?? ''),
+                (int) ($order->org_id ?? 0),
+                $this->trimNullableString($order->channel ?? null),
+                $this->trimNullableString($order->provider_app ?? null)
+            );
+
             return $this->decoratePaymentPayloadForRecovery($cached, $paymentRecoveryToken);
         }
 
@@ -712,6 +767,12 @@ class CommerceController extends Controller
         }
 
         $presented = $this->presentCheckoutPayAction($normalizedProvider, $payAction);
+        $this->orders->markPaymentPending(
+            $orderNo,
+            (int) ($order->org_id ?? 0),
+            $this->trimNullableString($order->channel ?? null),
+            $this->trimNullableString($order->provider_app ?? null)
+        );
         $this->persistOrderPaymentPayload($order, $scene, $presented);
 
         return $this->decoratePaymentPayloadForRecovery($presented, $paymentRecoveryToken);
@@ -1096,6 +1157,55 @@ class CommerceController extends Controller
         return $sku !== '' ? strtoupper($sku) : '';
     }
 
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array{channel:?string,provider_app:?string}
+     */
+    private function resolveOrderLedgerContext(
+        Request $request,
+        array $payload,
+        ?string $attemptId,
+        string $provider
+    ): array {
+        $explicitChannel = Order::normalizeChannel(
+            $this->trimNullableString($payload['channel'] ?? $request->header('X-Channel', ''))
+        );
+        $attemptChannel = $this->resolveAttemptOrderChannel($attemptId);
+        $channel = $explicitChannel ?? $attemptChannel ?? 'web';
+
+        $providerApp = $this->trimNullableString($payload['provider_app'] ?? $request->header('X-Provider-App', ''));
+        if ($providerApp === null) {
+            $providerApp = match (strtolower(trim($provider))) {
+                'wechatpay' => $channel === 'wechat_miniapp'
+                    ? $this->trimNullableString(config('pay.wechat.default.mini_app_id', config('pay.wechat.default.mp_app_id', config('pay.wechat.default.app_id', ''))))
+                    : null,
+                'alipay' => $channel === 'alipay_miniapp'
+                    ? $this->trimNullableString(config('pay.alipay.default.app_id', ''))
+                    : null,
+                default => null,
+            };
+        }
+
+        return [
+            'channel' => $channel,
+            'provider_app' => $providerApp,
+        ];
+    }
+
+    private function resolveAttemptOrderChannel(?string $attemptId): ?string
+    {
+        $normalizedAttemptId = $this->trimNullableString($attemptId);
+        if ($normalizedAttemptId === null) {
+            return null;
+        }
+
+        $attemptChannel = DB::table('attempts')
+            ->where('id', $normalizedAttemptId)
+            ->value('channel');
+
+        return Order::normalizeChannel(is_scalar($attemptChannel) ? (string) $attemptChannel : null);
+    }
+
     private function resolveContactEmail(array $payload, ?string $userId): ?string
     {
         $inputEmail = $this->normalizeEmail((string) ($payload['email'] ?? ''));
@@ -1156,22 +1266,29 @@ class CommerceController extends Controller
         return $this->orders->presentOrderDelivery($order);
     }
 
-    private function normalizePublicOrderStatus(string $status): string
+    private function resolvePublicOrderStatus(object $order): string
     {
-        $status = strtolower(trim($status));
+        return $this->normalizePublicOrderStatus(
+            $this->orders->resolvedPaymentState($order)
+        );
+    }
+
+    private function normalizePublicOrderStatus(string $paymentState): string
+    {
+        $status = strtolower(trim($paymentState));
 
         return match ($status) {
-            'paid', 'fulfilled' => 'paid',
+            'paid' => 'paid',
             'failed' => 'failed',
-            'canceled', 'cancelled' => 'canceled',
+            'canceled', 'cancelled', 'expired' => 'canceled',
             'refunded' => 'refunded',
             default => 'pending',
         };
     }
 
-    private function publicOrderMessage(string $status): string
+    private function publicOrderMessage(object $order): string
     {
-        return match ($this->normalizePublicOrderStatus($status)) {
+        return match ($this->resolvePublicOrderStatus($order)) {
             'paid' => 'Payment confirmed.',
             'failed' => 'Payment failed.',
             'canceled' => 'Order canceled.',

--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -1846,7 +1846,11 @@ class PaymentWebhookHandlerCore
                 ->update($updates);
         }
 
-        $transition = $this->orders->transition($orderNo, 'refunded', $orgId);
+        $transition = $this->orders->transition($orderNo, 'refunded', $orgId, [
+            'provider_trade_no' => $normalized['external_trade_no'] ?? null,
+            'last_payment_event_at' => $normalized['paid_at'] ?? null,
+            'refunded_at' => $normalized['paid_at'] ?? $now,
+        ]);
         if (! ($transition['ok'] ?? false)) {
             return $transition;
         }

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -15,6 +15,42 @@ class Order extends Model
 
     public const PAYMENT_RECOVERY_TOKEN_TTL_SECONDS = 2592000;
 
+    public const STATUS_CREATED = 'created';
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_PAID = 'paid';
+
+    public const STATUS_FULFILLED = 'fulfilled';
+
+    public const STATUS_FAILED = 'failed';
+
+    public const STATUS_CANCELED = 'canceled';
+
+    public const STATUS_REFUNDED = 'refunded';
+
+    public const PAYMENT_STATE_CREATED = 'created';
+
+    public const PAYMENT_STATE_PENDING = 'pending';
+
+    public const PAYMENT_STATE_PAID = 'paid';
+
+    public const PAYMENT_STATE_FAILED = 'failed';
+
+    public const PAYMENT_STATE_CANCELED = 'canceled';
+
+    public const PAYMENT_STATE_EXPIRED = 'expired';
+
+    public const PAYMENT_STATE_REFUNDED = 'refunded';
+
+    public const GRANT_STATE_NOT_STARTED = 'not_started';
+
+    public const GRANT_STATE_GRANTED = 'granted';
+
+    public const GRANT_STATE_GRANT_FAILED = 'grant_failed';
+
+    public const GRANT_STATE_REVOKED = 'revoked';
+
     protected $table = 'orders';
 
     public $incrementing = false;
@@ -25,8 +61,12 @@ class Order extends Model
         'id',
         'order_no',
         'provider',
+        'channel',
+        'provider_app',
         'provider_order_id',
         'status',
+        'payment_state',
+        'grant_state',
         'amount_total',
         'amount_cents',
         'amount_refunded',
@@ -45,10 +85,16 @@ class Order extends Model
         'scale_code_v2',
         'scale_uid',
         'external_trade_no',
+        'provider_trade_no',
         'contact_email_hash',
+        'external_user_ref',
         'metadata',
         'meta_json',
         'paid_at',
+        'expired_at',
+        'closed_at',
+        'last_payment_event_at',
+        'last_reconciled_at',
         'fulfilled_at',
         'refunded_at',
     ];
@@ -61,9 +107,97 @@ class Order extends Model
         'metadata' => 'array',
         'meta_json' => 'array',
         'paid_at' => 'datetime',
+        'expired_at' => 'datetime',
+        'closed_at' => 'datetime',
+        'last_payment_event_at' => 'datetime',
+        'last_reconciled_at' => 'datetime',
         'fulfilled_at' => 'datetime',
         'refunded_at' => 'datetime',
     ];
+
+    public static function paymentStateFromLegacyStatus(?string $status): string
+    {
+        return match (strtolower(trim((string) $status))) {
+            self::STATUS_PENDING => self::PAYMENT_STATE_PENDING,
+            self::STATUS_PAID,
+            self::STATUS_FULFILLED => self::PAYMENT_STATE_PAID,
+            self::STATUS_FAILED => self::PAYMENT_STATE_FAILED,
+            self::STATUS_CANCELED,
+            'cancelled' => self::PAYMENT_STATE_CANCELED,
+            'expired' => self::PAYMENT_STATE_EXPIRED,
+            self::STATUS_REFUNDED => self::PAYMENT_STATE_REFUNDED,
+            default => self::PAYMENT_STATE_CREATED,
+        };
+    }
+
+    public static function normalizePaymentState(?string $paymentState, ?string $legacyStatus = null): string
+    {
+        $normalized = strtolower(trim((string) $paymentState));
+        $legacyResolved = self::paymentStateFromLegacyStatus($legacyStatus);
+
+        return in_array($normalized, [
+            self::PAYMENT_STATE_CREATED,
+            self::PAYMENT_STATE_PENDING,
+            self::PAYMENT_STATE_PAID,
+            self::PAYMENT_STATE_FAILED,
+            self::PAYMENT_STATE_CANCELED,
+            self::PAYMENT_STATE_EXPIRED,
+            self::PAYMENT_STATE_REFUNDED,
+        ], true)
+            ? ($normalized === self::PAYMENT_STATE_CREATED && $legacyResolved !== self::PAYMENT_STATE_CREATED
+                ? $legacyResolved
+                : $normalized)
+            : $legacyResolved;
+    }
+
+    public static function normalizeGrantState(?string $grantState, ?string $legacyStatus = null): string
+    {
+        $normalized = strtolower(trim((string) $grantState));
+        $legacyResolved = strtolower(trim((string) $legacyStatus)) === self::STATUS_FULFILLED
+            ? self::GRANT_STATE_GRANTED
+            : self::GRANT_STATE_NOT_STARTED;
+
+        if (in_array($normalized, [
+            self::GRANT_STATE_NOT_STARTED,
+            self::GRANT_STATE_GRANTED,
+            self::GRANT_STATE_GRANT_FAILED,
+            self::GRANT_STATE_REVOKED,
+        ], true)) {
+            return $normalized === self::GRANT_STATE_NOT_STARTED && $legacyResolved === self::GRANT_STATE_GRANTED
+                ? $legacyResolved
+                : $normalized;
+        }
+
+        return $legacyResolved;
+    }
+
+    public static function normalizeChannel(?string $channel): ?string
+    {
+        $normalized = strtolower(trim((string) $channel));
+
+        return match ($normalized) {
+            'web', 'website', 'browser', 'h5' => 'web',
+            'wechat', 'wechatpay', 'wechat_miniapp', 'wechat-miniapp', 'wx_miniapp', 'wx-miniapp', 'miniprogram', 'mini_program' => 'wechat_miniapp',
+            'alipay', 'alipay_miniapp', 'alipay-miniapp' => 'alipay_miniapp',
+            default => null,
+        };
+    }
+
+    public function resolvedPaymentState(): string
+    {
+        return self::normalizePaymentState(
+            $this->getAttribute('payment_state'),
+            (string) $this->getAttribute('status')
+        );
+    }
+
+    public function resolvedGrantState(): string
+    {
+        return self::normalizeGrantState(
+            $this->getAttribute('grant_state'),
+            (string) $this->getAttribute('status')
+        );
+    }
 
     public function paymentEvents(): HasMany
     {

--- a/backend/app/Services/Commerce/EntitlementManager.php
+++ b/backend/app/Services/Commerce/EntitlementManager.php
@@ -11,6 +11,7 @@ class EntitlementManager
 {
     public function __construct(
         private readonly UnifiedAccessProjectionWriter $accessProjections,
+        private readonly OrderManager $orders,
     ) {}
 
     public function hasFullAccess(
@@ -103,7 +104,7 @@ class EntitlementManager
             $modules ?? $catalog->modulesForBenefitCode($orgId, $benefitCode)
         );
         $freeModule = $catalog->freeModuleForBenefitCode($orgId, $benefitCode);
-        if ($grantedModules !== [] && $freeModule !== '' && !in_array($freeModule, $grantedModules, true)) {
+        if ($grantedModules !== [] && $freeModule !== '' && ! in_array($freeModule, $grantedModules, true)) {
             $grantedModules[] = $freeModule;
             $grantedModules = ReportAccess::normalizeModules($grantedModules);
         }
@@ -127,9 +128,14 @@ class EntitlementManager
                 $existing = DB::table('benefit_grants')->where('id', (string) ($existing->id ?? ''))->first() ?: $existing;
             }
 
+            $normalizedExistingOrderNo = trim((string) ($orderNo ?? ''));
+            if ($normalizedExistingOrderNo !== '') {
+                $this->orders->syncGrantState($normalizedExistingOrderNo, $orgId, 'granted');
+            }
+
             $this->refreshAccessProjection($attemptId, [
                 'source_system' => 'entitlement_manager',
-                'source_ref' => $orderNo !== '' ? $orderNo : $benefitCode,
+                'source_ref' => $normalizedExistingOrderNo !== '' ? $normalizedExistingOrderNo : $benefitCode,
                 'actor_type' => $userId !== '' ? 'user' : 'anon',
                 'actor_id' => $userId !== '' ? $userId : $anonId,
                 'reason_code' => 'entitlement_granted',
@@ -190,6 +196,9 @@ class EntitlementManager
         DB::table('benefit_grants')->insert($row);
 
         $grant = DB::table('benefit_grants')->where('id', $row['id'])->first();
+        if ($normalizedOrderNo !== '') {
+            $this->orders->syncGrantState($normalizedOrderNo, $orgId, 'granted');
+        }
         $this->refreshAccessProjection($attemptId, [
             'source_system' => 'entitlement_manager',
             'source_ref' => $normalizedOrderNo !== '' ? $normalizedOrderNo : $benefitCode,
@@ -302,6 +311,8 @@ class EntitlementManager
             ]);
 
         if ($byOrderNo > 0) {
+            $this->orders->syncGrantState($orderNo, $orderOrgId, 'revoked');
+
             return [
                 'ok' => true,
                 'revoked' => $byOrderNo,
@@ -320,6 +331,10 @@ class EntitlementManager
                 'updated_at' => $now,
                 'revoked_at' => $now,
             ]);
+
+        if ($revoked > 0) {
+            $this->orders->syncGrantState($orderNo, $orderOrgId, 'revoked');
+        }
 
         return [
             'ok' => true,

--- a/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
+++ b/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
@@ -105,7 +105,7 @@ final class MbtiAccessHubBuilder
 
         return [
             'access_state' => $this->resolveDeliveryAccessState(
-                (string) ($order->status ?? ''),
+                $order,
                 $canViewReport,
                 $canRequestClaimEmail,
                 $canResend
@@ -195,7 +195,7 @@ final class MbtiAccessHubBuilder
     }
 
     private function resolveDeliveryAccessState(
-        string $status,
+        object $order,
         bool $canViewReport,
         bool $canRequestClaimEmail,
         bool $canResend
@@ -204,7 +204,7 @@ final class MbtiAccessHubBuilder
             return ReportAccess::ACCESS_HUB_STATE_READY;
         }
 
-        if ($this->isPendingStatus($status)) {
+        if ($this->isPendingStatus($order)) {
             return ReportAccess::ACCESS_HUB_STATE_PENDING;
         }
 
@@ -248,13 +248,17 @@ final class MbtiAccessHubBuilder
             : null;
     }
 
-    private function isPendingStatus(string $status): bool
+    private function isPendingStatus(object $order): bool
     {
-        return ! in_array(
-            strtolower(trim($status)),
-            ['paid', 'fulfilled', 'failed', 'canceled', 'cancelled', 'refunded'],
-            true
-        );
+        $paymentState = $this->orders->resolvedPaymentState($order);
+
+        return ! in_array($paymentState, [
+            \App\Models\Order::PAYMENT_STATE_PAID,
+            \App\Models\Order::PAYMENT_STATE_FAILED,
+            \App\Models\Order::PAYMENT_STATE_CANCELED,
+            \App\Models\Order::PAYMENT_STATE_EXPIRED,
+            \App\Models\Order::PAYMENT_STATE_REFUNDED,
+        ], true);
     }
 
     private function isMbtiScale(mixed $scaleCode): bool

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -13,7 +13,12 @@ use Illuminate\Support\Str;
 
 class OrderManager
 {
-    private const FINAL_STATUSES = ['fulfilled', 'failed', 'canceled', 'refunded'];
+    private const FINAL_STATUSES = [
+        Order::STATUS_FULFILLED,
+        Order::STATUS_FAILED,
+        Order::STATUS_CANCELED,
+        Order::STATUS_REFUNDED,
+    ];
 
     private const MAX_ORDER_QUANTITY = 1000;
 
@@ -40,6 +45,7 @@ class OrderManager
         ?string $requestId = null,
         array $attribution = [],
         array $emailCapture = [],
+        array $ledgerContext = [],
     ): array {
         $requestedSku = $this->skus->normalizeSku($sku);
         if ($requestedSku === '') {
@@ -87,6 +93,14 @@ class OrderManager
 
         $idempotencyKey = $this->normalizeIdempotencyKey($idempotencyKey);
         $useIdempotency = $idempotencyKey !== '';
+        $resolvedLedgerContext = $this->resolveLedgerContext(
+            $provider,
+            $targetAttemptId,
+            $normalizedUserId,
+            $normalizedAnonId,
+            $contactEmailHash,
+            $ledgerContext
+        );
 
         $createRow = function () use (
             $orgId,
@@ -107,7 +121,8 @@ class OrderManager
             $contactEmailHash,
             $requestId,
             $attribution,
-            $emailCapture
+            $emailCapture,
+            $resolvedLedgerContext
         ): array {
             $orderNo = 'ord_'.Str::uuid();
             $now = now();
@@ -136,15 +151,25 @@ class OrderManager
                 'target_attempt_id' => $this->trimOrNull($targetAttemptId),
                 'amount_cents' => $unitPriceCents * $quantity,
                 'currency' => (string) ($skuRow->currency ?? 'USD'),
-                'status' => 'created',
+                'status' => Order::STATUS_CREATED,
+                'payment_state' => Order::PAYMENT_STATE_CREATED,
+                'grant_state' => Order::GRANT_STATE_NOT_STARTED,
                 'provider' => $provider,
+                'channel' => $resolvedLedgerContext['channel'],
+                'provider_app' => $resolvedLedgerContext['provider_app'],
                 'external_trade_no' => null,
+                'provider_trade_no' => null,
                 'paid_at' => null,
+                'expired_at' => null,
+                'closed_at' => null,
+                'last_payment_event_at' => null,
+                'last_reconciled_at' => null,
                 'created_at' => $now,
                 'updated_at' => $now,
                 'requested_sku' => $requestedSku,
                 'effective_sku' => $effectiveSku !== '' ? $effectiveSku : $skuToLookup,
                 'entitlement_id' => $entitlementId,
+                'external_user_ref' => $resolvedLedgerContext['external_user_ref'],
                 'meta_json' => $orderMeta !== []
                     ? json_encode($orderMeta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
                     : null,
@@ -420,6 +445,8 @@ class OrderManager
             })
             ->orderByRaw("
                 case
+                    when lower(coalesce(payment_state, '')) = 'paid' then 0
+                    when lower(coalesce(payment_state, '')) in ('created', 'pending') then 1
                     when lower(coalesce(status, '')) in ('paid', 'fulfilled') then 0
                     when lower(coalesce(status, '')) in ('created', 'pending') then 1
                     else 2
@@ -433,7 +460,23 @@ class OrderManager
 
     public function isPaidOrFulfilledStatus(?string $status): bool
     {
-        return $this->isDeliveryEligibleStatus((string) $status);
+        return Order::normalizePaymentState(null, $status) === Order::PAYMENT_STATE_PAID;
+    }
+
+    public function resolvedPaymentState(object $order): string
+    {
+        return Order::normalizePaymentState(
+            (string) ($order->payment_state ?? ''),
+            (string) ($order->status ?? '')
+        );
+    }
+
+    public function resolvedGrantState(object $order): string
+    {
+        return Order::normalizeGrantState(
+            (string) ($order->grant_state ?? ''),
+            (string) ($order->status ?? '')
+        );
     }
 
     /**
@@ -575,6 +618,135 @@ class OrderManager
         ];
     }
 
+    public function markPaymentPending(
+        string $orderNo,
+        int $orgId,
+        ?string $channel = null,
+        ?string $providerApp = null
+    ): array {
+        $orderNo = trim($orderNo);
+        if ($orderNo === '') {
+            return $this->badRequest('ORDER_REQUIRED', 'order_no is required.');
+        }
+
+        $order = DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->where('org_id', $orgId)
+            ->first();
+        if (! $order) {
+            return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
+        }
+
+        $paymentState = $this->resolvedPaymentState($order);
+        if (in_array($paymentState, [
+            Order::PAYMENT_STATE_PAID,
+            Order::PAYMENT_STATE_FAILED,
+            Order::PAYMENT_STATE_CANCELED,
+            Order::PAYMENT_STATE_EXPIRED,
+            Order::PAYMENT_STATE_REFUNDED,
+        ], true)) {
+            return [
+                'ok' => true,
+                'order' => $order,
+                'skipped' => true,
+            ];
+        }
+
+        $normalizedChannel = Order::normalizeChannel($channel);
+        $normalizedProviderApp = $this->trimOrNull($providerApp);
+        $updates = [
+            'payment_state' => Order::PAYMENT_STATE_PENDING,
+            'updated_at' => now(),
+        ];
+
+        $legacyStatus = strtolower(trim((string) ($order->status ?? '')));
+        if ($legacyStatus === '' || $legacyStatus === Order::STATUS_CREATED) {
+            $updates['status'] = Order::STATUS_PENDING;
+        }
+
+        if ($normalizedChannel !== null && $this->trimOrNull((string) ($order->channel ?? '')) === null) {
+            $updates['channel'] = $normalizedChannel;
+        }
+
+        if ($normalizedProviderApp !== null && $this->trimOrNull((string) ($order->provider_app ?? '')) === null) {
+            $updates['provider_app'] = $normalizedProviderApp;
+        }
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->where('org_id', $orgId)
+            ->update($updates);
+
+        return [
+            'ok' => true,
+            'order' => DB::table('orders')
+                ->where('order_no', $orderNo)
+                ->where('org_id', $orgId)
+                ->first(),
+        ];
+    }
+
+    public function syncGrantState(
+        string $orderNo,
+        int $orgId,
+        string $grantState
+    ): void {
+        $orderNo = trim($orderNo);
+        if ($orderNo === '') {
+            return;
+        }
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->where('org_id', $orgId)
+            ->update([
+                'grant_state' => Order::normalizeGrantState($grantState),
+                'updated_at' => now(),
+            ]);
+    }
+
+    public function touchPaymentLedger(
+        string $orderNo,
+        int $orgId,
+        ?string $providerTradeNo = null,
+        ?string $eventAt = null,
+        ?string $paymentState = null
+    ): void {
+        $orderNo = trim($orderNo);
+        if ($orderNo === '') {
+            return;
+        }
+
+        $eventTimestamp = ($eventAt !== null && trim($eventAt) !== '') ? $eventAt : now()->toDateTimeString();
+        $updates = [
+            'updated_at' => now(),
+            'last_payment_event_at' => $eventTimestamp,
+        ];
+
+        $normalizedProviderTradeNo = $this->trimOrNull($providerTradeNo);
+        if ($normalizedProviderTradeNo !== null) {
+            $updates['provider_trade_no'] = $normalizedProviderTradeNo;
+        }
+
+        if ($paymentState !== null) {
+            $normalizedPaymentState = Order::normalizePaymentState($paymentState);
+            $updates['payment_state'] = $normalizedPaymentState;
+
+            if ($normalizedPaymentState === Order::PAYMENT_STATE_CANCELED) {
+                $updates['closed_at'] = $eventTimestamp;
+            }
+
+            if ($normalizedPaymentState === Order::PAYMENT_STATE_EXPIRED) {
+                $updates['expired_at'] = $eventTimestamp;
+            }
+        }
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->where('org_id', $orgId)
+            ->update($updates);
+    }
+
     public function transitionToPaidAtomic(
         string $orderNo,
         int $orgId,
@@ -601,6 +773,7 @@ class OrderManager
         }
 
         if (in_array($fromStatus, ['paid', 'fulfilled'], true)) {
+            $this->touchPaymentLedger($orderNo, $orgId, $externalTradeNo, $paidAt, Order::PAYMENT_STATE_PAID);
             $this->syncPurchasedInviteFromOrder($order, $paidAt);
 
             return [
@@ -616,8 +789,10 @@ class OrderManager
 
         $now = now();
         $updates = [
-            'status' => 'paid',
+            'status' => Order::STATUS_PAID,
+            'payment_state' => Order::PAYMENT_STATE_PAID,
             'updated_at' => $now,
+            'last_payment_event_at' => ($paidAt !== null && $paidAt !== '') ? $paidAt : $now,
         ];
 
         if (empty($order->paid_at)) {
@@ -626,6 +801,7 @@ class OrderManager
 
         if ($externalTradeNo) {
             $updates['external_trade_no'] = $externalTradeNo;
+            $updates['provider_trade_no'] = $externalTradeNo;
         }
 
         $updated = DB::table('orders')
@@ -661,7 +837,7 @@ class OrderManager
         ];
     }
 
-    public function transition(string $orderNo, string $toStatus, ?int $orgId = null): array
+    public function transition(string $orderNo, string $toStatus, ?int $orgId = null, array $context = []): array
     {
         $orderNo = trim($orderNo);
         $toStatus = strtolower(trim($toStatus));
@@ -704,17 +880,7 @@ class OrderManager
             'updated_at' => now(),
         ];
 
-        if ($toStatus === 'paid') {
-            $updates['paid_at'] = $updates['updated_at'];
-        }
-
-        if ($toStatus === 'fulfilled') {
-            $updates['fulfilled_at'] = $updates['updated_at'];
-        }
-
-        if ($toStatus === 'refunded') {
-            $updates['refunded_at'] = $updates['updated_at'];
-        }
+        $updates = array_replace($updates, $this->ledgerUpdatesForTransition($toStatus, $order, $context));
 
         $updateQuery = DB::table('orders')->where('order_no', $orderNo);
         if ($orgId !== null) {
@@ -741,7 +907,7 @@ class OrderManager
         }
 
         $order = DB::table('orders')->where('order_no', $orderNo)->first();
-        if (in_array($toStatus, ['paid', 'fulfilled'], true)) {
+        if (in_array($toStatus, [Order::STATUS_PAID, Order::STATUS_FULFILLED], true)) {
             $this->syncPurchasedInviteFromOrder($order, null);
         }
 
@@ -794,16 +960,29 @@ class OrderManager
 
     private function isTransitionAllowed(string $fromStatus, string $toStatus): bool
     {
-        if ($fromStatus === 'created' && in_array($toStatus, ['pending', 'paid', 'failed', 'canceled', 'refunded'], true)) {
+        if ($fromStatus === Order::STATUS_CREATED && in_array($toStatus, [
+            Order::STATUS_PENDING,
+            Order::STATUS_PAID,
+            Order::STATUS_FAILED,
+            Order::STATUS_CANCELED,
+            'expired',
+            Order::STATUS_REFUNDED,
+        ], true)) {
             return true;
         }
-        if ($fromStatus === 'pending' && in_array($toStatus, ['paid', 'failed', 'canceled', 'refunded'], true)) {
+        if ($fromStatus === Order::STATUS_PENDING && in_array($toStatus, [
+            Order::STATUS_PAID,
+            Order::STATUS_FAILED,
+            Order::STATUS_CANCELED,
+            'expired',
+            Order::STATUS_REFUNDED,
+        ], true)) {
             return true;
         }
-        if ($fromStatus === 'paid' && $toStatus === 'fulfilled') {
+        if ($fromStatus === Order::STATUS_PAID && $toStatus === Order::STATUS_FULFILLED) {
             return true;
         }
-        if ($fromStatus === 'fulfilled' && $toStatus === 'refunded') {
+        if ($fromStatus === Order::STATUS_FULFILLED && $toStatus === Order::STATUS_REFUNDED) {
             return true;
         }
 
@@ -850,7 +1029,7 @@ class OrderManager
         $attemptId = $this->resolveKnownAttemptId($orgId, $order->target_attempt_id ?? null);
         $reportUrl = $attemptId !== null ? $this->reportUrl($attemptId) : null;
         $reportPdfUrl = $attemptId !== null ? $this->reportPdfUrl($attemptId) : null;
-        $deliveryEligible = $attemptId !== null && $this->isDeliveryEligibleStatus((string) ($order->status ?? ''));
+        $deliveryEligible = $attemptId !== null && $this->isDeliveryEligibleOrder($order);
         $recipient = $attemptId !== null
             ? $this->emailOutbox->resolvePaymentSuccessRecipient(
                 $this->trimOrNull((string) ($order->user_id ?? '')),
@@ -971,7 +1150,7 @@ class OrderManager
 
     private function isDeliveryEligibleStatus(string $status): bool
     {
-        return in_array(strtolower(trim($status)), ['paid', 'fulfilled'], true);
+        return Order::normalizePaymentState(null, $status) === Order::PAYMENT_STATE_PAID;
     }
 
     private function resolveOrderProductSummary(object $order): ?string
@@ -1142,6 +1321,175 @@ class OrderManager
         DB::table('mbti_compare_invites')
             ->where('id', $compareInviteId)
             ->update($update);
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function ledgerUpdatesForTransition(string $toStatus, object $order, array $context): array
+    {
+        $updates = [];
+        $transitionedAt = $context['transitioned_at'] ?? now();
+        $providerTradeNo = $this->trimOrNull($context['provider_trade_no'] ?? null);
+        $paymentEventAt = $this->trimOrNull($context['last_payment_event_at'] ?? null);
+        $explicitPaymentState = isset($context['payment_state'])
+            ? Order::normalizePaymentState((string) $context['payment_state'])
+            : null;
+
+        if ($providerTradeNo !== null) {
+            $updates['provider_trade_no'] = $providerTradeNo;
+        }
+        if ($paymentEventAt !== null) {
+            $updates['last_payment_event_at'] = $paymentEventAt;
+        }
+
+        switch ($toStatus) {
+            case Order::STATUS_PENDING:
+                $updates['payment_state'] = $explicitPaymentState ?? Order::PAYMENT_STATE_PENDING;
+                break;
+            case Order::STATUS_PAID:
+                $updates['payment_state'] = $explicitPaymentState ?? Order::PAYMENT_STATE_PAID;
+                $updates['paid_at'] = $context['paid_at'] ?? ($order->paid_at ?? $transitionedAt);
+                $updates['grant_state'] = $this->resolvedGrantState($order);
+                break;
+            case Order::STATUS_FULFILLED:
+                $updates['payment_state'] = $explicitPaymentState ?? Order::PAYMENT_STATE_PAID;
+                $updates['fulfilled_at'] = $order->fulfilled_at ?? $transitionedAt;
+                break;
+            case Order::STATUS_FAILED:
+                $updates['payment_state'] = $explicitPaymentState ?? Order::PAYMENT_STATE_FAILED;
+                break;
+            case Order::STATUS_CANCELED:
+                $updates['payment_state'] = $explicitPaymentState ?? Order::PAYMENT_STATE_CANCELED;
+                $updates['closed_at'] = $context['closed_at'] ?? $transitionedAt;
+                if (($updates['payment_state'] ?? null) === Order::PAYMENT_STATE_EXPIRED) {
+                    $updates['expired_at'] = $context['expired_at'] ?? $transitionedAt;
+                }
+                break;
+            case 'expired':
+                $updates['payment_state'] = $explicitPaymentState ?? Order::PAYMENT_STATE_EXPIRED;
+                $updates['expired_at'] = $context['expired_at'] ?? $transitionedAt;
+                break;
+            case Order::STATUS_REFUNDED:
+                $updates['payment_state'] = $explicitPaymentState ?? Order::PAYMENT_STATE_REFUNDED;
+                $updates['refunded_at'] = $context['refunded_at'] ?? ($order->refunded_at ?? $transitionedAt);
+                break;
+        }
+
+        return $updates;
+    }
+
+    private function isDeliveryEligibleOrder(object $order): bool
+    {
+        if ($this->resolvedPaymentState($order) !== Order::PAYMENT_STATE_PAID) {
+            return false;
+        }
+
+        if ($this->resolvedGrantState($order) === Order::GRANT_STATE_GRANTED) {
+            return true;
+        }
+
+        return $this->isLegacyDeliveryEligibleOrder($order);
+    }
+
+    private function isLegacyDeliveryEligibleOrder(object $order): bool
+    {
+        $legacyStatus = strtolower(trim((string) ($order->status ?? '')));
+        if (! in_array($legacyStatus, [
+            Order::STATUS_PAID,
+            Order::STATUS_FULFILLED,
+        ], true)) {
+            return false;
+        }
+
+        $rawPaymentState = strtolower(trim((string) ($order->payment_state ?? '')));
+        if ($rawPaymentState !== '' && $rawPaymentState !== Order::PAYMENT_STATE_CREATED) {
+            return false;
+        }
+
+        $rawGrantState = strtolower(trim((string) ($order->grant_state ?? '')));
+
+        return $rawGrantState === '' || $rawGrantState === Order::GRANT_STATE_NOT_STARTED;
+    }
+
+    /**
+     * @param  array<string,mixed>  $ledgerContext
+     * @return array{
+     *     channel:?string,
+     *     provider_app:?string,
+     *     external_user_ref:?string
+     * }
+     */
+    private function resolveLedgerContext(
+        string $provider,
+        ?string $targetAttemptId,
+        ?string $userId,
+        ?string $anonId,
+        ?string $contactEmailHash,
+        array $ledgerContext
+    ): array {
+        $explicitChannel = Order::normalizeChannel(
+            is_scalar($ledgerContext['channel'] ?? null) ? (string) $ledgerContext['channel'] : null
+        );
+        $attemptChannel = $this->resolveAttemptChannel($targetAttemptId);
+        $channel = $explicitChannel ?? $attemptChannel ?? 'web';
+
+        $providerApp = $this->trimOrNull(
+            is_scalar($ledgerContext['provider_app'] ?? null) ? (string) $ledgerContext['provider_app'] : null
+        );
+
+        if ($providerApp === null) {
+            $providerApp = match (strtolower(trim($provider))) {
+                'wechatpay' => $channel === 'wechat_miniapp'
+                    ? $this->trimOrNull((string) config('pay.wechat.default.mini_app_id', config('pay.wechat.default.mp_app_id', config('pay.wechat.default.app_id', ''))))
+                    : null,
+                'alipay' => $channel === 'alipay_miniapp'
+                    ? $this->trimOrNull((string) config('pay.alipay.default.app_id', ''))
+                    : null,
+                default => null,
+            };
+        }
+
+        return [
+            'channel' => $channel,
+            'provider_app' => $providerApp,
+            'external_user_ref' => $this->resolveExternalUserRef($userId, $anonId, $contactEmailHash),
+        ];
+    }
+
+    private function resolveAttemptChannel(?string $targetAttemptId): ?string
+    {
+        $attemptId = $this->trimOrNull($targetAttemptId);
+        if ($attemptId === null || ! Schema::hasTable('attempts')) {
+            return null;
+        }
+
+        $attemptChannel = DB::table('attempts')
+            ->where('id', $attemptId)
+            ->value('channel');
+
+        return Order::normalizeChannel(is_scalar($attemptChannel) ? (string) $attemptChannel : null);
+    }
+
+    private function resolveExternalUserRef(?string $userId, ?string $anonId, ?string $contactEmailHash): ?string
+    {
+        $normalizedUserId = $this->trimOrNull($userId);
+        if ($normalizedUserId !== null) {
+            return substr('user:'.$normalizedUserId, 0, 128);
+        }
+
+        $normalizedAnonId = $this->trimOrNull($anonId);
+        if ($normalizedAnonId !== null) {
+            return substr('anon:'.$normalizedAnonId, 0, 128);
+        }
+
+        $normalizedContactHash = $this->trimOrNull($contactEmailHash);
+        if ($normalizedContactHash !== null) {
+            return substr('email_hash:'.$normalizedContactHash, 0, 128);
+        }
+
+        return null;
     }
 
     private function normalizeRequestId(mixed $value): ?string

--- a/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
@@ -10,9 +10,7 @@ use Illuminate\Support\Str;
 
 class WebhookEntitlementService
 {
-    public function __construct(private PaymentWebhookHandlerCore $core)
-    {
-    }
+    public function __construct(private PaymentWebhookHandlerCore $core) {}
 
     public function handle(array $ctx): array
     {
@@ -267,6 +265,21 @@ class WebhookEntitlementService
                     ]);
                     $eventContext = $this->core->buildEventContext($orderMeta, $anonId);
 
+                    $providerTradeNo = is_scalar($normalized['external_trade_no'] ?? null)
+                        ? (string) $normalized['external_trade_no']
+                        : null;
+                    $eventAt = is_scalar($normalized['paid_at'] ?? null)
+                        ? (string) $normalized['paid_at']
+                        : null;
+                    $nonSuccessPaymentState = $this->resolveNonSuccessPaymentState($eventType);
+                    $this->core->orderManager()->touchPaymentLedger(
+                        $orderNo,
+                        $orgId,
+                        $providerTradeNo,
+                        $eventAt,
+                        $nonSuccessPaymentState
+                    );
+
                     if ($isRefundEvent) {
                         $refund = $this->core->handleRefund($orderNo, $order, $normalized, $providerEventId, $orgId);
                         if (! ($refund['ok'] ?? false)) {
@@ -283,6 +296,40 @@ class WebhookEntitlementService
                         $this->core->markEventProcessed($provider, $providerEventId);
 
                         return $refund;
+                    }
+
+                    if ($nonSuccessPaymentState !== null) {
+                        $legacyStatus = $nonSuccessPaymentState === \App\Models\Order::PAYMENT_STATE_FAILED
+                            ? \App\Models\Order::STATUS_FAILED
+                            : \App\Models\Order::STATUS_CANCELED;
+                        $transition = $this->core->orderManager()->transition($orderNo, $legacyStatus, $orgId, [
+                            'payment_state' => $nonSuccessPaymentState,
+                            'provider_trade_no' => $providerTradeNo,
+                            'last_payment_event_at' => $eventAt,
+                            'closed_at' => $eventAt,
+                            'expired_at' => $eventAt,
+                        ]);
+
+                        if (! ($transition['ok'] ?? false)) {
+                            $this->core->markEventError(
+                                $provider,
+                                $providerEventId,
+                                'failed',
+                                (string) ($transition['error'] ?? 'ORDER_STATUS_INVALID'),
+                                (string) ($transition['message'] ?? 'order transition failed.')
+                            );
+
+                            return $transition;
+                        }
+
+                        $this->core->markEventProcessed($provider, $providerEventId);
+
+                        return [
+                            'ok' => true,
+                            'order_no' => $orderNo,
+                            'provider_event_id' => $providerEventId,
+                            'payment_state' => $nonSuccessPaymentState,
+                        ];
                     }
 
                     $effectiveSku = strtoupper((string) ($normalizedSkuMeta['effective_sku']
@@ -484,6 +531,7 @@ class WebhookEntitlementService
                             );
 
                             if (! ($grant['ok'] ?? false)) {
+                                $this->core->orderManager()->syncGrantState($orderNo, $orgId, \App\Models\Order::GRANT_STATE_GRANT_FAILED);
                                 $this->core->markEventError(
                                     $provider,
                                     $providerEventId,
@@ -585,5 +633,28 @@ class WebhookEntitlementService
         }
 
         return substr($normalized, 0, 128);
+    }
+
+    private function resolveNonSuccessPaymentState(string $eventType): ?string
+    {
+        $normalized = strtolower(trim($eventType));
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (str_contains($normalized, 'refund')) {
+            return null;
+        }
+
+        foreach (['close', 'closed', 'cancel', 'canceled', 'cancelled', 'expire', 'expired'] as $needle) {
+            if (str_contains($normalized, $needle)) {
+                return str_contains($normalized, 'expire')
+                    ? \App\Models\Order::PAYMENT_STATE_EXPIRED
+                    : \App\Models\Order::PAYMENT_STATE_CANCELED;
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/app/Services/Payments/PaymentService.php
+++ b/backend/app/Services/Payments/PaymentService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Payments;
 
+use App\Models\Order;
 use App\Services\Commerce\SkuPriceService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -9,22 +10,30 @@ use Illuminate\Support\Str;
 class PaymentService
 {
     public const BENEFIT_TYPE = 'report_unlock';
+
     public const BENEFIT_REF = 'mbti_report_v1';
+
     private const PAYMENT_PROVIDER_INTERNAL = 'internal';
+
     private const PAYMENT_PROVIDER_MOCK = 'mock';
+
     private const MAX_ORDER_QUANTITY = 1000;
+
     private const MAX_INT32 = 2147483647;
 
     public function __construct(
         private PaymentRouter $router,
         private SkuPriceService $skuPriceService,
-    ) {
-    }
+    ) {}
 
     public function createOrder(array $data, array $actor = []): array
     {
         $itemSku = strtoupper(trim((string) ($data['item_sku'] ?? '')));
         $currency = strtoupper(trim((string) ($data['currency'] ?? 'CNY')));
+        $userId = $this->trimOrNull($data['user_id'] ?? ($actor['user_id'] ?? null));
+        $anonId = $this->trimOrNull($data['anon_id'] ?? ($actor['anon_id'] ?? null));
+        $channel = Order::normalizeChannel($this->trimOrNull($data['channel'] ?? null)) ?? 'web';
+        $providerApp = $this->trimOrNull($data['provider_app'] ?? null);
         $qtyRaw = $data['quantity'] ?? 1;
         $qty = is_numeric($qtyRaw) ? (int) $qtyRaw : 1;
         if ($qty < 1 || $qty > self::MAX_ORDER_QUANTITY) {
@@ -44,17 +53,23 @@ class PaymentService
         $amountCents = $unitPriceCents * $qty;
 
         $orderId = (string) Str::uuid();
+        $orderNo = 'ord_'.Str::uuid();
         $now = now();
 
         $row = [
             'id' => $orderId,
-            'user_id' => $this->trimOrNull($data['user_id'] ?? ($actor['user_id'] ?? null)),
-            'anon_id' => $this->trimOrNull($data['anon_id'] ?? ($actor['anon_id'] ?? null)),
+            'order_no' => $orderNo,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
             'device_id' => $this->trimOrNull($data['device_id'] ?? null),
             'provider' => $this->trimOrNull($data['provider'] ?? null) ?: 'internal',
+            'channel' => $channel,
+            'provider_app' => $providerApp,
             'provider_order_id' => $this->trimOrNull($data['provider_order_id'] ?? null),
             'org_id' => $legacyOrgId,
-            'status' => 'pending',
+            'status' => Order::STATUS_PENDING,
+            'payment_state' => Order::PAYMENT_STATE_PENDING,
+            'grant_state' => Order::GRANT_STATE_NOT_STARTED,
             'currency' => $currency,
             'amount_total' => $amountCents,
             'amount_cents' => $amountCents,
@@ -64,6 +79,7 @@ class PaymentService
             'quantity' => $qty,
             'request_id' => $this->trimOrNull($data['request_id'] ?? null),
             'created_ip' => $this->trimOrNull($data['ip'] ?? null),
+            'external_user_ref' => $this->resolveExternalUserRef($userId, $anonId),
             'paid_at' => null,
             'fulfilled_at' => null,
             'refunded_at' => null,
@@ -83,11 +99,14 @@ class PaymentService
     public function markPaid(string $orderId, string $userId, ?string $anonId, array $context = []): array
     {
         $order = $this->ownedOrderQuery($orderId, $userId, $anonId)->first();
-        if (!$order) {
+        if (! $order) {
             return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
         }
 
         if (in_array($order->status, ['paid', 'fulfilled'], true)) {
+            $this->syncLedgerStateForLegacyOrder($orderId, (string) ($order->status ?? ''));
+            $order = DB::table('orders')->where('id', $orderId)->first() ?: $order;
+
             return [
                 'ok' => true,
                 'order' => $order,
@@ -101,10 +120,10 @@ class PaymentService
         $now = now();
 
         $provider = self::PAYMENT_PROVIDER_INTERNAL;
-        $providerEventId = 'dev_mark_paid:' . $orderId;
+        $providerEventId = 'dev_mark_paid:'.$orderId;
         $existing = $this->paymentEventQuery($provider, $providerEventId)->first();
 
-        if (!$existing) {
+        if (! $existing) {
             $payload = [
                 'mode' => 'dev',
                 'event' => 'mark_paid',
@@ -132,7 +151,8 @@ class PaymentService
         DB::table('orders')
             ->where('id', $orderId)
             ->update([
-                'status' => 'paid',
+                'status' => Order::STATUS_PAID,
+                'payment_state' => Order::PAYMENT_STATE_PAID,
                 'paid_at' => $now,
                 'updated_at' => $now,
             ]);
@@ -148,20 +168,25 @@ class PaymentService
     public function fulfill(string $orderId, string $userId, ?string $anonId): array
     {
         $order = $this->ownedOrderQuery($orderId, $userId, $anonId)->first();
-        if (!$order) {
+        if (! $order) {
             return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
         }
 
-        if (!in_array($order->status, ['paid', 'fulfilled'], true)) {
+        if ($order->status === 'fulfilled') {
+            $this->syncLedgerStateForLegacyOrder($orderId, (string) ($order->status ?? ''));
+            $order = DB::table('orders')->where('id', $orderId)->first() ?: $order;
+        }
+
+        if (! in_array($order->status, ['paid', 'fulfilled'], true)) {
             return $this->conflict('ORDER_NOT_PAID', 'order status not paid.');
         }
 
         $targetUserId = $this->trimOrNull($userId) ?: $this->trimOrNull($order->user_id ?? null);
-        if (!$targetUserId) {
+        if (! $targetUserId) {
             $targetUserId = $this->trimOrNull($anonId) ?: $this->trimOrNull($order->anon_id ?? null);
         }
 
-        if (!$targetUserId) {
+        if (! $targetUserId) {
             return [
                 'ok' => false,
                 'status' => 422,
@@ -177,7 +202,7 @@ class PaymentService
             ->where('benefit_ref', self::BENEFIT_REF)
             ->first();
 
-        if (!$benefitRow) {
+        if (! $benefitRow) {
             $benefitRow = [
                 'id' => (string) Str::uuid(),
                 'user_id' => $targetUserId,
@@ -198,7 +223,9 @@ class PaymentService
             DB::table('orders')
                 ->where('id', $orderId)
                 ->update([
-                    'status' => 'fulfilled',
+                    'status' => Order::STATUS_FULFILLED,
+                    'payment_state' => Order::PAYMENT_STATE_PAID,
+                    'grant_state' => Order::GRANT_STATE_GRANTED,
                     'fulfilled_at' => $now,
                     'updated_at' => $now,
                 ]);
@@ -255,21 +282,22 @@ class PaymentService
     {
         $provider = self::PAYMENT_PROVIDER_MOCK;
         $providerEventId = $this->trimOrNull($payload['provider_event_id'] ?? null);
-        if (!$providerEventId) {
+        if (! $providerEventId) {
             return $this->invalid('MISSING_EVENT_ID', 'provider_event_id missing.');
         }
 
         $providerOrderId = $this->trimOrNull($payload['provider_order_id'] ?? null);
-        if (!$providerOrderId) {
+        if (! $providerOrderId) {
             return $this->invalid('MISSING_ORDER_ID', 'provider_order_id missing.');
         }
 
         $eventType = $this->trimOrNull($payload['event_type'] ?? null);
-        if (!$eventType) {
+        if (! $eventType) {
             return $this->invalid('MISSING_EVENT_TYPE', 'event_type missing.');
         }
 
         $signatureOk = (bool) ($context['signature_ok'] ?? false);
+
         return DB::transaction(function () use (
             $provider,
             $providerEventId,
@@ -285,7 +313,7 @@ class PaymentService
                 ->first();
 
             $now = now();
-            if (!$order) {
+            if (! $order) {
                 return [
                     'ok' => false,
                     'status' => 404,
@@ -331,7 +359,7 @@ class PaymentService
                 ];
             }
 
-            if (!$signatureOk) {
+            if (! $signatureOk) {
                 $this->paymentEventQuery($provider, $providerEventId)->update([
                     'handled_at' => $now,
                     'handle_status' => 'signature_invalid',
@@ -363,7 +391,7 @@ class PaymentService
                     $actorId = $actorUserId ?? $actorAnonId ?? '';
 
                     $fulfillResult = $this->fulfill($orderId, $actorId, $actorAnonId);
-                    if (!$fulfillResult['ok']) {
+                    if (! $fulfillResult['ok']) {
                         $handleStatus = 'fulfill_failed';
                     }
                 } else {
@@ -420,7 +448,7 @@ class PaymentService
         $anonId = $this->trimOrNull($anonId);
 
         $query = DB::table('orders')->where('id', $orderId);
-        if (!$userId && !$anonId) {
+        if (! $userId && ! $anonId) {
             return $query->whereRaw('1=0');
         }
 
@@ -441,7 +469,7 @@ class PaymentService
                 }
             }
 
-            if (!$applied) {
+            if (! $applied) {
                 $q->whereRaw('1=0');
             }
         });
@@ -491,11 +519,49 @@ class PaymentService
 
     private function trimOrNull($value): ?string
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return null;
         }
         $v = trim($value);
+
         return $v !== '' ? $v : null;
+    }
+
+    private function resolveExternalUserRef(?string $userId, ?string $anonId): ?string
+    {
+        if ($userId !== null) {
+            return substr('user:'.$userId, 0, 128);
+        }
+
+        if ($anonId !== null) {
+            return substr('anon:'.$anonId, 0, 128);
+        }
+
+        return null;
+    }
+
+    private function syncLedgerStateForLegacyOrder(string $orderId, string $status): void
+    {
+        $normalizedStatus = strtolower(trim($status));
+        $updates = [];
+
+        if (in_array($normalizedStatus, [Order::STATUS_PAID, Order::STATUS_FULFILLED], true)) {
+            $updates['payment_state'] = Order::PAYMENT_STATE_PAID;
+        }
+
+        if ($normalizedStatus === Order::STATUS_FULFILLED) {
+            $updates['grant_state'] = Order::GRANT_STATE_GRANTED;
+        }
+
+        if ($updates === []) {
+            return;
+        }
+
+        $updates['updated_at'] = now();
+
+        DB::table('orders')
+            ->where('id', $orderId)
+            ->update($updates);
     }
 
     private function presentBenefit($row): array

--- a/backend/database/migrations/2026_03_26_120000_add_order_ledger_states_to_orders_table.php
+++ b/backend/database/migrations/2026_03_26_120000_add_order_ledger_states_to_orders_table.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const CHANNEL_INDEX = 'orders_channel_idx';
+
+    private const PAYMENT_STATE_INDEX = 'orders_payment_state_idx';
+
+    private const GRANT_STATE_INDEX = 'orders_grant_state_idx';
+
+    private const PAID_AT_INDEX = 'orders_paid_at_idx';
+
+    private const PROVIDER_TRADE_NO_INDEX = 'orders_provider_trade_no_idx';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('orders')) {
+            return;
+        }
+
+        Schema::table('orders', function (Blueprint $table): void {
+            if (! Schema::hasColumn('orders', 'channel')) {
+                $table->string('channel', 64)->nullable()->after('provider');
+            }
+            if (! Schema::hasColumn('orders', 'provider_app')) {
+                $table->string('provider_app', 128)->nullable()->after('channel');
+            }
+            if (! Schema::hasColumn('orders', 'payment_state')) {
+                $table->string('payment_state', 32)->default('created')->after('status');
+            }
+            if (! Schema::hasColumn('orders', 'grant_state')) {
+                $table->string('grant_state', 32)->default('not_started')->after('payment_state');
+            }
+            if (! Schema::hasColumn('orders', 'provider_trade_no')) {
+                $table->string('provider_trade_no', 128)->nullable()->after('external_trade_no');
+            }
+            if (! Schema::hasColumn('orders', 'expired_at')) {
+                $table->timestamp('expired_at')->nullable()->after('paid_at');
+            }
+            if (! Schema::hasColumn('orders', 'closed_at')) {
+                $table->timestamp('closed_at')->nullable()->after('expired_at');
+            }
+            if (! Schema::hasColumn('orders', 'last_payment_event_at')) {
+                $table->timestamp('last_payment_event_at')->nullable()->after('closed_at');
+            }
+            if (! Schema::hasColumn('orders', 'last_reconciled_at')) {
+                $table->timestamp('last_reconciled_at')->nullable()->after('last_payment_event_at');
+            }
+            if (! Schema::hasColumn('orders', 'external_user_ref')) {
+                $table->string('external_user_ref', 128)->nullable()->after('contact_email_hash');
+            }
+        });
+
+        $this->ensureIndex('orders', 'channel', self::CHANNEL_INDEX);
+        $this->ensureIndex('orders', 'payment_state', self::PAYMENT_STATE_INDEX);
+        $this->ensureIndex('orders', 'grant_state', self::GRANT_STATE_INDEX);
+        $this->ensureIndex('orders', 'paid_at', self::PAID_AT_INDEX);
+        $this->ensureIndex('orders', 'provider_trade_no', self::PROVIDER_TRADE_NO_INDEX);
+
+        $this->backfillPaymentState();
+        $this->backfillGrantState();
+        $this->backfillExternalUserRef();
+    }
+
+    public function down(): void
+    {
+        // Forward-only migration.
+    }
+
+    private function ensureIndex(string $table, string $column, string $indexName): void
+    {
+        if (! Schema::hasColumn($table, $column) || SchemaIndex::indexExists($table, $indexName)) {
+            return;
+        }
+
+        Schema::table($table, function (Blueprint $table) use ($column, $indexName): void {
+            $table->index($column, $indexName);
+        });
+    }
+
+    private function backfillPaymentState(): void
+    {
+        if (! Schema::hasColumn('orders', 'payment_state') || ! Schema::hasColumn('orders', 'status')) {
+            return;
+        }
+
+        DB::table('orders')->update(['payment_state' => 'created']);
+
+        foreach ([
+            'created' => 'created',
+            'pending' => 'pending',
+            'paid' => 'paid',
+            'fulfilled' => 'paid',
+            'failed' => 'failed',
+            'canceled' => 'canceled',
+            'cancelled' => 'canceled',
+            'expired' => 'expired',
+            'refunded' => 'refunded',
+        ] as $status => $paymentState) {
+            DB::table('orders')
+                ->whereRaw("lower(coalesce(status, '')) = ?", [$status])
+                ->update(['payment_state' => $paymentState]);
+        }
+    }
+
+    private function backfillGrantState(): void
+    {
+        if (! Schema::hasColumn('orders', 'grant_state')) {
+            return;
+        }
+
+        DB::table('orders')->update(['grant_state' => 'not_started']);
+
+        if (Schema::hasTable('benefit_grants') && Schema::hasColumn('benefit_grants', 'order_no')) {
+            if (Schema::hasColumn('benefit_grants', 'status')) {
+                DB::table('orders')
+                    ->whereIn('order_no', function ($query): void {
+                        $query->select('order_no')
+                            ->from('benefit_grants')
+                            ->whereNotNull('order_no')
+                            ->where('order_no', '!=', '')
+                            ->whereRaw("lower(coalesce(status, '')) = ?", ['active'])
+                            ->distinct();
+                    })
+                    ->update(['grant_state' => 'granted']);
+
+                DB::table('orders')
+                    ->where('grant_state', 'not_started')
+                    ->whereIn('order_no', function ($query): void {
+                        $query->select('order_no')
+                            ->from('benefit_grants')
+                            ->whereNotNull('order_no')
+                            ->where('order_no', '!=', '')
+                            ->whereRaw("lower(coalesce(status, '')) = ?", ['revoked'])
+                            ->distinct();
+                    })
+                    ->update(['grant_state' => 'revoked']);
+            } else {
+                DB::table('orders')
+                    ->whereIn('order_no', function ($query): void {
+                        $query->select('order_no')
+                            ->from('benefit_grants')
+                            ->whereNotNull('order_no')
+                            ->where('order_no', '!=', '')
+                            ->distinct();
+                    })
+                    ->update(['grant_state' => 'granted']);
+            }
+        }
+
+        if (Schema::hasColumn('orders', 'status')) {
+            DB::table('orders')
+                ->whereRaw("lower(coalesce(status, '')) = ?", ['fulfilled'])
+                ->update(['grant_state' => 'granted']);
+        }
+    }
+
+    private function backfillExternalUserRef(): void
+    {
+        if (! Schema::hasColumn('orders', 'external_user_ref')) {
+            return;
+        }
+
+        DB::table('orders')
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->select(['id', 'user_id', 'anon_id', 'contact_email_hash'])
+            ->chunk(500, function ($rows): void {
+                foreach ($rows as $row) {
+                    $externalUserRef = $this->resolveExternalUserRef(
+                        $row->user_id ?? null,
+                        $row->anon_id ?? null,
+                        $row->contact_email_hash ?? null
+                    );
+
+                    if ($externalUserRef === null) {
+                        continue;
+                    }
+
+                    DB::table('orders')
+                        ->where('id', (string) $row->id)
+                        ->where(function ($query): void {
+                            $query->whereNull('external_user_ref')
+                                ->orWhere('external_user_ref', '');
+                        })
+                        ->update([
+                            'external_user_ref' => $externalUserRef,
+                        ]);
+                }
+            });
+    }
+
+    private function resolveExternalUserRef(mixed $userId, mixed $anonId, mixed $contactEmailHash): ?string
+    {
+        $normalizedUserId = trim((string) $userId);
+        if ($normalizedUserId !== '') {
+            return substr('user:'.$normalizedUserId, 0, 128);
+        }
+
+        $normalizedAnonId = trim((string) $anonId);
+        if ($normalizedAnonId !== '') {
+            return substr('anon:'.$normalizedAnonId, 0, 128);
+        }
+
+        $normalizedContactHash = trim((string) $contactEmailHash);
+        if ($normalizedContactHash !== '') {
+            return substr('email_hash:'.$normalizedContactHash, 0, 128);
+        }
+
+        return null;
+    }
+};

--- a/backend/tests/Feature/Commerce/OrderLedgerBackfillTest.php
+++ b/backend/tests/Feature/Commerce/OrderLedgerBackfillTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class OrderLedgerBackfillTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_order_ledger_backfill_maps_legacy_status_and_existing_grants(): void
+    {
+        $orderNo = 'ord_backfill_contract_1';
+        $attemptId = (string) Str::uuid();
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_backfill_contract',
+            'sku' => 'MBTI_REPORT_FULL',
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 299,
+            'amount_total' => 299,
+            'amount_refunded' => 0,
+            'currency' => 'CNY',
+            'status' => 'fulfilled',
+            'payment_state' => 'created',
+            'grant_state' => 'not_started',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'provider_trade_no' => null,
+            'contact_email_hash' => null,
+            'external_user_ref' => null,
+            'created_at' => now()->subDay(),
+            'updated_at' => now()->subDay(),
+            'paid_at' => now()->subDay(),
+            'fulfilled_at' => now()->subHours(20),
+            'refunded_at' => null,
+        ]);
+
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'user_id' => null,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'status' => 'active',
+            'benefit_ref' => 'anon_backfill_contract',
+            'benefit_type' => 'report_unlock',
+            'source_order_id' => (string) Str::uuid(),
+            'created_at' => now()->subDay(),
+            'updated_at' => now()->subDay(),
+        ]);
+
+        $migration = require database_path('migrations/2026_03_26_120000_add_order_ledger_states_to_orders_table.php');
+        $migration->up();
+
+        $row = DB::table('orders')->where('order_no', $orderNo)->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('paid', (string) ($row->payment_state ?? ''));
+        $this->assertSame('granted', (string) ($row->grant_state ?? ''));
+        $this->assertSame('anon:anon_backfill_contract', (string) ($row->external_user_ref ?? ''));
+    }
+
+    public function test_order_ledger_backfill_marks_revoked_grants_without_active_entitlement(): void
+    {
+        $orderNo = 'ord_backfill_contract_revoked_1';
+        $attemptId = (string) Str::uuid();
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_backfill_revoked',
+            'sku' => 'MBTI_REPORT_FULL',
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 299,
+            'amount_total' => 299,
+            'amount_refunded' => 299,
+            'currency' => 'CNY',
+            'status' => 'refunded',
+            'payment_state' => 'created',
+            'grant_state' => 'not_started',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'provider_trade_no' => null,
+            'contact_email_hash' => null,
+            'external_user_ref' => null,
+            'created_at' => now()->subDay(),
+            'updated_at' => now()->subHours(20),
+            'paid_at' => now()->subDay(),
+            'fulfilled_at' => now()->subHours(22),
+            'refunded_at' => now()->subHours(20),
+        ]);
+
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'user_id' => null,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'status' => 'revoked',
+            'benefit_ref' => 'anon_backfill_revoked',
+            'benefit_type' => 'report_unlock',
+            'source_order_id' => (string) Str::uuid(),
+            'created_at' => now()->subDay(),
+            'updated_at' => now()->subHours(20),
+        ]);
+
+        $migration = require database_path('migrations/2026_03_26_120000_add_order_ledger_states_to_orders_table.php');
+        $migration->up();
+
+        $row = DB::table('orders')->where('order_no', $orderNo)->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('refunded', (string) ($row->payment_state ?? ''));
+        $this->assertSame('revoked', (string) ($row->grant_state ?? ''));
+    }
+}

--- a/backend/tests/Feature/Commerce/OrderLedgerStateContractTest.php
+++ b/backend/tests/Feature/Commerce/OrderLedgerStateContractTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Models\Attempt;
+use App\Services\Commerce\EntitlementManager;
+use App\Services\Commerce\OrderManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class OrderLedgerStateContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_order_manager_initializes_split_order_ledger_fields(): void
+    {
+        $attemptId = $this->createAttempt('anon_order_ledger_init', 'web');
+        $this->seedSku('MBTI_REPORT_FULL', 'MBTI_REPORT_FULL');
+
+        $created = app(OrderManager::class)->createOrder(
+            0,
+            null,
+            'anon_order_ledger_init',
+            'MBTI_REPORT_FULL',
+            1,
+            $attemptId,
+            'billing',
+            null,
+            'order-ledger-init@example.com',
+            null,
+            [],
+            [],
+            [
+                'channel' => 'wechat_miniapp',
+                'provider_app' => 'wx-miniapp-primary',
+            ]
+        );
+
+        $this->assertTrue((bool) ($created['ok'] ?? false));
+
+        $order = DB::table('orders')
+            ->where('order_no', (string) ($created['order_no'] ?? ''))
+            ->first();
+
+        $this->assertNotNull($order);
+        $this->assertSame('created', (string) ($order->status ?? ''));
+        $this->assertSame('created', (string) ($order->payment_state ?? ''));
+        $this->assertSame('not_started', (string) ($order->grant_state ?? ''));
+        $this->assertSame('wechat_miniapp', (string) ($order->channel ?? ''));
+        $this->assertSame('wx-miniapp-primary', (string) ($order->provider_app ?? ''));
+        $this->assertSame('anon:anon_order_ledger_init', (string) ($order->external_user_ref ?? ''));
+    }
+
+    public function test_order_ledger_tracks_pending_paid_and_granted_separately(): void
+    {
+        $attemptId = $this->createAttempt('anon_order_ledger_flow', 'web');
+        $this->seedSku('MBTI_REPORT_FULL', 'MBTI_REPORT_FULL');
+
+        $created = app(OrderManager::class)->createOrder(
+            0,
+            null,
+            'anon_order_ledger_flow',
+            'MBTI_REPORT_FULL',
+            1,
+            $attemptId,
+            'billing',
+            null,
+            'order-ledger-flow@example.com',
+            null,
+            [],
+            [],
+            [
+                'channel' => 'web',
+            ]
+        );
+
+        $orderNo = (string) ($created['order_no'] ?? '');
+        $this->assertNotSame('', $orderNo);
+
+        app(OrderManager::class)->markPaymentPending($orderNo, 0, 'web', null);
+
+        $pending = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($pending);
+        $this->assertSame('pending', (string) ($pending->status ?? ''));
+        $this->assertSame('pending', (string) ($pending->payment_state ?? ''));
+        $this->assertSame('not_started', (string) ($pending->grant_state ?? ''));
+
+        $deliveryBeforePaid = app(OrderManager::class)->presentOrderDelivery($pending);
+        $this->assertFalse((bool) data_get($deliveryBeforePaid, 'delivery.can_view_report'));
+
+        $paid = app(OrderManager::class)->transitionToPaidAtomic(
+            $orderNo,
+            0,
+            'trade_order_ledger_flow_1',
+            now()->toIso8601String()
+        );
+
+        $this->assertTrue((bool) ($paid['ok'] ?? false));
+
+        $paidOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($paidOrder);
+        $this->assertSame('paid', (string) ($paidOrder->payment_state ?? ''));
+        $this->assertSame('not_started', (string) ($paidOrder->grant_state ?? ''));
+        $this->assertSame('trade_order_ledger_flow_1', (string) ($paidOrder->provider_trade_no ?? ''));
+
+        $deliveryAfterPaid = app(OrderManager::class)->presentOrderDelivery($paidOrder);
+        $this->assertFalse((bool) data_get($deliveryAfterPaid, 'delivery.can_view_report'));
+
+        $grant = app(EntitlementManager::class)->grantAttemptUnlock(
+            0,
+            null,
+            'anon_order_ledger_flow',
+            'MBTI_REPORT_FULL',
+            $attemptId,
+            $orderNo
+        );
+
+        $this->assertTrue((bool) ($grant['ok'] ?? false));
+
+        $fulfilled = app(OrderManager::class)->transition($orderNo, 'fulfilled', 0);
+        $this->assertTrue((bool) ($fulfilled['ok'] ?? false));
+
+        $fulfilledOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($fulfilledOrder);
+        $this->assertSame('fulfilled', (string) ($fulfilledOrder->status ?? ''));
+        $this->assertSame('paid', (string) ($fulfilledOrder->payment_state ?? ''));
+        $this->assertSame('granted', (string) ($fulfilledOrder->grant_state ?? ''));
+
+        $deliveryAfterGrant = app(OrderManager::class)->presentOrderDelivery($fulfilledOrder);
+        $this->assertTrue((bool) data_get($deliveryAfterGrant, 'delivery.can_view_report'));
+    }
+
+    private function createAttempt(string $anonId, string $channel): string
+    {
+        $attempt = Attempt::query()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 60,
+            'answers_summary_json' => ['stage' => 'seed'],
+            'client_platform' => 'test',
+            'channel' => $channel,
+            'started_at' => now()->subMinutes(3),
+            'submitted_at' => now(),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'mbti_spec_v1',
+        ]);
+
+        return (string) $attempt->id;
+    }
+
+    private function seedSku(string $sku, string $benefitCode): void
+    {
+        $now = now();
+
+        DB::table('skus')->updateOrInsert(
+            ['sku' => $sku],
+            [
+                'org_id' => 0,
+                'scale_code' => 'MBTI',
+                'kind' => 'report_unlock',
+                'unit_qty' => 1,
+                'benefit_code' => $benefitCode,
+                'scope' => 'attempt',
+                'price_cents' => 299,
+                'currency' => 'CNY',
+                'is_active' => true,
+                'meta_json' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+    }
+}

--- a/backend/tests/Feature/Commerce/OrderPricingTest.php
+++ b/backend/tests/Feature/Commerce/OrderPricingTest.php
@@ -35,8 +35,15 @@ final class OrderPricingTest extends TestCase
 
         $stored = DB::table('orders')->where('id', $orderId)->first();
         $this->assertNotNull($stored);
+        $this->assertStringStartsWith('ord_', (string) ($stored->order_no ?? ''));
         $this->assertSame(1990, (int) ($stored->amount_total ?? 0));
         $this->assertSame(1990, (int) ($stored->amount_cents ?? 0));
+        $this->assertSame('pending', (string) ($stored->status ?? ''));
+        $this->assertSame('pending', (string) ($stored->payment_state ?? ''));
+        $this->assertSame('not_started', (string) ($stored->grant_state ?? ''));
+        $this->assertSame('user:u_pricing_1', (string) ($stored->external_user_ref ?? ''));
+        $this->assertSame('web', (string) ($stored->channel ?? ''));
+        $this->assertNull($stored->provider_app ?? null);
     }
 
     public function test_create_order_throws_invalid_sku_exception_when_sku_does_not_exist(): void
@@ -71,6 +78,41 @@ final class OrderPricingTest extends TestCase
         $this->assertFalse((bool) ($result['ok'] ?? true));
         $this->assertSame('AMOUNT_TOO_LARGE', (string) ($result['error_code'] ?? ''));
         $this->assertSame(422, (int) ($result['status'] ?? 0));
+    }
+
+    public function test_mark_paid_and_fulfill_keep_split_states_in_sync(): void
+    {
+        $this->seedSku('MBTI_FULL', 1990, 'CNY');
+
+        $created = app(PaymentService::class)->createOrder([
+            'user_id' => 'u_pricing_flow',
+            'item_sku' => 'MBTI_FULL',
+            'quantity' => 1,
+            'currency' => 'CNY',
+            'channel' => 'web',
+        ]);
+
+        $order = $created['order'] ?? null;
+        $orderId = is_array($order) ? (string) ($order['id'] ?? '') : (string) ($order->id ?? '');
+        $this->assertNotSame('', $orderId);
+
+        $paid = app(PaymentService::class)->markPaid($orderId, 'u_pricing_flow', null);
+        $this->assertTrue((bool) ($paid['ok'] ?? false));
+
+        $paidRow = DB::table('orders')->where('id', $orderId)->first();
+        $this->assertNotNull($paidRow);
+        $this->assertSame('paid', (string) ($paidRow->status ?? ''));
+        $this->assertSame('paid', (string) ($paidRow->payment_state ?? ''));
+        $this->assertSame('not_started', (string) ($paidRow->grant_state ?? ''));
+
+        $fulfilled = app(PaymentService::class)->fulfill($orderId, 'u_pricing_flow', null);
+        $this->assertTrue((bool) ($fulfilled['ok'] ?? false));
+
+        $fulfilledRow = DB::table('orders')->where('id', $orderId)->first();
+        $this->assertNotNull($fulfilledRow);
+        $this->assertSame('fulfilled', (string) ($fulfilledRow->status ?? ''));
+        $this->assertSame('paid', (string) ($fulfilledRow->payment_state ?? ''));
+        $this->assertSame('granted', (string) ($fulfilledRow->grant_state ?? ''));
     }
 
     private function seedSku(string $sku, int $priceCents, string $currency): void

--- a/backend/tests/Feature/Commerce/RefundRevokesEntitlementTest.php
+++ b/backend/tests/Feature/Commerce/RefundRevokesEntitlementTest.php
@@ -81,6 +81,8 @@ class RefundRevokesEntitlementTest extends TestCase
         $job->handle(app(OrderManager::class), app(EntitlementManager::class));
 
         $this->assertSame('refunded', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
+        $this->assertSame('refunded', (string) DB::table('orders')->where('order_no', $orderNo)->value('payment_state'));
+        $this->assertSame('revoked', (string) DB::table('orders')->where('order_no', $orderNo)->value('grant_state'));
         $this->assertSame('revoked', (string) DB::table('benefit_grants')->where('order_no', $orderNo)->value('status'));
 
         $this->assertDatabaseHas('audit_logs', [

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -136,6 +136,9 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertStatus(200);
         $response->assertJsonPath('provider', 'billing');
         $response->assertJsonPath('status', 'pending');
+        $response->assertJsonPath('payment_state', 'pending');
+        $response->assertJsonPath('grant_state', 'not_started');
+        $response->assertJsonPath('channel', 'web');
         $response->assertJsonPath('result_url', 'https://web.example.test/en/result/'.$attemptId);
 
         $orderNo = (string) $response->json('order_no');
@@ -147,6 +150,9 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $this->assertStringContainsString('/en/pay/wait', $waitUrl);
         $this->assertStringContainsString('order_no='.$orderNo, $waitUrl);
         $this->assertStringContainsString('payment_recovery_token=', $waitUrl);
+        $this->assertSame('pending', (string) DB::table('orders')->where('order_no', $orderNo)->value('payment_state'));
+        $this->assertSame('not_started', (string) DB::table('orders')->where('order_no', $orderNo)->value('grant_state'));
+        $this->assertSame('web', (string) DB::table('orders')->where('order_no', $orderNo)->value('channel'));
     }
 
     public function test_checkout_wechatpay_desktop_returns_qr_action(): void

--- a/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
@@ -266,6 +266,9 @@ final class PaymentWebhookControllerTest extends TestCase
         $this->assertNoLegacyErrorKey($second);
 
         $this->assertSame('fulfilled', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
+        $this->assertSame('paid', (string) DB::table('orders')->where('order_no', $orderNo)->value('payment_state'));
+        $this->assertSame('not_started', (string) DB::table('orders')->where('order_no', $orderNo)->value('grant_state'));
+        $this->assertNotNull(DB::table('orders')->where('order_no', $orderNo)->value('last_payment_event_at'));
         $this->assertSame(1, DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_sec002_bill_1')

--- a/backend/tests/Unit/Services/Commerce/WechatPayGatewayOrderNoMappingTest.php
+++ b/backend/tests/Unit/Services/Commerce/WechatPayGatewayOrderNoMappingTest.php
@@ -19,7 +19,7 @@ final class WechatPayGatewayOrderNoMappingTest extends TestCase
 
     public function test_normalize_payload_supports_resource_ciphertext_array(): void
     {
-        $gateway = new WechatPayGateway();
+        $gateway = new WechatPayGateway;
 
         $normalized = $gateway->normalizePayload([
             'id' => 'evt_resource_ciphertext_array_001',
@@ -46,7 +46,7 @@ final class WechatPayGatewayOrderNoMappingTest extends TestCase
 
     public function test_normalize_payload_supports_result_ciphertext_json_string(): void
     {
-        $gateway = new WechatPayGateway();
+        $gateway = new WechatPayGateway;
 
         $cipher = json_encode([
             'out_trade_no' => '8300b57f665041c19b48143275669567',
@@ -77,7 +77,7 @@ final class WechatPayGatewayOrderNoMappingTest extends TestCase
     {
         $this->seedCommerceCatalog();
 
-        $outTradeNo = 'wx' . substr(hash('sha256', 'legacy-order-no-001'), 0, 30);
+        $outTradeNo = 'wx'.substr(hash('sha256', 'legacy-order-no-001'), 0, 30);
         $expectedOrderNo = $this->createOrderAndBindExternalTradeNo($outTradeNo);
 
         $cipher = json_encode([
@@ -92,7 +92,7 @@ final class WechatPayGatewayOrderNoMappingTest extends TestCase
 
         $this->assertIsString($cipher);
 
-        $gateway = new WechatPayGateway();
+        $gateway = new WechatPayGateway;
         $normalized = $gateway->normalizePayload([
             'resource' => [
                 'ciphertext' => $cipher,
@@ -159,17 +159,28 @@ final class WechatPayGatewayOrderNoMappingTest extends TestCase
     private function resolveSeededSku(): string
     {
         if (Schema::hasColumn('skus', 'org_id')) {
-            $sku = (string) DB::table('skus')->where('org_id', 0)->orderBy('sku')->value('sku');
+            $sku = (string) DB::table('skus')
+                ->where('org_id', 0)
+                ->where('is_active', true)
+                ->orderBy('sku')
+                ->value('sku');
             if ($sku !== '') {
                 return $sku;
             }
 
-            $sku = (string) DB::table('skus')->where('org_id', 1)->orderBy('sku')->value('sku');
+            $sku = (string) DB::table('skus')
+                ->where('org_id', 1)
+                ->where('is_active', true)
+                ->orderBy('sku')
+                ->value('sku');
             if ($sku !== '') {
                 return $sku;
             }
         }
 
-        return (string) DB::table('skus')->orderBy('sku')->value('sku');
+        return (string) DB::table('skus')
+            ->where('is_active', true)
+            ->orderBy('sku')
+            ->value('sku');
     }
 }


### PR DESCRIPTION
## Summary
This PR finishes OP-1 by turning the existing `orders` table into a backend-owned unified order ledger that can reliably answer three operational questions: who created an order, who is still unpaid, and who has paid but has not yet been granted access.

The core issue before this change was not the absence of an order table, but that payment truth and grant truth were still mixed together in legacy `status` semantics. That made unpaid orders hard to reason about, made paid-but-not-granted states hard to surface, and allowed some legacy writers and readers to drift away from the new ledger contract.

## What changed
The PR adds additive ledger fields on `orders`, including normalized payment and grant state, channel metadata, provider-side trade identifiers, and key timestamps. The legacy `status` field is preserved for compatibility, but new code now treats `payment_state` and `grant_state` as the primary truth.

Order creation, checkout pay-action generation, verified payment webhooks, entitlement grants, and refund handling now all write back into the split-state ledger model. This keeps backend callback handling as the source of truth while allowing the ledger to distinguish `created`, `pending`, `paid`, `failed`, `canceled`, `expired`, `refunded`, `not_started`, `granted`, `grant_failed`, and `revoked` without overloading one text field.

The PR also includes a minimal additive backfill migration so historical rows are mapped into the new state model. That backfill now avoids falsely marking revoked grants as granted by preferring active grant rows and only marking revoked orders as revoked when no active entitlement remains.

Finally, the work closes the remaining OP-1 compatibility gaps that surfaced during review. Legacy read flows that only had old `status` values were being misread as `pending` because the new columns defaulted to `created`/`not_started`. The resolver now safely falls back to legacy truth when a row is clearly still legacy-shaped. The legacy `PaymentService` writer was also aligned so that if it is still used anywhere, it produces ledger-compatible rows instead of bypassing the OP-1 contract.

## User impact
Before this PR, operations could not reliably separate unpaid orders from paid orders awaiting fulfillment, and some read/recovery endpoints could regress when they encountered legacy-only rows. After this PR, the backend can expose and reason about those states consistently without trusting frontend success pages or provider consoles as the source of truth.

## Scope boundaries kept
This PR does not introduce payment attempts, reconciliation jobs, close-expired schedulers, new provider integrations, or a large ops dashboard rewrite. It stays within the OP-1 boundary of standardizing the order ledger itself.

## Validation
I validated the ledger contract and compatibility paths with focused backend coverage, including:

- `php artisan route:list --path=api/v0.3/orders`
- `php artisan test --filter="OrderPricingTest|OrderLedgerBackfillTest|CommerceOrderLookupSecurityTest|CommerceOrderReadFallbackTest|ClaimReportEmailRequestTest|CommerceCheckoutPayActionTest|PaymentWebhookControllerTest|CommerceRefundWebhookTest|CommerceWebhookIdempotencyTest|RefundRevokesEntitlementTest" --stop-on-failure`
- `php artisan test --filter="MbtiReportHttpContractRegressionTest|CommerceOrderResendTest|PaymentWebhookProcessorAtomicityTest|PaymentWebhookIdempotencyTest" --stop-on-failure`
- `php artisan test --filter="EmailLifecycleRolloutCommandTest|PostPurchaseFollowupTemplateDeliveryTest|EmailOutboxSendCommandTest" --stop-on-failure`
