### PR TITLE
[codex] release freeze hardening api

### DIFF
--- a/backend/scripts/ci_verify_scales.sh
+++ b/backend/scripts/ci_verify_scales.sh
@@ -25,6 +25,7 @@ bash "${BACKEND_DIR}/scripts/ci_verify_mbti.sh"
 
 if [[ "${RUN_BIG5_OCEAN_GATE}" != "1" ]]; then
   echo "[CI][scales] BIG5_OCEAN gate not requested; skip BIG5 compiled evidence checks"
+  echo "[CI][scales] use backend/scripts/release_freeze_verify.sh when MBTI + BIG5 release-freeze evidence is required"
   exit 0
 fi
 

--- a/backend/scripts/release_freeze_verify.sh
+++ b/backend/scripts/release_freeze_verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "[release-freeze][backend] MBTI + BIG5 release freeze verify"
+echo "[release-freeze][backend] step 1/4 legacy isolation gate"
+bash "${BACKEND_DIR}/scripts/pr73_verify.sh"
+
+echo "[release-freeze][backend] step 2/4 current MBTI + BIG5 write-path smoke"
+cd "${BACKEND_DIR}"
+php artisan test \
+  tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php \
+  tests/Feature/Compliance/Big5DisclaimerAcceptanceTest.php \
+  tests/Feature/Observability/BigFiveMetricsContractTest.php
+
+echo "[release-freeze][backend] step 3/4 current scale gates and BIG5 evidence"
+php artisan test \
+  tests/Feature/Ops/ScaleIdentityContractCiTest.php \
+  tests/Feature/Content/BigFiveQuestionsMinCompiledEvidenceContractTest.php \
+  tests/Feature/Performance/Big5PerfBudgetTest.php
+
+echo "[release-freeze][backend] step 4/4 contract freeze set"
+php artisan test \
+  tests/Feature/V0_3/MbtiReadPathParityContractTest.php \
+  tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php \
+  tests/Feature/V0_3/AttemptReportAccessReadTest.php \
+  tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php \
+  tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php \
+  tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php \
+  tests/Feature/Attempts/BigFiveHistoryCompareTest.php \
+  tests/Feature/Report/BigFivePdfDeliveryTest.php \
+  tests/Feature/V0_3/ShareSummaryContractTest.php
+
+echo "[release-freeze][backend] verify ok"

--- a/docs/verify/pr32_verify.md
+++ b/docs/verify/pr32_verify.md
@@ -1,5 +1,7 @@
 # PR32 Verify
 
+> Historical note (2026-03-27): this file is kept for PR audit history only. It is not part of the active MBTI + BIG5 release-freeze evidence chain.
+
 - Date: 2026-02-05
 - Env: local
 - Commands:

--- a/docs/verify/pr52_verify.md
+++ b/docs/verify/pr52_verify.md
@@ -1,5 +1,8 @@
 # PR52 Verify
 
+> Historical PR verification note.
+> This document records the 2026-02-07 PR52 verification chain only. It is not the current MBTI + Big5 release-freeze source of truth.
+
 - Date: 2026-02-07
 - Commands:
   - php artisan route:list

--- a/docs/verify/pr60_recon.md
+++ b/docs/verify/pr60_recon.md
@@ -1,5 +1,8 @@
 # PR60 Recon
 
+> Historical PR recon note.
+> This document captures the PR60 risk scan context at the time it was written. It is not the current MBTI + Big5 release-freeze source of truth.
+
 - Keywords: AttemptsController|OrderManager|PsychometricsController
 - 相关入口文件：
   - backend/app/Http/Controllers/API/V0_3/AttemptsController.php

