### PR TITLE
[codex] Ship OP-2 payment attempt layer and callback truth chain

### DIFF
--- a/backend/app/Filament/Ops/Resources/OrderResource.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource.php
@@ -118,6 +118,20 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                 Tables\Columns\TextColumn::make('grant_state')
                     ->badge()
                     ->toggleable(),
+                Tables\Columns\TextColumn::make('payment_attempts_count')
+                    ->label('Payment attempts')
+                    ->numeric()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('latest_payment_attempt_state')
+                    ->badge()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('latest_payment_attempt_provider')
+                    ->label('Attempt provider')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('latest_payment_attempt_provider_trade_no')
+                    ->label('Attempt provider ref')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('latest_payment_status')
                     ->label('Payment status')
                     ->state(fn (Order $record): string => $support->paymentStatus($record)['label'])

--- a/backend/app/Filament/Ops/Resources/OrderResource/RelationManagers/PaymentEventsRelationManager.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/RelationManagers/PaymentEventsRelationManager.php
@@ -26,6 +26,7 @@ class PaymentEventsRelationManager extends RelationManager
             ->columns([
                 Tables\Columns\TextColumn::make('provider')->sortable(),
                 Tables\Columns\TextColumn::make('provider_event_id')->searchable()->copyable(),
+                Tables\Columns\TextColumn::make('payment_attempt_id')->label('Attempt ID')->copyable()->toggleable(),
                 Tables\Columns\TextColumn::make('status')->badge()->sortable(),
                 Tables\Columns\IconColumn::make('signature_ok')->boolean(),
                 Tables\Columns\TextColumn::make('handle_status')->badge(),

--- a/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
@@ -50,6 +50,18 @@ final class OrderLinkageSupport
                 ->selectSub($this->paymentField('handled_at'), 'latest_payment_handled_at');
         }
 
+        if (SchemaBaseline::hasTable('payment_attempts')) {
+            $query
+                ->selectSub($this->paymentAttemptCountField(), 'payment_attempts_count')
+                ->selectSub($this->paymentAttemptField('id'), 'latest_payment_attempt_id')
+                ->selectSub($this->paymentAttemptField('state'), 'latest_payment_attempt_state')
+                ->selectSub($this->paymentAttemptField('provider'), 'latest_payment_attempt_provider')
+                ->selectSub($this->paymentAttemptField('provider_trade_no'), 'latest_payment_attempt_provider_trade_no')
+                ->selectSub($this->paymentAttemptField('external_trade_no'), 'latest_payment_attempt_external_trade_no');
+        } else {
+            $query->selectRaw('0 as payment_attempts_count');
+        }
+
         if (SchemaBaseline::hasTable('benefit_grants')) {
             $query
                 ->selectSub($this->benefitField('id'), 'latest_benefit_grant_id')
@@ -877,6 +889,22 @@ final class OrderLinkageSupport
             ->whereColumn('payment_events.order_no', 'orders.order_no')
             ->orderByRaw('coalesce(processed_at, handled_at, updated_at, created_at) desc')
             ->limit(1);
+    }
+
+    private function paymentAttemptField(string $column): QueryBuilder
+    {
+        return DB::table('payment_attempts')
+            ->select($column)
+            ->whereColumn('payment_attempts.order_no', 'orders.order_no')
+            ->orderByDesc('attempt_no')
+            ->limit(1);
+    }
+
+    private function paymentAttemptCountField(): QueryBuilder
+    {
+        return DB::table('payment_attempts')
+            ->selectRaw('count(*)')
+            ->whereColumn('payment_attempts.order_no', 'orders.order_no');
     }
 
     private function benefitField(string $column): QueryBuilder

--- a/backend/app/Filament/Ops/Resources/PaymentEventResource.php
+++ b/backend/app/Filament/Ops/Resources/PaymentEventResource.php
@@ -55,6 +55,7 @@ class PaymentEventResource extends BaseTenantResource
                 Tables\Columns\TextColumn::make('provider')->sortable(),
                 Tables\Columns\TextColumn::make('provider_event_id')->label('Event ID')->searchable()->copyable(),
                 Tables\Columns\TextColumn::make('order_no')->searchable()->copyable(),
+                Tables\Columns\TextColumn::make('payment_attempt_id')->label('Attempt ID')->searchable()->copyable()->toggleable(),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->color(fn (string $state): string => StatusBadge::color($state))

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -166,6 +166,10 @@ class CommerceController extends Controller
         $status = $this->resolvePublicOrderStatus($order);
         $message = $this->publicOrderMessage($order);
         $delivery = $this->buildOrderDelivery($order);
+        $paymentAttemptSummary = $this->orders->paymentAttemptSummary(
+            (string) ($order->order_no ?? ''),
+            (int) ($order->org_id ?? $orgId)
+        );
         $paymentRecoveryToken = $paymentRecoveryVerified && $requestedPaymentRecoveryToken !== null
             ? $requestedPaymentRecoveryToken
             : $this->orders->issuePaymentRecoveryToken($order);
@@ -204,6 +208,8 @@ class CommerceController extends Controller
             'result_url' => $recoveryUrls['result_url'],
             'pay' => $payment['pay'],
             'checkout_url' => $payment['checkout_url'],
+            'payment_attempts_count' => $paymentAttemptSummary['count'],
+            'latest_payment_attempt' => $paymentAttemptSummary['latest'],
             'delivery' => $delivery['delivery'],
         ];
 
@@ -303,6 +309,10 @@ class CommerceController extends Controller
                     $paymentRecoveryToken
                 );
                 $order = $this->orders->findOrderByOrderNo((string) ($order->order_no ?? $existingOrderNo), $orgId) ?? $order;
+                $paymentAttemptSummary = $this->orders->paymentAttemptSummary(
+                    (string) ($order->order_no ?? $existingOrderNo),
+                    (int) ($order->org_id ?? $orgId)
+                );
 
                 return response()->json([
                     'ok' => true,
@@ -319,6 +329,8 @@ class CommerceController extends Controller
                     'result_url' => $recoveryUrls['result_url'],
                     'pay' => $payment['pay'],
                     'checkout_url' => $payment['checkout_url'],
+                    'payment_attempts_count' => $paymentAttemptSummary['count'],
+                    'latest_payment_attempt' => $paymentAttemptSummary['latest'],
                 ]);
             }
         }
@@ -385,6 +397,10 @@ class CommerceController extends Controller
         if ($description === '') {
             $description = 'FermatMind Order';
         }
+        $paymentScene = $this->resolvePaymentActionScene((string) $request->userAgent());
+        $paymentAttempt = $order !== null
+            ? $this->createPaymentAttemptForOrder($order, $provider, $paymentScene)
+            : null;
 
         $payAction = $this->resolveCheckoutPayAction(
             $provider,
@@ -398,6 +414,13 @@ class CommerceController extends Controller
         );
 
         if (($payAction['ok'] ?? true) !== true) {
+            if ($paymentAttempt !== null) {
+                $this->orders->advancePaymentAttempt((string) ($paymentAttempt->id ?? ''), [
+                    'state' => \App\Models\PaymentAttempt::STATE_FAILED,
+                    'last_error_code' => $this->trimNullableString($payAction['error_code'] ?? null),
+                    'last_error_message' => $this->trimNullableString($payAction['message'] ?? null),
+                ]);
+            }
             $status = (int) ($payAction['status'] ?? 502);
             abort($status >= 400 ? $status : 502, (string) ($payAction['message'] ?? 'payment unavailable.'));
         }
@@ -418,21 +441,35 @@ class CommerceController extends Controller
         }
 
         if ($order !== null) {
-            $this->orders->markPaymentPending(
+            $freshOrder = $this->orders->findOrderByOrderNo(
                 (string) ($order->order_no ?? ''),
-                (int) ($order->org_id ?? $orgId),
+                (int) ($order->org_id ?? $orgId)
+            ) ?? $order;
+            $this->orders->markPaymentPending(
+                (string) ($freshOrder->order_no ?? ''),
+                (int) ($freshOrder->org_id ?? $orgId),
                 $ledgerContext['channel'] ?? null,
                 $ledgerContext['provider_app'] ?? null
             );
+            $paymentAttempt = $this->recordPaymentAttemptPresentation(
+                $paymentAttempt,
+                $freshOrder,
+                $paymentScene,
+                $payAction,
+                $payPayload,
+                $checkoutUrl
+            );
             $this->persistOrderPaymentPayload(
-                $order,
-                $this->resolvePaymentActionScene((string) $request->userAgent()),
+                $freshOrder,
+                $paymentScene,
                 [
                     'provider' => $provider,
                     'pay' => $payPayload,
                     'checkout_url' => $checkoutUrl,
-                ]
+                ],
+                $this->trimNullableString($paymentAttempt->id ?? null)
             );
+            $order = $freshOrder;
         }
 
         $paymentRecoveryToken = $order !== null ? $this->orders->issuePaymentRecoveryToken($order) : null;
@@ -467,6 +504,18 @@ class CommerceController extends Controller
             'result_url' => $recoveryUrls['result_url'],
             'pay' => $presentedPayment['pay'],
             'checkout_url' => $presentedPayment['checkout_url'],
