### PR TITLE
Align MBTI quality read-side truth

### DIFF
--- a/backend/app/Filament/Ops/Resources/ResultResource/Support/ResultExplorerSupport.php
+++ b/backend/app/Filament/Ops/Resources/ResultResource/Support/ResultExplorerSupport.php
@@ -1259,24 +1259,24 @@ final class ResultExplorerSupport
      */
     private function fetchAttemptQualitySummary(Result $result): array
     {
-        if (! SchemaBaseline::hasTable('attempt_quality')) {
-            return ['summary' => '-', 'hint' => null];
-        }
-
-        $row = DB::table('attempt_quality')
-            ->select(['grade', 'created_at'])
-            ->where('attempt_id', (string) $result->attempt_id)
-            ->orderByDesc('created_at')
-            ->first();
-
-        if ($row === null) {
-            return ['summary' => 'missing', 'hint' => 'Raw checks_json stays hidden.'];
-        }
-
-        return [
-            'summary' => $this->stringOrDash($row->grade ?? null),
-            'hint' => 'Raw checks_json stays hidden.',
+        $payload = $this->arrayFromMixed($result->result_json);
+        $candidates = [
+            $payload['quality'] ?? null,
+            data_get($payload, 'normed_json.quality'),
         ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $summary = trim((string) ($candidate['grade'] ?? $candidate['level'] ?? ''));
+            if ($summary !== '') {
+                return ['summary' => $summary, 'hint' => null];
+            }
+        }
+
+        return ['summary' => '-', 'hint' => null];
     }
 
     /**

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -122,6 +122,7 @@ final class ReportPdfDocumentService
         )));
         $qualityLevel = strtoupper(trim((string) (
             data_get($gate, 'quality.level')
+            ?? data_get($result?->result_json, 'quality.level')
             ?? data_get($result?->result_json, 'normed_json.quality.level', '')
         )));
 

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -806,6 +806,7 @@ class ReportGatekeeper
     private function extractScoreContract(Result $result): array
     {
         $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $topLevelQuality = is_array($payload['quality'] ?? null) ? $payload['quality'] : [];
         $candidates = [
             $payload['normed_json'] ?? null,
             $payload['breakdown_json']['score_result'] ?? null,
@@ -819,19 +820,19 @@ class ReportGatekeeper
 
             $norms = is_array($candidate['norms'] ?? null) ? $candidate['norms'] : [];
             $quality = is_array($candidate['quality'] ?? null) ? $candidate['quality'] : [];
-            if ($norms === [] && $quality === []) {
+            if ($norms === [] && $quality === [] && $topLevelQuality === []) {
                 continue;
             }
 
             return [
                 'norms' => $norms,
-                'quality' => $quality,
+                'quality' => $topLevelQuality !== [] ? $topLevelQuality : $quality,
             ];
         }
 
         return [
             'norms' => [],
-            'quality' => [],
+            'quality' => $topLevelQuality,
         ];
     }
 

--- a/backend/tests/Feature/Ops/ResultsExplorerTest.php
+++ b/backend/tests/Feature/Ops/ResultsExplorerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Ops;
 
 use App\Filament\Ops\Resources\ResultResource\Pages\ListResults;
+use App\Filament\Ops\Resources\ResultResource\Support\ResultExplorerSupport;
 use App\Models\AdminUser;
 use App\Models\Attempt;
 use App\Models\Organization;
@@ -164,6 +165,35 @@ final class ResultsExplorerTest extends TestCase
             ->assertDontSee('Report page')
             ->assertDontSee('Attempt Explorer')
             ->assertSee('Report drill-through is unavailable while the attempt row is missing.');
+    }
+
+    public function test_results_explorer_prefers_result_quality_truth_and_no_longer_depends_on_attempt_quality(): void
+    {
+        $truthChain = $this->seedDiagnosticChain(orgId: 88, orderNo: 'ord_results_truth_001');
+        $truthResult = Result::query()->findOrFail((string) $truthChain['result']->getKey());
+        $truthPayload = is_array($truthResult->result_json ?? null) ? $truthResult->result_json : [];
+        $truthPayload['quality'] = [
+            'level' => 'B',
+            'grade' => 'B',
+        ];
+        $truthResult->update(['result_json' => $truthPayload]);
+        DB::table('attempt_quality')
+            ->where('attempt_id', (string) $truthChain['attempt_id'])
+            ->update(['grade' => 'A']);
+
+        $fallbackChain = $this->seedDiagnosticChain(orgId: 89, orderNo: 'ord_results_fallback_001');
+        $fallbackResult = Result::query()->findOrFail((string) $fallbackChain['result']->getKey());
+
+        /** @var ResultExplorerSupport $support */
+        $support = app(ResultExplorerSupport::class);
+
+        $truthDetail = $support->buildDetail($truthResult->fresh());
+        $truthQuality = collect($truthDetail['attempt_summary']['fields'])->firstWhere('label', 'quality');
+        $this->assertSame('B', $truthQuality['value'] ?? null);
+
+        $fallbackDetail = $support->buildDetail($fallbackResult);
+        $fallbackQuality = collect($fallbackDetail['attempt_summary']['fields'])->firstWhere('label', 'quality');
+        $this->assertSame('-', $fallbackQuality['value'] ?? null);
     }
 
     private function createOrganization(string $name): Organization