--- a/docs/verify/release-freeze-mbti-big5.md
+++ b/docs/verify/release-freeze-mbti-big5.md
@@ -1,0 +1,53 @@
+# MBTI + BIG5 Release Freeze Verify
+
+当前 MBTI 与 BIG5 主链的 release-freeze backend verify 入口是：
+
+- `backend/scripts/release_freeze_verify.sh`
+
+它显式串起四层证据：
+
+1. legacy isolation
+   - `backend/scripts/pr73_verify.sh`
+2. current MBTI + BIG5 write-path smoke
+   - `tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php`
+   - `tests/Feature/Compliance/Big5DisclaimerAcceptanceTest.php`
+   - `tests/Feature/Observability/BigFiveMetricsContractTest.php`
+3. current scale gates and BIG5 evidence
+   - `tests/Feature/Ops/ScaleIdentityContractCiTest.php`
+   - `tests/Feature/Content/BigFiveQuestionsMinCompiledEvidenceContractTest.php`
+   - `tests/Feature/Performance/Big5PerfBudgetTest.php`
+4. backend contract freeze set
+   - `tests/Feature/V0_3/MbtiReadPathParityContractTest.php`
+   - `tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php`
+   - `tests/Feature/V0_3/AttemptReportAccessReadTest.php`
+   - `tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php`
+   - `tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php`
+   - `tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php`
+   - `tests/Feature/Attempts/BigFiveHistoryCompareTest.php`
+   - `tests/Feature/Report/BigFivePdfDeliveryTest.php`
+   - `tests/Feature/V0_3/ShareSummaryContractTest.php`
+
+## Scope
+
+This verify chain is for release hardening only:
+
+- freeze current read-side contracts
+- prove MBTI + BIG5 smoke parity
+- prove legacy MBTI runtime isolation
+- collect release evidence without expanding product scope
+
+## Non-goals
+
+This verify chain does not cover:
+
+- new feature work
+- scorer changes
+- CMS / analytics expansion
+- visual baseline expansion
+- marketing or product-surface redesign
+
+## Historical notes
+
+Older files such as `docs/verify/pr52_verify.md` and `docs/verify/pr60_recon.md` are historical PR artifacts. Keep them for audit history, but do not treat them as the current release-freeze authority.
+`backend/scripts/pr32_verify.sh` and `docs/verify/pr32_verify.md` are also historical PR-specific artifacts and are no longer part of the active release-freeze evidence chain.
+`backend/scripts/ci_verify_scales.sh` remains useful for CI-scale sweeps, but it is not the release-freeze authority because it still preserves older MBTI baseline behavior that is broader than the current MBTI + BIG5 launch surface.


### PR DESCRIPTION
## Summary
This release-hardening PR freezes the current MBTI and Big Five backend read-side and verification surface without expanding product scope. It adds a dedicated release-freeze verify entry, switches that release authority to current contract and gate evidence instead of older PR-era baseline scripts, and updates active verify docs so the current release authority is explicit.

## Problem
The backend read-side contracts for MBTI and Big Five were already stable, but the release evidence chain was still split across older PR-specific scripts and notes. Some legacy verify assets remained useful for audit history, yet they were too easy to confuse with the active release authority. The backend also lacked a single release-freeze entry point that bundled legacy isolation, current write-path smoke, current scale gates, and the final contract freeze set.

## Root cause
The platform converged on the current MBTI and Big Five launch surface incrementally. Verification assets accumulated over several PRs, but no dedicated closeout pass had yet consolidated them into one release-freeze backend path.

## What changed
- added `backend/scripts/release_freeze_verify.sh` as the backend release-freeze entry point
- defined the release-freeze evidence chain as four explicit stages:
  - legacy isolation gate
  - current MBTI + Big Five write-path smoke
  - current scale identity / Big Five compiled evidence / perf budget gates
  - backend contract freeze set
- updated the release-freeze verify doc to describe the active backend authority
- kept `ci_verify_scales.sh` as a broader CI sweep, but clarified that it is not the release-freeze authority
- marked older PR verification / recon docs as historical so they no longer read like current launch guidance

## Validation
- `bash -n backend/scripts/release_freeze_verify.sh`
- `bash backend/scripts/release_freeze_verify.sh`

That release-freeze script runs:
- `backend/scripts/pr73_verify.sh`
- `php artisan test tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php tests/Feature/Compliance/Big5DisclaimerAcceptanceTest.php tests/Feature/Observability/BigFiveMetricsContractTest.php`
- `php artisan test tests/Feature/Ops/ScaleIdentityContractCiTest.php tests/Feature/Content/BigFiveQuestionsMinCompiledEvidenceContractTest.php tests/Feature/Performance/Big5PerfBudgetTest.php`
- `php artisan test tests/Feature/V0_3/MbtiReadPathParityContractTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php tests/Feature/V0_3/MbtiQualityCurrentSubmitTest.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php tests/Feature/Attempts/BigFiveHistoryCompareTest.php tests/Feature/Report/BigFivePdfDeliveryTest.php tests/Feature/V0_3/ShareSummaryContractTest.php`

## Scope notes
This PR does not change scorer logic, content packs, CMS, analytics, or product runtime behavior. It only hardens the release evidence chain and marks the current backend launch authority clearly.
