### PR TITLE
[codex] Ship OP-4 commerce ops drill-down and exception workbench

### DIFF
--- a/backend/app/Filament/Ops/Resources/BenefitGrantResource.php
+++ b/backend/app/Filament/Ops/Resources/BenefitGrantResource.php
@@ -9,6 +9,7 @@ use App\Filament\Ops\Support\StatusBadge;
 use App\Filament\Shared\BaseTenantResource;
 use App\Models\AdminApproval;
 use App\Models\BenefitGrant;
+use App\Models\Order;
 use App\Services\Audit\AuditLogger;
 use App\Support\Rbac\PermissionNames;
 use Filament\Forms;
@@ -86,6 +87,19 @@ class BenefitGrantResource extends BaseTenantResource
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),
+                Tables\Actions\Action::make('openOrder')
+                    ->label('Open Order')
+                    ->icon('heroicon-o-shopping-cart')
+                    ->url(function (BenefitGrant $record): ?string {
+                        $orderId = Order::query()
+                            ->withoutGlobalScopes()
+                            ->where('order_no', (string) ($record->order_no ?? ''))
+                            ->value('id');
+
+                        return $orderId !== null ? OrderResource::getUrl('view', ['record' => (string) $orderId]) : null;
+                    })
+                    ->openUrlInNewTab(false)
+                    ->visible(fn (BenefitGrant $record): bool => filled($record->order_no ?? null)),
                 Tables\Actions\Action::make('requestRevoke')
                     ->label('Request Revoke')
                     ->icon('heroicon-o-no-symbol')

--- a/backend/app/Filament/Ops/Resources/OrderResource.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource.php
@@ -6,6 +6,7 @@ namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\OrderResource\Pages;
 use App\Filament\Ops\Resources\OrderResource\RelationManagers\BenefitGrantsRelationManager;
+use App\Filament\Ops\Resources\OrderResource\RelationManagers\PaymentAttemptsRelationManager;
 use App\Filament\Ops\Resources\OrderResource\RelationManagers\PaymentEventsRelationManager;
 use App\Filament\Ops\Resources\OrderResource\Support\OrderLinkageSupport;
 use App\Models\Order;
@@ -118,6 +119,16 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                 Tables\Columns\TextColumn::make('grant_state')
                     ->badge()
                     ->toggleable(),
