### PR TITLE
[codex] clean mbti legacy builder residue docs

### DIFF
--- a/backend/app/Internal/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilderV2Core.php
+++ b/backend/app/Internal/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilderV2Core.php
@@ -9,6 +9,11 @@ use App\Services\Rules\RuleEngine;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * Internal legacy MBTI builder core retained for legacy fixture/golden coverage.
+ *
+ * Current runtime report assembly is served by ReportComposer / ReportPayloadAssembler.
+ */
 class LegacyMbtiReportPayloadBuilderV2Core
 {
     public function __construct(
@@ -431,7 +436,7 @@ try {
         'scores_pct'              => $scoresPct,
         'axis_states'             => $axisStates,
         'engine'                  => 'm3',
-        'source'                  => 'LegacyMbtiAttemptService::buildHighlights',
+        'source'                  => 'LegacyMbtiReportPayloadBuilderV2Core::buildHighlights',
     ];
 
     if (method_exists($applier, 'applyHighlights')) {

--- a/backend/app/Services/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilder.php
+++ b/backend/app/Services/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilder.php
@@ -8,6 +8,11 @@ use App\Services\Legacy\Mbti\Report\V2\LegacyMbtiReportPayloadBuilderV2;
 use App\Services\Legacy\Mbti\Report\V2\LegacyMbtiReportPayloadBuilderV2Facade;
 use App\Services\Legacy\Mbti\Report\V2\LegacyMbtiReportPayloadComposer;
 
+/**
+ * Legacy MBTI payload builder kept for compatibility tests and golden fixtures.
+ *
+ * It is not part of the current v0.3 runtime report chain.
+ */
 final class LegacyMbtiReportPayloadBuilder
 {
     private LegacyMbtiReportPayloadBuilderV2 $legacy;

--- a/backend/app/Services/Legacy/Mbti/Report/V2/LegacyMbtiReportPayloadBuilderV2.php
+++ b/backend/app/Services/Legacy/Mbti/Report/V2/LegacyMbtiReportPayloadBuilderV2.php
@@ -6,6 +6,9 @@ namespace App\Services\Legacy\Mbti\Report\V2;
 
 use App\Internal\Legacy\Mbti\Report\LegacyMbtiReportPayloadBuilderV2Core;
 
+/**
+ * Thin legacy adapter retained for builder compatibility tests.
+ */
 class LegacyMbtiReportPayloadBuilderV2 extends LegacyMbtiReportPayloadBuilderV2Core
 {
 }

--- a/backend/app/Services/Legacy/Mbti/Report/V2/LegacyMbtiReportPayloadBuilderV2Facade.php
+++ b/backend/app/Services/Legacy/Mbti/Report/V2/LegacyMbtiReportPayloadBuilderV2Facade.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\Legacy\Mbti\Report\V2;
 
+/**
+ * Legacy facade retained so builder golden tests can keep their historical entrypoint.
+ */
 final class LegacyMbtiReportPayloadBuilderV2Facade
 {
     public function __construct(private readonly LegacyMbtiReportPayloadComposer $composer)

--- a/backend/app/Services/Legacy/Mbti/Report/V2/LegacyMbtiReportPayloadComposer.php
+++ b/backend/app/Services/Legacy/Mbti/Report/V2/LegacyMbtiReportPayloadComposer.php
@@ -12,6 +12,9 @@ use App\Services\Legacy\Mbti\Report\V2\Sections\NarrativeSectionBuilder;
 use App\Services\Legacy\Mbti\Report\V2\Sections\RecommendationsSectionBuilder;
 use App\Services\Legacy\Mbti\Report\V2\Sections\ScoresSectionBuilder;
 
+/**
+ * Legacy section composer retained for compat/test coverage only.
+ */
 final class LegacyMbtiReportPayloadComposer
 {
     /**

--- a/backend/tests/Feature/HighlightBuilderBuildFromStoreTest.php
+++ b/backend/tests/Feature/HighlightBuilderBuildFromStoreTest.php
@@ -48,7 +48,7 @@ $this->app->forgetInstance(\App\Services\ContentPackResolver::class);
         config()->set('fap.content.region', $region);
         config()->set('fap.content.locale', $locale);
         config()->set('fap.content.content_package_version', $version);
-        config()->set('fap.content_package_version', $version); // MbtiController / some call-sites
+        config()->set('fap.content_package_version', $version); // legacy builder / some historical call-sites
 
         // 4) 再兜底：如果有地方直接读 content.scale/content.region/content.locale
         config()->set('content.scale', $scale);

--- a/docs/commerce/report-snapshot-v1.md
+++ b/docs/commerce/report-snapshot-v1.md
@@ -63,11 +63,11 @@
 ## 7. ReportLookup 关系澄清
 - /api/v0.3/lookup/* 只做 attempt/order 定位并返回 report_api，不直接读 snapshot
 - 真正消费 snapshot 的是 /api/v0.3/attempts/{id}/report（Gatekeeper）
-- v0.3 legacy report 仍走 legacy report_jobs 链路（需显式标注）
+- 历史上曾有 legacy report_jobs 兼容链路；current `/api/v0.3/attempts/{id}/report` 已不再由 legacy controller/service 提供。
 
 补充说明：
 - `LookupController` 的 `/lookup/ticket|device|order` 输出的是 `result_api/report_api` 定位信息。
-- `GET /api/v0.3/attempts/{attemptId}/report` 由 `LegacyReportController` + `LegacyReportService` 处理，核心依赖 `report_jobs` 与 `GenerateReportJob`，不是 `report_snapshots`。
+- `GET /api/v0.3/attempts/{attemptId}/report` 当前由 `AttemptReadController` + `ReportGatekeeper` 驱动；`LegacyReportService` 仅保留 isolated compatibility 行为。
 
 ## 8. 存储真相
 - Snapshot payload 存于 DB（report_snapshots JSON/text-json 列）

--- a/docs/verify/pr15_recon.md
+++ b/docs/verify/pr15_recon.md
@@ -9,8 +9,8 @@
   - 采用显式 $commands 列表 + Commands 目录自动加载；新增命令建议显式注册避免缓存找不到。
 - backend/app/Http/Controllers/LookupController.php
   - 现有 lookup 接口使用统一 envelope：ok=true/false + error/message。
-- backend/app/Http/Controllers/MbtiController.php
-  - 现有 v0.2 scale meta / questions 参考响应结构（ok + payload）。
+- 历史参考：`backend/app/Http/Controllers/MbtiController.php` 已在后续 PR 中删除。
+  - 这里仅保留它曾提供过 v0.2 scale meta / questions 响应结构的历史备注。
 
 ## 相关 DB 表/迁移
 - 当前 migrations 中未发现 scales_registry / scale_slugs 相关表。

--- a/docs/verify/pr16_recon.md
+++ b/docs/verify/pr16_recon.md
@@ -5,10 +5,10 @@ Date: 2026-01-29
 ## 相关入口文件（questions 输出链路）
 - `backend/routes/api.php`
   - v0.2 已有 `/api/v0.3/content-packs/{pack_id}/{dir_version}/questions`
-  - v0.2 MBTI questions: `MbtiController::questions()`
+  - 历史上 v0.2 MBTI questions 曾走 `MbtiController::questions()`；该控制器已在后续 PR 中删除
   - v0.3 目前仅有 scales index/show/lookup，无 questions endpoint
-- `backend/app/Http/Controllers/MbtiController.php`
-  - 直接读 content_packages/*/questions.json，固定 MBTI 144 题校验
+- 历史入口：`backend/app/Http/Controllers/MbtiController.php`（已删除）
+  - 当时直接读 content_packages/*/questions.json，固定 MBTI 144 题校验
 - `backend/app/Http/Controllers/API/V0_2/ContentPacksController.php`
   - 使用 `ContentPacksIndex` 定位 questions.json 与 manifest.json
 - `backend/app/Services/Content/ContentPacksIndex.php`
@@ -19,7 +19,7 @@ Date: 2026-01-29
 ## pack 定位与读取关键点
 - `content_packs.root` 指向 repo 根目录的 `content_packages`（local/s3 兼容）
 - `ContentPacksIndex::find(pack_id, dir_version)` 为 v0.2 内容包读取主入口
-- MBTI 读取直接按默认 region/locale/dir_version 组路径（`MbtiController`）
+- 历史上 MBTI 读取曾直接按默认 region/locale/dir_version 组路径（`MbtiController`）；current runtime 已不再依赖该控制器
 
 ## FapSelfCheck 现有结构
 - `backend/app/Console/Commands/FapSelfCheck.php`

--- a/docs/verify/pr17_recon.md
+++ b/docs/verify/pr17_recon.md
@@ -6,9 +6,8 @@ Date: 2026-01-29
 - `backend/routes/api.php`
   - v0.2 已有 `/api/v0.3/attempts`, `/attempts/start`, `/attempts/{id}/result`, `/attempts/{id}/report`
   - v0.3 仅有 `/api/v0.3/scales`、`/scales/lookup`、`/scales/{scale_code}`、`/scales/{scale_code}/questions`
-- `backend/app/Http/Controllers/MbtiController.php`
-  - v0.2 attempts start/submit/result/report 主链路
-  - MBTI 计分逻辑 + result_json 写入 + report v1.2 输出
+- 历史入口：`backend/app/Http/Controllers/MbtiController.php`（已删除）
+  - 当时承载 v0.2 attempts start/submit/result/report 主链路
 - `backend/app/Services/Score/MbtiAttemptScorer.php`
   - MBTI 计分核心算法（scores_pct / type_code / axis_states）
 - `backend/app/Services/Report/ReportComposer.php`

--- a/docs/verify/pr18_recon.md
+++ b/docs/verify/pr18_recon.md
@@ -7,7 +7,8 @@
 - v0.3 Scales lookup: `backend/app/Http/Controllers/API/V0_3/ScalesLookupController.php`
 - Scale registry 服务：`backend/app/Services/Scale/ScaleRegistry.php`
 - Event 写入：`backend/app/Services/Analytics/EventRecorder.php`
-- Report jobs：`backend/app/Models/ReportJob.php`, `backend/app/Jobs/GenerateReportJob.php`, `backend/app/Http/Controllers/MbtiController.php`
+- Report jobs：`backend/app/Models/ReportJob.php`, `backend/app/Jobs/GenerateReportJob.php`
+  - `MbtiController.php` 是当时的历史入口，现已删除
 - 鉴权中间件：`backend/app/Http/Middleware/FmTokenAuth.php`
   - 从 `fm_tokens` DB 解析 `user_id` 并注入 request attributes `fm_user_id/user_id`
 - Token 签发：`backend/app/Services/Auth/FmTokenService.php`

--- a/docs/verify/pr34_recon.md
+++ b/docs/verify/pr34_recon.md
@@ -5,7 +5,7 @@
 - 相关入口文件（命中 KEY_RE 后补齐）：
   - backend/app/Services/ContentPackResolver.php（legacy：fallback + loadJson/loadText 热路径）
   - backend/app/Services/Content/ContentStore.php（hot_redis 资产缓存策略）
-  - backend/app/Http/Controllers/MbtiController.php（/api/v0.3/attempts/{id}/report）
+  - 历史入口：backend/app/Http/Controllers/MbtiController.php（后续 PR 已删除；current `/api/v0.3/attempts/{id}/report` 走 `AttemptReadController`）
   - backend/app/Http/Middleware/FmTokenOptional.php（fm_user_id / fm_anon_id 注入）
   - backend/routes/api.php（v0.2 路由与 middleware 口径）
   - backend/config/cache.php（hot_redis store）
@@ -27,7 +27,7 @@
 - 需要新增/修改点：
   - ContentLoaderService：Cache::remember 统一缓存读盘（pack_id + dir_version + rel_path → key）
   - ContentPackResolver：fallback 扫描与 file_get_contents 只在 cache miss 执行
-  - MbtiController::getReport：IDOR 防护（owner 校验失败统一 404）
+  - 历史整改项：MbtiController::getReport 的 IDOR 防护；current ownership/read path 已迁到 v0.3 current controllers
 
 - 风险点与规避（端口/CI 工具依赖/pack-seed-config 一致性/sqlite 迁移一致性/404 口径/脱敏）：
   - 缓存 key 禁止写入绝对路径；key 使用 pack_id + dir_version + rel_path 的 hash

--- a/docs/verify/pr35_recon.md
+++ b/docs/verify/pr35_recon.md
@@ -5,7 +5,7 @@
   - backend/app/Services/Assessment/Drivers/GenericLikertDriver.php
   - backend/app/Services/Commerce/PaymentWebhookProcessor.php
   - backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
-  - backend/app/Http/Controllers/MbtiController.php
+  - 历史入口：backend/app/Http/Controllers/MbtiController.php（已删除）
   - backend/app/Services/Content/ContentLoaderService.php
 - 相关路由：
   - POST /api/v0.3/webhooks/payment/{provider}

--- a/docs/verify/pr38_recon.md
+++ b/docs/verify/pr38_recon.md
@@ -5,7 +5,7 @@
 - 相关入口文件：
   - backend/app/Services/Content/ContentLoaderService.php
   - backend/app/Services/ContentPackResolver.php
-  - backend/app/Http/Controllers/MbtiController.php
+  - 历史入口：backend/app/Http/Controllers/MbtiController.php（已删除）
 
 - 相关测试：
   - backend/tests/Unit/Services/ContentLoaderMtimeCacheTest.php（新增）
@@ -14,7 +14,7 @@
 - 需要新增/修改点：
   - ContentLoaderService：cache key 加入 filemtime（已存在），并确保 Cache 异常自动降级直读
   - ContentPackResolver：loader 回调仅返回 abs path，读盘由 ContentLoaderService 统一完成
-  - MbtiController::canAccessAttemptReport：anon/user 不匹配时支持 share_id 校验（query 优先，header 次之）
+  - 历史整改项：MbtiController::canAccessAttemptReport；current share/access 校验已迁到 current v0.3 read path
   - 404 口径保持一致
 
 - 风险点与规避：

--- a/docs/verify/pr60_recon.md
+++ b/docs/verify/pr60_recon.md
@@ -29,7 +29,7 @@
 
 ```text
 38:  GET|HEAD  api/v0.2/attempts/{id}/quality API\V0_2\PsychometricsController@q…
-39:  GET|HEAD  api/v0.2/attempts/{id}/report ........... MbtiController@getReport
+39:  GET|HEAD  api/v0.2/attempts/{id}/report ........... historical `MbtiController@getReport` route (removed later)
 43:  GET|HEAD  api/v0.2/attempts/{id}/stats API\V0_2\PsychometricsController@sta…
 95:  POST      api/v0.3/attempts/start ........ API\V0_3\AttemptsController@start
 96:  POST      api/v0.3/attempts/submit ...... API\V0_3\AttemptsController@submit


### PR DESCRIPTION
## Summary

This PR is a cleanup pass after the MBTI runtime/report consolidation work. It does not change the current runtime report path. Instead, it removes misleading documentation and comment residue, and marks the remaining legacy MBTI builder stack as compatibility/test-only code.

## Problem

After the earlier PRs, the MBTI current runtime is already served by the current v0.3 report pipeline. However, a number of docs, recon notes, and comments still implied that removed legacy entrypoints such as `MbtiController` or old legacy report ownership were still active.

At the same time, the legacy MBTI report builder classes still existed in the codebase without clear intent markers, which made them easy to misread as still being part of the current runtime.

That state is confusing for maintenance:
- active docs could point engineers at deleted or obsolete entrypoints
- builder residue looked more “runtime-ish” than it really is
- comments still referenced dead services

## What changed

### Docs / verify cleanup

Updated active docs and verify notes so they no longer present deleted legacy entrypoints as current runtime ownership:
- `docs/commerce/report-snapshot-v1.md`
- `docs/verify/pr15_recon.md`
- `docs/verify/pr16_recon.md`
- `docs/verify/pr17_recon.md`
- `docs/verify/pr18_recon.md`
- `docs/verify/pr34_recon.md`
- `docs/verify/pr35_recon.md`
- `docs/verify/pr38_recon.md`
- `docs/verify/pr60_recon.md`

These edits reframe the old MBTI controller/report path as historical/removed and point current ownership back to the current v0.3 pipeline.

### Legacy builder isolation markers

Added small docblocks to the retained legacy builder stack:
- `LegacyMbtiReportPayloadBuilder`
- `LegacyMbtiReportPayloadBuilderV2`
- `LegacyMbtiReportPayloadComposer`
- `LegacyMbtiReportPayloadBuilderV2Facade`
- `LegacyMbtiReportPayloadBuilderV2Core`

The docblocks now explicitly state that this stack is retained for compatibility tests / golden fixtures and is not part of the current runtime report chain.

### Comment cleanup

- Updated one test comment in `HighlightBuilderBuildFromStoreTest` so it no longer points at deleted `MbtiController` call-sites.
- Updated the internal source label in `LegacyMbtiReportPayloadBuilderV2Core` from `LegacyMbtiAttemptService::buildHighlights` to `LegacyMbtiReportPayloadBuilderV2Core::buildHighlights`, which matches the actual retained code and avoids referencing a deleted service.

## Scope guardrails

This PR intentionally does **not**:
- change the current report composer/gate pipeline
- change scorer behavior
- change frontend behavior
- change content resolver/canonicalization
- delete the legacy builder stack itself
- modify golden fixture payload contents

## Validation

Ran targeted checks:

- `php -l backend/app/Services/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilder.php`
- `php -l backend/app/Services/Legacy/Mbti/Report/V2/LegacyMbtiReportPayloadBuilderV2.php`
- `php -l backend/app/Services/Legacy/Mbti/Report/V2/LegacyMbtiReportPayloadComposer.php`
- `php -l backend/app/Services/Legacy/Mbti/Report/V2/LegacyMbtiReportPayloadBuilderV2Facade.php`
- `php -l backend/app/Internal/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilderV2Core.php`
- `php -l backend/tests/Feature/HighlightBuilderBuildFromStoreTest.php`
- `php artisan test tests/Feature/LegacyMbti/ReportPayloadGoldenMasterTest.php tests/Unit/Legacy/Mbti/LegacyMbtiReportPayloadBuilderTest.php tests/Feature/Legacy/LegacyReportServicePsychometricsIncludeTest.php`

All targeted checks passed.
