### PR TITLE
[codex] fix exact manifest file index portability

### DIFF
--- a/backend/database/migrations/2026_03_20_070100_create_content_release_exact_manifest_files_table.php
+++ b/backend/database/migrations/2026_03_20_070100_create_content_release_exact_manifest_files_table.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,10 +15,15 @@ return new class extends Migration
             return;
         }
 
-        Schema::create('content_release_exact_manifest_files', function (Blueprint $table): void {
+        $portableAscii = $this->supportsPortableAsciiLogicalPathIndex();
+
+        Schema::create('content_release_exact_manifest_files', function (Blueprint $table) use ($portableAscii): void {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('content_release_exact_manifest_id');
-            $table->string('logical_path', 1024);
+            $logicalPath = $table->string('logical_path', 1024);
+            if ($portableAscii) {
+                $logicalPath->charset('ascii')->collation('ascii_bin');
+            }
             $table->char('blob_hash', 64);
             $table->unsignedBigInteger('size_bytes')->default(0);
             $table->string('role', 64)->nullable();
@@ -39,5 +45,12 @@ return new class extends Migration
     {
         // forward-only migration: rollback disabled to prevent data loss in production.
         // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function supportsPortableAsciiLogicalPathIndex(): bool
+    {
+        $driver = DB::connection()->getDriverName();
+
+        return in_array($driver, ['mysql', 'mariadb'], true);
     }
 };

--- a/backend/database/migrations/2026_03_26_200000_normalize_content_release_exact_manifest_files_index_portability.php
+++ b/backend/database/migrations/2026_03_26_200000_normalize_content_release_exact_manifest_files_index_portability.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'content_release_exact_manifest_files';
+
+    private const UNIQUE_INDEX = 'cremf_manifest_path_uq';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            return;
+        }
+
+        if (! $this->supportsPortableAsciiLogicalPathNormalization()) {
+            return;
+        }
+
+        if (! Schema::hasColumn(self::TABLE, 'logical_path')) {
+            return;
+        }
+
+        if (SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->dropUnique(self::UNIQUE_INDEX);
+            });
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->string('logical_path', 1024)
+                ->charset('ascii')
+                ->collation('ascii_bin')
+                ->change();
+        });
+
+        if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->unique(['content_release_exact_manifest_id', 'logical_path'], self::UNIQUE_INDEX);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function supportsPortableAsciiLogicalPathNormalization(): bool
+    {
+        $driver = DB::connection()->getDriverName();
+
+        return in_array($driver, ['mysql', 'mariadb'], true);
+    }
+};

--- a/backend/tests/Feature/Storage/ArtifactSchemaFoundationMigrationTest.php
+++ b/backend/tests/Feature/Storage/ArtifactSchemaFoundationMigrationTest.php
@@ -265,6 +265,26 @@ final class ArtifactSchemaFoundationMigrationTest extends TestCase
                     'sbl_verified_idx',
                 ],
             ],
+            'content_release_exact_manifest_files' => [
+                'content_release_exact_manifest_files',
+                [
+                    'id',
+                    'content_release_exact_manifest_id',
+                    'logical_path',
+                    'blob_hash',
+                    'size_bytes',
+                    'role',
+                    'content_type',
+                    'encoding',
+                    'checksum',
+                    'created_at',
+                    'updated_at',
+                ],
+                [
+                    'cremf_manifest_path_uq',
+                    'cremf_blob_hash_idx',
+                ],
+            ],
         ];
     }
 }