+                Tables\Columns\TextColumn::make('commerce_exception')
+                    ->label('Exception')
+                    ->state(fn (Order $record): string => $support->primaryException($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => $support->primaryException($record)['state']),
+                Tables\Columns\TextColumn::make('exception_count')
+                    ->label('Exception count')
+                    ->state(fn (Order $record): int => $support->exceptionCount($record))
+                    ->numeric()
+                    ->toggleable(),
                 Tables\Columns\TextColumn::make('payment_attempts_count')
                     ->label('Payment attempts')
                     ->numeric()
@@ -127,19 +138,36 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                     ->toggleable(),
                 Tables\Columns\TextColumn::make('latest_payment_attempt_provider')
                     ->label('Attempt provider')
-                    ->toggleable(isToggledHiddenByDefault: true),
+                    ->toggleable(),
                 Tables\Columns\TextColumn::make('latest_payment_attempt_provider_trade_no')
                     ->label('Attempt provider ref')
                     ->copyable()
-                    ->toggleable(isToggledHiddenByDefault: true),
+                    ->toggleable(),
                 Tables\Columns\TextColumn::make('last_reconciled_at')
                     ->dateTime()
                     ->toggleable(),
+                Tables\Columns\TextColumn::make('compensation_status')
+                    ->label('Compensation')
+                    ->state(fn (Order $record): string => $support->compensationStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => $support->compensationStatus($record)['state']),
                 Tables\Columns\TextColumn::make('latest_payment_status')
                     ->label('Payment status')
                     ->state(fn (Order $record): string => $support->paymentStatus($record)['label'])
                     ->badge()
                     ->color(fn (Order $record): string => $support->paymentStatus($record)['state']),
+                Tables\Columns\TextColumn::make('latest_handle_status')
+                    ->label('Handle status')
+                    ->badge()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('latest_benefit_status')
+                    ->label('Grant status')
+                    ->badge()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('latest_access_state')
+                    ->label('Access state')
+                    ->badge()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('target_attempt_id')
                     ->label('attempt_id')
                     ->copyable(),
@@ -244,6 +272,12 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                     ->options(fn (): array => $support->distinctOrderOptions('payment_state')),
                 Tables\Filters\SelectFilter::make('grant_state')
                     ->options(fn (): array => $support->distinctOrderOptions('grant_state')),
+                Tables\Filters\SelectFilter::make('commerce_exception_filter')
+                    ->label('Commerce exception')
+                    ->options($support->exceptionOptions())
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyExceptionFilter($query, $data['value'] ?? null);
+                    }),
                 Tables\Filters\TernaryFilter::make('paid_success')
                     ->label('Paid success')
                     ->queries(
@@ -327,6 +361,7 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
     public static function getRelations(): array
     {
         return [
+            PaymentAttemptsRelationManager::class,
             PaymentEventsRelationManager::class,
             BenefitGrantsRelationManager::class,
         ];

--- a/backend/app/Filament/Ops/Resources/OrderResource/Pages/ViewOrder.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Pages/ViewOrder.php
@@ -25,8 +25,15 @@ class ViewOrder extends ViewRecord
     public array $orderSummary = ['fields' => [], 'notes' => []];
 
     /**
+     * @var list<array<string,mixed>>
+     */
+    public array $paymentAttempts = [];
+
+    /**
      * @var list<array{
+     *     id:string,
      *     provider_event_id:string,
+     *     payment_attempt_id:string,
      *     status:array{label:string,state:string},
      *     handle_status:array{label:string,state:string},
      *     signature:array{label:string,state:string},
@@ -56,6 +63,16 @@ class ViewOrder extends ViewRecord
     /**
      * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
      */
+    public array $accessSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $compensationSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
     public array $exceptionSummary = ['fields' => [], 'notes' => []];
 
     /**
@@ -71,27 +88,30 @@ class ViewOrder extends ViewRecord
 
         $this->headline = $detail['headline'];
         $this->orderSummary = $detail['order_summary'];
+        $this->paymentAttempts = $detail['payment_attempts'];
         $this->paymentEvents = $detail['payment_events'];
         $this->benefitSummary = $detail['benefit_summary'];
         $this->reportSummary = $detail['report_summary'];
         $this->attemptSummary = $detail['attempt_summary'];
+        $this->accessSummary = $detail['access_summary'];
+        $this->compensationSummary = $detail['compensation_summary'];
         $this->exceptionSummary = $detail['exception_summary'];
         $this->links = $detail['links'];
     }
 
     public function getTitle(): string
     {
-        return 'Unlock / Commerce Linkage';
+        return 'Commerce Timeline';
     }
 
     public function getHeading(): string
     {
-        return 'Unlock / Commerce Linkage';
+        return 'Commerce Timeline';
     }
 
     public function getSubheading(): ?string
     {
-        return 'Read-only order diagnostics across payment, grant, report, PDF, and share linkage.';
+        return 'Read-only order diagnostics across payment attempts, webhook events, unlock, access, compensation, report, PDF, and share linkage.';
     }
 
     public function getBreadcrumb(): string

--- a/backend/app/Filament/Ops/Resources/OrderResource/RelationManagers/BenefitGrantsRelationManager.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/RelationManagers/BenefitGrantsRelationManager.php
@@ -33,7 +33,9 @@ class BenefitGrantsRelationManager extends RelationManager
             ])
             ->defaultSort('created_at', 'desc')
             ->headerActions([])
-            ->actions([])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
             ->bulkActions([]);
     }
 }

--- a/backend/app/Filament/Ops/Resources/OrderResource/RelationManagers/PaymentAttemptsRelationManager.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/RelationManagers/PaymentAttemptsRelationManager.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\OrderResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+
+final class PaymentAttemptsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'paymentAttempts';
+
+    protected static ?string $title = null;
+
+    public static function getTitle(Model $ownerRecord, string $pageClass): string
+    {
+        return 'Payment Attempts';
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('attempt_no')->numeric()->sortable(),
+                Tables\Columns\TextColumn::make('provider')->sortable(),
+                Tables\Columns\TextColumn::make('state')->badge()->sortable(),
+                Tables\Columns\TextColumn::make('provider_trade_no')->copyable()->toggleable(),
+                Tables\Columns\TextColumn::make('external_trade_no')->copyable()->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('callback_received_at')->dateTime()->toggleable(),
+                Tables\Columns\TextColumn::make('verified_at')->dateTime()->toggleable(),
+                Tables\Columns\TextColumn::make('finalized_at')->dateTime()->toggleable(),
+                Tables\Columns\TextColumn::make('last_error_code')->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('attempt_no', 'desc')
+            ->headerActions([])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+}

--- a/backend/app/Filament/Ops/Resources/OrderResource/RelationManagers/PaymentEventsRelationManager.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/RelationManagers/PaymentEventsRelationManager.php
@@ -35,7 +35,9 @@ class PaymentEventsRelationManager extends RelationManager
             ])
             ->defaultSort('created_at', 'desc')
             ->headerActions([])
-            ->actions([])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
             ->bulkActions([]);
     }
 }

--- a/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Resources\OrderResource\Support;
 
+use App\Filament\Ops\Resources\BenefitGrantResource;
+use App\Filament\Ops\Resources\PaymentAttemptResource;
+use App\Filament\Ops\Resources\PaymentEventResource;
 use App\Models\Order;
+use App\Models\PaymentAttempt;
 use App\Services\Commerce\OrderManager;
 use App\Support\SchemaBaseline;
 use Illuminate\Database\Eloquent\Builder;
@@ -14,6 +18,30 @@ use Illuminate\Support\Facades\DB;
 
 final class OrderLinkageSupport
 {
+    private const EXCEPTION_LABELS = [
+        'pending_unpaid' => 'pending_unpaid',
+        'provider_created_not_paid' => 'provider_created_not_paid',
+        'callback_missing' => 'callback_missing',
+        'paid_no_grant' => 'paid_no_grant',
+        'grant_without_paid' => 'grant_without_paid',
+        'webhook_error' => 'webhook_error',
+        'compensation_touched' => 'compensation_touched',
+        'refund_revoked' => 'refund_revoked',
+        'late_callback_corrected' => 'late_callback_corrected',
+    ];
+
+    private const PRIMARY_EXCEPTION_ORDER = [
+        'webhook_error',
+        'callback_missing',
+        'late_callback_corrected',
+        'paid_no_grant',
+        'grant_without_paid',
+        'refund_revoked',
+        'provider_created_not_paid',
+        'pending_unpaid',
+        'compensation_touched',
+    ];
+
     /**
      * @return Builder<Order>
      */
@@ -57,7 +85,12 @@ final class OrderLinkageSupport
                 ->selectSub($this->paymentAttemptField('state'), 'latest_payment_attempt_state')
                 ->selectSub($this->paymentAttemptField('provider'), 'latest_payment_attempt_provider')
                 ->selectSub($this->paymentAttemptField('provider_trade_no'), 'latest_payment_attempt_provider_trade_no')
-                ->selectSub($this->paymentAttemptField('external_trade_no'), 'latest_payment_attempt_external_trade_no');
+                ->selectSub($this->paymentAttemptField('external_trade_no'), 'latest_payment_attempt_external_trade_no')
+                ->selectSub($this->paymentAttemptField('callback_received_at'), 'latest_payment_attempt_callback_received_at')
+                ->selectSub($this->paymentAttemptField('verified_at'), 'latest_payment_attempt_verified_at')
+                ->selectSub($this->paymentAttemptField('finalized_at'), 'latest_payment_attempt_finalized_at')
+                ->selectSub($this->paymentAttemptField('last_error_code'), 'latest_payment_attempt_last_error_code')
+                ->selectSub($this->paymentAttemptField('last_error_message'), 'latest_payment_attempt_last_error_message');
         } else {
             $query->selectRaw('0 as payment_attempts_count');
         }
@@ -84,6 +117,16 @@ final class OrderLinkageSupport
                 ->selectSub($this->snapshotExistsField(), 'has_report_snapshot');
         } else {
             $query->selectRaw('0 as has_report_snapshot');
+        }
+
+        if (SchemaBaseline::hasTable('unified_access_projections')) {
+            $query
+                ->selectSub($this->accessProjectionField('access_state'), 'latest_access_state')
+                ->selectSub($this->accessProjectionField('report_state'), 'latest_access_report_state')
+                ->selectSub($this->accessProjectionField('pdf_state'), 'latest_access_pdf_state')
+                ->selectSub($this->accessProjectionField('reason_code'), 'latest_access_reason_code')
+                ->selectSub($this->accessProjectionField('projection_version'), 'latest_access_projection_version')
+                ->selectSub($this->accessProjectionField('refreshed_at'), 'latest_access_refreshed_at');
         }
 
         if (SchemaBaseline::hasTable('report_jobs')) {
@@ -306,6 +349,70 @@ final class OrderLinkageSupport
             ->sort()
             ->mapWithKeys(fn (string $value): array => [$value => $value])
             ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function exceptionOptions(): array
+    {
+        return self::EXCEPTION_LABELS;
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyExceptionFilter(Builder $query, ?string $value): void
+    {
+        $exception = strtolower(trim((string) $value));
+        if ($exception === '' || ! array_key_exists($exception, self::EXCEPTION_LABELS)) {
+            return;
+        }
+
+        match ($exception) {
+            'pending_unpaid' => $query
+                ->whereIn('orders.payment_state', [Order::PAYMENT_STATE_CREATED, Order::PAYMENT_STATE_PENDING])
+                ->where(function (Builder $builder): void {
+                    $builder
+                        ->whereNotExists($this->paymentAttemptExistsQuery())
+                        ->orWhereExists($this->paymentAttemptStateExistsQuery([PaymentAttempt::STATE_INITIATED]));
+                }),
+            'provider_created_not_paid' => $query
+                ->whereIn('orders.payment_state', [Order::PAYMENT_STATE_CREATED, Order::PAYMENT_STATE_PENDING])
+                ->whereExists($this->paymentAttemptStateExistsQuery([
+                    PaymentAttempt::STATE_PROVIDER_CREATED,
+                    PaymentAttempt::STATE_CLIENT_PRESENTED,
+                ])),
+            'callback_missing' => $query
+                ->whereIn('orders.payment_state', [Order::PAYMENT_STATE_CREATED, Order::PAYMENT_STATE_PENDING])
+                ->whereExists($this->paymentAttemptStateExistsQuery([
+                    PaymentAttempt::STATE_CALLBACK_RECEIVED,
+                    PaymentAttempt::STATE_VERIFIED,
+                ])),
+            'paid_no_grant' => $query
+                ->where('orders.payment_state', Order::PAYMENT_STATE_PAID)
+                ->where('orders.grant_state', '!=', Order::GRANT_STATE_GRANTED)
+                ->whereNotExists($this->activeBenefitExistsQuery())
+                ->where($this->notRefundedLikeOrderClause()),
+            'grant_without_paid' => $query
+                ->whereExists($this->activeBenefitExistsQuery())
+                ->where(function (Builder $builder): void {
+                    $builder
+                        ->whereNotIn('orders.payment_state', [Order::PAYMENT_STATE_PAID, Order::PAYMENT_STATE_REFUNDED])
+                        ->orWhereNull('orders.payment_state');
+                }),
+            'webhook_error' => $query->whereExists($this->webhookErrorExistsQuery()),
+            'compensation_touched' => $query->whereNotNull('orders.last_reconciled_at'),
+            'refund_revoked' => $query
+                ->where('orders.payment_state', Order::PAYMENT_STATE_REFUNDED)
+                ->whereExists($this->revokedBenefitExistsQuery()),
+            'late_callback_corrected' => $query
+                ->where('orders.payment_state', Order::PAYMENT_STATE_PAID)
+                ->whereNotNull('orders.last_reconciled_at')
+                ->whereNotNull('orders.paid_at')
+                ->whereColumn('orders.paid_at', '>', 'orders.last_reconciled_at'),
+            default => null,
+        };
     }
 
     /**
@@ -581,6 +688,57 @@ final class OrderLinkageSupport
     /**
      * @return array{label:string,state:string}
      */
+    public function primaryException(object $order): array
+    {
+        foreach (self::PRIMARY_EXCEPTION_ORDER as $key) {
+            if ($this->matchesException($key, $order)) {
+                return ['label' => $key, 'state' => $this->exceptionState($key)];
+            }
+        }
+
+        return ['label' => 'clear', 'state' => 'success'];
+    }
+
+    public function exceptionCount(object $order): int
+    {
+        $count = 0;
+
+        foreach (array_keys(self::EXCEPTION_LABELS) as $key) {
+            if ($this->matchesException($key, $order)) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function compensationStatus(object $order): array
+    {
+        if (! filled($order->last_reconciled_at ?? null)) {
+            return ['label' => 'untouched', 'state' => 'gray'];
+        }
+
+        if ($this->matchesException('late_callback_corrected', $order)) {
+            return ['label' => 'corrected_after_compensation', 'state' => 'success'];
+        }
+
+        $paymentState = $this->resolvedPaymentStateValue($order);
+
+        return match ($paymentState) {
+            Order::PAYMENT_STATE_PAID => ['label' => 'paid_after_compensation', 'state' => 'success'],
+            Order::PAYMENT_STATE_FAILED,
+            Order::PAYMENT_STATE_CANCELED,
+            Order::PAYMENT_STATE_EXPIRED => ['label' => 'closed_after_compensation', 'state' => 'warning'],
+            default => ['label' => 'touched', 'state' => 'warning'],
+        };
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
     public function unlockStatus(object $order): array
     {
         if ($this->hasActiveBenefitGrant($order)) {
@@ -687,6 +845,7 @@ final class OrderLinkageSupport
      * @return array{
      *     headline: array<string, array{label:string,state:string}>,
      *     order_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     payment_attempts: list<array<string, mixed>>,
      *     payment_events: list<array{
      *         provider_event_id:string,
      *         status:array{label:string,state:string},
@@ -700,6 +859,8 @@ final class OrderLinkageSupport
      *     benefit_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
      *     report_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
      *     attempt_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     access_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     compensation_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
      *     exception_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
      *     links: list<array{label:string,url:string,kind:string}>
      * }
@@ -708,13 +869,17 @@ final class OrderLinkageSupport
     {
         $orderRow = DB::table('orders')->where('id', (string) $order->getKey())->first() ?? $order;
         $resolvedAttemptId = $this->resolvedAttemptId($order);
+        $orderNo = (string) ($orderRow->order_no ?? '');
         $paymentEvents = $this->paymentEvents((string) ($orderRow->order_no ?? ''));
+        $paymentAttempts = $this->paymentAttempts($orderNo);
+        $latestPaymentAttempt = $paymentAttempts[0] ?? null;
         $grants = $this->benefitGrants((string) ($orderRow->order_no ?? ''), $resolvedAttemptId);
         $activeGrant = $this->activeGrant($grants);
         $snapshot = $this->reportSnapshot((string) ($orderRow->order_no ?? ''), $resolvedAttemptId);
         $reportPayload = $this->decodeJson($snapshot->report_json ?? null);
         $reportJob = $this->reportJob($resolvedAttemptId);
         $attempt = $this->attempt($resolvedAttemptId);
+        $accessProjection = $this->accessProjection($resolvedAttemptId);
         $result = $this->result($resolvedAttemptId);
         $share = $this->share($resolvedAttemptId);
         $delivery = app(OrderManager::class)->presentOrderDelivery($orderRow);
@@ -744,6 +909,8 @@ final class OrderLinkageSupport
                 $this->field('requested_sku', $this->requestedSku($order)),
                 $this->field('effective_sku', $this->effectiveSku($order)),
                 $this->field('benefit_code', $this->stringOrDash($activeGrant->benefit_code ?? ($order->latest_benefit_code ?? null))),
+                $this->field('payment_attempts', $this->stringOrDash($order->payment_attempts_count ?? count($paymentAttempts))),
+                $this->field('last_reconciled_at', $this->formatTimestamp($orderRow->last_reconciled_at ?? null)),
                 $this->pillField(
                     'contact_email_present',
                     $this->truthy($deliveryState['contact_email_present'] ?? null) ? 'present' : 'missing',
@@ -828,7 +995,9 @@ final class OrderLinkageSupport
 
         $paymentSummary = array_map(function (object $event): array {
             return [
+                'id' => $this->stringOrDash($event->id ?? null),
                 'provider_event_id' => $this->stringOrDash($event->provider_event_id ?? null),
+                'payment_attempt_id' => $this->stringOrDash($event->payment_attempt_id ?? null),
                 'status' => [
                     'label' => $this->stringOrDash($event->status ?? null),
                     'state' => $this->statusState((string) ($event->status ?? '')),
@@ -848,20 +1017,77 @@ final class OrderLinkageSupport
             ];
         }, $paymentEvents);
 
+        $paymentAttemptSummary = array_map(function (object $paymentAttempt): array {
+            return [
+                'id' => $this->stringOrDash($paymentAttempt->id ?? null),
+                'attempt_no' => $this->stringOrDash($paymentAttempt->attempt_no ?? null),
+                'provider' => $this->stringOrDash($paymentAttempt->provider ?? null),
+                'state' => [
+                    'label' => $this->stringOrDash($paymentAttempt->state ?? null),
+                    'state' => $this->statusState((string) ($paymentAttempt->state ?? '')),
+                ],
+                'provider_trade_no' => $this->stringOrDash($paymentAttempt->provider_trade_no ?? null),
+                'external_trade_no' => $this->stringOrDash($paymentAttempt->external_trade_no ?? null),
+                'provider_session_ref' => $this->stringOrDash($paymentAttempt->provider_session_ref ?? null),
+                'callback_received_at' => $this->formatTimestamp($paymentAttempt->callback_received_at ?? null),
+                'verified_at' => $this->formatTimestamp($paymentAttempt->verified_at ?? null),
+                'finalized_at' => $this->formatTimestamp($paymentAttempt->finalized_at ?? null),
+                'last_error_code' => $this->stringOrDash($paymentAttempt->last_error_code ?? null),
+                'last_error_message' => $this->shortText($paymentAttempt->last_error_message ?? null),
+            ];
+        }, $paymentAttempts);
+
+        $accessSummary = [
+            'fields' => [
+                $this->pillField('access_state', $this->stringOrDash($accessProjection->access_state ?? ($order->latest_access_state ?? null)), $this->statusState((string) ($accessProjection->access_state ?? ($order->latest_access_state ?? '')))),
+                $this->pillField('report_state', $this->stringOrDash($accessProjection->report_state ?? null), $this->statusState((string) ($accessProjection->report_state ?? ''))),
+                $this->pillField('pdf_state', $this->stringOrDash($accessProjection->pdf_state ?? null), $this->statusState((string) ($accessProjection->pdf_state ?? ''))),
+                $this->field('reason_code', $this->stringOrDash($accessProjection->reason_code ?? ($order->latest_access_reason_code ?? null))),
+                $this->field('projection_version', $this->stringOrDash($accessProjection->projection_version ?? ($order->latest_access_projection_version ?? null))),
+                $this->field('produced_at', $this->formatTimestamp($accessProjection->produced_at ?? null)),
+                $this->field('refreshed_at', $this->formatTimestamp($accessProjection->refreshed_at ?? ($order->latest_access_refreshed_at ?? null))),
+            ],
+            'notes' => [
+                'Unified access projection stays read-only here. This page only surfaces the latest access truth alongside the order.',
+            ],
+        ];
+
+        $compensationState = $this->compensationStatus($order);
+        $compensationSummary = [
+            'fields' => [
+                $this->pillField('compensation_status', $compensationState['label'], $compensationState['state']),
+                $this->field('last_reconciled_at', $this->formatTimestamp($orderRow->last_reconciled_at ?? null)),
+                $this->field('latest_attempt_state', $this->stringOrDash($latestPaymentAttempt->state ?? ($order->latest_payment_attempt_state ?? null))),
+                $this->field('latest_attempt_provider', $this->stringOrDash($latestPaymentAttempt->provider ?? ($order->latest_payment_attempt_provider ?? null))),
+                $this->field('latest_attempt_ref', $this->stringOrDash($latestPaymentAttempt->provider_trade_no ?? ($order->latest_payment_attempt_provider_trade_no ?? null))),
+                $this->field(
+                    'suggested_command',
+                    $orderNo !== '' ? 'php artisan commerce:compensate-pending-orders --order='.$orderNo.' --dry-run' : '-',
+                    'Command hint only. OP-4 keeps compensation execution in CLI.'
+                ),
+            ],
+            'notes' => [
+                'Compensation remains a command-driven workflow. This page only tells ops whether compensation has already touched the order.',
+            ],
+        ];
+
         $exceptionSummary = [
-            'fields' => $this->exceptionFields($orderRow, $paymentEvents, $activeGrant, $snapshot, $reportJob, $deliveryState, $resolvedAttemptId),
+            'fields' => $this->exceptionFields($order, $paymentEvents, $activeGrant, $snapshot, $reportJob, $deliveryState, $resolvedAttemptId),
             'notes' => ['These rules are explicit v1 diagnostics, not a full rule engine or BI funnel.'],
         ];
 
         return [
             'headline' => $headline,
             'order_summary' => $orderSummary,
+            'payment_attempts' => $paymentAttemptSummary,
             'payment_events' => $paymentSummary,
             'benefit_summary' => $benefitSummary,
             'report_summary' => $reportSummary,
             'attempt_summary' => $attemptSummary,
+            'access_summary' => $accessSummary,
+            'compensation_summary' => $compensationSummary,
             'exception_summary' => $exceptionSummary,
-            'links' => $this->links($orderRow, $resolvedAttemptId, $shareId !== '' ? $shareId : null, $attempt),
+            'links' => $this->links($order, $orderRow, $resolvedAttemptId, $shareId !== '' ? $shareId : null, $attempt, $latestPaymentAttempt, $paymentEvents[0] ?? null, $activeGrant),
         ];
     }
 
@@ -905,6 +1131,15 @@ final class OrderLinkageSupport
         return DB::table('payment_attempts')
             ->selectRaw('count(*)')
             ->whereColumn('payment_attempts.order_no', 'orders.order_no');
+    }
+
+    private function accessProjectionField(string $column): QueryBuilder
+    {
+        return DB::table('unified_access_projections')
+            ->select($column)
+            ->whereColumn('unified_access_projections.attempt_id', 'orders.target_attempt_id')
+            ->orderByRaw('coalesce(refreshed_at, produced_at) desc')
+            ->limit(1);
     }
 
     private function benefitField(string $column): QueryBuilder
@@ -994,6 +1229,60 @@ final class OrderLinkageSupport
                 ->where(function (QueryBuilder $builder): void {
                     $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
                         ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
+                });
+        };
+    }
+
+    private function revokedBenefitExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $benefitQuery): void {
+            $benefitQuery
+                ->selectRaw('1')
+                ->from('benefit_grants')
+                ->whereRaw("lower(coalesce(benefit_grants.status, '')) in (?, ?)", ['revoked', 'expired'])
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
+                        ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
+                });
+        };
+    }
+
+    private function paymentAttemptExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $attemptQuery): void {
+            $attemptQuery
+                ->selectRaw('1')
+                ->from('payment_attempts')
+                ->whereColumn('payment_attempts.order_no', 'orders.order_no');
+        };
+    }
+
+    /**
+     * @param  list<string>  $states
+     */
+    private function paymentAttemptStateExistsQuery(array $states): \Closure
+    {
+        return function (QueryBuilder $attemptQuery) use ($states): void {
+            $attemptQuery
+                ->selectRaw('1')
+                ->from('payment_attempts')
+                ->whereColumn('payment_attempts.order_no', 'orders.order_no')
+                ->whereIn('payment_attempts.state', $states);
+        };
+    }
+
+    private function webhookErrorExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $eventQuery): void {
+            $eventQuery
+                ->selectRaw('1')
+                ->from('payment_events')
+                ->whereColumn('payment_events.order_no', 'orders.order_no')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->where('signature_ok', 0)
+                        ->orWhereIn('status', ['failed', 'rejected', 'post_commit_failed'])
+                        ->orWhereIn('handle_status', ['failed', 'reprocess_failed'])
+                        ->orWhereNotNull('last_error_message');
                 });
         };
     }