+            'payment_attempts_count' => $order !== null
+                ? $this->orders->paymentAttemptSummary(
+                    (string) ($order->order_no ?? ''),
+                    (int) ($order->org_id ?? 0)
+                )['count']
+                : 0,
+            'latest_payment_attempt' => $order !== null
+                ? $this->orders->paymentAttemptSummary(
+                    (string) ($order->order_no ?? ''),
+                    (int) ($order->org_id ?? 0)
+                )['latest']
+                : null,
         ]);
     }
 
@@ -531,6 +580,10 @@ class CommerceController extends Controller
             $order = $this->orders->findOrderByOrderNo((string) ($order->order_no ?? $orderNo), $orgId) ?? $order;
             $status = $this->resolvePublicOrderStatus($order);
         }
+        $paymentAttemptSummary = $this->orders->paymentAttemptSummary(
+            (string) ($order->order_no ?? $orderNo),
+            (int) ($order->org_id ?? $orgId)
+        );
 
         $payload = [
             'ok' => true,
@@ -546,6 +599,8 @@ class CommerceController extends Controller
             'result_url' => $recoveryUrls['result_url'],
             'pay' => $payment['pay'],
             'checkout_url' => $payment['checkout_url'],
+            'payment_attempts_count' => $paymentAttemptSummary['count'],
+            'latest_payment_attempt' => $paymentAttemptSummary['latest'],
             'delivery' => $delivery['delivery'],
         ];
 
@@ -739,6 +794,7 @@ class CommerceController extends Controller
         if ($description === '') {
             $description = 'FermatMind Order';
         }
+        $paymentAttempt = $this->createPaymentAttemptForOrder($order, $normalizedProvider, $scene);
 
         $payAction = $this->resolveCheckoutPayAction(
             $normalizedProvider,
@@ -758,6 +814,13 @@ class CommerceController extends Controller
                 'status' => (string) ($order->status ?? ''),
                 'reason' => $payAction['error_code'] ?? $payAction['message'] ?? 'unknown',
             ]);
+            if ($paymentAttempt !== null) {
+                $this->orders->advancePaymentAttempt((string) ($paymentAttempt->id ?? ''), [
+                    'state' => \App\Models\PaymentAttempt::STATE_FAILED,
+                    'last_error_code' => $this->trimNullableString($payAction['error_code'] ?? null),
+                    'last_error_message' => $this->trimNullableString($payAction['message'] ?? null),
+                ]);
+            }
 
             return [
                 'provider' => $normalizedProvider,
@@ -773,7 +836,21 @@ class CommerceController extends Controller
             $this->trimNullableString($order->channel ?? null),
             $this->trimNullableString($order->provider_app ?? null)
         );
-        $this->persistOrderPaymentPayload($order, $scene, $presented);
+        $freshOrder = $this->orders->findOrderByOrderNo($orderNo, (int) ($order->org_id ?? 0)) ?? $order;
+        $paymentAttempt = $this->recordPaymentAttemptPresentation(
+            $paymentAttempt,
+            $freshOrder,
+            $scene,
+            $payAction,
+            is_array($presented['pay'] ?? null) ? $presented['pay'] : null,
+            $this->trimNullableString($presented['checkout_url'] ?? null)
+        );
+        $this->persistOrderPaymentPayload(
+            $freshOrder,
+            $scene,
+            $presented,
+            $this->trimNullableString($paymentAttempt->id ?? null)
+        );
 
         return $this->decoratePaymentPayloadForRecovery($presented, $paymentRecoveryToken);
     }
@@ -865,7 +942,7 @@ class CommerceController extends Controller
      *     checkout_url:?string
      * }  $payload
      */
-    private function persistOrderPaymentPayload(object $order, string $scene, array $payload): void
+    private function persistOrderPaymentPayload(object $order, string $scene, array $payload, ?string $paymentAttemptId = null): void
     {
         $provider = strtolower(trim((string) ($payload['provider'] ?? '')));
         $pay = $payload['pay'] ?? null;
@@ -893,6 +970,7 @@ class CommerceController extends Controller
                 'provider' => $provider,
             ],
             'checkout_url' => $payload['checkout_url'] ?? null,
+            'payment_attempt_id' => $paymentAttemptId,
             'cached_at' => now()->toIso8601String(),
         ];
         $cache[$provider] = $providerCache;
@@ -905,6 +983,122 @@ class CommerceController extends Controller
                 'meta_json' => json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
                 'updated_at' => now(),
             ]);
+    }
+
+    private function createPaymentAttemptForOrder(object $order, string $provider, string $scene): ?object
+    {
+        $created = $this->orders->createPaymentAttempt(
+            (string) ($order->order_no ?? ''),
+            (int) ($order->org_id ?? 0),
+            $provider,
+            $this->trimNullableString($order->channel ?? null),
+            $this->trimNullableString($order->provider_app ?? null),
+            $scene,
+            (int) ($order->amount_cents ?? $order->amount_total ?? 0),
+            (string) ($order->currency ?? 'USD'),
+            [
+                'source' => 'order_payment_action',
+                'scene' => $scene,
+            ]
+        );
+
+        if (($created['ok'] ?? false) !== true) {
+            Log::warning('ORDER_PAYMENT_ATTEMPT_CREATE_FAILED', [
+                'order_no' => (string) ($order->order_no ?? ''),
+                'provider' => $provider,
+                'error_code' => $created['error_code'] ?? $created['error'] ?? 'unknown',
+            ]);
+
+            return null;
+        }
+
+        return is_object($created['attempt'] ?? null) ? $created['attempt'] : null;
+    }
+
+    private function recordPaymentAttemptPresentation(
+        ?object $paymentAttempt,
+        object $order,
+        string $scene,
+        array $payAction,
+        ?array $payPayload,
+        ?string $checkoutUrl
+    ): ?object {
+        if ($paymentAttempt === null) {
+            return null;
+        }
+
+        $provider = strtolower(trim((string) ($order->provider ?? '')));
+        $payloadMeta = [
+            'scene' => $scene,
+            'pay_type' => strtolower(trim((string) ($payPayload['type'] ?? ''))),
+            'pay_value_sha256' => $this->digestNullableString($payPayload['value'] ?? null),
+            'checkout_url_sha256' => $this->digestNullableString($checkoutUrl),
+            'has_checkout_url' => $checkoutUrl !== null && trim($checkoutUrl) !== '',
+        ];
+        $externalTradeNo = $this->trimNullableString($payAction['external_trade_no'] ?? null)
+            ?? $this->trimNullableString($order->external_trade_no ?? null);
+        $providerSessionRef = $this->resolveProviderSessionRef(
+            $provider,
+            $payPayload,
+            $checkoutUrl,
+            $payAction
+        );
+
+        if ($payPayload !== null) {
+            $paymentAttempt = $this->orders->advancePaymentAttempt((string) ($paymentAttempt->id ?? ''), [
+                'state' => \App\Models\PaymentAttempt::STATE_PROVIDER_CREATED,
+                'external_trade_no' => $externalTradeNo,
+                'provider_session_ref' => $providerSessionRef,
+                'provider_created_at' => now()->toDateTimeString(),
+                'payload_meta_json' => $payloadMeta,
+            ]);
+
+            return $this->orders->advancePaymentAttempt((string) ($paymentAttempt->id ?? ''), [
+                'state' => \App\Models\PaymentAttempt::STATE_CLIENT_PRESENTED,
+                'client_presented_at' => now()->toDateTimeString(),
+                'payload_meta_json' => $payloadMeta,
+            ]);
+        }
+
+        return $this->orders->advancePaymentAttempt((string) ($paymentAttempt->id ?? ''), [
+            'payload_meta_json' => $payloadMeta,
+        ]);
+    }
+
+    private function resolveProviderSessionRef(
+        string $provider,
+        ?array $payPayload,
+        ?string $checkoutUrl,
+        array $payAction
+    ): ?string {
+        $provider = strtolower(trim($provider));
+
+        if ($provider === 'lemonsqueezy') {
+            $path = trim((string) parse_url((string) ($checkoutUrl ?? ''), PHP_URL_PATH));
+            if ($path !== '') {
+                $segment = basename($path);
+                if ($segment !== '') {
+                    return substr($segment, 0, 191);
+                }
+            }
+        }
+
+        $explicit = $this->trimNullableString($payAction['provider_session_ref'] ?? null);
+        if ($explicit !== null) {
+            return $explicit;
+        }
+
+        return $this->trimNullableString($payPayload['provider_session_ref'] ?? null);
+    }
+
+    private function digestNullableString(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        return hash('sha256', $normalized);
     }
 
     private function resolvePaymentActionScene(string $userAgent): string

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -6,6 +6,7 @@ use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Order extends Model
 {
@@ -202,6 +203,17 @@ class Order extends Model
     public function paymentEvents(): HasMany
     {
         return $this->hasMany(PaymentEvent::class, 'order_no', 'order_no');
+    }
+
+    public function paymentAttempts(): HasMany
+    {
+        return $this->hasMany(PaymentAttempt::class, 'order_no', 'order_no');
+    }
+
+    public function latestPaymentAttempt(): HasOne
+    {
+        return $this->hasOne(PaymentAttempt::class, 'order_no', 'order_no')
+            ->ofMany('attempt_no', 'max');
     }
 
     public function benefitGrants(): HasMany

--- a/backend/app/Models/PaymentAttempt.php
+++ b/backend/app/Models/PaymentAttempt.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PaymentAttempt extends Model
+{
+    use HasOrgScope;
+
+    public const STATE_INITIATED = 'initiated';
+
+    public const STATE_PROVIDER_CREATED = 'provider_created';
+
+    public const STATE_CLIENT_PRESENTED = 'client_presented';
+
+    public const STATE_CALLBACK_RECEIVED = 'callback_received';
+
+    public const STATE_VERIFIED = 'verified';
+
+    public const STATE_PAID = 'paid';
+
+    public const STATE_FAILED = 'failed';
+
+    public const STATE_CANCELED = 'canceled';
+
+    public const STATE_EXPIRED = 'expired';
+
+    protected $table = 'payment_attempts';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'org_id',
+        'order_id',
+        'order_no',
+        'attempt_no',
+        'provider',
+        'channel',
+        'provider_app',
+        'pay_scene',
+        'state',
+        'external_trade_no',
+        'provider_trade_no',
+        'provider_session_ref',
+        'amount_expected',
+        'currency',
+        'payload_meta_json',
+        'latest_payment_event_id',
+        'initiated_at',
+        'provider_created_at',
+        'client_presented_at',
+        'callback_received_at',
+        'verified_at',
+        'finalized_at',
+        'last_error_code',
+        'last_error_message',
+        'meta_json',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'attempt_no' => 'integer',
+        'amount_expected' => 'integer',
+        'payload_meta_json' => 'array',
+        'meta_json' => 'array',
+        'initiated_at' => 'datetime',
+        'provider_created_at' => 'datetime',
+        'client_presented_at' => 'datetime',
+        'callback_received_at' => 'datetime',
+        'verified_at' => 'datetime',
+        'finalized_at' => 'datetime',
+    ];
+
+    public static function normalizedState(?string $state): string
+    {
+        $normalized = strtolower(trim((string) $state));
+
+        return in_array($normalized, [
+            self::STATE_INITIATED,
+            self::STATE_PROVIDER_CREATED,
+            self::STATE_CLIENT_PRESENTED,
+            self::STATE_CALLBACK_RECEIVED,
+            self::STATE_VERIFIED,
+            self::STATE_PAID,
+            self::STATE_FAILED,
+            self::STATE_CANCELED,
+            self::STATE_EXPIRED,
+        ], true)
+            ? $normalized
+            : self::STATE_INITIATED;
+    }
+
+    public static function isFinalState(?string $state): bool
+    {
+        return in_array(self::normalizedState($state), [
+            self::STATE_PAID,
+            self::STATE_FAILED,
+            self::STATE_CANCELED,
+            self::STATE_EXPIRED,
+        ], true);
+    }
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class, 'order_id', 'id');
+    }
+
+    public function latestPaymentEvent(): BelongsTo
+    {
+        return $this->belongsTo(PaymentEvent::class, 'latest_payment_event_id', 'id');
+    }
+
+    public function paymentEvents(): HasMany
+    {
+        return $this->hasMany(PaymentEvent::class, 'payment_attempt_id', 'id');
+    }
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return self::allowOrgZeroWithResolvedContext();
+    }
+}

