### PR TITLE
[codex] fix storage blob location index portability

### DIFF
--- a/backend/database/migrations/2026_03_20_060000_create_storage_blob_locations_table.php
+++ b/backend/database/migrations/2026_03_20_060000_create_storage_blob_locations_table.php
@@ -4,43 +4,53 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('storage_blob_locations')) {
-            return;
+        $portableAscii = $this->supportsPortableAsciiIndexNormalization();
+
+        if (! Schema::hasTable('storage_blob_locations')) {
+            Schema::create('storage_blob_locations', function (Blueprint $table) use ($portableAscii): void {
+                $table->bigIncrements('id');
+                $table->char('blob_hash', 64);
+                $disk = $table->string('disk', 32);
+                $storagePath = $table->string('storage_path', 1024);
+                if ($portableAscii) {
+                    $disk->charset('ascii')->collation('ascii_bin');
+                    $storagePath->charset('ascii')->collation('ascii_bin');
+                }
+                $table->string('location_kind', 32)->default('remote_copy');
+                $table->unsignedBigInteger('size_bytes')->default(0);
+                $table->string('checksum', 128)->nullable();
+                $table->string('etag', 256)->nullable();
+                $table->string('storage_class', 64)->nullable();
+                $table->timestamp('verified_at')->nullable();
+                $table->json('meta_json')->nullable();
+                $table->timestamps();
+
+                $table->unique(['disk', 'storage_path'], 'sbl_disk_path_uq');
+                $table->index(['blob_hash'], 'sbl_blob_hash_idx');
+                $table->index(['verified_at'], 'sbl_verified_idx');
+                $table->foreign('blob_hash', 'sbl_blob_hash_fk')
+                    ->references('hash')
+                    ->on('storage_blobs')
+                    ->cascadeOnDelete();
+            });
         }
-
-        Schema::create('storage_blob_locations', function (Blueprint $table): void {
-            $table->bigIncrements('id');
-            $table->char('blob_hash', 64);
-            $table->string('disk', 32);
-            $table->string('storage_path', 1024);
-            $table->string('location_kind', 32)->default('remote_copy');
-            $table->unsignedBigInteger('size_bytes')->default(0);
-            $table->string('checksum', 128)->nullable();
-            $table->string('etag', 256)->nullable();
-            $table->string('storage_class', 64)->nullable();
-            $table->timestamp('verified_at')->nullable();
-            $table->json('meta_json')->nullable();
-            $table->timestamps();
-
-            $table->unique(['disk', 'storage_path'], 'sbl_disk_path_uq');
-            $table->index(['blob_hash'], 'sbl_blob_hash_idx');
-            $table->index(['verified_at'], 'sbl_verified_idx');
-            $table->foreign('blob_hash', 'sbl_blob_hash_fk')
-                ->references('hash')
-                ->on('storage_blobs')
-                ->cascadeOnDelete();
-        });
     }
 
     public function down(): void
     {
         // forward-only migration: rollback disabled to prevent data loss in production.
         // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function supportsPortableAsciiIndexNormalization(): bool
+    {
+        return in_array(DB::connection()->getDriverName(), ['mysql', 'mariadb'], true);
     }
 };

--- a/backend/database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php
+++ b/backend/database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'storage_blob_locations';
+
+    private const UNIQUE_INDEX = 'sbl_disk_path_uq';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            return;
+        }
+
+        if (! $this->supportsPortableAsciiIndexNormalization()) {
+            return;
+        }
+
+        if (
+            ! Schema::hasColumn(self::TABLE, 'disk')
+            || ! Schema::hasColumn(self::TABLE, 'storage_path')
+        ) {
+            return;
+        }
+
+        if (SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->dropUnique(self::UNIQUE_INDEX);
+            });
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->string('disk', 32)
+                ->charset('ascii')
+                ->collation('ascii_bin')
+                ->change();
+            $table->string('storage_path', 1024)
+                ->charset('ascii')
+                ->collation('ascii_bin')
+                ->change();
+        });
+
+        if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->unique(['disk', 'storage_path'], self::UNIQUE_INDEX);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function supportsPortableAsciiIndexNormalization(): bool
+    {
+        $driver = DB::connection()->getDriverName();
+
+        return in_array($driver, ['mysql', 'mariadb'], true);
+    }
+};