@@ -1122,7 +1411,9 @@ final class OrderLinkageSupport
 
         return DB::table('payment_events')
             ->select([
+                'id',
                 'provider_event_id',
+                'payment_attempt_id',
                 'status',
                 'handle_status',
                 'signature_ok',
@@ -1133,6 +1424,37 @@ final class OrderLinkageSupport
             ])
             ->where('order_no', $orderNo)
             ->orderByRaw('coalesce(processed_at, handled_at, updated_at, created_at) desc')
+            ->limit(10)
+            ->get()
+            ->all();
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function paymentAttempts(string $orderNo): array
+    {
+        if ($orderNo === '' || ! SchemaBaseline::hasTable('payment_attempts')) {
+            return [];
+        }
+
+        return DB::table('payment_attempts')
+            ->select([
+                'id',
+                'attempt_no',
+                'provider',
+                'state',
+                'provider_trade_no',
+                'external_trade_no',
+                'provider_session_ref',
+                'callback_received_at',
+                'verified_at',
+                'finalized_at',
+                'last_error_code',
+                'last_error_message',
+            ])
+            ->where('order_no', $orderNo)
+            ->orderByDesc('attempt_no')
             ->limit(10)
             ->get()
             ->all();
@@ -1252,6 +1574,18 @@ final class OrderLinkageSupport
             ->first();
     }
 
+    private function accessProjection(?string $attemptId): ?object
+    {
+        if ($attemptId === null || ! SchemaBaseline::hasTable('unified_access_projections')) {
+            return null;
+        }
+
+        return DB::table('unified_access_projections')
+            ->where('attempt_id', $attemptId)
+            ->orderByRaw('coalesce(refreshed_at, produced_at) desc')
+            ->first();
+    }
+
     /**
      * @return list<array{label:string,value:string,hint:?string,kind:string,state:?string}>
      */
@@ -1264,55 +1598,56 @@ final class OrderLinkageSupport
         array $deliveryState,
         ?string $resolvedAttemptId,
     ): array {
-        $paymentHandled = collect($paymentEvents)->contains(function (object $event): bool {
-            return filled($event->handled_at ?? null)
-                || in_array(strtolower(trim((string) ($event->handle_status ?? ''))), ['processed', 'handled', 'succeeded'], true);
-        });
-
-        $paid = $this->isPaidLike((string) ($order->status ?? '')) || filled($order->paid_at ?? null);
         $snapshotStatus = strtolower(trim((string) ($snapshot->status ?? '')));
         $reportJobStatus = strtolower(trim((string) ($reportJob->status ?? '')));
         $pdfReady = (bool) ($deliveryState['can_download_pdf'] ?? false);
+        $fields = [];
 
-        return [
-            $this->pillField(
-                'paid_but_no_grant',
-                $paid && $activeGrant === null ? 'triggered' : 'clear',
-                $paid && $activeGrant === null ? 'danger' : 'success',
-                $paid && $activeGrant === null ? 'Payment succeeded but no active benefit_grant exists.' : null
-            ),
-            $this->pillField(
-                'grant_exists_but_snapshot_missing',
-                $activeGrant !== null && $snapshot === null ? 'triggered' : 'clear',
-                $activeGrant !== null && $snapshot === null ? 'danger' : 'success',
-                $activeGrant !== null && $snapshot === null ? 'Unlock fact exists without a report_snapshot.' : null
-            ),
-            $this->pillField(
-                'snapshot_failed',
-                in_array($snapshotStatus, ['failed', 'error'], true) || in_array($reportJobStatus, ['failed', 'error'], true) ? 'triggered' : 'clear',
-                in_array($snapshotStatus, ['failed', 'error'], true) || in_array($reportJobStatus, ['failed', 'error'], true) ? 'danger' : 'success',
-                $this->shortText(($snapshot->last_error ?? null) ?: ($reportJob->last_error ?? null))
-            ),
-            $this->pillField(
-                'pdf_unavailable',
-                $resolvedAttemptId !== null && ! $pdfReady ? 'triggered' : 'clear',
-                $resolvedAttemptId !== null && ! $pdfReady ? 'warning' : 'success',
-                $resolvedAttemptId !== null && ! $pdfReady ? 'Attempt is linked but PDF is not marked ready.' : null
-            ),
-            $this->pillField(
-                'order_exists_but_no_payment_handled',
-                ! $paymentHandled ? 'triggered' : 'clear',
-                ! $paymentHandled ? 'warning' : 'success',
-                ! $paymentHandled ? 'No handled payment event summary is available yet.' : null
-            ),
-        ];
+        foreach (array_keys(self::EXCEPTION_LABELS) as $key) {
+            $triggered = $this->matchesException($key, $order);
+            $fields[] = $this->pillField(
+                $key,
+                $triggered ? 'triggered' : 'clear',
+                $triggered ? $this->exceptionState($key) : 'success',
+                $triggered ? $this->exceptionHint($key, $order) : null
+            );
+        }
+
+        $fields[] = $this->pillField(
+            'grant_exists_but_snapshot_missing',
+            $activeGrant !== null && $snapshot === null ? 'triggered' : 'clear',
+            $activeGrant !== null && $snapshot === null ? 'danger' : 'success',
+            $activeGrant !== null && $snapshot === null ? 'Unlock fact exists without a report_snapshot.' : null
+        );
+        $fields[] = $this->pillField(
+            'snapshot_failed',
+            in_array($snapshotStatus, ['failed', 'error'], true) || in_array($reportJobStatus, ['failed', 'error'], true) ? 'triggered' : 'clear',
+            in_array($snapshotStatus, ['failed', 'error'], true) || in_array($reportJobStatus, ['failed', 'error'], true) ? 'danger' : 'success',
+            $this->shortText(($snapshot->last_error ?? null) ?: ($reportJob->last_error ?? null))
+        );
+        $fields[] = $this->pillField(
+            'pdf_unavailable',
+            $resolvedAttemptId !== null && ! $pdfReady ? 'triggered' : 'clear',
+            $resolvedAttemptId !== null && ! $pdfReady ? 'warning' : 'success',
+            $resolvedAttemptId !== null && ! $pdfReady ? 'Attempt is linked but PDF is not marked ready.' : null
+        );
+
+        return $fields;
     }
 
     /**
      * @return list<array{label:string,url:string,kind:string}>
      */
-    private function links(object $order, ?string $attemptId, ?string $shareId, ?object $attempt): array
-    {
+    private function links(
+        object $orderRecord,
+        object $order,
+        ?string $attemptId,
+        ?string $shareId,
+        ?object $attempt,
+        ?object $latestPaymentAttempt,
+        ?object $latestPaymentEvent,
+        ?object $activeGrant,
+    ): array {
         $base = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
         $localeSegment = $this->localeSegment((string) ($attempt->locale ?? ''));
         $links = [];
@@ -1357,13 +1692,130 @@ final class OrderLinkageSupport
             ];
         }
 
+        if (($latestPaymentAttempt->id ?? null) !== null) {
+            $links[] = [
+                'label' => 'Latest payment attempt',
+                'url' => PaymentAttemptResource::getUrl('view', ['record' => (string) $latestPaymentAttempt->id]),
+                'kind' => 'ops',
+            ];
+        }
+
+        if (($latestPaymentEvent->id ?? null) !== null) {
+            $links[] = [
+                'label' => 'Latest payment event',
+                'url' => PaymentEventResource::getUrl('view', ['record' => (string) $latestPaymentEvent->id]),
+                'kind' => 'ops',
+            ];
+        }
+
+        if (($activeGrant->id ?? null) !== null) {
+            $links[] = [
+                'label' => 'Latest benefit grant',
+                'url' => BenefitGrantResource::getUrl('view', ['record' => (string) $activeGrant->id]),
+                'kind' => 'ops',
+            ];
+        }
+
         $links[] = [
             'label' => 'Order Lookup',
             'url' => '/ops/order-lookup',
             'kind' => 'ops',
         ];
 