--- a/backend/app/Models/PaymentEvent.php
+++ b/backend/app/Models/PaymentEvent.php
@@ -24,6 +24,7 @@ class PaymentEvent extends Model
         'provider',
         'provider_event_id',
         'order_id',
+        'payment_attempt_id',
         'order_no',
         'event_type',
         'signature_ok',
@@ -62,6 +63,11 @@ class PaymentEvent extends Model
     public function order(): BelongsTo
     {
         return $this->belongsTo(Order::class, 'order_no', 'order_no');
+    }
+
+    public function paymentAttempt(): BelongsTo
+    {
+        return $this->belongsTo(PaymentAttempt::class, 'payment_attempt_id', 'id');
     }
 
     public static function allowOrgZeroContext(): bool

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -3,6 +3,7 @@
 namespace App\Services\Commerce;
 
 use App\Models\Order;
+use App\Models\PaymentAttempt;
 use App\Services\Email\EmailOutboxService;
 use App\Services\Payments\PaymentProviderRegistry;
 use App\Services\Report\ReportAccess;
@@ -703,6 +704,298 @@ class OrderManager
                 'grant_state' => Order::normalizeGrantState($grantState),
                 'updated_at' => now(),
             ]);
+    }
+
+    public function createPaymentAttempt(
+        string $orderNo,
+        int $orgId,
+        string $provider,
+        ?string $channel,
+        ?string $providerApp,
+        ?string $payScene,
+        int $amountExpected,
+        ?string $currency,
+        array $payloadMeta = [],
+        array $meta = [],
+    ): array {
+        if (! Schema::hasTable('payment_attempts')) {
+            return $this->conflict('PAYMENT_ATTEMPTS_UNAVAILABLE', 'payment attempts unavailable.');
+        }
+
+        $orderNo = trim($orderNo);
+        if ($orderNo === '') {
+            return $this->badRequest('ORDER_REQUIRED', 'order_no is required.');
+        }
+
+        return DB::transaction(function () use (
+            $orderNo,
+            $orgId,
+            $provider,
+            $channel,
+            $providerApp,
+            $payScene,
+            $amountExpected,
+            $currency,
+            $payloadMeta,
+            $meta,
+        ): array {
+            $order = DB::table('orders')
+                ->where('order_no', $orderNo)
+                ->where('org_id', $orgId)
+                ->lockForUpdate()
+                ->first();
+            if (! $order) {
+                return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
+            }
+
+            $nextAttemptNo = ((int) DB::table('payment_attempts')
+                ->where('order_id', (string) ($order->id ?? ''))
+                ->max('attempt_no')) + 1;
+            if ($nextAttemptNo <= 0) {
+                $nextAttemptNo = 1;
+            }
+
+            $now = now();
+            $row = [
+                'id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'order_id' => (string) ($order->id ?? ''),
+                'order_no' => $orderNo,
+                'attempt_no' => $nextAttemptNo,
+                'provider' => strtolower(trim($provider)),
+                'channel' => Order::normalizeChannel($channel),
+                'provider_app' => $this->trimOrNull($providerApp),
+                'pay_scene' => $this->normalizePaymentAttemptPayScene($payScene),
+                'state' => PaymentAttempt::STATE_INITIATED,
+                'external_trade_no' => null,
+                'provider_trade_no' => null,
+                'provider_session_ref' => null,
+                'amount_expected' => max(0, $amountExpected),
+                'currency' => strtoupper(trim((string) $currency)) !== '' ? strtoupper(trim((string) $currency)) : 'USD',
+                'payload_meta_json' => $this->encodeJsonColumn($payloadMeta),
+                'latest_payment_event_id' => null,
+                'initiated_at' => $now,
+                'provider_created_at' => null,
+                'client_presented_at' => null,
+                'callback_received_at' => null,
+                'verified_at' => null,
+                'finalized_at' => null,
+                'last_error_code' => null,
+                'last_error_message' => null,
+                'meta_json' => $this->encodeJsonColumn($meta),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+
+            DB::table('payment_attempts')->insert($row);
+
+            return [
+                'ok' => true,
+                'attempt' => DB::table('payment_attempts')->where('id', $row['id'])->first() ?? (object) $row,
+            ];
+        });
+    }
+
+    public function advancePaymentAttempt(string $attemptId, array $context = []): ?object
+    {
+        if (! Schema::hasTable('payment_attempts')) {
+            return null;
+        }
+
+        $attemptId = trim($attemptId);
+        if ($attemptId === '') {
+            return null;
+        }
+
+        $attempt = DB::table('payment_attempts')
+            ->where('id', $attemptId)
+            ->first();
+        if (! $attempt) {
+            return null;
+        }
+
+        $resolvedState = $this->resolveNextPaymentAttemptState(
+            (string) ($attempt->state ?? ''),
+            $context['state'] ?? null
+        );
+        $updates = [
+            'state' => $resolvedState,
+            'updated_at' => now(),
+        ];
+
+        foreach ([
+            'external_trade_no',
+            'provider_trade_no',
+            'provider_session_ref',
+            'latest_payment_event_id',
+            'last_error_code',
+            'last_error_message',
+        ] as $field) {
+            $value = $this->trimOrNull($context[$field] ?? null);
+            if ($value !== null) {
+                $updates[$field] = $value;
+            }
+        }
+
+        foreach ([
+            'initiated_at',
+            'provider_created_at',
+            'client_presented_at',
+            'callback_received_at',
+            'verified_at',
+            'finalized_at',
+        ] as $field) {
+            $value = $this->trimOrNull($context[$field] ?? null);
+            if ($value !== null) {
+                $updates[$field] = $value;
+            }
+        }
+
+        if ($resolvedState === PaymentAttempt::STATE_PROVIDER_CREATED && empty($attempt->provider_created_at)) {
+            $updates['provider_created_at'] = $updates['provider_created_at'] ?? now();
+        }
+
+        if ($resolvedState === PaymentAttempt::STATE_CLIENT_PRESENTED && empty($attempt->client_presented_at)) {
+            $updates['client_presented_at'] = $updates['client_presented_at'] ?? now();
+        }
+
+        if ($resolvedState === PaymentAttempt::STATE_CALLBACK_RECEIVED && empty($attempt->callback_received_at)) {
+            $updates['callback_received_at'] = $updates['callback_received_at'] ?? now();
+        }
+
+        if (in_array($resolvedState, [
+            PaymentAttempt::STATE_VERIFIED,
+            PaymentAttempt::STATE_PAID,
+            PaymentAttempt::STATE_FAILED,
+            PaymentAttempt::STATE_CANCELED,
+            PaymentAttempt::STATE_EXPIRED,
+        ], true) && empty($attempt->verified_at)) {
+            $updates['verified_at'] = $updates['verified_at'] ?? now();
+        }
+
+        if (PaymentAttempt::isFinalState($resolvedState) && empty($attempt->finalized_at)) {
+            $updates['finalized_at'] = $updates['finalized_at'] ?? now();
+        }
+
+        if (array_key_exists('payload_meta_json', $context)) {
+            $updates['payload_meta_json'] = $this->encodeJsonColumn(
+                $this->mergeJsonColumns($attempt->payload_meta_json ?? null, $context['payload_meta_json'])
+            );
+        }
+
+        if (array_key_exists('meta_json', $context)) {
+            $updates['meta_json'] = $this->encodeJsonColumn(
+                $this->mergeJsonColumns($attempt->meta_json ?? null, $context['meta_json'])
+            );
+        }
+
+        DB::table('payment_attempts')
+            ->where('id', $attemptId)
+            ->update($updates);
+
+        return DB::table('payment_attempts')->where('id', $attemptId)->first();
+    }
+
+    public function bindPaymentEventToAttempt(
+        string $orderNo,
+        int $orgId,
+        string $provider,
+        string $paymentEventId,
+        ?string $externalTradeNo = null,
+        ?string $providerTradeNo = null,
+        ?string $callbackReceivedAt = null
+    ): ?object {
+        if (! Schema::hasTable('payment_attempts') || ! Schema::hasColumn('payment_events', 'payment_attempt_id')) {
+            return null;
+        }
+
+        $paymentEventId = trim($paymentEventId);
+        if ($paymentEventId === '') {
+            return null;
+        }
+
+        $event = DB::table('payment_events')->where('id', $paymentEventId)->first();
+        if (! $event) {
+            return null;
+        }
+
+        $existingAttemptId = $this->trimOrNull((string) ($event->payment_attempt_id ?? ''));
+        if ($existingAttemptId !== null) {
+            return $this->advancePaymentAttempt($existingAttemptId, [
+                'state' => PaymentAttempt::STATE_CALLBACK_RECEIVED,
+                'latest_payment_event_id' => $paymentEventId,
+                'external_trade_no' => $externalTradeNo,
+                'provider_trade_no' => $providerTradeNo,
+                'callback_received_at' => $callbackReceivedAt,
+            ]);
+        }
+
+        $order = DB::table('orders')
+            ->where('order_no', trim($orderNo))
+            ->where('org_id', $orgId)
+            ->first();
+        if (! $order) {
+            return null;
+        }
+
+        $attempt = $this->resolvePaymentAttemptForWebhook(
+            (string) ($order->id ?? ''),
+            strtolower(trim($provider)),
+            $externalTradeNo,
+            $providerTradeNo
+        );
+        if (! $attempt) {
+            return null;
+        }
+
+        DB::table('payment_events')
+            ->where('id', $paymentEventId)
+            ->update([
+                'payment_attempt_id' => (string) ($attempt->id ?? ''),
+                'updated_at' => now(),
+            ]);
+
+        return $this->advancePaymentAttempt((string) ($attempt->id ?? ''), [
+            'state' => PaymentAttempt::STATE_CALLBACK_RECEIVED,
+            'latest_payment_event_id' => $paymentEventId,
+            'external_trade_no' => $externalTradeNo,
+            'provider_trade_no' => $providerTradeNo,
+            'callback_received_at' => $callbackReceivedAt,
+        ]);
+    }
+
+    public function paymentAttemptSummary(string $orderNo, int $orgId): array
+    {
+        if (! Schema::hasTable('payment_attempts')) {
+            return [
+                'count' => 0,
+                'latest' => null,
+            ];
+        }
+
+        $count = (int) DB::table('payment_attempts')
+            ->where('order_no', $orderNo)
+            ->where('org_id', $orgId)
+            ->count();
+
+        $latest = DB::table('payment_attempts')
+            ->where('order_no', $orderNo)
+            ->where('org_id', $orgId)
+            ->orderByDesc('attempt_no')
+            ->first();
+
+        return [
+            'count' => $count,
+            'latest' => $latest ? [
+                'id' => (string) ($latest->id ?? ''),
+                'attempt_no' => (int) ($latest->attempt_no ?? 0),
+                'provider' => (string) ($latest->provider ?? ''),
+                'state' => (string) ($latest->state ?? ''),
+                'external_trade_no' => $latest->external_trade_no ?? null,
+                'provider_trade_no' => $latest->provider_trade_no ?? null,
+                'provider_session_ref' => $latest->provider_session_ref ?? null,
+            ] : null,
+        ];
     }
 
     public function touchPaymentLedger(
@@ -1490,6 +1783,116 @@ class OrderManager
         }
 
         return null;
+    }
+
+    private function resolveNextPaymentAttemptState(string $currentState, mixed $requestedState): string
+    {
+        $normalizedCurrent = PaymentAttempt::normalizedState($currentState);
+        $normalizedRequested = PaymentAttempt::normalizedState(is_scalar($requestedState) ? (string) $requestedState : null);
+
+        if ($this->paymentAttemptStateRank($normalizedRequested) >= $this->paymentAttemptStateRank($normalizedCurrent)) {
+            return $normalizedRequested;
+        }
+
+        return $normalizedCurrent;
+    }
+
+    private function paymentAttemptStateRank(string $state): int
+    {
+        return match (PaymentAttempt::normalizedState($state)) {
+            PaymentAttempt::STATE_INITIATED => 10,
+            PaymentAttempt::STATE_PROVIDER_CREATED => 20,
+            PaymentAttempt::STATE_CLIENT_PRESENTED => 30,
+            PaymentAttempt::STATE_CALLBACK_RECEIVED => 40,
+            PaymentAttempt::STATE_VERIFIED => 50,
+            PaymentAttempt::STATE_PAID,
+            PaymentAttempt::STATE_FAILED,
+            PaymentAttempt::STATE_CANCELED,
+            PaymentAttempt::STATE_EXPIRED => 60,
+            default => 0,
+        };
+    }
+
+    private function resolvePaymentAttemptForWebhook(
+        string $orderId,
+        string $provider,
+        ?string $externalTradeNo,
+        ?string $providerTradeNo
+    ): ?object {
+        if ($orderId === '') {
+            return null;
+        }
+
+        $tradeRefs = array_values(array_filter(array_unique([
+            $this->trimOrNull($externalTradeNo),
+            $this->trimOrNull($providerTradeNo),
+        ])));
+
+        if ($tradeRefs !== []) {
+            $matched = DB::table('payment_attempts')
+                ->where('order_id', $orderId)
+                ->where('provider', $provider)
+                ->where(function ($query) use ($tradeRefs): void {
+                    foreach ($tradeRefs as $tradeRef) {
+                        $query->orWhere('external_trade_no', $tradeRef)
+                            ->orWhere('provider_trade_no', $tradeRef)
+                            ->orWhere('provider_session_ref', $tradeRef);
+                    }
+                })
+                ->orderByDesc('attempt_no')
+                ->first();
+            if ($matched) {
+                return $matched;
+            }
+        }
+
+        $openAttempt = DB::table('payment_attempts')
+            ->where('order_id', $orderId)
+            ->where('provider', $provider)
+            ->whereNotIn('state', [
+                PaymentAttempt::STATE_PAID,
+                PaymentAttempt::STATE_FAILED,
+                PaymentAttempt::STATE_CANCELED,
+                PaymentAttempt::STATE_EXPIRED,
+            ])
+            ->orderByDesc('attempt_no')
+            ->first();
+        if ($openAttempt) {
+            return $openAttempt;
+        }
+
+        return DB::table('payment_attempts')
+            ->where('order_id', $orderId)
+            ->where('provider', $provider)
+            ->orderByDesc('attempt_no')
+            ->first();
+    }
+
+    private function normalizePaymentAttemptPayScene(?string $payScene): ?string
+    {
+        $normalized = strtolower(trim((string) $payScene));
+        if ($normalized === '') {
+            return null;
+        }
+
+        return mb_strlen($normalized, 'UTF-8') > 32
+            ? mb_substr($normalized, 0, 32, 'UTF-8')
+            : $normalized;
+    }
+
+    private function mergeJsonColumns(mixed $existing, mixed $incoming): array
+    {
+        $existingArray = $this->decodeMeta($existing);
+        $incomingArray = is_array($incoming) ? $incoming : $this->decodeMeta($incoming);
+
+        return array_replace_recursive($existingArray, $incomingArray);
+    }
+
+    private function encodeJsonColumn(array $payload): ?string
+    {
+        return $payload !== []
+            ? json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+            : null;
     }
 
     private function normalizeRequestId(mixed $value): ?string

