### PR TITLE
Add Big5 structured facet projection

### DIFF
--- a/backend/app/Services/BigFive/BigFivePublicProjectionService.php
+++ b/backend/app/Services/BigFive/BigFivePublicProjectionService.php
@@ -14,6 +14,15 @@ final class BigFivePublicProjectionService
 {
     private const DOMAIN_ORDER = ['O', 'C', 'E', 'A', 'N'];
 
+    private const FACET_ORDER = [
+        'N1', 'E1', 'O1', 'A1', 'C1',
+        'N2', 'E2', 'O2', 'A2', 'C2',
+        'N3', 'E3', 'O3', 'A3', 'C3',
+        'N4', 'E4', 'O4', 'A4', 'C4',
+        'N5', 'E5', 'O5', 'A5', 'C5',
+        'N6', 'E6', 'O6', 'A6', 'C6',
+    ];
+
     public function __construct(
         private readonly ControlledGenerationRuntime $controlledGenerationRuntime,
         private readonly ControlledNarrativeLayerService $controlledNarrativeLayerService,
@@ -31,6 +40,42 @@ final class BigFivePublicProjectionService
         'E' => ['en' => 'Extraversion', 'zh' => '外向性'],
         'A' => ['en' => 'Agreeableness', 'zh' => '宜人性'],
         'N' => ['en' => 'Neuroticism', 'zh' => '情绪性'],
+    ];
+
+    /**
+     * @var array<string,string>
+     */
+    private const FACET_NAME_SLUG = [
+        'N1' => 'anxiety',
+        'N2' => 'anger',
+        'N3' => 'depression',
+        'N4' => 'self_consciousness',
+        'N5' => 'immoderation',
+        'N6' => 'vulnerability',
+        'E1' => 'friendliness',
+        'E2' => 'gregariousness',
+        'E3' => 'assertiveness',
+        'E4' => 'activity_level',
+        'E5' => 'excitement_seeking',
+        'E6' => 'cheerfulness',
+        'O1' => 'imagination',
+        'O2' => 'artistic_interests',
+        'O3' => 'emotionality',
+        'O4' => 'adventurousness',
+        'O5' => 'intellect',
+        'O6' => 'liberalism',
+        'A1' => 'trust',
+        'A2' => 'morality',
+        'A3' => 'altruism',
+        'A4' => 'cooperation',
+        'A5' => 'modesty',
+        'A6' => 'sympathy',
+        'C1' => 'self_efficacy',
+        'C2' => 'orderliness',
+        'C3' => 'dutifulness',
+        'C4' => 'achievement_striving',
+        'C5' => 'self_discipline',
+        'C6' => 'cautiousness',
     ];
 
     /**
@@ -87,8 +132,11 @@ final class BigFivePublicProjectionService
     {
         $locale = $this->normalizeLocale($locale);
         $domainsMean = is_array(data_get($scoreResult, 'raw_scores.domains_mean')) ? data_get($scoreResult, 'raw_scores.domains_mean') : [];
+        $facetsMean = is_array(data_get($scoreResult, 'raw_scores.facets_mean')) ? data_get($scoreResult, 'raw_scores.facets_mean') : [];
         $domainsPercentile = is_array(data_get($scoreResult, 'scores_0_100.domains_percentile')) ? data_get($scoreResult, 'scores_0_100.domains_percentile') : [];
+        $facetsPercentile = is_array(data_get($scoreResult, 'scores_0_100.facets_percentile')) ? data_get($scoreResult, 'scores_0_100.facets_percentile') : [];
         $domainBuckets = is_array(data_get($scoreResult, 'facts.domain_buckets')) ? data_get($scoreResult, 'facts.domain_buckets') : [];
+        $facetBuckets = is_array(data_get($scoreResult, 'facts.facet_buckets')) ? data_get($scoreResult, 'facts.facet_buckets') : [];
         $topStrengthFacets = array_values(array_filter(array_map('strval', is_array(data_get($scoreResult, 'facts.top_strength_facets')) ? data_get($scoreResult, 'facts.top_strength_facets') : [])));
         $topGrowthFacets = array_values(array_filter(array_map('strval', is_array(data_get($scoreResult, 'facts.top_growth_facets')) ? data_get($scoreResult, 'facts.top_growth_facets') : [])));
         $tags = array_values(array_filter(array_map('strval', is_array($scoreResult['tags'] ?? null) ? $scoreResult['tags'] : [])));
@@ -107,6 +155,24 @@ final class BigFivePublicProjectionService
                 'percentile' => (int) ($domainsPercentile[$trait] ?? 0),
                 'band' => $band,
                 'band_label' => $this->bandLabel($trait, $band, $locale),
+            ];
+        }
+
+        $facetVector = [];
+        foreach (self::FACET_ORDER as $facet) {
+            $bucket = strtolower(trim((string) ($facetBuckets[$facet] ?? 'mid')));
+            if (! in_array($bucket, ['low', 'mid', 'high', 'extreme_low', 'extreme_high'], true)) {
+                $bucket = 'mid';
+            }
+
+            $facetVector[] = [
+                'key' => $facet,
+                'label' => $this->facetLabel($facet),
+                'slug' => self::FACET_NAME_SLUG[$facet] ?? strtolower($facet),
+                'domain' => substr($facet, 0, 1),
+                'mean' => round((float) ($facetsMean[$facet] ?? 0.0), 2),
+                'percentile' => (int) ($facetsPercentile[$facet] ?? 0),
+                'bucket' => $bucket,
             ];
         }
 
@@ -147,6 +213,7 @@ final class BigFivePublicProjectionService
         $projection = [
             'schema_version' => 'big5.public_projection.v1',
             'trait_vector' => $traitVector,
+            'facet_vector' => $facetVector,
             'trait_bands' => $traitBands,
             'dominant_traits' => $dominantTraits,
             'variant_keys' => $variantKeys,
@@ -249,6 +316,19 @@ final class BigFivePublicProjectionService
     private function traitLabel(string $trait, string $locale): string
     {
         return self::TRAIT_LABELS[$trait][$locale] ?? $trait;
+    }
+
+    private function facetLabel(string $facet): string
+    {
+        $slug = self::FACET_NAME_SLUG[$facet] ?? strtolower($facet);
+        $words = array_filter(explode('_', $slug), static fn (string $word): bool => $word !== '');
+        if ($words === []) {
+            return $facet;
+        }
+
+        $title = implode(' ', array_map(static fn (string $word): string => ucfirst($word), $words));
+
+        return sprintf('%s %s', $facet, $title);
     }
 
     private function bandLabel(string $trait, string $band, string $locale): string

--- a/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
+++ b/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
@@ -36,6 +36,10 @@ final class BigFiveHistoryCompareTest extends TestCase
         $response->assertJsonPath('scale_code', 'BIG5_OCEAN');
         $response->assertJsonPath('history_compare.current_attempt_id', $latestAttemptId);
         $response->assertJsonPath('history_compare.previous_attempt_id', $olderAttemptId);
+        $response->assertJsonPath('history_compare.current_domains_mean.O', 3.5);
+        $response->assertJsonPath('history_compare.previous_domains_mean.O', 3);
+        $response->assertJsonPath('history_compare.current_domains_mean.A', 3.6);
+        $response->assertJsonPath('history_compare.previous_domains_mean.A', 3.3);
         $response->assertJsonPath('history_compare.domains_delta.O.delta', 0.5);
         $response->assertJsonPath('history_compare.domains_delta.O.direction', 'up');
         $response->assertJsonPath('history_compare.domains_delta.E.delta', -0.2);

--- a/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
@@ -43,6 +43,9 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         $resultResponse->assertJsonPath('big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
         $resultResponse->assertJsonPath('big5_public_projection_v1.ordered_section_keys.0', 'traits.overview');
         $resultResponse->assertJsonPath('big5_public_projection_v1.trait_bands.O', 'mid');
+        $resultResponse->assertJsonCount(30, 'big5_public_projection_v1.facet_vector');
+        $resultResponse->assertJsonPath('big5_public_projection_v1.facet_vector.0.key', 'N1');
+        $resultResponse->assertJsonPath('big5_public_projection_v1.facet_vector.0.domain', 'N');
         $resultResponse->assertJsonPath('big5_public_projection_v1.controlled_narrative_v1.version', 'controlled_narrative.v1');
         $resultResponse->assertJsonPath('big5_public_projection_v1.controlled_narrative_v1.runtime_mode', 'mock');
         $resultResponse->assertJsonPath('big5_public_projection_v1.cultural_calibration_v1.version', 'cultural_calibration.v1');
@@ -59,7 +62,11 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         $reportResponse->assertOk();
         $reportResponse->assertJsonPath('big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
         $reportResponse->assertJsonPath('big5_public_projection_v1.ordered_section_keys.1', 'traits.why_this_profile');
+        $reportResponse->assertJsonCount(30, 'big5_public_projection_v1.facet_vector');
+        $reportResponse->assertJsonPath('big5_public_projection_v1.facet_vector.0.key', 'N1');
+        $reportResponse->assertJsonPath('big5_public_projection_v1.facet_vector.0.domain', 'N');
         $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
+        $reportResponse->assertJsonCount(30, 'report._meta.big5_public_projection_v1.facet_vector');
         $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.controlled_narrative_v1.version', 'controlled_narrative.v1');
         $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.cultural_calibration_v1.version', 'cultural_calibration.v1');
         $reportResponse->assertJsonPath('report._meta.big5_public_projection_v1.comparative_v1.version', 'comparative.norming.v1');

--- a/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
@@ -18,12 +18,15 @@ final class BigFivePublicProjectionServiceTest extends TestCase
                     'engine_version' => 'big5_ipipneo120_v3.0.0',
                     'raw_scores' => [
                         'domains_mean' => ['O' => 4.2, 'C' => 3.8, 'E' => 3.2, 'A' => 3.9, 'N' => 2.3],
+                        'facets_mean' => ['N1' => 2.1, 'E1' => 3.4, 'O1' => 4.6],
                     ],
                     'scores_0_100' => [
                         'domains_percentile' => ['O' => 81, 'C' => 73, 'E' => 48, 'A' => 76, 'N' => 22],
+                        'facets_percentile' => ['N1' => 18, 'E1' => 57, 'O1' => 93],
                     ],
                     'facts' => [
                         'domain_buckets' => ['O' => 'high', 'C' => 'high', 'E' => 'mid', 'A' => 'high', 'N' => 'low'],
+                        'facet_buckets' => ['N1' => 'low', 'E1' => 'mid', 'O1' => 'high'],
                         'top_strength_facets' => ['O5', 'A3', 'C4'],
                         'top_growth_facets' => ['E3', 'E2', 'C5'],
                     ],
@@ -42,6 +45,14 @@ final class BigFivePublicProjectionServiceTest extends TestCase
         $this->assertSame('high', data_get($projection, 'trait_bands.O'));
         $this->assertSame('low', data_get($projection, 'trait_bands.N'));
         $this->assertSame('O', data_get($projection, 'dominant_traits.0.key'));
+        $this->assertCount(30, (array) ($projection['facet_vector'] ?? []));
+        $this->assertSame('N1', data_get($projection, 'facet_vector.0.key'));
+        $this->assertSame('N', data_get($projection, 'facet_vector.0.domain'));
+        $this->assertSame(18, data_get($projection, 'facet_vector.0.percentile'));
+        $this->assertSame(2.1, data_get($projection, 'facet_vector.0.mean'));
+        $this->assertSame('low', data_get($projection, 'facet_vector.0.bucket'));
+        $this->assertSame('O1', data_get($projection, 'facet_vector.2.key'));
+        $this->assertSame(93, data_get($projection, 'facet_vector.2.percentile'));
         $this->assertContains('profile:explorer', (array) ($projection['variant_keys'] ?? []));
         $this->assertSame('exploratory', data_get($projection, 'scene_fingerprint.novelty'));
         $this->assertSame('traits.overview', data_get($projection, 'ordered_section_keys.0'));
@@ -61,12 +72,15 @@ final class BigFivePublicProjectionServiceTest extends TestCase
                     'engine_version' => 'big5_ipipneo120_v3.0.0',
                     'raw_scores' => [
                         'domains_mean' => ['O' => 3.0, 'C' => 3.0, 'E' => 3.0, 'A' => 3.0, 'N' => 3.0],
+                        'facets_mean' => ['N1' => 3.0, 'E1' => 3.0, 'O1' => 3.0],
                     ],
                     'scores_0_100' => [
                         'domains_percentile' => ['O' => 70, 'C' => 70, 'E' => 55, 'A' => 70, 'N' => 55],
+                        'facets_percentile' => ['N1' => 51, 'E1' => 49, 'O1' => 52],
                     ],
                     'facts' => [
                         'domain_buckets' => ['O' => 'high', 'C' => 'high', 'E' => 'mid', 'A' => 'high', 'N' => 'mid'],
+                        'facet_buckets' => ['N1' => 'mid', 'E1' => 'mid', 'O1' => 'mid'],
                         'top_strength_facets' => ['O2', 'C3', 'A4'],
                         'top_growth_facets' => ['E2', 'N3', 'O1'],
                     ],
@@ -88,6 +102,7 @@ final class BigFivePublicProjectionServiceTest extends TestCase
             static fn (array $trait): string => (string) ($trait['key'] ?? ''),
             (array) ($projection['dominant_traits'] ?? [])
         )));
+        $this->assertCount(30, (array) ($projection['facet_vector'] ?? []));
         $this->assertSame('E', data_get($projection, 'action_plan_summary.focus_trait'));
     }
 }


### PR DESCRIPTION
## Summary
- add additive `facet_vector` data to `big5_public_projection_v1`
- preserve existing Big5 report/result fields while exposing a stable facet-level source of truth
- lock the new projection contract and history compare shape with focused backend tests

## Verification
- php -l app/Services/BigFive/BigFivePublicProjectionService.php
- php -l tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
- php -l tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
- php -l tests/Feature/Attempts/BigFiveHistoryCompareTest.php
- php artisan test tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php tests/Feature/Attempts/BigFiveHistoryCompareTest.php