+        if (filled($orderRecord->last_reconciled_at ?? null) && trim((string) ($order->order_no ?? '')) !== '') {
+            $links[] = [
+                'label' => 'Compensation hint',
+                'url' => '#compensation-summary',
+                'kind' => 'ops',
+            ];
+        }
+
         return $links;
+    }
+
+    private function resolvedPaymentStateValue(object $order): string
+    {
+        return Order::normalizePaymentState(
+            (string) ($order->payment_state ?? ''),
+            (string) ($order->status ?? '')
+        );
+    }
+
+    private function resolvedGrantStateValue(object $order): string
+    {
+        return Order::normalizeGrantState(
+            (string) ($order->grant_state ?? ''),
+            (string) ($order->status ?? '')
+        );
+    }
+
+    private function latestPaymentAttemptState(object $order): string
+    {
+        return PaymentAttempt::normalizedState((string) ($order->latest_payment_attempt_state ?? ''));
+    }
+
+    private function matchesException(string $key, object $order): bool
+    {
+        $paymentState = $this->resolvedPaymentStateValue($order);
+        $grantState = $this->resolvedGrantStateValue($order);
+        $attemptState = $this->latestPaymentAttemptState($order);
+        $hasAttempt = (int) ($order->payment_attempts_count ?? 0) > 0;
+        $hasActiveGrant = $this->hasActiveBenefitGrant($order);
+        $latestHandleStatus = strtolower(trim((string) ($order->latest_handle_status ?? '')));
+        $latestPaymentStatus = strtolower(trim((string) ($order->latest_payment_status ?? '')));
+        $latestPaymentError = trim((string) ($order->latest_payment_error ?? ''));
+        $latestSignatureOk = $order->latest_signature_ok ?? null;
+
+        return match ($key) {
+            'pending_unpaid' => in_array($paymentState, [Order::PAYMENT_STATE_CREATED, Order::PAYMENT_STATE_PENDING], true)
+                && (! $hasAttempt || $attemptState === PaymentAttempt::STATE_INITIATED),
+            'provider_created_not_paid' => in_array($paymentState, [Order::PAYMENT_STATE_CREATED, Order::PAYMENT_STATE_PENDING], true)
+                && in_array($attemptState, [PaymentAttempt::STATE_PROVIDER_CREATED, PaymentAttempt::STATE_CLIENT_PRESENTED], true),
+            'callback_missing' => in_array($paymentState, [Order::PAYMENT_STATE_CREATED, Order::PAYMENT_STATE_PENDING], true)
+                && in_array($attemptState, [PaymentAttempt::STATE_CALLBACK_RECEIVED, PaymentAttempt::STATE_VERIFIED], true),
+            'paid_no_grant' => $paymentState === Order::PAYMENT_STATE_PAID
+                && $grantState !== Order::GRANT_STATE_GRANTED
+                && ! $hasActiveGrant,
+            'grant_without_paid' => $hasActiveGrant
+                && ! in_array($paymentState, [Order::PAYMENT_STATE_PAID, Order::PAYMENT_STATE_REFUNDED], true),
+            'webhook_error' => $latestSignatureOk !== null && ! $this->truthy($latestSignatureOk)
+                || in_array($latestPaymentStatus, ['failed', 'rejected', 'post_commit_failed'], true)
+                || in_array($latestHandleStatus, ['failed', 'reprocess_failed'], true)
+                || $latestPaymentError !== '',
+            'compensation_touched' => filled($order->last_reconciled_at ?? null),
+            'refund_revoked' => $paymentState === Order::PAYMENT_STATE_REFUNDED
+                && in_array(strtolower(trim((string) ($order->latest_benefit_status ?? ''))), ['revoked', 'expired'], true),
+            'late_callback_corrected' => $paymentState === Order::PAYMENT_STATE_PAID
+                && filled($order->last_reconciled_at ?? null)
+                && filled($order->paid_at ?? null)
+                && Carbon::parse((string) $order->paid_at)->gt(Carbon::parse((string) $order->last_reconciled_at)),
+            default => false,
+        };
+    }
+
+    private function exceptionState(string $key): string
+    {
+        return match ($key) {
+            'webhook_error', 'paid_no_grant', 'grant_without_paid' => 'danger',
+            'late_callback_corrected' => 'success',
+            default => 'warning',
+        };
+    }
+
+    private function exceptionHint(string $key, object $order): string
+    {
+        return match ($key) {
+            'pending_unpaid' => 'No provider-created attempt is visible yet. This still looks like a true unpaid order.',
+            'provider_created_not_paid' => 'A provider session exists, but the order has not reached a paid terminal state.',
+            'callback_missing' => 'Attempt reached callback_received/verified while the order still reads pending. Check webhook handling.',
+            'paid_no_grant' => 'Payment is confirmed, but grant/access is not unlocked yet.',
+            'grant_without_paid' => 'A grant exists without a paid order state. Audit entitlement issuance.',
+            'webhook_error' => 'Latest webhook signature or handling status indicates an error.',
+            'compensation_touched' => 'Compensation touched this order at '.$this->formatTimestamp($order->last_reconciled_at ?? null).'.',
+            'refund_revoked' => 'Refunded order has a revoked/expired grant trail.',
+            'late_callback_corrected' => 'Late callback corrected an order after compensation already touched it.',
+            default => '-',
+        };
     }
 
     private function resolvedAttemptId(object $order): ?string
@@ -1404,7 +1856,7 @@ final class OrderLinkageSupport
         return match (true) {
             $status === '' => 'gray',
             in_array($status, ['paid', 'fulfilled', 'active', 'ready', 'full', 'completed', 'processed', 'handled', 'succeeded'], true) => 'success',
-            in_array($status, ['pending', 'queued', 'running', 'processing'], true) => 'warning',
+            in_array($status, ['pending', 'queued', 'running', 'processing', 'initiated', 'provider_created', 'client_presented', 'callback_received', 'verified'], true) => 'warning',
             in_array($status, ['failed', 'error', 'revoked', 'expired', 'invalid', 'refunded'], true) => 'danger',
             default => 'gray',
         };

