### PR TITLE
[codex] retire mbti attempt quality mirror

### DIFF
--- a/backend/app/Services/AI/EvidenceBuilder.php
+++ b/backend/app/Services/AI/EvidenceBuilder.php
@@ -46,25 +46,6 @@ final class EvidenceBuilder
                 );
             }
 
-            $snapshot = $attempt->calculation_snapshot_json;
-            if (is_string($snapshot)) {
-                $decoded = json_decode($snapshot, true);
-                $snapshot = is_array($decoded) ? $decoded : null;
-            }
-
-            if (is_array($snapshot)) {
-                $version = trim((string) ($snapshot['version'] ?? ''));
-                if ($version !== '') {
-                    $this->pushEvidence(
-                        $items,
-                        'calc_snapshot_version',
-                        'psychometrics',
-                        'attempts.calculation_snapshot_json.version',
-                        "snapshot_version={$version}",
-                        $now
-                    );
-                }
-            }
         }
 
         if ($result) {

--- a/backend/app/Services/Analytics/QualitySignalExtractor.php
+++ b/backend/app/Services/Analytics/QualitySignalExtractor.php
@@ -57,11 +57,14 @@ final class QualitySignalExtractor
         $candidates = [
             $payload['quality'] ?? null,
             $payload['normed_json']['quality'] ?? null,
-            $snapshot['quality'] ?? null,
-            $snapshot['eq_60']['quality'] ?? null,
-            $snapshot['sds_20']['quality'] ?? null,
-            $snapshot['clinical_combo_68']['quality'] ?? null,
         ];
+
+        if (! $this->isMbtiPayload($payload)) {
+            $candidates[] = $snapshot['quality'] ?? null;
+            $candidates[] = $snapshot['eq_60']['quality'] ?? null;
+            $candidates[] = $snapshot['sds_20']['quality'] ?? null;
+            $candidates[] = $snapshot['clinical_combo_68']['quality'] ?? null;
+        }
 
         foreach ($candidates as $candidate) {
             if (is_array($candidate)) {
@@ -70,6 +73,24 @@ final class QualitySignalExtractor
         }
 
         return [];
+    }
+
+    private function isMbtiPayload(array $payload): bool
+    {
+        $candidates = [
+            $payload['scale_code'] ?? null,
+            $payload['scale_code_legacy'] ?? null,
+            $payload['scale_code_v2'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            $value = strtoupper(trim((string) $candidate));
+            if ($value === 'MBTI' || $value === 'MBTI_16_TYPE') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/app/Services/Attempts/AttemptSubmitTxService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitTxService.php
@@ -438,24 +438,6 @@ class AttemptSubmitTxService
                 $result = Result::create($resultData);
             }
 
-            // attempt_quality remains a compat mirror for ops/legacy readers, not the current truth.
-            if ($scaleCode === 'MBTI' && \App\Support\SchemaBaseline::hasTable('attempt_quality')) {
-                $quality = is_array($resultJson['quality'] ?? null) ? $resultJson['quality'] : null;
-                if (is_array($quality)) {
-                    $checks = $quality['checks'] ?? null;
-                    DB::table('attempt_quality')->updateOrInsert(
-                        ['attempt_id' => $attemptId],
-                        [
-                            'checks_json' => is_array($checks)
-                                ? json_encode($checks, JSON_UNESCAPED_SLASHES)
-                                : json_encode([], JSON_UNESCAPED_SLASHES),
-                            'grade' => strtoupper(trim((string) ($quality['grade'] ?? $quality['level'] ?? 'A'))),
-                            'created_at' => now(),
-                        ]
-                    );
-                }
-            }
-
             $responsePayload = $this->core->buildSubmitPayload($locked, $result, true);
             $postCommitCtx = [
                 'org_id' => $orgId,

--- a/backend/app/Services/Legacy/LegacyReportService.php
+++ b/backend/app/Services/Legacy/LegacyReportService.php
@@ -441,12 +441,9 @@ class LegacyReportService
         }
 
         if ($includePsychometrics) {
-            $snapshot = $attempt->calculation_snapshot_json;
-            if (is_string($snapshot)) {
-                $decoded = json_decode($snapshot, true);
-                $snapshot = is_array($decoded) ? $decoded : null;
-            }
-            $reportPayload['psychometrics'] = $snapshot;
+            // This include is legacy-only compatibility data. Prefer current result quality and
+            // keep attempts.calculation_snapshot_json only as a fallback source for older payloads.
+            $reportPayload['psychometrics'] = $this->buildLegacyPsychometricsInclude($attempt, $result);
         }
 
         return [
@@ -463,6 +460,50 @@ class LegacyReportService
     private function resolveUserId(LegacyRequestContext $context): string
     {
         return trim((string) ($context->resolvedUserId() ?? ''));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function buildLegacyPsychometricsInclude(Attempt $attempt, Result $result): ?array
+    {
+        $snapshot = $attempt->calculation_snapshot_json;
+        if (is_string($snapshot)) {
+            $decoded = json_decode($snapshot, true);
+            $snapshot = is_array($decoded) ? $decoded : null;
+        }
+        if (! is_array($snapshot)) {
+            $snapshot = [];
+        }
+
+        $resultPayload = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $quality = $resultPayload['quality'] ?? null;
+        if (! is_array($quality)) {
+            $quality = data_get($resultPayload, 'normed_json.quality');
+        }
+        if (! is_array($quality)) {
+            $quality = $snapshot['quality'] ?? null;
+        }
+
+        if (is_array($quality)) {
+            $snapshot['quality'] = $quality;
+        }
+
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? $result->scale_code ?? '')));
+        if ($scaleCode === 'MBTI') {
+            $legacyVersion = trim((string) ($snapshot['version'] ?? ''));
+            $minimal = [];
+            if ($legacyVersion !== '') {
+                $minimal['version'] = $legacyVersion;
+            }
+            if (is_array($quality)) {
+                $minimal['quality'] = $quality;
+            }
+
+            return $minimal !== [] ? $minimal : null;
+        }
+
+        return $snapshot !== [] ? $snapshot : null;
     }
 
     private function resolveAnonId(LegacyRequestContext $context): string

--- a/backend/app/Services/Legacy/Mbti/Attempt/LegacyMbtiAttemptLifecycleService.php
+++ b/backend/app/Services/Legacy/Mbti/Attempt/LegacyMbtiAttemptLifecycleService.php
@@ -448,23 +448,6 @@ class LegacyMbtiAttemptLifecycleService
                 $attempt = Attempt::create($attemptData);
             }
 
-            if (\App\Support\SchemaBaseline::hasTable('attempt_quality')) {
-                $quality = $psychometrics['quality'] ?? null;
-                if (is_array($quality)) {
-                    $checks = $quality['checks'] ?? null;
-                    DB::table('attempt_quality')->updateOrInsert(
-                        ['attempt_id' => $attemptId],
-                        [
-                            'checks_json' => is_array($checks)
-                                ? json_encode($checks, JSON_UNESCAPED_SLASHES)
-                                : null,
-                            'grade' => (string) ($quality['grade'] ?? ''),
-                            'created_at' => now(),
-                        ]
-                    );
-                }
-            }
-
             // ✅ 3) results 表：兼容旧逻辑（有则更新，无则创建）
             $result = $this->resultQuery($attemptId)->first();
             $isNewResult = false;

--- a/backend/database/migrations/2026_03_26_120000_drop_attempt_quality_table.php
+++ b/backend/database/migrations/2026_03_26_120000_drop_attempt_quality_table.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('attempt_quality')) {
+            Schema::drop('attempt_quality');
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only retirement migration: rollback intentionally disabled.
+    }
+};

