### PR TITLE
[codex] Big5 history result-center row contract

### DIFF
--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -6,10 +6,60 @@ use App\Exceptions\Api\ApiProblemException;
 use App\Models\Attempt;
 use App\Models\Result;
 use App\Models\UnifiedAccessProjection;
+use App\Services\Report\Resolvers\OfferResolver;
+use App\Services\Scale\ScaleRegistry;
+use App\Services\Scale\ScaleRolloutGate;
 use App\Support\ApiPagination;
 
 class MeAttemptsService
 {
+    /**
+     * @var array<string,array<string,mixed>|null>
+     */
+    private array $bigFivePrimaryOfferCache = [];
+
+    /**
+     * @var array<string,array{title:string,domain:string}>
+     */
+    private const BIG_FIVE_FACET_META = [
+        'N1' => ['title' => 'Anxiety', 'domain' => 'N'],
+        'N2' => ['title' => 'Anger', 'domain' => 'N'],
+        'N3' => ['title' => 'Depression', 'domain' => 'N'],
+        'N4' => ['title' => 'Self Consciousness', 'domain' => 'N'],
+        'N5' => ['title' => 'Immoderation', 'domain' => 'N'],
+        'N6' => ['title' => 'Vulnerability', 'domain' => 'N'],
+        'E1' => ['title' => 'Friendliness', 'domain' => 'E'],
+        'E2' => ['title' => 'Gregariousness', 'domain' => 'E'],
+        'E3' => ['title' => 'Assertiveness', 'domain' => 'E'],
+        'E4' => ['title' => 'Activity Level', 'domain' => 'E'],
+        'E5' => ['title' => 'Excitement Seeking', 'domain' => 'E'],
+        'E6' => ['title' => 'Cheerfulness', 'domain' => 'E'],
+        'O1' => ['title' => 'Imagination', 'domain' => 'O'],
+        'O2' => ['title' => 'Artistic Interests', 'domain' => 'O'],
+        'O3' => ['title' => 'Emotionality', 'domain' => 'O'],
+        'O4' => ['title' => 'Adventurousness', 'domain' => 'O'],
+        'O5' => ['title' => 'Intellect', 'domain' => 'O'],
+        'O6' => ['title' => 'Liberalism', 'domain' => 'O'],
+        'A1' => ['title' => 'Trust', 'domain' => 'A'],
+        'A2' => ['title' => 'Morality', 'domain' => 'A'],
+        'A3' => ['title' => 'Altruism', 'domain' => 'A'],
+        'A4' => ['title' => 'Cooperation', 'domain' => 'A'],
+        'A5' => ['title' => 'Modesty', 'domain' => 'A'],
+        'A6' => ['title' => 'Sympathy', 'domain' => 'A'],
+        'C1' => ['title' => 'Self Efficacy', 'domain' => 'C'],
+        'C2' => ['title' => 'Orderliness', 'domain' => 'C'],
+        'C3' => ['title' => 'Dutifulness', 'domain' => 'C'],
+        'C4' => ['title' => 'Achievement Striving', 'domain' => 'C'],
+        'C5' => ['title' => 'Self Discipline', 'domain' => 'C'],
+        'C6' => ['title' => 'Cautiousness', 'domain' => 'C'],
+    ];
+
+    public function __construct(
+        private readonly ScaleRegistry $scaleRegistry,
+        private readonly OfferResolver $offerResolver,
+    ) {
+    }
+
     public function list(
         int $orgId,
         ?string $userId,
@@ -124,6 +174,7 @@ class MeAttemptsService
     {
         $attemptId = (string) ($attempt->id ?? '');
         $domainsMean = $this->extractDomainsMean($result?->result_json);
+        $accessSummary = null;
 
         $output = [
             'attempt_id' => $attemptId,
@@ -156,11 +207,13 @@ class MeAttemptsService
         }
 
         if ($this->shouldIncludeAccessSummary($attempt)) {
-            $output['access_summary'] = $this->buildAccessSummary(
+            $accessSummary = $this->buildAccessSummary(
                 $attempt,
                 $projection,
                 $result instanceof Result
             );
+            $output['access_summary'] = $accessSummary;
+            $output = array_merge($output, $this->buildBigFiveRowSummary($attempt, $result, $accessSummary));
         }
 
         return $output;
@@ -300,6 +353,244 @@ class MeAttemptsService
         return [];
     }
 
+    /**
+     * @param  array<string,mixed>|null  $accessSummary
+     * @return array<string,mixed>
+     */
+    private function buildBigFiveRowSummary(Attempt $attempt, ?Result $result, ?array $accessSummary): array
+    {
+        $scoreResult = $this->extractBigFiveScoreResult($result);
+
+        return [
+            'top_facets_summary_v1' => $this->buildTopFacetsSummary($scoreResult),
+            'quality_summary' => $this->buildQualitySummary($scoreResult),
+            'norms_summary' => $this->buildNormsSummary($scoreResult),
+            'offer_summary' => $this->buildOfferSummary($attempt, $accessSummary),
+            'share_summary' => $this->buildShareSummary($result, $accessSummary),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractBigFiveScoreResult(?Result $result): array
+    {
+        if (! $result instanceof Result) {
+            return [];
+        }
+
+        $resultJson = $this->decodeResultJson($result->result_json);
+        $candidates = [
+            $result->normed_json ?? null,
+            $resultJson['normed_json'] ?? null,
+            data_get($resultJson, 'breakdown_json.score_result'),
+            data_get($resultJson, 'axis_scores_json.score_result'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @return array{items:list<array{key:string,label:string,domain:string,percentile:?int,bucket:?string,kind:?string}>}
+     */
+    private function buildTopFacetsSummary(array $scoreResult): array
+    {
+        $facetPercentiles = is_array(data_get($scoreResult, 'scores_0_100.facets_percentile'))
+            ? data_get($scoreResult, 'scores_0_100.facets_percentile')
+            : [];
+        $facetBuckets = is_array(data_get($scoreResult, 'facts.facet_buckets'))
+            ? data_get($scoreResult, 'facts.facet_buckets')
+            : [];
+        $topStrength = $this->normalizeFacetCodeList(data_get($scoreResult, 'facts.top_strength_facets'));
+        $topGrowth = $this->normalizeFacetCodeList(data_get($scoreResult, 'facts.top_growth_facets'));
+
+        $items = [];
+
+        foreach (['strength' => $topStrength, 'growth' => $topGrowth] as $kind => $codes) {
+            foreach ($codes as $code) {
+                $items[$code] = $this->presentFacetSummaryItem($code, $facetPercentiles, $facetBuckets, $kind);
+            }
+        }
+
+        if ($items === [] && is_array($facetPercentiles) && $facetPercentiles !== []) {
+            $ranked = [];
+            foreach ($facetPercentiles as $key => $value) {
+                $code = $this->normalizeFacetCode($key);
+                if ($code === '') {
+                    continue;
+                }
+
+                $percentile = (int) round((float) $value);
+                $ranked[$code] = abs($percentile - 50);
+            }
+
+            arsort($ranked);
+            foreach (array_slice(array_keys($ranked), 0, 4) as $code) {
+                $items[$code] = $this->presentFacetSummaryItem($code, $facetPercentiles, $facetBuckets, null);
+            }
+        }
+
+        return [
+            'items' => array_values($items),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @return array{level:string,grade:?string}
+     */
+    private function buildQualitySummary(array $scoreResult): array
+    {
+        $quality = is_array($scoreResult['quality'] ?? null) ? $scoreResult['quality'] : [];
+        $level = strtoupper(trim((string) ($quality['level'] ?? 'UNKNOWN')));
+        if ($level === '') {
+            $level = 'UNKNOWN';
+        }
+
+        $grade = strtoupper(trim((string) ($quality['grade'] ?? '')));
+        if ($grade === '' && preg_match('/^[A-D]$/', $level) === 1) {
+            $grade = $level;
+        }
+
+        return [
+            'level' => $level,
+            'grade' => $grade !== '' ? $grade : null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @return array{status:string,norms_version:?string}
+     */
+    private function buildNormsSummary(array $scoreResult): array
+    {
+        $norms = is_array($scoreResult['norms'] ?? null) ? $scoreResult['norms'] : [];
+        $status = strtoupper(trim((string) ($norms['status'] ?? 'MISSING')));
+        if ($status === '') {
+            $status = 'MISSING';
+        }
+
+        return [
+            'status' => $status,
+            'norms_version' => $this->nullableText($norms['norms_version'] ?? null),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $accessSummary
+     * @return array{primary_offer:array<string,mixed>|null}
+     */
+    private function buildOfferSummary(Attempt $attempt, ?array $accessSummary): array
+    {
+        $accessState = strtolower(trim((string) ($accessSummary['access_state'] ?? '')));
+        $reportState = strtolower(trim((string) ($accessSummary['report_state'] ?? '')));
+
+        if ($accessState !== 'locked' || $reportState !== 'ready') {
+            return ['primary_offer' => null];
+        }
+
+        return [
+            'primary_offer' => $this->resolveBigFivePrimaryOffer($attempt),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $accessSummary
+     * @return array{enabled:bool,share_kind:string}
+     */
+    private function buildShareSummary(?Result $result, ?array $accessSummary): array
+    {
+        $reportState = strtolower(trim((string) ($accessSummary['report_state'] ?? '')));
+
+        return [
+            'enabled' => $result instanceof Result && $reportState === 'ready',
+            'share_kind' => 'big5_result',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function resolveBigFivePrimaryOffer(Attempt $attempt): ?array
+    {
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        $orgId = (int) ($attempt->org_id ?? 0);
+        $cacheKey = $orgId.'|'.$scaleCode;
+
+        if (array_key_exists($cacheKey, $this->bigFivePrimaryOfferCache)) {
+            return $this->bigFivePrimaryOfferCache[$cacheKey];
+        }
+
+        $registry = $this->scaleRegistry->getByCode($scaleCode, $orgId);
+        if (! is_array($registry)) {
+            return $this->bigFivePrimaryOfferCache[$cacheKey] = null;
+        }
+
+        $paywallMode = ScaleRolloutGate::paywallMode($registry);
+        if ($paywallMode !== ScaleRolloutGate::PAYWALL_FULL) {
+            return $this->bigFivePrimaryOfferCache[$cacheKey] = null;
+        }
+
+        $viewPolicy = $this->offerResolver->normalizeViewPolicy($registry['view_policy_json'] ?? null);
+        $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
+        $paywall = $this->offerResolver->buildPaywall($viewPolicy, $commercial, [], $scaleCode, $orgId);
+        $offers = array_values(array_filter(
+            is_array($paywall['offers'] ?? null) ? $paywall['offers'] : [],
+            static fn ($offer): bool => is_array($offer)
+        ));
+
+        $effectiveSku = strtoupper(trim((string) ($paywall['upgrade_sku_effective'] ?? '')));
+        $anchorSku = strtoupper(trim((string) ($paywall['upgrade_sku'] ?? '')));
+
+        $primaryOffer = null;
+        if ($effectiveSku !== '') {
+            foreach ($offers as $offer) {
+                if (strtoupper(trim((string) ($offer['sku'] ?? ''))) === $effectiveSku) {
+                    $primaryOffer = $offer;
+                    break;
+                }
+            }
+        }
+
+        if ($primaryOffer === null && $anchorSku !== '') {
+            foreach ($offers as $offer) {
+                if (strtoupper(trim((string) ($offer['sku'] ?? ''))) === $anchorSku) {
+                    $primaryOffer = $offer;
+                    break;
+                }
+            }
+        }
+
+        if ($primaryOffer === null) {
+            $primaryOffer = $offers[0] ?? null;
+        }
+
+        if (! is_array($primaryOffer)) {
+            return $this->bigFivePrimaryOfferCache[$cacheKey] = null;
+        }
+
+        return $this->bigFivePrimaryOfferCache[$cacheKey] = [
+            'sku' => $this->nullableText($primaryOffer['sku'] ?? null),
+            'label' => $this->nullableText($primaryOffer['label'] ?? $primaryOffer['title'] ?? null),
+            'title' => $this->nullableText($primaryOffer['title'] ?? $primaryOffer['label'] ?? null),
+            'formatted_price' => $this->formatMoney(
+                isset($primaryOffer['price_cents']) ? (int) $primaryOffer['price_cents'] : null,
+                $this->nullableText($primaryOffer['currency'] ?? null)
+            ),
+            'price_cents' => isset($primaryOffer['price_cents']) ? (int) $primaryOffer['price_cents'] : null,
+            'currency' => $this->nullableText($primaryOffer['currency'] ?? null),
+            'benefit_code' => $this->nullableText($primaryOffer['benefit_code'] ?? null),
+            'modules_included' => $this->normalizeStringArray($primaryOffer['modules_included'] ?? null),
+        ];
+    }
+
     private function shouldIncludeAccessSummary(Attempt $attempt): bool
     {
         return strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'BIG5_OCEAN';
@@ -390,5 +681,96 @@ class MeAttemptsService
 
         $decoded = json_decode($value, true);
         return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $facetPercentiles
+     * @param  array<string,mixed>  $facetBuckets
+     * @return array{key:string,label:string,domain:string,percentile:?int,bucket:?string,kind:?string}
+     */
+    private function presentFacetSummaryItem(
+        string $code,
+        array $facetPercentiles,
+        array $facetBuckets,
+        ?string $kind
+    ): array {
+        $meta = self::BIG_FIVE_FACET_META[$code] ?? [
+            'title' => $code,
+            'domain' => substr($code, 0, 1),
+        ];
+
+        $percentile = array_key_exists($code, $facetPercentiles)
+            ? (int) round((float) $facetPercentiles[$code])
+            : null;
+        $bucket = $this->normalizeFacetBucket($facetBuckets[$code] ?? null);
+
+        return [
+            'key' => $code,
+            'label' => sprintf('%s %s', $code, (string) ($meta['title'] ?? $code)),
+            'domain' => (string) ($meta['domain'] ?? substr($code, 0, 1)),
+            'percentile' => $percentile,
+            'bucket' => $bucket,
+            'kind' => $kind,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeFacetCodeList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $codes = [];
+        foreach ($value as $item) {
+            $code = $this->normalizeFacetCode($item);
+            if ($code === '') {
+                continue;
+            }
+            $codes[$code] = $code;
+        }
+
+        return array_values($codes);
+    }
+
+    private function normalizeFacetCode(mixed $value): string
+    {
+        if (! is_string($value)) {
+            return '';
+        }
+
+        $code = strtoupper(trim($value));
+        return array_key_exists($code, self::BIG_FIVE_FACET_META) ? $code : '';
+    }
+
+    private function normalizeFacetBucket(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $bucket = strtolower(trim($value));
+        return in_array($bucket, ['low', 'mid', 'high', 'extreme_low', 'extreme_high'], true)
+            ? $bucket
+            : null;
+    }
+
+    private function formatMoney(?int $priceCents, ?string $currency): ?string
+    {
+        if ($priceCents === null || $priceCents < 0) {
+            return null;
+        }
+
+        $currency = strtoupper(trim((string) $currency));
+        $amount = number_format($priceCents / 100, 2, '.', '');
+
+        return match ($currency) {
+            'CNY' => '¥'.$amount,
+            'USD' => '$'.$amount,
+            'EUR' => '€'.$amount,
+            default => trim($amount.' '.$currency),
+        };
     }
 }

--- a/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
+++ b/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
@@ -6,6 +6,8 @@ namespace Tests\Feature\Attempts;
 
 use App\Models\Attempt;
 use App\Models\UnifiedAccessProjection;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -17,6 +19,9 @@ final class BigFiveHistoryCompareTest extends TestCase
 
     public function test_me_attempts_big5_returns_history_compare_summary(): void
     {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+
         $userId = 8101;
         $anonId = 'anon_big5_history';
         $this->seedUser($userId);
@@ -25,8 +30,40 @@ final class BigFiveHistoryCompareTest extends TestCase
         $olderAttemptId = $this->seedBigFiveAttempt($anonId, (string) $userId, now()->subDays(2));
         $latestAttemptId = $this->seedBigFiveAttempt($anonId, (string) $userId, now()->subDay());
 
-        $this->seedBigFiveResult($olderAttemptId, ['O' => 3.0, 'C' => 3.1, 'E' => 3.2, 'A' => 3.3, 'N' => 3.4]);
-        $this->seedBigFiveResult($latestAttemptId, ['O' => 3.5, 'C' => 3.1, 'E' => 3.0, 'A' => 3.6, 'N' => 3.2]);
+        $this->seedBigFiveResult(
+            $olderAttemptId,
+            ['O' => 3.0, 'C' => 3.1, 'E' => 3.2, 'A' => 3.3, 'N' => 3.4],
+            [
+                'scores_0_100' => [
+                    'domains_percentile' => ['O' => 42, 'C' => 48, 'E' => 55, 'A' => 63, 'N' => 71],
+                    'facets_percentile' => ['N1' => 79, 'E2' => 35, 'A3' => 66],
+                ],
+                'facts' => [
+                    'facet_buckets' => ['N1' => 'high', 'E2' => 'low', 'A3' => 'high'],
+                    'top_strength_facets' => ['N1', 'A3'],
+                    'top_growth_facets' => ['E2'],
+                ],
+                'quality' => ['level' => 'B'],
+                'norms' => ['status' => 'CALIBRATED', 'norms_version' => '2025Q4'],
+            ]
+        );
+        $this->seedBigFiveResult(
+            $latestAttemptId,
+            ['O' => 3.5, 'C' => 3.1, 'E' => 3.0, 'A' => 3.6, 'N' => 3.2],
+            [
+                'scores_0_100' => [
+                    'domains_percentile' => ['O' => 84, 'C' => 63, 'E' => 51, 'A' => 78, 'N' => 40],
+                    'facets_percentile' => ['O5' => 88, 'A3' => 73, 'C4' => 69, 'E2' => 34],
+                ],
+                'facts' => [
+                    'facet_buckets' => ['O5' => 'high', 'A3' => 'high', 'C4' => 'mid', 'E2' => 'low'],
+                    'top_strength_facets' => ['O5', 'A3', 'C4'],
+                    'top_growth_facets' => ['E2'],
+                ],
+                'quality' => ['level' => 'A'],
+                'norms' => ['status' => 'CALIBRATED', 'norms_version' => '2026Q1'],
+            ]
+        );
         $this->seedAccessProjection($olderAttemptId, [
             'access_state' => 'locked',
             'report_state' => 'ready',
@@ -79,6 +116,15 @@ final class BigFiveHistoryCompareTest extends TestCase
         $response->assertJsonPath('items.0.access_summary.variant', 'full');
         $response->assertJsonPath('items.0.access_summary.actions.page_href', "/result/{$latestAttemptId}");
         $response->assertJsonPath('items.0.access_summary.actions.pdf_href', "/api/v0.3/attempts/{$latestAttemptId}/report.pdf");
+        $response->assertJsonPath('items.0.top_facets_summary_v1.items.0.key', 'O5');
+        $response->assertJsonPath('items.0.top_facets_summary_v1.items.1.key', 'A3');
+        $response->assertJsonPath('items.0.quality_summary.level', 'A');
+        $response->assertJsonPath('items.0.quality_summary.grade', 'A');
+        $response->assertJsonPath('items.0.norms_summary.status', 'CALIBRATED');
+        $response->assertJsonPath('items.0.norms_summary.norms_version', '2026Q1');
+        $response->assertJsonPath('items.0.offer_summary.primary_offer', null);
+        $response->assertJsonPath('items.0.share_summary.enabled', true);
+        $response->assertJsonPath('items.0.share_summary.share_kind', 'big5_result');
         $response->assertJsonPath('items.1.access_summary.access_state', 'locked');
         $response->assertJsonPath('items.1.access_summary.report_state', 'ready');
         $response->assertJsonPath('items.1.access_summary.pdf_state', 'unavailable');
@@ -86,6 +132,16 @@ final class BigFiveHistoryCompareTest extends TestCase
         $response->assertJsonPath('items.1.access_summary.variant', 'free');
         $response->assertJsonPath('items.1.access_summary.actions.page_href', "/result/{$olderAttemptId}");
         $response->assertJsonPath('items.1.access_summary.actions.pdf_href', null);
+        $response->assertJsonPath('items.1.top_facets_summary_v1.items.0.key', 'N1');
+        $response->assertJsonPath('items.1.quality_summary.level', 'B');
+        $response->assertJsonPath('items.1.quality_summary.grade', 'B');
+        $response->assertJsonPath('items.1.norms_summary.status', 'CALIBRATED');
+        $response->assertJsonPath('items.1.norms_summary.norms_version', '2025Q4');
+        $response->assertJsonPath('items.1.offer_summary.primary_offer.sku', 'SKU_BIG5_FULL_REPORT_299');
+        $response->assertJsonPath('items.1.offer_summary.primary_offer.benefit_code', 'BIG5_FULL_REPORT');
+        $response->assertJsonPath('items.1.offer_summary.primary_offer.formatted_price', '¥2.99');
+        $response->assertJsonPath('items.1.offer_summary.primary_offer.modules_included.0', 'big5_full');
+        $response->assertJsonPath('items.1.share_summary.enabled', true);
     }
 
     private function seedBigFiveAttempt(string $anonId, string $userId, \DateTimeInterface $submittedAt): string
@@ -121,8 +177,31 @@ final class BigFiveHistoryCompareTest extends TestCase
     /**
      * @param array{O:float,C:float,E:float,A:float,N:float} $domainsMean
      */
-    private function seedBigFiveResult(string $attemptId, array $domainsMean): void
+    private function seedBigFiveResult(string $attemptId, array $domainsMean, array $overrides = []): void
     {
+        $scorePayload = array_replace_recursive([
+            'raw_scores' => [
+                'domains_mean' => $domainsMean,
+                'facets_mean' => [],
+            ],
+            'scores_0_100' => [
+                'domains_percentile' => [],
+                'facets_percentile' => [],
+            ],
+            'facts' => [
+                'facet_buckets' => [],
+                'top_strength_facets' => [],
+                'top_growth_facets' => [],
+            ],
+            'quality' => [
+                'level' => 'A',
+            ],
+            'norms' => [
+                'status' => 'MISSING',
+                'norms_version' => null,
+            ],
+        ], $overrides);
+
         DB::table('results')->insert([
             'id' => (string) Str::uuid(),
             'attempt_id' => $attemptId,
@@ -136,6 +215,9 @@ final class BigFiveHistoryCompareTest extends TestCase
             'profile_version' => null,
             'content_package_version' => 'v1',
             'result_json' => json_encode([
+                'normed_json' => $scorePayload,
+                'breakdown_json' => ['score_result' => $scorePayload],
+                'axis_scores_json' => ['score_result' => $scorePayload],
                 'raw_scores' => [
                     'domains_mean' => $domainsMean,
                     'facets_mean' => [],


### PR DESCRIPTION
## Summary
This PR upgrades BIG5 `/me/attempts` rows into result-center contracts for history cards.

## Problem
BIG5 history rows only exposed `result_summary.domains_mean` and `access_summary`, so the web history page could not render stronger row summaries, row-level unlock surfaces, or share affordances without extra requests.

## Root Cause
`MeAttemptsService::presentAttempt()` presented a deliberately thin BIG5 row contract and did not reuse the existing score-result, paywall, or share authorities already available elsewhere in the report stack.

## Fix
- add `top_facets_summary_v1` on BIG5 `/me/attempts` rows using existing facet percentile and facet bucket data from stored score results
- add `quality_summary` and `norms_summary` as lightweight row-level badges
- add `offer_summary.primary_offer` by reusing existing scale-registry and `OfferResolver` paywall authority, only for locked-but-ready BIG5 rows
- add `share_summary` as a lightweight row capability hint
- keep `result_summary`, `access_summary`, and `history_compare` semantics unchanged
- extend the existing BIG5 history feature test to assert the additive contract and guard the old fields against regression

## Validation
- `php artisan test tests/Feature/Attempts/BigFiveHistoryCompareTest.php`