--- a/backend/tests/Feature/Storage/ArtifactSchemaFoundationMigrationTest.php
+++ b/backend/tests/Feature/Storage/ArtifactSchemaFoundationMigrationTest.php
@@ -242,6 +242,29 @@ final class ArtifactSchemaFoundationMigrationTest extends TestCase
                     'artifact_reconcile_cases_status_idx',
                 ],
             ],
+            'storage_blob_locations' => [
+                'storage_blob_locations',
+                [
+                    'id',
+                    'blob_hash',
+                    'disk',
+                    'storage_path',
+                    'location_kind',
+                    'size_bytes',
+                    'checksum',
+                    'etag',
+                    'storage_class',
+                    'verified_at',
+                    'meta_json',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'sbl_disk_path_uq',
+                    'sbl_blob_hash_idx',
+                    'sbl_verified_idx',
+                ],
+            ],
         ];
     }
 }

--- a/backend/tests/Feature/Storage/StorageBlobLocationsIndexPortabilityTest.php
+++ b/backend/tests/Feature/Storage/StorageBlobLocationsIndexPortabilityTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class StorageBlobLocationsIndexPortabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_storage_blob_locations_schema_preserves_full_unique_semantics_without_prefix_indexes(): void
+    {
+        $this->assertTrue(Schema::hasTable('storage_blob_locations'));
+        $this->assertTrue(Schema::hasColumn('storage_blob_locations', 'disk'));
+        $this->assertTrue(Schema::hasColumn('storage_blob_locations', 'storage_path'));
+        $this->assertTrue(SchemaIndex::indexExists('storage_blob_locations', 'sbl_disk_path_uq'));
+
+        $createMigration = (string) file_get_contents(
+            base_path('database/migrations/2026_03_20_060000_create_storage_blob_locations_table.php')
+        );
+        $normalizeMigration = (string) file_get_contents(
+            base_path('database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php')
+        );
+
+        $this->assertStringContainsString("->string('disk', 32)", $createMigration);
+        $this->assertStringContainsString("->string('storage_path', 1024)", $createMigration);
+        $this->assertStringContainsString("charset('ascii')", $createMigration);
+        $this->assertStringContainsString("collation('ascii_bin')", $createMigration);
+        $this->assertStringContainsString(
+            "->string('disk', 32)\n                ->charset('ascii')\n                ->collation('ascii_bin')\n                ->change();",
+            $normalizeMigration
+        );
+        $this->assertStringContainsString(
+            "->string('storage_path', 1024)\n                ->charset('ascii')\n                ->collation('ascii_bin')\n                ->change();",
+            $normalizeMigration
+        );
+        $this->assertStringNotContainsString('storage_path(191)', $createMigration.$normalizeMigration);
+        $this->assertStringNotContainsString('storage_path(255)', $createMigration.$normalizeMigration);
+
+        $driver = DB::connection()->getDriverName();
+        if (! in_array($driver, ['mysql', 'mariadb'], true)) {
+            $this->addToAssertionCount(1);
+
+            return;
+        }
+
+        $database = (string) DB::getDatabaseName();
+        $columns = collect(DB::select(
+            'SELECT column_name, character_set_name, collation_name
+             FROM information_schema.columns
+             WHERE table_schema = ? AND table_name = ? AND column_name IN (?, ?)',
+            [$database, 'storage_blob_locations', 'disk', 'storage_path']
+        ))->keyBy(fn (object $row): string => (string) ($row->column_name ?? $row->COLUMN_NAME ?? ''));
+
+        $this->assertSame('ascii', $this->normalizeColumnMeta($columns, 'disk', 'character_set_name'));
+        $this->assertSame('ascii_bin', $this->normalizeColumnMeta($columns, 'disk', 'collation_name'));
+        $this->assertSame('ascii', $this->normalizeColumnMeta($columns, 'storage_path', 'character_set_name'));
+        $this->assertSame('ascii_bin', $this->normalizeColumnMeta($columns, 'storage_path', 'collation_name'));
+
+        $indexRows = DB::select(
+            'SELECT column_name, sub_part
+             FROM information_schema.statistics
+             WHERE table_schema = ? AND table_name = ? AND index_name = ?
+             ORDER BY seq_in_index',
+            [$database, 'storage_blob_locations', 'sbl_disk_path_uq']
+        );
+
+        $this->assertCount(2, $indexRows);
+        $this->assertSame('disk', (string) ($indexRows[0]->column_name ?? $indexRows[0]->COLUMN_NAME ?? ''));
+        $this->assertSame('storage_path', (string) ($indexRows[1]->column_name ?? $indexRows[1]->COLUMN_NAME ?? ''));
+        $this->assertNull($indexRows[0]->sub_part ?? $indexRows[0]->SUB_PART ?? null);
+        $this->assertNull($indexRows[1]->sub_part ?? $indexRows[1]->SUB_PART ?? null);
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection<string, object>  $columns
+     */
+    private function normalizeColumnMeta($columns, string $column, string $field): ?string
+    {
+        $row = $columns->get($column);
+        if (! is_object($row)) {
+            return null;
+        }
+
+        return (string) ($row->{$field} ?? $row->{strtoupper($field)} ?? null);
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes the MySQL portability failure in `2026_03_20_060000_create_storage_blob_locations_table`, where the unique index on `(disk, storage_path)` exceeded MySQL's 3072-byte key limit under the default multibyte collation and blocked `php artisan migrate` on staging.

The fix keeps the full uniqueness contract intact. It does not shorten `storage_path`, does not switch to a prefix unique index, and does not change storage control-plane semantics. Instead, it normalizes the indexed columns to ASCII binary collation on MySQL/MariaDB, which matches the actual usage of these fields as storage disk tokens and storage object keys / paths.

The change covers both schema paths that matter:

- fresh bootstrap: the original create migration now creates the indexed columns with portable collation on MySQL/MariaDB while remaining compatible with sqlite test bootstraps
- existing environments: a new forward-only normalize migration converges any pre-existing `storage_blob_locations` table by rebuilding `sbl_disk_path_uq` after changing `disk` and `storage_path` to `ascii_bin`

The PR also adds focused regression coverage to ensure the table and index exist, that the fix does not regress into prefix unique behavior, and that storage schema foundation tests cover `storage_blob_locations`.

## Scope

- no route changes
- no controller or middleware changes
- no payment / order / webhook changes
- no storage domain semantic changes outside this index portability fix
- no data cleanup
- no new dependencies

## Validation

Ran:

- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `cd backend && php artisan test --filter="StorageBlobLocationsIndexPortabilityTest|ArtifactSchemaFoundationMigrationTest" --stop-on-failure`
- `cd backend && ./vendor/bin/pint database/migrations/2026_03_20_060000_create_storage_blob_locations_table.php database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php tests/Feature/Storage/StorageBlobLocationsIndexPortabilityTest.php tests/Feature/Storage/ArtifactSchemaFoundationMigrationTest.php`

## Known unrelated baseline

The broader regex `php artisan test --filter="StorageBlobLocations|ArtifactSchemaFoundationMigration|Migration" --stop-on-failure` still pulls in existing repo-wide migration baseline failures unrelated to this fix, including:

- `Tests\\Unit\\Migrations\\CreateMigrationsMustConvergeTest`
- `Tests\\Sre\\MigrationPurityGateTest`

These failures pre-exist this PR and are not caused by the `storage_blob_locations` index portability change.