--- a/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
@@ -271,6 +271,15 @@ class WebhookEntitlementService
                     $eventAt = is_scalar($normalized['paid_at'] ?? null)
                         ? (string) $normalized['paid_at']
                         : null;
+                    $boundPaymentAttempt = $this->core->orderManager()->bindPaymentEventToAttempt(
+                        $orderNo,
+                        $orgId,
+                        $provider,
+                        (string) ($eventRow->id ?? ''),
+                        $providerTradeNo,
+                        $providerTradeNo,
+                        $eventAt
+                    );
                     $nonSuccessPaymentState = $this->resolveNonSuccessPaymentState($eventType);
                     $this->core->orderManager()->touchPaymentLedger(
                         $orderNo,
@@ -292,6 +301,14 @@ class WebhookEntitlementService
                             );
 
                             return $refund;
+                        }
+                        if ($boundPaymentAttempt !== null) {
+                            $this->core->orderManager()->advancePaymentAttempt((string) ($boundPaymentAttempt->id ?? ''), [
+                                'state' => \App\Models\PaymentAttempt::STATE_VERIFIED,
+                                'latest_payment_event_id' => (string) ($eventRow->id ?? ''),
+                                'provider_trade_no' => $providerTradeNo,
+                                'verified_at' => $eventAt,
+                            ]);
                         }
                         $this->core->markEventProcessed($provider, $providerEventId);
 