--- a/backend/app/Filament/Ops/Resources/PaymentAttemptResource.php
+++ b/backend/app/Filament/Ops/Resources/PaymentAttemptResource.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\PaymentAttemptResource\Pages;
+use App\Filament\Shared\BaseTenantResource;
+use App\Models\PaymentAttempt;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Tables;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+final class PaymentAttemptResource extends BaseTenantResource
+{
+    protected static ?string $model = PaymentAttempt::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-banknotes';
+
+    protected static ?string $navigationGroup = 'Commerce';
+
+    protected static ?string $navigationLabel = 'Payment Attempts';
+
+    protected static ?int $navigationSort = 12;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.commerce');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Payment Attempts';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Section::make('Attempt')
+                ->schema([
+                    Forms\Components\TextInput::make('id')->disabled(),
+                    Forms\Components\TextInput::make('order_no')->disabled(),
+                    Forms\Components\TextInput::make('attempt_no')->disabled(),
+                    Forms\Components\TextInput::make('provider')->disabled(),
+                    Forms\Components\TextInput::make('state')->disabled(),
+                    Forms\Components\TextInput::make('channel')->disabled(),
+                    Forms\Components\TextInput::make('provider_app')->disabled(),
+                    Forms\Components\TextInput::make('pay_scene')->disabled(),
+                ])
+                ->columns(4),
+            Forms\Components\Section::make('Provider refs')
+                ->schema([
+                    Forms\Components\TextInput::make('external_trade_no')->disabled(),
+                    Forms\Components\TextInput::make('provider_trade_no')->disabled(),
+                    Forms\Components\TextInput::make('provider_session_ref')->disabled(),
+                    Forms\Components\TextInput::make('latest_payment_event_id')->disabled(),
+                ])
+                ->columns(2),
+            Forms\Components\Section::make('Timeline')
+                ->schema([
+                    Forms\Components\DateTimePicker::make('initiated_at')->disabled(),
+                    Forms\Components\DateTimePicker::make('provider_created_at')->disabled(),
+                    Forms\Components\DateTimePicker::make('client_presented_at')->disabled(),
+                    Forms\Components\DateTimePicker::make('callback_received_at')->disabled(),
+                    Forms\Components\DateTimePicker::make('verified_at')->disabled(),
+                    Forms\Components\DateTimePicker::make('finalized_at')->disabled(),
+                ])
+                ->columns(3),
+            Forms\Components\Section::make('Diagnostics')
+                ->schema([
+                    Forms\Components\TextInput::make('amount_expected')->disabled(),
+                    Forms\Components\TextInput::make('currency')->disabled(),
+                    Forms\Components\TextInput::make('last_error_code')->disabled(),
+                    Forms\Components\Textarea::make('last_error_message')
+                        ->rows(3)
+                        ->disabled(),
+                ])
+                ->columns(2),
+        ]);
+    }
+
+    public static function canViewAny(): bool
+    {
+        return self::canCommerceAccess();
+    }
+
+    public static function canView($record): bool
+    {
+        return self::canCommerceAccess();
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit($record): bool
+    {
+        return false;
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->searchPlaceholder('attempt_id / order_no / provider_trade_no / external_trade_no / provider_session_ref')
+            ->searchDebounce('600ms')
+            ->recordUrl(fn (PaymentAttempt $record): string => self::getUrl('view', ['record' => $record]))
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('attempt_id')
+                    ->copyable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('order_no')
+                    ->copyable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('attempt_no')
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('provider')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('state')
+                    ->badge()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('provider_trade_no')
+                    ->label('provider_trade_no')
+                    ->copyable()
+                    ->searchable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('external_trade_no')
+                    ->label('external_trade_no')
+                    ->copyable()
+                    ->searchable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('provider_session_ref')
+                    ->label('provider_session_ref')
+                    ->copyable()
+                    ->searchable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('callback_received_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('verified_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('finalized_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('latest_payment_event_id')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('last_error_code')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('org_id')
+                    ->numeric()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('updated_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('provider')
+                    ->options(fn (): array => PaymentAttempt::query()
+                        ->whereNotNull('provider')
+                        ->where('provider', '!=', '')
+                        ->distinct()
+                        ->orderBy('provider')
+                        ->pluck('provider', 'provider')
+                        ->all()),
+                Tables\Filters\SelectFilter::make('state')
+                    ->options([
+                        PaymentAttempt::STATE_INITIATED => PaymentAttempt::STATE_INITIATED,
+                        PaymentAttempt::STATE_PROVIDER_CREATED => PaymentAttempt::STATE_PROVIDER_CREATED,
+                        PaymentAttempt::STATE_CLIENT_PRESENTED => PaymentAttempt::STATE_CLIENT_PRESENTED,
+                        PaymentAttempt::STATE_CALLBACK_RECEIVED => PaymentAttempt::STATE_CALLBACK_RECEIVED,
+                        PaymentAttempt::STATE_VERIFIED => PaymentAttempt::STATE_VERIFIED,
+                        PaymentAttempt::STATE_PAID => PaymentAttempt::STATE_PAID,
+                        PaymentAttempt::STATE_FAILED => PaymentAttempt::STATE_FAILED,
+                        PaymentAttempt::STATE_CANCELED => PaymentAttempt::STATE_CANCELED,
+                        PaymentAttempt::STATE_EXPIRED => PaymentAttempt::STATE_EXPIRED,
+                    ]),
+                Tables\Filters\Filter::make('order_no')
+                    ->form([
+                        Forms\Components\TextInput::make('order_no')->label('Order No'),
+                    ])
+                    ->query(function (Builder $query, array $data): void {
+                        $orderNo = trim((string) ($data['order_no'] ?? ''));
+                        if ($orderNo === '') {
+                            return;
+                        }
+
+                        $query->where('order_no', 'like', '%'.$orderNo.'%');
+                    }),
+                Tables\Filters\TernaryFilter::make('callback_received')
+                    ->label('Callback received')
+                    ->queries(
+                        true: fn (Builder $query): Builder => $query->whereNotNull('callback_received_at'),
+                        false: fn (Builder $query): Builder => $query->whereNull('callback_received_at'),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+            ])
+            ->filtersLayout(FiltersLayout::AboveContentCollapsible)
+            ->filtersFormColumns(4)
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPaymentAttempts::route('/'),
+            'view' => Pages\ViewPaymentAttempt::route('/{record}'),
+        ];
+    }
+
+    private static function canCommerceAccess(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_MENU_COMMERCE)
+                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/PaymentAttemptResource/Pages/ListPaymentAttempts.php
+++ b/backend/app/Filament/Ops/Resources/PaymentAttemptResource/Pages/ListPaymentAttempts.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\PaymentAttemptResource\Pages;
+
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
+use App\Filament\Ops\Resources\PaymentAttemptResource;
+use Filament\Resources\Pages\ListRecords;
+
+final class ListPaymentAttempts extends ListRecords
+{
+    use HasSharedListEmptyState;
+
+    protected static string $resource = PaymentAttemptResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/PaymentAttemptResource/Pages/ViewPaymentAttempt.php
+++ b/backend/app/Filament/Ops/Resources/PaymentAttemptResource/Pages/ViewPaymentAttempt.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\PaymentAttemptResource\Pages;
+
+use App\Filament\Ops\Resources\PaymentAttemptResource;
+use Filament\Resources\Pages\ViewRecord;
+
+final class ViewPaymentAttempt extends ViewRecord
+{
+    protected static string $resource = PaymentAttemptResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/PaymentEventResource.php
+++ b/backend/app/Filament/Ops/Resources/PaymentEventResource.php
@@ -8,6 +8,7 @@ use App\Filament\Ops\Resources\PaymentEventResource\Pages;
 use App\Filament\Ops\Support\StatusBadge;
 use App\Filament\Shared\BaseTenantResource;
 use App\Models\AdminApproval;
+use App\Models\Order;
 use App\Models\PaymentEvent;
 use App\Services\Audit\AuditLogger;
 use App\Support\Rbac\PermissionNames;
@@ -91,6 +92,27 @@ class PaymentEventResource extends BaseTenantResource
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),
+                Tables\Actions\Action::make('openOrder')
+                    ->label('Open Order')
+                    ->icon('heroicon-o-shopping-cart')
+                    ->url(function (PaymentEvent $record): ?string {
+                        $orderId = Order::query()
+                            ->withoutGlobalScopes()
+                            ->where('order_no', (string) ($record->order_no ?? ''))
+                            ->value('id');
+
+                        return $orderId !== null ? OrderResource::getUrl('view', ['record' => (string) $orderId]) : null;
+                    })
+                    ->openUrlInNewTab(false)
+                    ->visible(fn (PaymentEvent $record): bool => filled($record->order_no ?? null)),
+                Tables\Actions\Action::make('openAttempt')
+                    ->label('Open Attempt')
+                    ->icon('heroicon-o-banknotes')
+                    ->url(fn (PaymentEvent $record): ?string => filled($record->payment_attempt_id ?? null)
+                        ? PaymentAttemptResource::getUrl('view', ['record' => (string) $record->payment_attempt_id])
+                        : null)
+                    ->openUrlInNewTab(false)
+                    ->visible(fn (PaymentEvent $record): bool => filled($record->payment_attempt_id ?? null)),
                 Tables\Actions\Action::make('requestReprocess')
                     ->label('Request Reprocess')
                     ->icon('heroicon-o-arrow-path')

--- a/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
+++ b/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
@@ -25,9 +25,9 @@ class CommerceKpiWidget extends BaseWidget
         if ($orgId <= 0) {
             return [
                 Stat::make(__('ops.widgets.paid_orders_today'), '0')->description(__('ops.widgets.select_org_to_view_metrics')),
-                Stat::make(__('ops.widgets.pending_orders'), '0')->description(__('ops.widgets.no_org_selected')),
-                Stat::make(__('ops.widgets.revenue_today'), '0')->description(__('ops.widgets.no_org_selected')),
-                Stat::make(__('ops.widgets.unlock_rate'), '0%')->description(__('ops.widgets.no_org_selected')),
+                Stat::make('Pending unresolved', '0')->description(__('ops.widgets.no_org_selected')),
+                Stat::make('Paid no grant', '0')->description(__('ops.widgets.no_org_selected')),
+                Stat::make('Compensated recently', '0')->description(__('ops.widgets.no_org_selected')),
                 Stat::make(__('ops.widgets.refund_count'), '0')->description(__('ops.widgets.no_org_selected')),
                 Stat::make(__('ops.widgets.webhook_failures'), '0')->description(__('ops.widgets.no_org_selected')),
             ];
@@ -35,40 +35,35 @@ class CommerceKpiWidget extends BaseWidget
 
         $paidOrders = (int) DB::table('orders')
             ->where('org_id', $orgId)
-            ->whereIn('status', ['paid', 'fulfilled', 'refunded'])
-            ->where('created_at', '>=', $start)
-            ->where('created_at', '<', $end)
+            ->where('payment_state', 'paid')
+            ->where('paid_at', '>=', $start)
+            ->where('paid_at', '<', $end)
             ->count();
 
-        $todayRevenue = (int) DB::table('orders')
-            ->where('org_id', $orgId)
-            ->whereIn('status', ['paid', 'fulfilled'])
-            ->where('created_at', '>=', $start)
-            ->where('created_at', '<', $end)
-            ->sum(DB::raw('COALESCE(amount_cents, 0)'));
-
-        $pendingOrders = (int) DB::table('orders')
+        $pendingUnresolved = (int) DB::table('orders')
             ->where('org_id', $orgId)
             ->whereIn('payment_state', ['created', 'pending'])
             ->count();
 
+        $paidNoGrant = (int) DB::table('orders')
+            ->where('org_id', $orgId)
+            ->where('payment_state', 'paid')
+            ->where('grant_state', '!=', 'granted')
+            ->count();
+
+        $compensatedRecently = (int) DB::table('orders')
+            ->where('org_id', $orgId)
+            ->whereNotNull('last_reconciled_at')
+            ->where('last_reconciled_at', '>=', $start)
+            ->where('last_reconciled_at', '<', $end)
+            ->count();
+
         $refundCount = (int) DB::table('orders')
             ->where('org_id', $orgId)
-            ->where('status', 'refunded')
-            ->where('updated_at', '>=', $start)
-            ->where('updated_at', '<', $end)
+            ->where('payment_state', 'refunded')
+            ->where('refunded_at', '>=', $start)
+            ->where('refunded_at', '<', $end)
             ->count();
-
-        $unlockCount = (int) DB::table('benefit_grants')
-            ->where('org_id', $orgId)
-            ->where('status', 'active')
-            ->where('created_at', '>=', $start)
-            ->where('created_at', '<', $end)
-            ->count();
-
-        $unlockRate = $paidOrders > 0
-            ? round(($unlockCount / $paidOrders) * 100, 1)
-            : 0;
 
         $webhookFailures = (int) DB::table('payment_events')
             ->where('org_id', $orgId)
@@ -83,10 +78,12 @@ class CommerceKpiWidget extends BaseWidget
 
         return [
             Stat::make(__('ops.widgets.paid_orders_today'), (string) $paidOrders),
-            Stat::make(__('ops.widgets.pending_orders'), (string) $pendingOrders)
-                ->color($pendingOrders > 0 ? 'warning' : 'success'),
-            Stat::make(__('ops.widgets.revenue_today'), (string) $todayRevenue)->description(__('ops.widgets.cents')),
-            Stat::make(__('ops.widgets.unlock_rate'), (string) $unlockRate.'%'),
+            Stat::make('Pending unresolved', (string) $pendingUnresolved)
+                ->color($pendingUnresolved > 0 ? 'warning' : 'success'),
+            Stat::make('Paid no grant', (string) $paidNoGrant)
+                ->color($paidNoGrant > 0 ? 'danger' : 'success'),
+            Stat::make('Compensated recently', (string) $compensatedRecently)
+                ->color($compensatedRecently > 0 ? 'warning' : 'gray'),
             Stat::make(__('ops.widgets.refund_count'), (string) $refundCount)
                 ->color($refundCount > 0 ? 'warning' : 'success'),
             Stat::make(__('ops.widgets.webhook_failures'), (string) $webhookFailures)

--- a/backend/resources/views/filament/ops/resources/orders/view-order.blade.php
+++ b/backend/resources/views/filament/ops/resources/orders/view-order.blade.php
@@ -10,7 +10,7 @@
                     <div class="ops-shell-inline-intro">
                         <span class="ops-shell-inline-intro__eyebrow">Support diagnostic</span>
                         <p class="ops-shell-inline-intro__meta">
-                            Rooted on <code>{{ (string) ($record->order_no ?? $record->getKey()) }}</code>. This page keeps order, payment, unlock, report, PDF, and share breadcrumbs in one read-only surface.
+                            Rooted on <code>{{ (string) ($record->order_no ?? $record->getKey()) }}</code>. This page keeps order, payment attempts, webhook events, unlock, access, compensation, report, PDF, and share breadcrumbs in one read-only surface.
                         </p>
                     </div>
 
@@ -67,6 +67,54 @@
                     'fields' => $orderSummary['fields'] ?? [],
                     'notes' => $orderSummary['notes'] ?? [],
                 ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Payment Attempts</h3>
+                    <p class="ops-results-header__meta">Backend-owned initiation timeline with provider refs, callback milestones, and final state summaries.</p>
+                </div>
+            </div>
+
+            <div class="ops-card-list mt-4">
+                @forelse ($paymentAttempts as $paymentAttempt)
+                    <div class="ops-result-card">
+                        <div class="ops-result-card__header">
+                            <div>
+                                <p class="ops-result-card__title">attempt #{{ (string) ($paymentAttempt['attempt_no'] ?? '-') }}</p>
+                                <p class="ops-result-card__meta">
+                                    provider={{ (string) ($paymentAttempt['provider'] ?? '-') }}
+                                    | callback={{ (string) ($paymentAttempt['callback_received_at'] ?? '-') }}
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-wrap gap-2">
+                            <x-filament.ops.shared.status-pill
+                                :state="(string) ($paymentAttempt['state']['state'] ?? 'gray')"
+                                :label="'state: '.(string) ($paymentAttempt['state']['label'] ?? '-')"
+                            />
+                        </div>
+
+                        <div class="mt-4 space-y-2">
+                            <p class="ops-control-hint">attempt_id={{ (string) ($paymentAttempt['id'] ?? '-') }}</p>
+                            <p class="ops-control-hint">provider_trade_no={{ (string) ($paymentAttempt['provider_trade_no'] ?? '-') }}</p>
+                            <p class="ops-control-hint">external_trade_no={{ (string) ($paymentAttempt['external_trade_no'] ?? '-') }}</p>
+                            <p class="ops-control-hint">provider_session_ref={{ (string) ($paymentAttempt['provider_session_ref'] ?? '-') }}</p>
+                            <p class="ops-control-hint">verified={{ (string) ($paymentAttempt['verified_at'] ?? '-') }} | finalized={{ (string) ($paymentAttempt['finalized_at'] ?? '-') }}</p>
+                            <p class="ops-control-hint">error={{ (string) ($paymentAttempt['last_error_code'] ?? '-') }} | {{ (string) ($paymentAttempt['last_error_message'] ?? '-') }}</p>
+                        </div>
+                    </div>
+                @empty
+                    <x-filament.ops.shared.empty-state
+                        eyebrow="Payment attempts"
+                        icon="heroicon-o-banknotes"
+                        title="No payment attempts found"
+                        description="Legacy orders may still have a complete order ledger but no attempt timeline."
+                    />
+                @endforelse
             </div>
         </x-filament::section>
 
@@ -157,8 +205,8 @@
         <x-filament::section>
             <div class="ops-results-header">
                 <div>
-                    <h3 class="ops-results-header__title">Attempt Linkage</h3>
-                    <p class="ops-results-header__meta">Attempt, result, locale, region, and share attribution breadcrumbs for drill-through diagnostics.</p>
+                    <h3 class="ops-results-header__title">Assessment Attempt Linkage</h3>
+                    <p class="ops-results-header__meta">Assessment attempt, result, locale, region, and share attribution breadcrumbs for drill-through diagnostics.</p>
                 </div>
             </div>
 
@@ -170,11 +218,43 @@
             </div>
         </x-filament::section>
 
+        <x-filament::section id="compensation-summary">
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Unified Access</h3>
+                    <p class="ops-results-header__meta">Latest access projection summary so support can see whether unlock and report posture actually propagated.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $accessSummary['fields'] ?? [],
+                    'notes' => $accessSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Compensation Summary</h3>
+                    <p class="ops-results-header__meta">Latest reconcile touch, payment correction posture, and command hints without turning this page into a remediation console.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $compensationSummary['fields'] ?? [],
+                    'notes' => $compensationSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
         <x-filament::section>
             <div class="ops-results-header">
                 <div>
                     <h3 class="ops-results-header__title">Exception Diagnostics</h3>
-                    <p class="ops-results-header__meta">Explicit v1 exception rules for support and ops, without expanding into a full BI or remediation console.</p>
+                    <p class="ops-results-header__meta">Backend-owned commerce exception taxonomy for support and ops without expanding into a full BI or remediation console.</p>
                 </div>
             </div>
 

--- a/backend/tests/Feature/Ops/CommerceExceptionWorkbenchContractTest.php
+++ b/backend/tests/Feature/Ops/CommerceExceptionWorkbenchContractTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\OrderResource\Pages\ListOrders;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class CommerceExceptionWorkbenchContractTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_order_resource_exposes_exception_workbench_columns_and_filter(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Commerce Workbench Org');
+        $chain = $this->seedCommerceOpsChain(orgId: 61);
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListOrders::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$chain['order']])
+            ->assertTableColumnExists('commerce_exception')
+            ->assertTableColumnExists('exception_count')
+            ->assertTableColumnExists('payment_attempts_count')
+            ->assertTableColumnExists('latest_payment_attempt_state')
+            ->assertTableColumnExists('compensation_status')
+            ->assertTableFilterExists('commerce_exception_filter');
+    }
+}

--- a/backend/tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php
+++ b/backend/tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Widgets\CommerceKpiWidget;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class CommerceKpiExceptionSummaryTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    public function test_commerce_kpi_widget_uses_exception_oriented_summary(): void
+    {
+        $orgId = 75;
+
+        $this->seedCommerceOpsChain($orgId, 'ord_paid_today_ops', [
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'paid',
+            'paid_at' => now()->subMinutes(15),
+        ]);
+        $this->seedCommerceOpsChain($orgId, 'ord_pending_ops', [
+            'payment_state' => 'pending',
+            'grant_state' => 'not_started',
+            'status' => 'pending',
+            'payment_attempt_state' => 'provider_created',
+            'with_grant' => false,
+        ]);
+        $this->seedCommerceOpsChain($orgId, 'ord_paid_no_grant_ops_widget', [
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'status' => 'paid',
+            'with_grant' => false,
+            'paid_at' => now()->subMinutes(12),
+        ]);
+        $this->seedCommerceOpsChain($orgId, 'ord_compensated_ops', [
+            'payment_state' => 'expired',
+            'grant_state' => 'not_started',
+            'status' => 'canceled',
+            'with_grant' => false,
+            'last_reconciled_at' => now()->subMinutes(8),
+        ]);
+        $this->seedCommerceOpsChain($orgId, 'ord_webhook_error_ops', [
+            'payment_state' => 'pending',
+            'grant_state' => 'not_started',
+            'status' => 'pending',
+            'payment_event_status' => 'failed',
+            'payment_event_handle_status' => 'failed',
+            'signature_ok' => 0,
+            'with_grant' => false,
+        ]);
+
+        $context = app(OrgContext::class);
+        $context->set($orgId, null, null, null, OrgContext::KIND_TENANT);
+        app()->instance(OrgContext::class, $context);
+
+        $widget = app(CommerceKpiWidget::class);
+        $method = new ReflectionMethod($widget, 'getStats');
+        $method->setAccessible(true);
+        $stats = $method->invoke($widget);
+
+        $labels = array_map(fn ($stat): string => (string) $stat->getLabel(), $stats);
+        $valuesByLabel = [];
+        foreach ($stats as $stat) {
+            $valuesByLabel[(string) $stat->getLabel()] = (string) $stat->getValue();
+        }
+
+        $this->assertContains('Pending unresolved', $labels);
+        $this->assertContains('Paid no grant', $labels);
+        $this->assertContains('Compensated recently', $labels);
+        $this->assertSame('2', $valuesByLabel['Pending unresolved'] ?? null);
+        $this->assertSame('1', $valuesByLabel['Paid no grant'] ?? null);
+        $this->assertSame('1', $valuesByLabel['Compensated recently'] ?? null);
+    }
+}

--- a/backend/tests/Feature/Ops/CommerceOpsActionLinkageTest.php
+++ b/backend/tests/Feature/Ops/CommerceOpsActionLinkageTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class CommerceOpsActionLinkageTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_order_view_exposes_ops_action_links_for_manual_follow_up(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Commerce Linkage Org');
+        $chain = $this->seedCommerceOpsChain(orgId: 74, options: [
+            'last_reconciled_at' => now()->subMinutes(5),
+        ]);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/orders/'.$chain['order']->getKey())
+            ->assertOk()
+            ->assertSee('Latest payment attempt')
+            ->assertSee('Latest payment event')
+            ->assertSee('Latest benefit grant')
+            ->assertSee('Order Lookup')
+            ->assertSee('php artisan commerce:compensate-pending-orders --order='.$chain['order_no'].' --dry-run');
+    }
+}