--- a/backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
@@ -9,6 +9,8 @@ use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Report\Composer\ReportComposeContext;
 use App\Services\Report\Composer\ReportPayloadAssembler;
+use App\Services\Report\Pdf\ReportPdfDocumentService;
+use App\Services\Report\ReportGatekeeper;
 use App\Support\OrgContext;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -149,6 +151,80 @@ final class MbtiReadPathParityContractTest extends TestCase
             'tone_profile_v1.tone_fingerprint',
             (array) data_get($readContract, 'telemetry_parity_fields', [])
         );
+    }
+
+    public function test_result_read_and_pdf_fallback_prefer_top_level_quality_truth(): void
+    {
+        $this->seedScales();
+        Config::set('fap_experiments.experiments', []);
+
+        $anonId = 'mbti_quality_truth_anon';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+
+        $result = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
+        $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $payload['quality'] = [
+            'level' => 'B',
+            'grade' => 'B',
+            'flags' => ['TOP_LEVEL'],
+        ];
+        $payload['normed_json'] = [
+            'quality' => [
+                'level' => 'D',
+                'grade' => 'D',
+                'flags' => ['NORMED'],
+            ],
+        ];
+        $payload['breakdown_json'] = [
+            'score_result' => [
+                'quality' => [
+                    'level' => 'C',
+                    'grade' => 'C',
+                    'flags' => ['BREAKDOWN'],
+                ],
+            ],
+        ];
+        $payload['axis_scores_json']['score_result'] = [
+            'quality' => [
+                'level' => 'A',
+                'grade' => 'A',
+                'flags' => ['AXIS'],
+            ],
+        ];
+        $result->update(['result_json' => $payload]);
+        $result->refresh();
+
+        /** @var ReportGatekeeper $gatekeeper */
+        $gatekeeper = app(ReportGatekeeper::class);
+        $gate = $gatekeeper->resolve(0, $attemptId, null, $anonId, 'public');
+
+        $this->assertTrue((bool) ($gate['ok'] ?? false));
+        $this->assertSame('B', (string) data_get($gate, 'quality.level'));
+        $this->assertSame(['TOP_LEVEL'], (array) data_get($gate, 'quality.flags', []));
+
+        $response = $this->invokeController('result', $attemptId, $anonId);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('B', (string) data_get($response->getData(true), 'result.quality.level'));
+        $this->assertSame(['TOP_LEVEL'], (array) data_get($response->getData(true), 'result.quality.flags', []));
+
+        /** @var ReportPdfDocumentService $pdfService */
+        $pdfService = app(ReportPdfDocumentService::class);
+        $pdf = $pdfService->getOrGenerate(
+            Attempt::query()->findOrFail($attemptId),
+            [
+                'variant' => 'free',
+                'locked' => true,
+                'report' => [
+                    'sections' => [
+                        ['key' => 'traits'],
+                    ],
+                ],
+            ],
+            $result
+        );
+
+        $this->assertStringContainsString('Quality Level: B', $pdf['binary']);
     }
 
     private function seedScales(): void


### PR DESCRIPTION
## Summary
- prefer `results.result_json.quality` in MBTI read-side paths
- keep legacy quality fallbacks behind current truth for gate and PDF reads
- remove the last runtime `attempt_quality` reader from Results Explorer

## Validation
- `php -l backend/app/Services/Report/ReportGatekeeper.php`
- `php -l backend/app/Services/Report/Pdf/ReportPdfDocumentService.php`
- `php -l backend/app/Filament/Ops/Resources/ResultResource/Support/ResultExplorerSupport.php`
- `php -l backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php`
- `php -l backend/tests/Feature/Ops/ResultsExplorerTest.php`
- `php artisan test tests/Feature/V0_3/MbtiReadPathParityContractTest.php --filter="test_result_read_and_pdf_fallback_prefer_top_level_quality_truth"`
- `php artisan test tests/Feature/Ops/ResultsExplorerTest.php --filter="test_results_explorer_prefers_result_quality_truth_and_no_longer_depends_on_attempt_quality"`
- `php artisan test tests/Feature/Report/ReportGatekeeperDecompositionContractTest.php`
- `php artisan test tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php`