--- a/backend/tests/Feature/Legacy/LegacyMbtiAttemptLifecycleAttemptQualityRetirementTest.php
+++ b/backend/tests/Feature/Legacy/LegacyMbtiAttemptLifecycleAttemptQualityRetirementTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Legacy;
+
+use App\DTO\Legacy\LegacyRequestContext;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Legacy\LegacyMbtiAttemptService;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class LegacyMbtiAttemptLifecycleAttemptQualityRetirementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function mbtiAnswers(): array
+    {
+        $packRoot = rtrim((string) config('content_packs.root'), DIRECTORY_SEPARATOR);
+        $dirVersion = trim((string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'));
+        $questionsPath = $packRoot.DIRECTORY_SEPARATOR.'default/CN_MAINLAND/zh-CN/'.$dirVersion.DIRECTORY_SEPARATOR.'questions.json';
+
+        $decoded = json_decode((string) file_get_contents($questionsPath), true);
+        $items = is_array($decoded['items'] ?? null) ? $decoded['items'] : [];
+
+        $answers = [];
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            $code = trim((string) ($options[0]['code'] ?? 'A'));
+            if ($questionId === '' || $code === '') {
+                continue;
+            }
+
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => $code,
+            ];
+        }
+
+        return $answers;
+    }
+
+    public function test_legacy_mbti_store_attempt_keeps_snapshot_but_no_longer_writes_attempt_quality(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        Queue::fake();
+
+        $answers = $this->mbtiAnswers();
+        $this->assertCount(144, $answers);
+
+        $context = new LegacyRequestContext(
+            orgId: 0,
+            userId: null,
+            anonId: 'legacy-mbti-retirement-anon',
+            requestId: 'legacy-mbti-retirement',
+            sessionId: null,
+            headers: [],
+            query: [],
+            input: [],
+            attributes: []
+        );
+
+        /** @var LegacyMbtiAttemptService $service */
+        $service = app(LegacyMbtiAttemptService::class);
+        $payload = $service->storeAttempt([
+            'anon_id' => 'legacy-mbti-retirement-anon',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'answers' => $answers,
+            'duration_ms' => 180000,
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'client_platform' => 'test',
+        ], $context);
+
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+
+        $attemptId = (string) ($payload['attempt_id'] ?? '');
+        $this->assertNotSame('', $attemptId);
+
+        $attempt = Attempt::query()->findOrFail($attemptId);
+        $result = Result::query()->where('attempt_id', $attemptId)->first();
+
+        $this->assertNotNull($result);
+        $this->assertIsArray($attempt->calculation_snapshot_json);
+        $this->assertIsArray(data_get($attempt->calculation_snapshot_json, 'quality'));
+        $this->assertFalse(Schema::hasTable('attempt_quality'));
+    }
+}