--- a/backend/tests/Feature/Ops/OrderCommerceLinkageTest.php
+++ b/backend/tests/Feature/Ops/OrderCommerceLinkageTest.php
@@ -44,7 +44,6 @@ final class OrderCommerceLinkageTest extends TestCase
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->get('/ops/orders')
             ->assertOk()
-            ->assertSee('Unlock / Commerce Linkage')
             ->assertDontSee('Request Manual Grant')
             ->assertDontSee('Request Refund');
 
@@ -62,6 +61,12 @@ final class OrderCommerceLinkageTest extends TestCase
             ->assertTableColumnExists('amount_cents')
             ->assertTableColumnExists('currency')
             ->assertTableColumnExists('status')
+            ->assertTableColumnExists('payment_state')
+            ->assertTableColumnExists('grant_state')
+            ->assertTableColumnExists('commerce_exception')
+            ->assertTableColumnExists('payment_attempts_count')
+            ->assertTableColumnExists('latest_payment_attempt_state')
+            ->assertTableColumnExists('compensation_status')
             ->assertTableColumnExists('latest_payment_status')
             ->assertTableColumnExists('target_attempt_id')
             ->assertTableColumnExists('requested_sku')
@@ -89,10 +94,13 @@ final class OrderCommerceLinkageTest extends TestCase
             ->get('/ops/orders/'.$chain['order']->getKey())
             ->assertOk()
             ->assertSee('Order Summary')
+            ->assertSee('Payment Attempts')
             ->assertSee('Payment Events')
             ->assertSee('Benefit / Unlock')
             ->assertSee('Report / PDF Delivery')
-            ->assertSee('Attempt Linkage')
+            ->assertSee('Assessment Attempt Linkage')
+            ->assertSee('Unified Access')
+            ->assertSee('Compensation Summary')
             ->assertSee('Exception Diagnostics')
             ->assertSee('unlock: unlocked')
             ->assertSee('paid')
@@ -100,11 +108,16 @@ final class OrderCommerceLinkageTest extends TestCase
             ->assertSee('INTJ')
             ->assertSee((string) $chain['order_no'])
             ->assertSee((string) $chain['attempt_id'])
+            ->assertSee((string) $chain['payment_attempt_id'])
             ->assertSee((string) $chain['share_id'])
             ->assertSee('Order page')
             ->assertSee('Result page')
             ->assertSee('Report page')
             ->assertSee('Share page')
+            ->assertSee('Latest payment attempt')
+            ->assertSee('Latest payment event')
+            ->assertSee('Latest benefit grant')
+            ->assertSee('Order Lookup')
             ->assertDontSee('payload_json')
             ->assertDontSee('report_json')
             ->assertDontSee('report_full_json')
@@ -193,6 +206,7 @@ final class OrderCommerceLinkageTest extends TestCase
      *     order:Order,
      *     order_no:string,
      *     attempt_id:string,
+     *     payment_attempt_id:string,
      *     share_id:string,
      *     payment_secret:string,
      *     report_secret:string
@@ -204,6 +218,8 @@ final class OrderCommerceLinkageTest extends TestCase
         $shareId = (string) Str::uuid();
         $orderId = (string) Str::uuid();
         $paymentEventId = (string) Str::uuid();
+        $paymentAttemptId = (string) Str::uuid();
+        $benefitGrantId = (string) Str::uuid();
         $orderNo ??= 'ord_diag_'.Str::lower(Str::random(6));
         $paymentSecret = 'payment-secret-'.Str::lower(Str::random(6));
         $reportSecret = 'report-secret-'.Str::lower(Str::random(6));
@@ -313,6 +329,12 @@ final class OrderCommerceLinkageTest extends TestCase
         if (Schema::hasColumn('orders', 'provider_order_id')) {
             $orderRow['provider_order_id'] = 'pi_'.$orderNo;
         }
+        if (Schema::hasColumn('orders', 'payment_state')) {
+            $orderRow['payment_state'] = 'paid';
+        }
+        if (Schema::hasColumn('orders', 'grant_state')) {
+            $orderRow['grant_state'] = 'granted';
+        }
         if (Schema::hasColumn('orders', 'fulfilled_at')) {
             $orderRow['fulfilled_at'] = now()->subMinutes(7);
         }
@@ -346,6 +368,39 @@ final class OrderCommerceLinkageTest extends TestCase
 
         DB::table('orders')->insert($orderRow);
 