@@ -322,6 +339,18 @@ class WebhookEntitlementService
                             return $transition;
                         }
 
+                        if ($boundPaymentAttempt !== null) {
+                            $this->core->orderManager()->advancePaymentAttempt((string) ($boundPaymentAttempt->id ?? ''), [
+                                'state' => match ($nonSuccessPaymentState) {
+                                    \App\Models\Order::PAYMENT_STATE_FAILED => \App\Models\PaymentAttempt::STATE_FAILED,
+                                    \App\Models\Order::PAYMENT_STATE_EXPIRED => \App\Models\PaymentAttempt::STATE_EXPIRED,
+                                    default => \App\Models\PaymentAttempt::STATE_CANCELED,
+                                },
+                                'latest_payment_event_id' => (string) ($eventRow->id ?? ''),
+                                'provider_trade_no' => $providerTradeNo,
+                                'verified_at' => $eventAt,
+                            ]);
+                        }
                         $this->core->markEventProcessed($provider, $providerEventId);
 
                         return [
@@ -383,6 +412,18 @@ class WebhookEntitlementService
 
                             return $orderTransition;
                         }
+                    }
+
+                    if ($boundPaymentAttempt !== null) {
+                        $this->core->orderManager()->advancePaymentAttempt((string) ($boundPaymentAttempt->id ?? ''), [
+                            'state' => \App\Models\PaymentAttempt::STATE_PAID,
+                            'latest_payment_event_id' => (string) ($eventRow->id ?? ''),
+                            'provider_trade_no' => $providerTradeNo,
+                            'verified_at' => $eventAt,
+                            'external_trade_no' => is_scalar($normalized['external_trade_no'] ?? null)
+                                ? (string) $normalized['external_trade_no']
+                                : null,
+                        ]);
                     }
 
                     $updateRow = [

--- a/backend/app/Services/Payments/PaymentService.php
+++ b/backend/app/Services/Payments/PaymentService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Payments;
 
 use App\Models\Order;
+use App\Models\PaymentAttempt;
 use App\Services\Commerce\SkuPriceService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -89,6 +90,9 @@ class PaymentService
 
         DB::table('orders')->insert($row);
         $order = DB::table('orders')->where('id', $orderId)->first();
+        if ($order) {
+            $this->ensureLegacyPaymentAttempt($order);
+        }
 
         return [
             'ok' => true,
@@ -121,6 +125,7 @@ class PaymentService
 
         $provider = self::PAYMENT_PROVIDER_INTERNAL;
         $providerEventId = 'dev_mark_paid:'.$orderId;
+        $paymentAttempt = $this->ensureLegacyPaymentAttempt($order);
         $existing = $this->paymentEventQuery($provider, $providerEventId)->first();
 
         if (! $existing) {
@@ -135,6 +140,8 @@ class PaymentService
                 'provider' => $provider,
                 'provider_event_id' => $providerEventId,
                 'order_id' => $orderId,
+                'payment_attempt_id' => is_object($paymentAttempt) ? ($paymentAttempt->id ?? null) : null,
+                'order_no' => $order->order_no ?? null,
                 'event_type' => 'mark_paid',
                 'payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
                 'signature_ok' => true,
@@ -156,6 +163,15 @@ class PaymentService
                 'paid_at' => $now,
                 'updated_at' => $now,
             ]);
+        if ($paymentAttempt) {
+            $this->advanceLegacyPaymentAttempt((string) $paymentAttempt->id, [
+                'state' => PaymentAttempt::STATE_PAID,
+                'latest_payment_event_id' => $existing->id ?? $this->trimOrNull($this->paymentEventQuery($provider, $providerEventId)->value('id')),
+                'verified_at' => $now,
+                'callback_received_at' => $now,
+                'finalized_at' => $now,
+            ]);
+        }
 
         $order = DB::table('orders')->where('id', $orderId)->first();
 
@@ -330,6 +346,8 @@ class PaymentService
                 'provider' => $provider,
                 'provider_event_id' => $providerEventId,
                 'order_id' => $orderId,
+                'payment_attempt_id' => $this->trimOrNull((string) (is_object($legacyAttempt = $this->ensureLegacyPaymentAttempt($order)) ? ($legacyAttempt->id ?? '') : '')),
+                'order_no' => $order->order_no ?? null,
                 'event_type' => $eventType,
                 'payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
                 'signature_ok' => $signatureOk,
@@ -380,9 +398,19 @@ class PaymentService
                         ->where('id', $orderId)
                         ->update([
                             'status' => 'paid',
+                            'payment_state' => Order::PAYMENT_STATE_PAID,
                             'paid_at' => $now,
                             'updated_at' => $now,
                         ]);
+                }
+                if (! empty($eventRow['payment_attempt_id'])) {
+                    $this->advanceLegacyPaymentAttempt((string) $eventRow['payment_attempt_id'], [
+                        'state' => PaymentAttempt::STATE_PAID,
+                        'latest_payment_event_id' => (string) $eventRow['id'],
+                        'callback_received_at' => $now,
+                        'verified_at' => $now,
+                        'finalized_at' => $now,
+                    ]);
                 }
 
                 if (in_array($order->status, ['pending', 'paid', 'fulfilled'], true)) {
@@ -403,6 +431,7 @@ class PaymentService
                         ->where('id', $orderId)
                         ->update([
                             'status' => 'refunded',
+                            'payment_state' => Order::PAYMENT_STATE_REFUNDED,
                             'refunded_at' => $now,
                             'updated_at' => $now,
                         ]);
@@ -562,6 +591,120 @@ class PaymentService
         DB::table('orders')
             ->where('id', $orderId)
             ->update($updates);
+    }
+
+    private function ensureLegacyPaymentAttempt(object $order): ?object
+    {
+        if (! DB::getSchemaBuilder()->hasTable('payment_attempts')) {
+            return null;
+        }
+
+        $existing = $this->latestPaymentAttemptForOrder((string) ($order->id ?? ''));
+        if ($existing) {
+            return $existing;
+        }
+
+        $now = now();
+        $row = [
+            'id' => (string) Str::uuid(),
+            'org_id' => (int) ($order->org_id ?? 0),
+            'order_id' => (string) ($order->id ?? ''),
+            'order_no' => (string) ($order->order_no ?? ''),
+            'attempt_no' => 1,
+            'provider' => strtolower(trim((string) ($order->provider ?? self::PAYMENT_PROVIDER_INTERNAL))),
+            'channel' => Order::normalizeChannel((string) ($order->channel ?? '')) ?? 'web',
+            'provider_app' => $this->trimOrNull($order->provider_app ?? null),
+            'pay_scene' => null,
+            'state' => PaymentAttempt::STATE_INITIATED,
+            'external_trade_no' => $this->trimOrNull($order->external_trade_no ?? null),
+            'provider_trade_no' => $this->trimOrNull($order->provider_trade_no ?? null),
+            'provider_session_ref' => null,
+            'amount_expected' => (int) ($order->amount_cents ?? $order->amount_total ?? 0),
+            'currency' => strtoupper(trim((string) ($order->currency ?? 'USD'))),
+            'payload_meta_json' => json_encode(['source' => 'legacy_payment_service'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'latest_payment_event_id' => null,
+            'initiated_at' => $now,
+            'provider_created_at' => null,
+            'client_presented_at' => null,
+            'callback_received_at' => null,
+            'verified_at' => null,
+            'finalized_at' => null,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'meta_json' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+
+        DB::table('payment_attempts')->insert($row);
+
+        return DB::table('payment_attempts')->where('id', $row['id'])->first();
+    }
+
+    private function latestPaymentAttemptForOrder(string $orderId): ?object
+    {
+        if ($orderId === '' || ! DB::getSchemaBuilder()->hasTable('payment_attempts')) {
+            return null;
+        }
+
+        return DB::table('payment_attempts')
+            ->where('order_id', $orderId)
+            ->orderByDesc('attempt_no')
+            ->first();
+    }
+
+    private function advanceLegacyPaymentAttempt(string $attemptId, array $updates): void
+    {
+        if ($attemptId === '' || ! DB::getSchemaBuilder()->hasTable('payment_attempts')) {
+            return;
+        }
+
+        $current = DB::table('payment_attempts')->where('id', $attemptId)->first();
+        if (! $current) {
+            return;
+        }
+
+        $state = isset($updates['state']) ? PaymentAttempt::normalizedState((string) $updates['state']) : null;
+        if ($state !== null) {
+            $updates['state'] = $this->resolveLegacyAttemptState(
+                (string) ($current->state ?? ''),
+                $state
+            );
+        }
+
+        foreach (['callback_received_at', 'verified_at', 'finalized_at'] as $field) {
+            if (isset($updates[$field]) && ! is_string($updates[$field])) {
+                $updates[$field] = (string) $updates[$field];
+            }
+        }
+
+        $updates['updated_at'] = now();
+
+        DB::table('payment_attempts')
+            ->where('id', $attemptId)
+            ->update($updates);
+    }
+
+    private function resolveLegacyAttemptState(string $currentState, string $requestedState): string
+    {
+        $rank = [
+            PaymentAttempt::STATE_INITIATED => 10,
+            PaymentAttempt::STATE_PROVIDER_CREATED => 20,
+            PaymentAttempt::STATE_CLIENT_PRESENTED => 30,
+            PaymentAttempt::STATE_CALLBACK_RECEIVED => 40,
+            PaymentAttempt::STATE_VERIFIED => 50,
+            PaymentAttempt::STATE_PAID => 60,
+            PaymentAttempt::STATE_FAILED => 60,
+            PaymentAttempt::STATE_CANCELED => 60,
+            PaymentAttempt::STATE_EXPIRED => 60,
+        ];
+
+        $normalizedCurrent = PaymentAttempt::normalizedState($currentState);
+        $normalizedRequested = PaymentAttempt::normalizedState($requestedState);
+
+        return ($rank[$normalizedRequested] ?? 0) >= ($rank[$normalizedCurrent] ?? 0)
+            ? $normalizedRequested
+            : $normalizedCurrent;
     }
 
     private function presentBenefit($row): array

--- a/backend/database/migrations/2026_03_26_160000_create_payment_attempts_table.php
+++ b/backend/database/migrations/2026_03_26_160000_create_payment_attempts_table.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const ORDER_ATTEMPT_UNIQUE = 'payment_attempts_order_attempt_no_unique';
+
+    private const ORDER_NO_INDEX = 'payment_attempts_order_no_idx';
+
+    private const PROVIDER_INDEX = 'payment_attempts_provider_idx';
+
+    private const STATE_INDEX = 'payment_attempts_state_idx';
+
+    private const EXTERNAL_TRADE_NO_INDEX = 'payment_attempts_external_trade_no_idx';
+
+    private const PROVIDER_TRADE_NO_INDEX = 'payment_attempts_provider_trade_no_idx';
+
+    private const ORDER_PROVIDER_SCENE_INDEX = 'payment_attempts_order_provider_scene_idx';
+
+    private const EVENT_ATTEMPT_INDEX = 'payment_events_payment_attempt_id_idx';
+
+    public function up(): void
+    {
+        $this->convergePaymentAttempts();
+        $this->convergePaymentEvents();
+    }
+
+    public function down(): void
+    {
+        // Forward-only migration.
+    }
+
+    private function convergePaymentAttempts(): void
+    {
+        if (! Schema::hasTable('payment_attempts')) {
+            Schema::create('payment_attempts', function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->uuid('order_id');
+                $table->string('order_no', 64);
+                $table->unsignedInteger('attempt_no');
+                $table->string('provider', 32);
+                $table->string('channel', 64)->nullable();
+                $table->string('provider_app', 128)->nullable();
+                $table->string('pay_scene', 32)->nullable();
+                $table->string('state', 32)->default('initiated');
+                $table->string('external_trade_no', 128)->nullable();
+                $table->string('provider_trade_no', 128)->nullable();
+                $table->string('provider_session_ref', 191)->nullable();
+                $table->integer('amount_expected')->default(0);
+                $table->string('currency', 8)->default('USD');
+                $table->json('payload_meta_json')->nullable();
+                $table->uuid('latest_payment_event_id')->nullable();
+                $table->timestamp('initiated_at')->nullable();
+                $table->timestamp('provider_created_at')->nullable();
+                $table->timestamp('client_presented_at')->nullable();
+                $table->timestamp('callback_received_at')->nullable();
+                $table->timestamp('verified_at')->nullable();
+                $table->timestamp('finalized_at')->nullable();
+                $table->string('last_error_code', 64)->nullable();
+                $table->string('last_error_message', 255)->nullable();
+                $table->json('meta_json')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table('payment_attempts', function (Blueprint $table): void {
+                if (! Schema::hasColumn('payment_attempts', 'id')) {
+                    $table->uuid('id')->primary();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'org_id')) {
+                    $table->unsignedBigInteger('org_id')->default(0);
+                }
+                if (! Schema::hasColumn('payment_attempts', 'order_id')) {
+                    $table->uuid('order_id')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'order_no')) {
+                    $table->string('order_no', 64)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'attempt_no')) {
+                    $table->unsignedInteger('attempt_no')->default(1);
+                }
+                if (! Schema::hasColumn('payment_attempts', 'provider')) {
+                    $table->string('provider', 32)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'channel')) {
+                    $table->string('channel', 64)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'provider_app')) {
+                    $table->string('provider_app', 128)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'pay_scene')) {
+                    $table->string('pay_scene', 32)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'state')) {
+                    $table->string('state', 32)->default('initiated');
+                }
+                if (! Schema::hasColumn('payment_attempts', 'external_trade_no')) {
+                    $table->string('external_trade_no', 128)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'provider_trade_no')) {
+                    $table->string('provider_trade_no', 128)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'provider_session_ref')) {
+                    $table->string('provider_session_ref', 191)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'amount_expected')) {
+                    $table->integer('amount_expected')->default(0);
+                }
+                if (! Schema::hasColumn('payment_attempts', 'currency')) {
+                    $table->string('currency', 8)->default('USD');
+                }
+                if (! Schema::hasColumn('payment_attempts', 'payload_meta_json')) {
+                    $table->json('payload_meta_json')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'latest_payment_event_id')) {
+                    $table->uuid('latest_payment_event_id')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'initiated_at')) {
+                    $table->timestamp('initiated_at')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'provider_created_at')) {
+                    $table->timestamp('provider_created_at')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'client_presented_at')) {
+                    $table->timestamp('client_presented_at')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'callback_received_at')) {
+                    $table->timestamp('callback_received_at')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'verified_at')) {
+                    $table->timestamp('verified_at')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'finalized_at')) {
+                    $table->timestamp('finalized_at')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'last_error_code')) {
+                    $table->string('last_error_code', 64)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'last_error_message')) {
+                    $table->string('last_error_message', 255)->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'meta_json')) {
+                    $table->json('meta_json')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (! Schema::hasColumn('payment_attempts', 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $this->ensureUniqueIndex(
+            'payment_attempts',
+            self::ORDER_ATTEMPT_UNIQUE,
+            ['order_id', 'attempt_no']
+        );
+        $this->ensureIndex('payment_attempts', self::ORDER_NO_INDEX, ['order_no']);
+        $this->ensureIndex('payment_attempts', self::PROVIDER_INDEX, ['provider']);
+        $this->ensureIndex('payment_attempts', self::STATE_INDEX, ['state']);
+        $this->ensureIndex('payment_attempts', self::EXTERNAL_TRADE_NO_INDEX, ['external_trade_no']);
+        $this->ensureIndex('payment_attempts', self::PROVIDER_TRADE_NO_INDEX, ['provider_trade_no']);
+        $this->ensureIndex('payment_attempts', self::ORDER_PROVIDER_SCENE_INDEX, ['order_id', 'provider', 'pay_scene']);
+    }
+
+    private function convergePaymentEvents(): void
+    {
+        if (! Schema::hasTable('payment_events')) {
+            return;
+        }
+
+        Schema::table('payment_events', function (Blueprint $table): void {
+            if (! Schema::hasColumn('payment_events', 'payment_attempt_id')) {
+                $table->uuid('payment_attempt_id')->nullable()->after('order_id');
+            }
+        });
+
+        $this->ensureIndex('payment_events', self::EVENT_ATTEMPT_INDEX, ['payment_attempt_id']);
+    }
+
+    private function ensureIndex(string $table, string $indexName, array $columns): void
+    {
+        if (! Schema::hasTable($table) || SchemaIndex::indexExists($table, $indexName)) {
+            return;
+        }
+
+        foreach ($columns as $column) {
+            if (! Schema::hasColumn($table, $column)) {
+                return;
+            }
+        }
+
+        Schema::table($table, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+
+    private function ensureUniqueIndex(string $table, string $indexName, array $columns): void
+    {
+        if (! Schema::hasTable($table) || SchemaIndex::indexExists($table, $indexName)) {
+            return;
+        }
+
+        foreach ($columns as $column) {
+            if (! Schema::hasColumn($table, $column)) {
+                return;
+            }
+        }
+
+        Schema::table($table, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->unique($columns, $indexName);
+        });
+    }
+};

--- a/backend/tests/Feature/Commerce/OrderPricingTest.php
+++ b/backend/tests/Feature/Commerce/OrderPricingTest.php
@@ -44,6 +44,7 @@ final class OrderPricingTest extends TestCase
         $this->assertSame('user:u_pricing_1', (string) ($stored->external_user_ref ?? ''));
         $this->assertSame('web', (string) ($stored->channel ?? ''));
         $this->assertNull($stored->provider_app ?? null);
+        $this->assertSame(1, DB::table('payment_attempts')->where('order_id', $orderId)->count());
     }
 
     public function test_create_order_throws_invalid_sku_exception_when_sku_does_not_exist(): void

--- a/backend/tests/Feature/Commerce/PaymentAttemptStateContractTest.php
+++ b/backend/tests/Feature/Commerce/PaymentAttemptStateContractTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Models\Attempt;
+use App\Models\Order;
+use App\Models\PaymentAttempt;
+use App\Services\Commerce\OrderManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class PaymentAttemptStateContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_order_manager_creates_and_advances_payment_attempt(): void
+    {
+        config([
+            'payments.providers.wechatpay.enabled' => true,
+        ]);
+
+        $attemptId = $this->createAttempt();
+        $this->seedSku();
+
+        $created = app(OrderManager::class)->createOrder(
+            0,
+            null,
+            'anon_payment_attempt_contract',
+            'MBTI_REPORT_FULL',
+            1,
+            $attemptId,
+            'wechatpay',
+            null,
+            'payment-attempt-contract@example.com',
+            null,
+            [],
+            [],
+            [
+                'channel' => 'wechat_miniapp',
+                'provider_app' => 'wx-miniapp-primary',
+            ]
+        );
+
+        $this->assertTrue((bool) ($created['ok'] ?? false));
+        $orderNo = (string) ($created['order_no'] ?? '');
+        $this->assertNotSame('', $orderNo);
+
+        $attempt = app(OrderManager::class)->createPaymentAttempt(
+            $orderNo,
+            0,
+            'wechatpay',
+            'wechat_miniapp',
+            'wx-miniapp-primary',
+            'mobile',
+            299,
+            'CNY',
+            ['source' => 'contract_test']
+        )['attempt'] ?? null;
+
+        $this->assertNotNull($attempt);
+        $this->assertSame(1, (int) ($attempt->attempt_no ?? 0));
+        $this->assertSame(PaymentAttempt::STATE_INITIATED, (string) ($attempt->state ?? ''));
+
+        $providerCreated = app(OrderManager::class)->advancePaymentAttempt((string) ($attempt->id ?? ''), [
+            'state' => PaymentAttempt::STATE_PROVIDER_CREATED,
+            'external_trade_no' => 'wx_trade_contract_1',
+            'provider_created_at' => now()->toDateTimeString(),
+        ]);
+        $this->assertNotNull($providerCreated);
+        $this->assertSame(PaymentAttempt::STATE_PROVIDER_CREATED, (string) ($providerCreated->state ?? ''));
+        $this->assertSame('wx_trade_contract_1', (string) ($providerCreated->external_trade_no ?? ''));
+
+        $paid = app(OrderManager::class)->advancePaymentAttempt((string) ($attempt->id ?? ''), [
+            'state' => PaymentAttempt::STATE_PAID,
+            'provider_trade_no' => 'wx_provider_trade_contract_1',
+            'verified_at' => now()->toDateTimeString(),
+        ]);
+        $this->assertNotNull($paid);
+        $this->assertSame(PaymentAttempt::STATE_PAID, (string) ($paid->state ?? ''));
+        $this->assertSame('wx_provider_trade_contract_1', (string) ($paid->provider_trade_no ?? ''));
+        $this->assertNotNull($paid->finalized_at ?? null);
+
+        $order = Order::query()->where('order_no', $orderNo)->first();
+        $this->assertNotNull($order);
+        $this->assertSame(1, $order->paymentAttempts()->count());
+        $this->assertNotNull($order->latestPaymentAttempt);
+        $this->assertSame((string) ($attempt->id ?? ''), (string) ($order->latestPaymentAttempt->id ?? ''));
+    }
+
+    private function createAttempt(): string
+    {
+        $attempt = Attempt::query()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'anon_id' => 'anon_payment_attempt_contract',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 60,
+            'answers_summary_json' => ['stage' => 'seed'],
+            'client_platform' => 'test',
+            'channel' => 'wechat_miniapp',
+            'started_at' => now()->subMinutes(3),
+            'submitted_at' => now(),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'mbti_spec_v1',
+        ]);
+
+        return (string) $attempt->id;
+    }
+
+    private function seedSku(): void
+    {
+        DB::table('skus')->updateOrInsert(
+            ['sku' => 'MBTI_REPORT_FULL'],
+            [
+                'org_id' => 0,
+                'scale_code' => 'MBTI',
+                'kind' => 'report_unlock',
+                'unit_qty' => 1,
+                'benefit_code' => 'MBTI_REPORT_FULL',
+                'scope' => 'attempt',
+                'price_cents' => 299,
+                'currency' => 'CNY',
+                'is_active' => true,
+                'meta_json' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+    }
+}

--- a/backend/tests/Feature/Commerce/PaymentAttemptWebhookBindingTest.php
+++ b/backend/tests/Feature/Commerce/PaymentAttemptWebhookBindingTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Models\PaymentAttempt;
+use Database\Seeders\Pr19CommerceSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\Concerns\SignedBillingWebhook;
+use Tests\TestCase;
+
+final class PaymentAttemptWebhookBindingTest extends TestCase
+{
+    use RefreshDatabase;
+    use SignedBillingWebhook;
+
+    public function test_billing_webhook_binds_to_existing_open_payment_attempt(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+
+        $orderId = (string) Str::uuid();
+        $orderNo = 'ord_attempt_binding_1';
+        DB::table('orders')->insert([
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_attempt_binding',
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => null,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'status' => 'pending',
+            'payment_state' => 'pending',
+            'grant_state' => 'not_started',
+            'provider' => 'billing',
+            'channel' => 'web',
+            'provider_app' => null,
+            'external_trade_no' => null,
+            'provider_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 4990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_CREDIT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+
+        $paymentAttemptId = (string) Str::uuid();
+        DB::table('payment_attempts')->insert([
+            'id' => $paymentAttemptId,
+            'org_id' => 0,
+            'order_id' => $orderId,
+            'order_no' => $orderNo,
+            'attempt_no' => 1,
+            'provider' => 'billing',
+            'channel' => 'web',
+            'provider_app' => null,
+            'pay_scene' => 'desktop',
+            'state' => PaymentAttempt::STATE_CLIENT_PRESENTED,
+            'external_trade_no' => null,
+            'provider_trade_no' => null,
+            'provider_session_ref' => null,
+            'amount_expected' => 4990,
+            'currency' => 'USD',
+            'payload_meta_json' => json_encode(['source' => 'test'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'latest_payment_event_id' => null,
+            'initiated_at' => now()->subMinute(),
+            'provider_created_at' => now()->subMinute(),
+            'client_presented_at' => now()->subMinute(),
+            'callback_received_at' => null,
+            'verified_at' => null,
+            'finalized_at' => null,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'meta_json' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        $response = $this->postSignedBillingWebhook([
+            'provider_event_id' => 'evt_attempt_binding_1',
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_attempt_binding_1',
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['ok' => true]);
+
+        $event = DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_attempt_binding_1')
+            ->first();
+        $this->assertNotNull($event);
+        $this->assertSame($paymentAttemptId, (string) ($event->payment_attempt_id ?? ''));
+
+        $attempt = DB::table('payment_attempts')->where('id', $paymentAttemptId)->first();
+        $this->assertNotNull($attempt);
+        $this->assertSame(PaymentAttempt::STATE_PAID, (string) ($attempt->state ?? ''));
+        $this->assertSame('trade_attempt_binding_1', (string) ($attempt->provider_trade_no ?? ''));
+        $this->assertSame((string) ($event->id ?? ''), (string) ($attempt->latest_payment_event_id ?? ''));
+        $this->assertNotNull($attempt->callback_received_at ?? null);
+        $this->assertNotNull($attempt->verified_at ?? null);
+    }
+}

--- a/backend/tests/Feature/Commerce/Webhook/PaymentWebhookProcessorContractTest.php
+++ b/backend/tests/Feature/Commerce/Webhook/PaymentWebhookProcessorContractTest.php
@@ -8,6 +8,8 @@ use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Commerce\PaymentWebhookProcessor;
 use Database\Seeders\Pr19CommerceSeeder;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
@@ -30,7 +32,7 @@ final class PaymentWebhookProcessorContractTest extends TestCase
 
     public function test_duplicate_event_is_idempotent_and_db_state_is_stable(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
 
         $attemptId = $this->createMbtiAttemptWithResult();
         $orderNo = 'ord_contract_dup_1';
@@ -94,7 +96,7 @@ final class PaymentWebhookProcessorContractTest extends TestCase
 
     public function test_provider_mismatch_is_rejected_without_entitlement_write(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
 
         $orderNo = 'ord_contract_provider_mismatch_1';
 
@@ -155,7 +157,7 @@ final class PaymentWebhookProcessorContractTest extends TestCase
 
     public function test_semantic_reject_keeps_http_200_and_reject_reason_contract(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
 
         $orderNo = 'ord_contract_semantic_reject_1';
         DB::table('orders')->insert([
@@ -207,7 +209,7 @@ final class PaymentWebhookProcessorContractTest extends TestCase
 
     public function test_amount_and_currency_mismatch_are_rejected_with_stable_contract(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
         $processor = app(PaymentWebhookProcessor::class);
 
         $orderNo = 'ord_contract_amount_currency_1';
@@ -282,7 +284,7 @@ final class PaymentWebhookProcessorContractTest extends TestCase
 
     public function test_missing_order_keeps_contract_and_does_not_grant_benefit(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
 
         $res = $this->postSignedBillingWebhook([
             'provider_event_id' => 'evt_contract_order_missing_1',
@@ -305,7 +307,7 @@ final class PaymentWebhookProcessorContractTest extends TestCase
 
     public function test_refund_event_does_not_issue_duplicate_benefit_side_effects(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
 
         $orderNo = 'ord_contract_refund_1';
         DB::table('orders')->insert([
@@ -363,11 +365,15 @@ final class PaymentWebhookProcessorContractTest extends TestCase
 
     public function test_lock_timeout_returns_webhook_busy_contract(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
 
+        $cacheStore = new CacheRepository(new ArrayStore);
+        $this->app->instance('cache.store', $cacheStore);
+        $this->app->instance(\Illuminate\Contracts\Cache\Repository::class, $cacheStore);
         Cache::shouldReceive('lock')
             ->once()
-            ->andReturn(new class {
+            ->andReturn(new class
+            {
                 public function block(int $seconds, callable $callback): mixed
                 {
                     throw new LockTimeoutException('busy');
@@ -391,7 +397,7 @@ final class PaymentWebhookProcessorContractTest extends TestCase
 
     public function test_oversized_payload_is_rejected_by_controller_with_413(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
         config(['payments.webhook_max_payload_bytes' => 1024]);
 
         $res = $this->postSignedBillingWebhook([
@@ -409,7 +415,7 @@ final class PaymentWebhookProcessorContractTest extends TestCase
 
     public function test_controller_propagates_processor_status_in_contract_mode(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
 
         $mock = Mockery::mock(PaymentWebhookProcessor::class);
         $mock->shouldReceive('process')

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -153,6 +153,49 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $this->assertSame('pending', (string) DB::table('orders')->where('order_no', $orderNo)->value('payment_state'));
         $this->assertSame('not_started', (string) DB::table('orders')->where('order_no', $orderNo)->value('grant_state'));
         $this->assertSame('web', (string) DB::table('orders')->where('order_no', $orderNo)->value('channel'));
+        $this->assertSame(1, (int) ($response->json('payment_attempts_count') ?? 0));
+        $this->assertSame('initiated', (string) ($response->json('latest_payment_attempt.state') ?? ''));
+    }
+
+    public function test_cached_order_payment_action_does_not_create_duplicate_payment_attempts(): void
+    {
+        $this->seedCommerce();
+
+        config([
+            'payments.providers.wechatpay.enabled' => true,
+        ]);
+
+        $mock = Mockery::mock(WechatPayCheckoutService::class);
+        $mock->shouldReceive('createCheckoutAction')
+            ->once()
+            ->andReturn([
+                'ok' => true,
+                'type' => 'qr',
+                'value' => 'weixin://wxpay/bizpayurl?pr=attempt_cache_qr',
+            ]);
+        $this->app->instance(WechatPayCheckoutService::class, $mock);
+
+        $response = $this->checkout([
+            'sku' => 'MBTI_CREDIT',
+            'provider' => 'wechatpay',
+            'email' => 'attempt-cache@example.com',
+        ], [
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        ]);
+
+        $response->assertStatus(200);
+        $orderNo = (string) $response->json('order_no');
+        $paymentRecoveryToken = (string) $response->json('payment_recovery_token');
+        $this->assertNotSame('', $orderNo);
+        $this->assertSame(1, DB::table('payment_attempts')->where('order_no', $orderNo)->count());
+
+        $followup = $this->getJson('/api/v0.3/orders/'.$orderNo.'?include_payment_action=1&payment_recovery_token='.urlencode($paymentRecoveryToken), [
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        ]);
+
+        $followup->assertStatus(200);
+        $followup->assertJsonPath('payment_attempts_count', 1);
+        $this->assertSame(1, DB::table('payment_attempts')->where('order_no', $orderNo)->count());
     }
 
     public function test_checkout_wechatpay_desktop_returns_qr_action(): void

--- a/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
@@ -273,6 +273,10 @@ final class PaymentWebhookControllerTest extends TestCase
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_sec002_bill_1')
             ->count());
+        $this->assertNull(DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_sec002_bill_1')
+            ->value('payment_attempt_id'));
         $this->assertSame(0, DB::table('email_outbox')->count());
     }
 


### PR DESCRIPTION
## Summary
This PR ships OP-2 for the commerce backend by adding a backend-owned `payment_attempts` layer and wiring it into the existing order and webhook truth chain.

Before this change, the system had an order ledger in `orders` and callback truth in `payment_events`, but it could not reliably answer how many times a customer actually initiated payment, which launch was the latest one, or which callback belonged to which pay initiation. In practice that made pending orders hard to reason about and made provider-side success versus backend-side status drift harder to diagnose.

This change keeps `orders` as the primary ledger introduced in OP-1, and adds `payment_attempts` as a separate append-only initiation truth layer. Checkout and payment-action generation now create or reuse attempts in a controlled way, webhook processing binds verified events back to the matching attempt, and the latest attempt summary becomes available from order read models and minimal ops views.

## What changed
- add additive `payment_attempts` schema and model
- add `payment_events.payment_attempt_id` as a nullable linkage field
- add `Order -> paymentAttempts` and `latestPaymentAttempt` relations
- create payment attempts during real pay-action initiation, not during pure reads
- persist cached payment-action metadata with the attempt id so repeated recovery reads do not create duplicate attempts
- bind webhook events to attempts and advance attempt state through callback receipt and settlement
- align legacy `PaymentService` with split order states and attempt tracking so it no longer bypasses OP-1/OP-2 semantics
- expose minimal attempt visibility in order and payment-event ops resources
- add focused tests for attempt creation, reuse, webhook binding, and contract stability

## User impact
After this PR, the backend can answer:
- how many times a given order actually initiated payment
- what the latest attempt state is
- whether a callback attached to a concrete attempt
- whether a pending order has attempt history or is missing initiation truth entirely

This does not yet implement compensation, query-order repair, expiration cleanup, or full operator dashboards. Those remain out of scope for OP-2 and can build on top of this attempt layer.

## Validation
- `php artisan route:list --path=api/v0.3/orders`
- `php artisan route:list --path=api/v0.3/webhooks/payment`
- `php artisan migrate`
- `php artisan test --filter="PaymentAttemptStateContractTest|PaymentAttemptWebhookBindingTest|CommerceCheckoutPayActionTest|PaymentWebhookControllerTest|OrderLedgerStateContractTest|OrderPricingTest|PaymentWebhookProcessorContractTest" --stop-on-failure`
- `php artisan test --filter="CommerceWebhookIdempotencyTest|PaymentWebhookProcessorAtomicityTest|PaymentWebhookTrustBoundaryTest|WechatPayGatewayOrderNoMappingTest" --stop-on-failure`

## Notes
- `PaymentService` has been rechecked and now writes `payment_state`, `grant_state`, and attempt linkage; the earlier review note about it only writing legacy status no longer reproduces.
- Local test runs still surface one unrelated content/paywall baseline failure in `BigFivePaywallFlagModesTest`, which is outside OP-2 scope.
- `backend/content_packs/BIG5_OCEAN/v1/compiled/*` local test-generated changes were intentionally not included in this PR.