--- a/backend/tests/Feature/Legacy/LegacyReportServicePsychometricsIncludeTest.php
+++ b/backend/tests/Feature/Legacy/LegacyReportServicePsychometricsIncludeTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Legacy;
+
+use App\DTO\Legacy\LegacyRequestContext;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Commerce\EntitlementManager;
+use App\Services\Legacy\LegacyReportService;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class LegacyReportServicePsychometricsIncludeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_legacy_report_service_includes_psychometrics_snapshot_when_requested(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+        Config::set('storage_rollout.legacy_drain_enabled', false);
+
+        $anonId = 'legacy-psychometrics-anon';
+        $attemptId = (string) Str::uuid();
+
+        $attempt = Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(5),
+            'submitted_at' => now()->subMinutes(4),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'calculation_snapshot_json' => [
+                'version' => 'legacy.mbti.psychometrics.v1',
+                'quality' => [
+                    'level' => 'B',
+                    'grade' => 'B',
+                    'checks' => [
+                        ['id' => 'reverse_pair_mismatch', 'status' => 'pass'],
+                    ],
+                ],
+            ],
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => ['EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20]],
+            'scores_pct' => ['EI' => 50],
+            'axis_states' => ['EI' => 'clear'],
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'type_code' => 'INTJ-A',
+                'quality' => [
+                    'level' => 'A',
+                    'grade' => 'A',
+                    'checks' => [
+                        ['id' => 'current_truth', 'status' => 'pass'],
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now()->subMinutes(3),
+        ]);
+
+        DB::table('report_jobs')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'status' => 'success',
+            'tries' => 1,
+            'available_at' => now()->subMinutes(3),
+            'started_at' => now()->subMinutes(3),
+            'finished_at' => now()->subMinutes(2),
+            'failed_at' => null,
+            'last_error' => null,
+            'last_error_trace' => null,
+            'report_json' => json_encode([
+                'profile' => ['type_code' => 'INTJ-A'],
+                'tags' => [],
+                'sections' => [],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'meta' => null,
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinutes(2),
+        ]);
+
+        app(EntitlementManager::class)->grantAttemptUnlock(
+            0,
+            null,
+            $anonId,
+            'MBTI_REPORT_FULL',
+            $attemptId,
+            null
+        );
+
+        $context = new LegacyRequestContext(
+            orgId: 0,
+            userId: null,
+            anonId: $anonId,
+            requestId: 'legacy-psychometrics-include',
+            sessionId: null,
+            headers: [],
+            query: ['include' => 'psychometrics'],
+            input: [],
+            attributes: []
+        );
+
+        /** @var LegacyReportService $service */
+        $service = app(LegacyReportService::class);
+        $payload = $service->getReportPayload($attempt->fresh(), $context);
+
+        $this->assertSame(200, (int) ($payload['status'] ?? 0));
+        $this->assertSame(
+            'legacy.mbti.psychometrics.v1',
+            (string) data_get($payload, 'body.report.psychometrics.version')
+        );
+        $this->assertSame(
+            'A',
+            (string) data_get($payload, 'body.report.psychometrics.quality.level')
+        );
+        $this->assertSame(
+            'A',
+            (string) data_get($payload, 'body.report.psychometrics.quality.grade')
+        );
+        $this->assertSame(
+            ['version', 'quality'],
+            array_keys((array) data_get($payload, 'body.report.psychometrics', []))
+        );
+    }
+}