--- a/backend/tests/Feature/Storage/ContentReleaseExactManifestFilesIndexPortabilityTest.php
+++ b/backend/tests/Feature/Storage/ContentReleaseExactManifestFilesIndexPortabilityTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class ContentReleaseExactManifestFilesIndexPortabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_exact_manifest_files_schema_preserves_full_unique_semantics_without_prefix_indexes(): void
+    {
+        $this->assertTrue(Schema::hasTable('content_release_exact_manifest_files'));
+        $this->assertTrue(Schema::hasColumn('content_release_exact_manifest_files', 'content_release_exact_manifest_id'));
+        $this->assertTrue(Schema::hasColumn('content_release_exact_manifest_files', 'logical_path'));
+        $this->assertTrue(SchemaIndex::indexExists('content_release_exact_manifest_files', 'cremf_manifest_path_uq'));
+
+        $createMigration = (string) file_get_contents(
+            base_path('database/migrations/2026_03_20_070100_create_content_release_exact_manifest_files_table.php')
+        );
+        $normalizeMigration = (string) file_get_contents(
+            base_path('database/migrations/2026_03_26_200000_normalize_content_release_exact_manifest_files_index_portability.php')
+        );
+
+        $this->assertStringContainsString("->string('logical_path', 1024)", $createMigration);
+        $this->assertStringContainsString("charset('ascii')", $createMigration);
+        $this->assertStringContainsString("collation('ascii_bin')", $createMigration);
+        $this->assertStringContainsString(
+            "->string('logical_path', 1024)\n                ->charset('ascii')\n                ->collation('ascii_bin')\n                ->change();",
+            $normalizeMigration
+        );
+        $this->assertStringNotContainsString('logical_path(191)', $createMigration.$normalizeMigration);
+        $this->assertStringNotContainsString('logical_path(255)', $createMigration.$normalizeMigration);
+
+        $driver = DB::connection()->getDriverName();
+        if (! in_array($driver, ['mysql', 'mariadb'], true)) {
+            $this->addToAssertionCount(1);
+
+            return;
+        }
+
+        $database = (string) DB::getDatabaseName();
+        $columns = collect(DB::select(
+            'SELECT column_name, character_set_name, collation_name
+             FROM information_schema.columns
+             WHERE table_schema = ? AND table_name = ? AND column_name IN (?)',
+            [$database, 'content_release_exact_manifest_files', 'logical_path']
+        ))->keyBy(fn (object $row): string => (string) ($row->column_name ?? $row->COLUMN_NAME ?? ''));
+
+        $this->assertSame('ascii', $this->normalizeColumnMeta($columns, 'logical_path', 'character_set_name'));
+        $this->assertSame('ascii_bin', $this->normalizeColumnMeta($columns, 'logical_path', 'collation_name'));
+
+        $indexRows = DB::select(
+            'SELECT column_name, sub_part
+             FROM information_schema.statistics
+             WHERE table_schema = ? AND table_name = ? AND index_name = ?
+             ORDER BY seq_in_index',
+            [$database, 'content_release_exact_manifest_files', 'cremf_manifest_path_uq']
+        );
+
+        $this->assertCount(2, $indexRows);
+        $this->assertSame(
+            'content_release_exact_manifest_id',
+            (string) ($indexRows[0]->column_name ?? $indexRows[0]->COLUMN_NAME ?? '')
+        );
+        $this->assertSame('logical_path', (string) ($indexRows[1]->column_name ?? $indexRows[1]->COLUMN_NAME ?? ''));
+        $this->assertNull($indexRows[0]->sub_part ?? $indexRows[0]->SUB_PART ?? null);
+        $this->assertNull($indexRows[1]->sub_part ?? $indexRows[1]->SUB_PART ?? null);
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection<string, object>  $columns
+     */
+    private function normalizeColumnMeta($columns, string $column, string $field): ?string
+    {
+        $row = $columns->get($column);
+        if (! is_object($row)) {
+            return null;
+        }
+
+        return (string) ($row->{$field} ?? $row->{strtoupper($field)} ?? null);
+    }
+}


### PR DESCRIPTION
## Summary
This fixes the second MySQL 1071 portability failure in the exact manifest release chain. Staging was able to pass `create_storage_blob_locations_table`, but then blocked on `2026_03_20_070100_create_content_release_exact_manifest_files_table` when MySQL tried to build the full unique index on `(content_release_exact_manifest_id, logical_path)` under a multibyte collation.

The failure affected fresh bootstrap and staging migration runs, but the underlying schema contract had to remain the same: a manifest file row is still uniquely identified by the full logical path within a manifest, not by a truncated prefix.

## Root cause
`logical_path` is defined at length 1024 and participates in the unique index `cremf_manifest_path_uq`. Under MySQL's default multibyte collation, that index can exceed the 3072-byte key limit even though the business semantics are correct.

## Fix
The fix keeps the full uniqueness semantics intact without shortening `logical_path` and without using prefix unique indexes.

- update `2026_03_20_070100_create_content_release_exact_manifest_files_table` so MySQL/MariaDB creates `logical_path` with ASCII binary collation
- add a forward-only normalize migration for existing environments to normalize `logical_path` and rebuild `cremf_manifest_path_uq`
- add a focused portability regression test for the exact manifest file table
- extend artifact schema foundation coverage to include `content_release_exact_manifest_files`

Only `logical_path` is normalized. The foreign-key column `content_release_exact_manifest_id` remains unchanged so FK compatibility and existing manifest identity semantics are not disturbed.

## Validation
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `cd backend && php artisan test --filter="ContentReleaseExactManifestFilesIndexPortabilityTest|ArtifactSchemaFoundationMigrationTest" --stop-on-failure`
- `cd backend && php artisan test --filter="CommerceOrderLookupSecurityTest|CommerceOrderReadFallbackTest" --stop-on-failure`

## Known unrelated baseline
A broader migration regex still pulls in the existing repo-wide convergence baseline failure from `Tests\\Unit\\Migrations\\CreateMigrationsMustConvergeTest`. That is not introduced by this PR.