+        if (Schema::hasTable('payment_attempts')) {
+            DB::table('payment_attempts')->insert([
+                'id' => $paymentAttemptId,
+                'org_id' => $orgId,
+                'order_id' => $orderId,
+                'order_no' => $orderNo,
+                'attempt_no' => 1,
+                'provider' => 'stripe',
+                'channel' => 'web',
+                'provider_app' => 'web-primary',
+                'pay_scene' => 'checkout',
+                'state' => 'paid',
+                'external_trade_no' => 'ext_'.$orderNo,
+                'provider_trade_no' => 'pi_'.$orderNo,
+                'provider_session_ref' => 'cs_'.$orderNo,
+                'amount_expected' => 2990,
+                'currency' => 'USD',
+                'payload_meta_json' => json_encode(['surface' => 'ops-test'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'latest_payment_event_id' => null,
+                'initiated_at' => now()->subMinutes(10),
+                'provider_created_at' => now()->subMinutes(10),
+                'client_presented_at' => now()->subMinutes(10),
+                'callback_received_at' => now()->subMinutes(9),
+                'verified_at' => now()->subMinutes(9),
+                'finalized_at' => now()->subMinutes(9),
+                'last_error_code' => null,
+                'last_error_message' => null,
+                'meta_json' => null,
+                'created_at' => now()->subMinutes(10),
+                'updated_at' => now()->subMinutes(9),
+            ]);
+        }
+
         DB::table('payment_events')->insert([
             'id' => $paymentEventId,
             'org_id' => $orgId,
@@ -353,6 +408,7 @@ final class OrderCommerceLinkageTest extends TestCase
             'provider_event_id' => 'evt_'.Str::lower(Str::random(8)),
             'order_id' => $orderId,
             'order_no' => $orderNo,
+            'payment_attempt_id' => $paymentAttemptId,
             'event_type' => 'payment_intent.succeeded',
             'signature_ok' => 1,
             'status' => 'paid',
@@ -377,8 +433,14 @@ final class OrderCommerceLinkageTest extends TestCase
             'scale_uid' => '55555555-5555-4555-8555-555555555555',
         ]);
 
+        if (Schema::hasTable('payment_attempts')) {
+            DB::table('payment_attempts')
+                ->where('id', $paymentAttemptId)
+                ->update(['latest_payment_event_id' => $paymentEventId]);
+        }
+
         DB::table('benefit_grants')->insert([
-            'id' => (string) Str::uuid(),
+            'id' => $benefitGrantId,
             'org_id' => $orgId,
             'user_id' => '1001',
             'benefit_code' => 'MBTI_FULL_REPORT',
@@ -395,6 +457,23 @@ final class OrderCommerceLinkageTest extends TestCase
             'created_at' => now()->subMinutes(8),
             'updated_at' => now()->subMinutes(8),
         ]);
+
+        if (Schema::hasTable('unified_access_projections')) {
+            DB::table('unified_access_projections')->insert([
+                'attempt_id' => $attemptId,
+                'access_state' => 'granted',
+                'report_state' => 'ready',
+                'pdf_state' => 'ready',
+                'reason_code' => 'payment_granted',
+                'projection_version' => 1,
+                'actions_json' => json_encode(['can_download_pdf' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'payload_json' => json_encode(['source' => 'ops-test'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'produced_at' => now()->subMinutes(8),
+                'refreshed_at' => now()->subMinutes(7),
+                'created_at' => now()->subMinutes(8),
+                'updated_at' => now()->subMinutes(7),
+            ]);
+        }
 
         DB::table('shares')->insert([
             'id' => $shareId,
@@ -434,6 +513,7 @@ final class OrderCommerceLinkageTest extends TestCase
             'order' => $order,
             'order_no' => $orderNo,
             'attempt_id' => $attemptId,
+            'payment_attempt_id' => $paymentAttemptId,
             'share_id' => $shareId,
             'payment_secret' => $paymentSecret,
             'report_secret' => $reportSecret,

--- a/backend/tests/Feature/Ops/OrderExceptionFilterTest.php
+++ b/backend/tests/Feature/Ops/OrderExceptionFilterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\OrderResource\Support\OrderLinkageSupport;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class OrderExceptionFilterTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    public function test_exception_filter_can_isolate_paid_no_grant_and_callback_missing_orders(): void
+    {
+        $paidNoGrant = $this->seedCommerceOpsChain(orgId: 71, orderNo: 'ord_paid_no_grant_ops', options: [
+            'with_grant' => false,
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'status' => 'paid',
+            'payment_attempt_state' => 'paid',
+        ]);
+        $callbackMissing = $this->seedCommerceOpsChain(orgId: 71, orderNo: 'ord_callback_missing_ops', options: [
+            'with_grant' => false,
+            'payment_state' => 'pending',
+            'grant_state' => 'not_started',
+            'status' => 'pending',
+            'payment_attempt_state' => 'verified',
+        ]);
+        $clear = $this->seedCommerceOpsChain(orgId: 71, orderNo: 'ord_clear_ops');
+
+        $support = app(OrderLinkageSupport::class);
+
+        $paidNoGrantQuery = $support->query();
+        $support->applyExceptionFilter($paidNoGrantQuery, 'paid_no_grant');
+        $paidNoGrantOrders = $paidNoGrantQuery->pluck('order_no')->all();
+
+        $callbackMissingQuery = $support->query();
+        $support->applyExceptionFilter($callbackMissingQuery, 'callback_missing');
+        $callbackMissingOrders = $callbackMissingQuery->pluck('order_no')->all();
+
+        $this->assertContains($paidNoGrant['order_no'], $paidNoGrantOrders);
+        $this->assertNotContains($clear['order_no'], $paidNoGrantOrders);
+        $this->assertContains($callbackMissing['order_no'], $callbackMissingOrders);
+        $this->assertNotContains($clear['order_no'], $callbackMissingOrders);
+    }
+}

--- a/backend/tests/Feature/Ops/PaymentAttemptResourceTest.php
+++ b/backend/tests/Feature/Ops/PaymentAttemptResourceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\PaymentAttemptResource\Pages\ListPaymentAttempts;
+use App\Models\PaymentAttempt;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class PaymentAttemptResourceTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_payment_attempt_resource_is_readable_and_exposes_core_columns(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Payment Attempt Org');
+        $chain = $this->seedCommerceOpsChain(orgId: (int) $selectedOrg->id, options: [
+            'payment_attempt_state' => 'verified',
+        ]);
+
+        $paymentAttempt = PaymentAttempt::query()->withoutGlobalScopes()->findOrFail($chain['payment_attempt_id']);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/payment-attempts')
+            ->assertOk()
+            ->assertSee('Payment Attempts');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListPaymentAttempts::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$paymentAttempt])
+            ->assertTableColumnExists('order_no')
+            ->assertTableColumnExists('attempt_no')
+            ->assertTableColumnExists('provider')
+            ->assertTableColumnExists('state')
+            ->assertTableColumnExists('provider_trade_no')
+            ->assertTableFilterExists('state');
+
+        $this->get('/ops/payment-attempts/'.$paymentAttempt->getKey())
+            ->assertOk()
+            ->assertSee((string) $chain['order_no'])
+            ->assertSee((string) $chain['payment_attempt_id'])
+            ->assertSee('Provider refs')
+            ->assertSee('Timeline');
+    }
+}

--- a/backend/tests/Feature/Ops/Support/InteractsWithCommerceOpsWorkbench.php
+++ b/backend/tests/Feature/Ops/Support/InteractsWithCommerceOpsWorkbench.php
@@ -1,0 +1,444 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops\Support;
+
+use App\Models\AdminUser;
+use App\Models\Order;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+trait InteractsWithCommerceOpsWorkbench
+{
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array{
+     *     order:Order,
+     *     order_id:string,
+     *     order_no:string,
+     *     attempt_id:string,
+     *     payment_attempt_id:?string,
+     *     payment_event_id:?string,
+     *     benefit_grant_id:?string,
+     *     share_id:string
+     * }
+     */
+    private function seedCommerceOpsChain(int $orgId, ?string $orderNo = null, array $options = []): array
+    {
+        $attemptId = (string) Str::uuid();
+        $shareId = (string) Str::uuid();
+        $orderId = (string) Str::uuid();
+        $paymentAttemptId = (bool) ($options['with_payment_attempt'] ?? true) ? (string) Str::uuid() : null;
+        $paymentEventId = (bool) ($options['with_payment_event'] ?? true) ? (string) Str::uuid() : null;
+        $benefitGrantId = (bool) ($options['with_grant'] ?? true) ? (string) Str::uuid() : null;
+        $orderNo ??= 'ord_ops_'.Str::lower(Str::random(8));
+
+        $createdAt = $options['created_at'] ?? now()->subHours(2);
+        $updatedAt = $options['updated_at'] ?? now()->subMinutes(15);
+        $paymentState = (string) ($options['payment_state'] ?? Order::PAYMENT_STATE_PAID);
+        $grantState = (string) ($options['grant_state'] ?? Order::GRANT_STATE_GRANTED);
+        $orderStatus = (string) ($options['status'] ?? Order::STATUS_PAID);
+        $channel = (string) ($options['channel'] ?? 'web');
+        $provider = (string) ($options['provider'] ?? 'stripe');
+        $providerApp = (string) ($options['provider_app'] ?? 'web-primary');
+        $payScene = (string) ($options['pay_scene'] ?? 'checkout');
+        $paymentAttemptState = (string) ($options['payment_attempt_state'] ?? 'paid');
+        $eventStatus = (string) ($options['payment_event_status'] ?? 'paid');
+        $eventHandleStatus = (string) ($options['payment_event_handle_status'] ?? 'processed');
+        $signatureOk = (int) ($options['signature_ok'] ?? 1);
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'anon_id' => 'anon_ops',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+            'region' => 'US',
+            'locale' => 'en',
+            'question_count' => 93,
+            'answers_summary_json' => json_encode(['stage' => 'ops'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'channel' => $channel,
+            'started_at' => now()->subMinutes(45),
+            'submitted_at' => now()->subMinutes(35),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'content_package_version' => 'content_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'norm_version' => 'norm_2026_03',
+            'created_at' => now()->subMinutes(45),
+            'updated_at' => now()->subMinutes(35),
+            'result_json' => json_encode(['type_code' => 'INTJ'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ]);
+
+        DB::table('results')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ',
+            'scores_json' => json_encode(['EI' => 78], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'scores_pct' => json_encode(['EI' => 88], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'axis_states' => json_encode(['EI' => 'I'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'profile_version' => 'profile_2026_03',
+            'result_json' => json_encode(['private' => 'hidden'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'content_package_version' => 'content_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'is_valid' => 1,
+            'computed_at' => now()->subMinutes(30),
+            'created_at' => now()->subMinutes(30),
+            'updated_at' => now()->subMinutes(29),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'scale_code' => 'MBTI',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode([
+                'locked' => false,
+                'access_level' => 'full',
+                'variant' => 'full',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode(['variant' => 'free'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_full_json' => json_encode(['secret' => 'hidden'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'status' => 'ready',
+            'last_error' => null,
+            'created_at' => now()->subMinutes(25),
+            'updated_at' => now()->subMinutes(24),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        $orderRow = [
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'anon_id' => 'anon_ops',
+            'sku' => 'MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 2990,
+            'currency' => 'USD',
+            'status' => $orderStatus,
+            'payment_state' => $paymentState,
+            'grant_state' => $grantState,
+            'provider' => $provider,
+            'channel' => $channel,
+            'provider_app' => $providerApp,
+            'paid_at' => $options['paid_at'] ?? ($paymentState === Order::PAYMENT_STATE_PAID ? now()->subMinutes(20) : null),
+            'created_at' => $createdAt,
+            'updated_at' => $updatedAt,
+            'last_reconciled_at' => $options['last_reconciled_at'] ?? null,
+        ];
+
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $orderRow['amount_total'] = 2990;
+        }
+        if (Schema::hasColumn('orders', 'amount_refunded')) {
+            $orderRow['amount_refunded'] = (int) ($options['amount_refunded'] ?? 0);
+        }
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $orderRow['item_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'provider_order_id')) {
+            $orderRow['provider_order_id'] = 'pi_'.$orderNo;
+        }
+        if (Schema::hasColumn('orders', 'requested_sku')) {
+            $orderRow['requested_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'effective_sku')) {
+            $orderRow['effective_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'contact_email_hash')) {
+            $orderRow['contact_email_hash'] = hash('sha256', 'buyer+'.$orderNo.'@example.test');
+        }
+        if (Schema::hasColumn('orders', 'meta_json')) {
+            $orderRow['meta_json'] = json_encode([
+                'attribution' => [
+                    'share_id' => $shareId,
+                    'share_click_id' => 'click_'.$orderNo,
+                    'entrypoint' => 'checkout_return',
+                    'utm' => [
+                        'source' => 'ops',
+                        'medium' => 'organic',
+                        'campaign' => 'workbench',
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+        if (Schema::hasColumn('orders', 'closed_at')) {
+            $orderRow['closed_at'] = $options['closed_at'] ?? null;
+        }
+        if (Schema::hasColumn('orders', 'expired_at')) {
+            $orderRow['expired_at'] = $options['expired_at'] ?? null;
+        }
+        if (Schema::hasColumn('orders', 'refunded_at')) {
+            $orderRow['refunded_at'] = $options['refunded_at'] ?? null;
+        }
+
+        DB::table('orders')->insert($orderRow);
+
+        if ($paymentAttemptId !== null && Schema::hasTable('payment_attempts')) {
+            DB::table('payment_attempts')->insert([
+                'id' => $paymentAttemptId,
+                'org_id' => $orgId,
+                'order_id' => $orderId,
+                'order_no' => $orderNo,
+                'attempt_no' => 1,
+                'provider' => $provider,
+                'channel' => $channel,
+                'provider_app' => $providerApp,
+                'pay_scene' => $payScene,
+                'state' => $paymentAttemptState,
+                'external_trade_no' => 'ext_'.$orderNo,
+                'provider_trade_no' => $options['provider_trade_no'] ?? 'pi_'.$orderNo,
+                'provider_session_ref' => 'cs_'.$orderNo,
+                'amount_expected' => 2990,
+                'currency' => 'USD',
+                'payload_meta_json' => json_encode(['source' => 'ops-test'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'latest_payment_event_id' => null,
+                'initiated_at' => now()->subMinutes(25),
+                'provider_created_at' => now()->subMinutes(25),
+                'client_presented_at' => now()->subMinutes(24),
+                'callback_received_at' => $options['callback_received_at'] ?? ($paymentAttemptState !== 'initiated' ? now()->subMinutes(22) : null),
+                'verified_at' => $options['verified_at'] ?? (in_array($paymentAttemptState, ['verified', 'paid'], true) ? now()->subMinutes(21) : null),
+                'finalized_at' => $options['finalized_at'] ?? (in_array($paymentAttemptState, ['paid', 'failed', 'canceled', 'expired'], true) ? now()->subMinutes(20) : null),
+                'last_error_code' => $options['last_error_code'] ?? null,
+                'last_error_message' => $options['last_error_message'] ?? null,
+                'meta_json' => null,
+                'created_at' => now()->subMinutes(25),
+                'updated_at' => now()->subMinutes(20),
+            ]);
+        }
+
+        if ($paymentEventId !== null && Schema::hasTable('payment_events')) {
+            DB::table('payment_events')->insert([
+                'id' => $paymentEventId,
+                'org_id' => $orgId,
+                'provider' => $provider,
+                'provider_event_id' => 'evt_'.Str::lower(Str::random(8)),
+                'order_id' => $orderId,
+                'order_no' => $orderNo,
+                'payment_attempt_id' => $paymentAttemptId,
+                'event_type' => 'payment_intent.succeeded',
+                'signature_ok' => $signatureOk,
+                'status' => $eventStatus,
+                'attempts' => 1,
+                'last_error_code' => $options['event_error_code'] ?? null,
+                'last_error_message' => $options['event_error_message'] ?? null,
+                'processed_at' => now()->subMinutes(20),
+                'handled_at' => now()->subMinutes(20),
+                'handle_status' => $eventHandleStatus,
+                'reason' => $options['event_reason'] ?? 'checkout_paid',
+                'requested_sku' => 'MBTI_FULL_REPORT',
+                'effective_sku' => 'MBTI_FULL_REPORT',
+                'entitlement_id' => 'ent_'.$orderNo,
+                'payload_json' => json_encode(['secret' => 'hidden'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'payload_size_bytes' => 128,
+                'payload_sha256' => hash('sha256', 'hidden'),
+                'payload_s3_key' => null,
+                'payload_excerpt' => null,
+                'received_at' => now()->subMinutes(20),
+                'created_at' => now()->subMinutes(20),
+                'updated_at' => now()->subMinutes(20),
+                'scale_uid' => '55555555-5555-4555-8555-555555555555',
+            ]);
+
+            if ($paymentAttemptId !== null && Schema::hasTable('payment_attempts')) {
+                DB::table('payment_attempts')->where('id', $paymentAttemptId)->update([
+                    'latest_payment_event_id' => $paymentEventId,
+                ]);
+            }
+        }
+
+        if ($benefitGrantId !== null && Schema::hasTable('benefit_grants')) {
+            DB::table('benefit_grants')->insert([
+                'id' => $benefitGrantId,
+                'org_id' => $orgId,
+                'user_id' => '1001',
+                'benefit_code' => 'MBTI_FULL_REPORT',
+                'scope' => 'attempt',
+                'attempt_id' => $attemptId,
+                'status' => (string) ($options['grant_status'] ?? 'active'),
+                'expires_at' => now()->addDays(30),
+                'benefit_type' => 'report',
+                'benefit_ref' => 'benefit_'.$orderNo,
+                'order_no' => $orderNo,
+                'source_order_id' => $orderId,
+                'source_event_id' => $paymentEventId,
+                'meta_json' => json_encode(['source' => 'ops-test'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now()->subMinutes(18),
+                'updated_at' => now()->subMinutes(18),
+            ]);
+        }
+
+        if ((bool) ($options['with_access'] ?? true) && Schema::hasTable('unified_access_projections')) {
+            DB::table('unified_access_projections')->insert([
+                'attempt_id' => $attemptId,
+                'access_state' => (string) ($options['access_state'] ?? 'granted'),
+                'report_state' => (string) ($options['access_report_state'] ?? 'ready'),
+                'pdf_state' => (string) ($options['access_pdf_state'] ?? 'ready'),
+                'reason_code' => (string) ($options['access_reason_code'] ?? 'payment_granted'),
+                'projection_version' => 1,
+                'actions_json' => json_encode(['can_download_pdf' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'payload_json' => json_encode(['source' => 'ops-test'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'produced_at' => now()->subMinutes(17),
+                'refreshed_at' => now()->subMinutes(16),
+                'created_at' => now()->subMinutes(17),
+                'updated_at' => now()->subMinutes(16),
+            ]);
+        }
+
+        DB::table('shares')->insert([
+            'id' => $shareId,
+            'attempt_id' => $attemptId,
+            'anon_id' => 'anon_ops',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'content_2026_03',
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(9),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        DB::table('report_jobs')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'status' => 'succeeded',
+            'tries' => 1,
+            'available_at' => now()->subMinutes(28),
+            'started_at' => now()->subMinutes(28),
+            'finished_at' => now()->subMinutes(27),
+            'failed_at' => null,
+            'last_error' => null,
+            'last_error_trace' => null,
+            'report_json' => '{}',
+            'meta' => '{}',
+            'created_at' => now()->subMinutes(28),
+            'updated_at' => now()->subMinutes(27),
+            'org_id' => $orgId,
+        ]);
+
+        if (Schema::hasTable('email_outbox')) {
+            $emailRow = [
+                'id' => (string) Str::uuid(),
+                'user_id' => '1001',
+                'email' => 'redacted+'.substr(hash('sha256', $orderNo), 0, 20).'@privacy.local',
+                'template' => 'payment_success',
+                'payload_json' => json_encode(['order_no' => $orderNo], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'claim_token_hash' => hash('sha256', 'claim_'.$orderNo),
+                'claim_expires_at' => now()->addDay(),
+                'status' => 'sent',
+                'sent_at' => now()->subMinutes(5),
+                'consumed_at' => null,
+                'created_at' => now()->subMinutes(5),
+                'updated_at' => now()->subMinutes(5),
+            ];
+
+            if (Schema::hasColumn('email_outbox', 'attempt_id')) {
+                $emailRow['attempt_id'] = $attemptId;
+            }
+            if (Schema::hasColumn('email_outbox', 'to_email')) {
+                $emailRow['to_email'] = 'redacted+'.substr(hash('sha256', $orderNo), 0, 20).'@privacy.local';
+            }
+            if (Schema::hasColumn('email_outbox', 'locale')) {
+                $emailRow['locale'] = 'en';
+            }
+            if (Schema::hasColumn('email_outbox', 'template_key')) {
+                $emailRow['template_key'] = 'payment_success';
+            }
+            if (Schema::hasColumn('email_outbox', 'subject')) {
+                $emailRow['subject'] = 'Payment success';
+            }
+            if (Schema::hasColumn('email_outbox', 'body_html')) {
+                $emailRow['body_html'] = '<p>sent</p>';
+            }
+
+            DB::table('email_outbox')->insert($emailRow);
+        }
+
+        return [
+            'order' => Order::query()->withoutGlobalScopes()->whereKey($orderId)->firstOrFail(),
+            'order_id' => $orderId,
+            'order_no' => $orderNo,
+            'attempt_id' => $attemptId,
+            'payment_attempt_id' => $paymentAttemptId,
+            'payment_event_id' => $paymentEventId,
+            'benefit_grant_id' => $benefitGrantId,
+            'share_id' => $shareId,
+        ];
+    }
+}

--- a/backend/tests/Feature/Ops/ViewOrderCommerceTimelineTest.php
+++ b/backend/tests/Feature/Ops/ViewOrderCommerceTimelineTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class ViewOrderCommerceTimelineTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_order_view_renders_commerce_timeline_sections(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Commerce Timeline Org');
+        $chain = $this->seedCommerceOpsChain(orgId: 73, options: [
+            'last_reconciled_at' => now()->subMinutes(10),
+        ]);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/orders/'.$chain['order']->getKey())
+            ->assertOk()
+            ->assertSee('Commerce Timeline')
+            ->assertSee('Order Summary')
+            ->assertSee('Payment Attempts')
+            ->assertSee('Payment Events')
+            ->assertSee('Unified Access')
+            ->assertSee('Compensation Summary')
+            ->assertSee('Assessment Attempt Linkage')
+            ->assertSee((string) $chain['payment_attempt_id'])
+            ->assertSee((string) $chain['payment_event_id'])
+            ->assertSee((string) $chain['benefit_grant_id']);
+    }
+}


### PR DESCRIPTION
## Summary

This PR ships OP-4 for commerce ops: it turns the existing commerce truth layers into a minimal operator workbench instead of leaving order/payment/grant state spread across separate resources and command-line tooling.

At the order list level, ops can now classify and filter orders by backend-owned commerce exception taxonomy, including pending unpaid, provider-created but unpaid, callback missing, paid without grant, grant without paid, webhook error, compensation touched, refund revoked, and late callback corrected. This is grounded in the existing order, payment attempt, payment event, grant, access, and reconciliation data rather than inferred from frontend state.

At the order detail level, the old diagnostic page is upgraded into a commerce timeline that brings together the order summary, payment attempts, payment events, benefit grants, unified access summary, compensation summary, and exception diagnostics in one place. The goal is that an operator can look at one page and understand what happened, what state the order is currently in, and which adjacent resource or action path to open next.

This PR also adds minimal payment-attempt visibility in ops through a standalone PaymentAttempt resource and an order-scoped attempts relation. Existing point actions remain intact, but the workbench now aggregates the path to latest event, latest attempt, related grants, and order lookup so operators are no longer forced to context-switch across multiple disconnected resources.

## Scope

- no route changes
- no migrations
- no middleware changes
- no provider or payment-chain rewrites
- no scheduler or compensation automation changes
- no finance, billing, invoice, BI, or customer-support platform expansion
- frontend remains zero-diff

## Validation

Ran:

- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `cd backend && php artisan test --filter="CommerceOrderLookupSecurityTest|CommerceOrderReadFallbackTest" --stop-on-failure`
- `cd backend && php artisan test --filter="PaymentAttemptResourceTest|OrderCommerceLinkageTest|CommerceExceptionWorkbenchContractTest|OrderExceptionFilterTest|ViewOrderCommerceTimelineTest|CommerceOpsActionLinkageTest|CommerceKpiExceptionSummaryTest" --stop-on-failure`
- `cd backend && php artisan test --filter="PaymentAttemptStateContractTest|PaymentAttemptWebhookBindingTest|OrderLedgerStateContractTest|CommerceOrderLookupSecurityTest|CommerceOrderReadFallbackTest|CommercePendingCompensationCommandTest" --stop-on-failure`
- `cd backend && ./vendor/bin/pint app/Filament/Ops/Resources/OrderResource.php app/Filament/Ops/Resources/OrderResource/Pages/ViewOrder.php app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php app/Filament/Ops/Resources/PaymentEventResource.php app/Filament/Ops/Resources/BenefitGrantResource.php app/Filament/Ops/Widgets/CommerceKpiWidget.php resources/views/filament/ops/resources/orders/view-order.blade.php tests/Feature/Ops/OrderCommerceLinkageTest.php tests/Feature/Ops/CommerceExceptionWorkbenchContractTest.php tests/Feature/Ops/OrderExceptionFilterTest.php tests/Feature/Ops/PaymentAttemptResourceTest.php tests/Feature/Ops/ViewOrderCommerceTimelineTest.php tests/Feature/Ops/CommerceOpsActionLinkageTest.php tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php`

## Known unrelated baseline issues

- Broad `Ops` regex filters still pull in an unrelated existing failure in `BigFiveOpsWriteEndpointsTest`.
- `bash backend/scripts/ci_verify_mbti.sh` still fails on the pre-existing schema baseline issue `missing tables: attempt_quality`.
- Running the CI script also regenerates `backend/content_packs/CLINICAL_COMBO_68/v1/compiled/*`; those generated artifacts are not included in this PR.