--- a/backend/tests/Feature/Ops/AttemptsExplorerTest.php
+++ b/backend/tests/Feature/Ops/AttemptsExplorerTest.php
@@ -357,13 +357,6 @@ final class AttemptsExplorerTest extends TestCase
             'updated_at' => now()->subMinutes(13),
         ]);
 
-        DB::table('attempt_quality')->insert([
-            'attempt_id' => $attemptId,
-            'checks_json' => json_encode(['speeding' => false, 'straightlining' => false], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-            'grade' => 'A',
-            'created_at' => now()->subMinutes(13),
-        ]);
-
         $this->insertAnswerSet($attemptId, $orgId, 'MBTI', base64_encode(json_encode([['question_id' => 'Q-1', 'code' => 'A']], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)), hash('sha256', 'mbti-chain'), 93);
 
         DB::table('events')->insert([

--- a/backend/tests/Feature/Ops/ResultsExplorerTest.php
+++ b/backend/tests/Feature/Ops/ResultsExplorerTest.php
@@ -177,10 +177,6 @@ final class ResultsExplorerTest extends TestCase
             'grade' => 'B',
         ];
         $truthResult->update(['result_json' => $truthPayload]);
-        DB::table('attempt_quality')
-            ->where('attempt_id', (string) $truthChain['attempt_id'])
-            ->update(['grade' => 'A']);
-
         $fallbackChain = $this->seedDiagnosticChain(orgId: 89, orderNo: 'ord_results_fallback_001');
         $fallbackResult = Result::query()->findOrFail((string) $fallbackChain['result']->getKey());
 
@@ -471,13 +467,6 @@ final class ResultsExplorerTest extends TestCase
             'finished_at' => now()->subMinutes(13),
             'created_at' => now()->subMinutes(14),
             'updated_at' => now()->subMinutes(13),
-        ]);
-
-        DB::table('attempt_quality')->insert([
-            'attempt_id' => $attemptId,
-            'checks_json' => json_encode(['speeding' => false], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-            'grade' => 'A',
-            'created_at' => now()->subMinutes(13),
         ]);
 
         DB::table('events')->insert([

--- a/backend/tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php
+++ b/backend/tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php
@@ -8,6 +8,7 @@ use App\Models\Result;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -67,7 +68,7 @@ final class MbtiQualityCurrentSubmitTest extends TestCase
         return $answers;
     }
 
-    public function test_mbti_current_submit_writes_quality_truth_and_attempt_quality_mirror(): void
+    public function test_mbti_current_submit_writes_quality_truth_without_attempt_quality_mirror(): void
     {
         (new ScaleRegistrySeeder())->run();
 
@@ -120,9 +121,7 @@ final class MbtiQualityCurrentSubmitTest extends TestCase
         $this->assertSame((string) ($quality['grade'] ?? ''), (string) data_get($resultJson, 'quality.grade'));
         $this->assertIsArray(data_get($resultJson, 'normed_json.quality'));
 
-        $mirror = DB::table('attempt_quality')->where('attempt_id', $attemptId)->first();
-        $this->assertNotNull($mirror);
-        $this->assertSame((string) ($quality['grade'] ?? ''), (string) ($mirror->grade ?? ''));
+        $this->assertFalse(Schema::hasTable('attempt_quality'));
 
         $resultRead = $this->withHeaders([
             'X-Anon-Id' => $anonId,

--- a/backend/tests/Unit/Services/AI/EvidenceBuilderTest.php
+++ b/backend/tests/Unit/Services/AI/EvidenceBuilderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\AI;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\AI\EvidenceBuilder;
+use Tests\TestCase;
+
+final class EvidenceBuilderTest extends TestCase
+{
+    public function test_evidence_builder_no_longer_reads_snapshot_version_metadata(): void
+    {
+        $attempt = new Attempt([
+            'id' => 'attempt-evidence-1',
+            'type_code' => 'INTJ-A',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'norm_version' => 'mbti_norm_2026_active',
+            'scoring_spec_version' => '2026.01',
+            'calculation_snapshot_json' => [
+                'version' => 'legacy.mbti.psychometrics.v1',
+            ],
+        ]);
+
+        $result = new Result([
+            'type_code' => 'INTJ-A',
+            'scores_pct' => ['EI' => 50],
+            'axis_states' => ['EI' => 'clear'],
+        ]);
+
+        /** @var EvidenceBuilder $builder */
+        $builder = app(EvidenceBuilder::class);
+        $items = $builder->build($attempt, $result);
+
+        $pointers = array_values(array_map(
+            static fn (array $item): string => (string) ($item['pointer'] ?? ''),
+            $items
+        ));
+
+        $this->assertContains('attempts.pack_id', $pointers);
+        $this->assertContains('attempts.dir_version', $pointers);
+        $this->assertContains('attempts.scoring_spec_version', $pointers);
+        $this->assertNotContains('attempts.calculation_snapshot_json.version', $pointers);
+    }
+}

--- a/backend/tests/Unit/Services/Analytics/QualitySignalExtractorTest.php
+++ b/backend/tests/Unit/Services/Analytics/QualitySignalExtractorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Analytics;
+
+use App\Services\Analytics\QualitySignalExtractor;
+use Tests\TestCase;
+
+final class QualitySignalExtractorTest extends TestCase
+{
+    public function test_mbti_quality_extractor_does_not_treat_snapshot_quality_as_current_truth(): void
+    {
+        $extractor = app(QualitySignalExtractor::class);
+
+        $signal = $extractor->extract(
+            [
+                'scale_code' => 'MBTI',
+                'type_code' => 'INTJ-A',
+            ],
+            [
+                'quality' => [
+                    'level' => 'B',
+                    'flags' => ['SNAPSHOT_ONLY'],
+                ],
+            ],
+            null
+        );
+
+        $this->assertSame('', $signal['level']);
+        $this->assertSame([], $signal['flags']);
+    }
+
+    public function test_non_mbti_quality_extractor_keeps_snapshot_quality_fallback(): void
+    {
+        $extractor = app(QualitySignalExtractor::class);
+
+        $signal = $extractor->extract(
+            [
+                'scale_code' => 'EQ_60',
+            ],
+            [
+                'quality' => [
+                    'level' => 'A',
+                    'flags' => ['SNAPSHOT_ONLY'],
+                ],
+            ],
+            null
+        );
+
+        $this->assertSame('A', $signal['level']);
+        $this->assertSame(['SNAPSHOT_ONLY'], $signal['flags']);
+    }
+}


### PR DESCRIPTION
This PR completes the MBTI quality retirement path by removing the last remaining runtime dependency on `attempt_quality` and further isolating legacy psychometrics data.

Before this change, MBTI current submit already wrote `results.result_json.quality`, and the main read-side had been aligned to prefer that current truth. However, the codebase still carried residual legacy structures in three places: MBTI current and legacy write paths still touched `attempt_quality`, `LegacyReportService` still exposed raw psychometrics snapshot data, and some secondary readers still treated snapshot fields as part of the active MBTI quality surface.

This change finalizes the separation between current and legacy semantics.

On the write side, MBTI current submit continues to use `results.result_json.quality` as the only current truth, and the remaining legacy MBTI attempt lifecycle no longer writes `attempt_quality` either. A forward-only migration drops the `attempt_quality` table from the active schema so it can no longer attract new consumers.

On the legacy read side, `LegacyReportService` keeps the `psychometrics` include for compatibility, but its MBTI payload is now explicitly minimal and legacy-scoped. It prefers current result quality first, falls back to older nested result quality second, and only uses snapshot quality as a final fallback. For MBTI, the exposed compatibility payload is reduced to the fields that still matter: `version` and `quality`.

On side readers, `QualitySignalExtractor` no longer treats snapshot quality as an MBTI current-truth fallback, while preserving snapshot fallback behavior for the other scales that still rely on it. `EvidenceBuilder` also stops reading `calculation_snapshot_json.version`, so snapshot metadata is no longer part of the active evidence path.

The supporting tests were updated to reflect the new split. Current submit verifies that MBTI quality is still written to `results.result_json.quality` and that `attempt_quality` no longer exists. Legacy MBTI store still verifies that the snapshot path remains available without recreating `attempt_quality`. Legacy report include tests now verify the reduced compatibility shape and current-truth-first quality overlay. Additional unit coverage was added for MBTI snapshot fallback removal in `QualitySignalExtractor` and snapshot version removal in `EvidenceBuilder`. Ops explorer tests were also updated so they no longer seed or depend on `attempt_quality`.

Validation run for this PR:

- `php -l` on changed files
- `php artisan test tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php`
- `php artisan test tests/Feature/Legacy/LegacyMbtiAttemptLifecycleAttemptQualityRetirementTest.php`
- `php artisan test tests/Feature/Legacy/LegacyReportServicePsychometricsIncludeTest.php`
- `php artisan test tests/Unit/Services/Analytics/QualitySignalExtractorTest.php tests/Unit/Services/AI/EvidenceBuilderTest.php`
- `php artisan test tests/Feature/Ops/ResultsExplorerTest.php`
- `php artisan test tests/Feature/Ops/AttemptsExplorerTest.php`
