### PR TITLE
[codex] fix misleading no-org zero state in commerce KPI widget

### DIFF
--- a/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
+++ b/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\DB;
 
 class CommerceKpiWidget extends BaseWidget
 {
+    private const NO_ORG_PLACEHOLDER = '—';
+
     protected function getHeading(): ?string
     {
         return __('ops.widgets.today_business');
@@ -24,12 +26,12 @@ class CommerceKpiWidget extends BaseWidget
 
         if ($orgId <= 0) {
             return [
-                Stat::make(__('ops.widgets.paid_orders_today'), '0')->description(__('ops.widgets.select_org_to_view_metrics')),
-                Stat::make('Pending unresolved', '0')->description(__('ops.widgets.no_org_selected')),
-                Stat::make('Paid no grant', '0')->description(__('ops.widgets.no_org_selected')),
-                Stat::make('Compensated recently', '0')->description(__('ops.widgets.no_org_selected')),
-                Stat::make(__('ops.widgets.refund_count'), '0')->description(__('ops.widgets.no_org_selected')),
-                Stat::make(__('ops.widgets.webhook_failures'), '0')->description(__('ops.widgets.no_org_selected')),
+                $this->noOrgStat(__('ops.widgets.paid_orders_today'), __('ops.widgets.select_org_to_view_metrics')),
+                $this->noOrgStat('Pending unresolved', __('ops.widgets.no_org_selected')),
+                $this->noOrgStat('Paid no grant', __('ops.widgets.no_org_selected')),
+                $this->noOrgStat('Compensated recently', __('ops.widgets.no_org_selected')),
+                $this->noOrgStat(__('ops.widgets.refund_count'), __('ops.widgets.no_org_selected')),
+                $this->noOrgStat(__('ops.widgets.webhook_failures'), __('ops.widgets.no_org_selected')),
             ];
         }
 
@@ -89,5 +91,12 @@ class CommerceKpiWidget extends BaseWidget
             Stat::make(__('ops.widgets.webhook_failures'), (string) $webhookFailures)
                 ->color($webhookFailures > 0 ? 'danger' : 'success'),
         ];
+    }
+
+    private function noOrgStat(string $label, string $description): Stat
+    {
+        return Stat::make($label, self::NO_ORG_PLACEHOLDER)
+            ->description($description)
+            ->color('gray');
     }
 }

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -67,7 +67,7 @@ return [
         'unlock_rate' => 'Unlock Rate',
         'refund_count' => 'Refund Count',
         'webhook_failures' => 'Webhook Failures',
-        'select_org_to_view_metrics' => 'Select org to view live metrics',
+        'select_org_to_view_metrics' => 'No organization selected. Select an org to view live metrics.',
         'no_org_selected' => 'No organization selected',
         'cents' => 'cents',
         'webhook_failures_15m' => 'Webhook Failures (15m)',

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -67,7 +67,7 @@ return [
         'unlock_rate' => '解锁率',
         'refund_count' => '退款数量',
         'webhook_failures' => 'Webhook 失败数',
-        'select_org_to_view_metrics' => '请选择组织后查看实时指标',
+        'select_org_to_view_metrics' => '未选择组织，请选择组织后查看实时指标',
         'no_org_selected' => '未选择组织',
         'cents' => '分',
         'webhook_failures_15m' => 'Webhook 失败（15分钟）',

--- a/backend/tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php
+++ b/backend/tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php
@@ -75,8 +75,32 @@ final class CommerceKpiExceptionSummaryTest extends TestCase
         $this->assertContains('Pending unresolved', $labels);
         $this->assertContains('Paid no grant', $labels);
         $this->assertContains('Compensated recently', $labels);
+        $this->assertSame('2', $valuesByLabel[__('ops.widgets.paid_orders_today')] ?? null);
         $this->assertSame('2', $valuesByLabel['Pending unresolved'] ?? null);
         $this->assertSame('1', $valuesByLabel['Paid no grant'] ?? null);
         $this->assertSame('1', $valuesByLabel['Compensated recently'] ?? null);
+    }
+
+    public function test_commerce_kpi_widget_uses_placeholder_when_no_org_is_selected(): void
+    {
+        $context = app(OrgContext::class);
+        $context->set(0, null, null, null, OrgContext::KIND_PUBLIC);
+        app()->instance(OrgContext::class, $context);
+
+        $widget = app(CommerceKpiWidget::class);
+        $method = new ReflectionMethod($widget, 'getStats');
+        $method->setAccessible(true);
+        $stats = $method->invoke($widget);
+
+        $this->assertCount(6, $stats);
+        $this->assertSame('—', (string) $stats[0]->getValue());
+        $this->assertSame(__('ops.widgets.select_org_to_view_metrics'), (string) $stats[0]->getDescription());
+
+        foreach ($stats as $stat) {
+            $this->assertSame('—', (string) $stat->getValue());
+            $this->assertNotSame('0', (string) $stat->getValue());
+        }
+
+        $this->assertSame(__('ops.widgets.no_org_selected'), (string) $stats[1]->getDescription());
     }
 }


### PR DESCRIPTION
## Summary
Production already proves there are real paid orders today, but the Ops dashboard rendered hardcoded `0` values in `CommerceKpiWidget` whenever no org was selected. That behavior matched the existing org-scoped design, but it was UX-misleading because it looked like payment sync had failed. This PR changes only the no-org widget presentation so org-scoped KPI cards render a placeholder instead of numeric zero while preserving the current explanatory messaging.

The fix is intentionally narrow. It keeps the existing `orgId > 0` KPI query path unchanged, keeps `org_id = 0` consumer-order semantics unchanged, and does not touch routes, middleware, payment providers, webhook truth handling, order writers, or any dashboard redesign work.

## Scope
- update `CommerceKpiWidget` no-org rendering from `0` to `—`
- strengthen the no-org helper copy in existing ops translations
- add focused coverage for no-org placeholder behavior and selected-org query regression

## Why
The underlying production behavior is not a payment bug and not an order-state bug. The root cause is that the widget's no-org branch short-circuited to hardcoded zeros instead of a non-numeric empty state. Operators then read that `0` as a real KPI result rather than a scope-selection placeholder.

Changing the no-org branch to a placeholder fixes the misleading signal without changing data semantics. It also avoids the incorrect alternative of folding `org_id = 0` public orders into tenant-scoped statistics.

## Verification
- `php artisan test --filter=CommerceKpiExceptionSummaryTest --stop-on-failure`
- `php artisan test --filter="CommerceKpi|OpsDashboard|Widget" --stop-on-failure`
- `./vendor/bin/pint --test app/Filament/Ops/Widgets/CommerceKpiWidget.php tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php`
- `php artisan route:list --path=ops`
