### PR TITLE
feat: add MBTI preview contract dto

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -26,6 +26,7 @@ use App\Services\Mbti\MbtiWorkingLifeConsolidationService;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
+use App\Services\Report\MbtiPreviewContractBuilder;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportGatekeeper;
 use App\Services\Scale\ScaleCodeResponseProjector;
@@ -57,6 +58,7 @@ class AttemptReadController extends Controller
         private MbtiReadModelContractService $mbtiReadModelContractService,
         private MbtiWorkingLifeConsolidationService $mbtiWorkingLifeConsolidationService,
         private MbtiAccessHubBuilder $mbtiAccessHubBuilder,
+        private MbtiPreviewContractBuilder $mbtiPreviewContractBuilder,
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
         private ReportSubjectRepository $reportSubjects,
@@ -381,6 +383,9 @@ class AttemptReadController extends Controller
                 $gate,
                 $userId !== null ? (string) $userId : null,
                 $anonId
+            );
+            $responsePayload[MbtiPreviewContractBuilder::KEY] = $this->mbtiPreviewContractBuilder->buildFromReportEnvelope(
+                $responsePayload
             );
         } elseif ($scaleCode === 'BIG5_OCEAN') {
             $projection = data_get($responsePayload, 'report._meta.big5_public_projection_v1');

--- a/backend/app/Services/Report/MbtiPreviewContractBuilder.php
+++ b/backend/app/Services/Report/MbtiPreviewContractBuilder.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Report;
+
+final class MbtiPreviewContractBuilder
+{
+    public const KEY = 'mbti_preview_v1';
+
+    private const MODE_NONE = 'none';
+
+    private const MODE_MODULE_PREVIEW = 'module_preview';
+
+    /**
+     * @param  array<string,mixed>  $reportEnvelope
+     * @return array{
+     *   mode:string,
+     *   modules:list<string>,
+     *   sections:list<array{
+     *     key:string,
+     *     module_code:string,
+     *     has_preview_content:bool,
+     *     visible_preview_cards:list<array{
+     *       id:string,
+     *       title:string,
+     *       body:?string,
+     *       bullets:list<string>,
+     *       tips:list<string>,
+     *       tags:list<string>,
+     *       module_code:string,
+     *       access_level:string
+     *     }>,
+     *     has_locked_remainder:bool
+     *   }>
+     * }
+     */
+    public function buildFromReportEnvelope(array $reportEnvelope): array
+    {
+        $isPreviewCandidate = (bool) ($reportEnvelope['locked'] ?? false)
+            || ReportAccess::normalizeVariant((string) ($reportEnvelope['variant'] ?? '')) === ReportAccess::VARIANT_FREE
+            || ReportAccess::normalizeReportAccessLevel((string) ($reportEnvelope['access_level'] ?? '')) === ReportAccess::REPORT_ACCESS_FREE;
+
+        if (! $isPreviewCandidate) {
+            return [
+                'mode' => self::MODE_NONE,
+                'modules' => [],
+                'sections' => [],
+            ];
+        }
+
+        $previewModules = ReportAccess::normalizeModules(
+            is_array($reportEnvelope['modules_preview'] ?? null) ? $reportEnvelope['modules_preview'] : []
+        );
+
+        $sections = $this->buildSections(
+            is_array($reportEnvelope['report'] ?? null) ? ($reportEnvelope['report']['sections'] ?? null) : null,
+            $previewModules
+        );
+
+        $hasPreviewContent = false;
+        foreach ($sections as $section) {
+            if (($section['has_preview_content'] ?? false) === true) {
+                $hasPreviewContent = true;
+                break;
+            }
+        }
+
+        $mode = ($previewModules !== [] || $hasPreviewContent)
+            ? self::MODE_MODULE_PREVIEW
+            : self::MODE_NONE;
+
+        return [
+            'mode' => $mode,
+            'modules' => $mode === self::MODE_MODULE_PREVIEW ? $previewModules : [],
+            'sections' => $mode === self::MODE_MODULE_PREVIEW ? $sections : [],
+        ];
+    }
+
+    /**
+     * @param  mixed  $sectionsNode
+     * @param  list<string>  $previewModules
+     * @return list<array{
+     *   key:string,
+     *   module_code:string,
+     *   has_preview_content:bool,
+     *   visible_preview_cards:list<array{
+     *     id:string,
+     *     title:string,
+     *     body:?string,
+     *     bullets:list<string>,
+     *     tips:list<string>,
+     *     tags:list<string>,
+     *     module_code:string,
+     *     access_level:string
+     *   }>,
+     *   has_locked_remainder:bool
+     * }>
+     */
+    private function buildSections(mixed $sectionsNode, array $previewModules): array
+    {
+        $previewModuleSet = array_fill_keys($previewModules, true);
+
+        if (is_array($sectionsNode) && array_is_list($sectionsNode)) {
+            $out = [];
+            foreach ($sectionsNode as $rawSection) {
+                if (! is_array($rawSection)) {
+                    continue;
+                }
+
+                $section = $this->buildSection(
+                    $this->normalizeIdentifier($rawSection['key'] ?? ''),
+                    $rawSection,
+                    $previewModuleSet,
+                    'blocks'
+                );
+
+                if ($section !== null) {
+                    $out[] = $section;
+                }
+            }
+
+            return $out;
+        }
+
+        if (! is_array($sectionsNode)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($sectionsNode as $key => $rawSection) {
+            if (! is_array($rawSection)) {
+                continue;
+            }
+
+            $section = $this->buildSection(
+                $this->normalizeIdentifier($key),
+                $rawSection,
+                $previewModuleSet,
+                'cards'
+            );
+
+            if ($section !== null) {
+                $out[] = $section;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string,mixed>  $section
+     * @param  array<string,true>  $previewModuleSet
+     * @return array{
+     *   key:string,
+     *   module_code:string,
+     *   has_preview_content:bool,
+     *   visible_preview_cards:list<array{
+     *     id:string,
+     *     title:string,
+     *     body:?string,
+     *     bullets:list<string>,
+     *     tips:list<string>,
+     *     tags:list<string>,
+     *     module_code:string,
+     *     access_level:string
+     *   }>,
+     *   has_locked_remainder:bool
+     * }|null
+     */
+    private function buildSection(
+        string $sectionKey,
+        array $section,
+        array $previewModuleSet,
+        string $cardsField
+    ): ?array {
+        if ($sectionKey === '') {
+            return null;
+        }
+
+        $sectionModuleCode = $this->normalizeIdentifier($section['module_code'] ?? '');
+        if ($sectionModuleCode === '') {
+            $sectionModuleCode = ReportAccess::defaultModuleCodeForSection($sectionKey);
+        }
+
+        $visiblePreviewCards = [];
+        $hasPaidOrLockedContent = (bool) ($section['locked'] ?? false)
+            || $this->normalizeIdentifier($section['access_level'] ?? '') === ReportAccess::CARD_ACCESS_PAID;
+
+        foreach ($this->normalizeItems($section[$cardsField] ?? null) as $rawCard) {
+            $accessLevel = ReportAccess::normalizeCardAccessLevel((string) ($rawCard['access_level'] ?? ''));
+            $moduleCode = $this->normalizeIdentifier($rawCard['module_code'] ?? '');
+            if ($moduleCode === '') {
+                $moduleCode = $sectionModuleCode;
+            }
+
+            if ($accessLevel === ReportAccess::CARD_ACCESS_PAID) {
+                $hasPaidOrLockedContent = true;
+                continue;
+            }
+
+            if ($accessLevel !== ReportAccess::CARD_ACCESS_PREVIEW) {
+                continue;
+            }
+
+            if ($previewModuleSet !== [] && ! isset($previewModuleSet[$moduleCode])) {
+                $hasPaidOrLockedContent = true;
+                continue;
+            }
+
+            $title = $this->normalizeContentText($rawCard['title'] ?? null, $rawCard['label'] ?? null);
+            $body = $this->normalizeNullableContentText(
+                $rawCard['desc'] ?? null,
+                $rawCard['body'] ?? null,
+                $rawCard['content'] ?? null,
+                $rawCard['text'] ?? null
+            );
+            $bullets = $this->normalizeStringArray($rawCard['bullets'] ?? null);
+
+            if ($title === '' && $body === null && $bullets === []) {
+                continue;
+            }
+
+            $visiblePreviewCards[] = [
+                'id' => $this->normalizeContentText($rawCard['id'] ?? ''),
+                'title' => $title,
+                'body' => $body,
+                'bullets' => $bullets,
+                'tips' => $this->normalizeStringArray($rawCard['tips'] ?? null),
+                'tags' => $this->normalizeStringArray($rawCard['tags'] ?? null),
+                'module_code' => $moduleCode,
+                'access_level' => ReportAccess::CARD_ACCESS_PREVIEW,
+            ];
+        }
+
+        return [
+            'key' => $sectionKey,
+            'module_code' => $sectionModuleCode,
+            'has_preview_content' => $visiblePreviewCards !== [],
+            'visible_preview_cards' => $visiblePreviewCards,
+            'has_locked_remainder' => $hasPaidOrLockedContent,
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function normalizeItems(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $item) {
+            if (is_array($item)) {
+                $out[] = $item;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeStringArray(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $item) {
+            $normalized = $this->normalizeContentText($item);
+            if ($normalized !== '') {
+                $out[$normalized] = true;
+            }
+        }
+
+        return array_keys($out);
+    }
+
+    private function normalizeIdentifier(mixed ...$values): string
+    {
+        foreach ($values as $value) {
+            $normalized = strtolower(trim((string) $value));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return '';
+    }
+
+    private function normalizeContentText(mixed ...$values): string
+    {
+        foreach ($values as $value) {
+            $normalized = trim((string) $value);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return '';
+    }
+
+    private function normalizeNullableContentText(mixed ...$values): ?string
+    {
+        $normalized = $this->normalizeContentText(...$values);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php
+++ b/backend/tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php
@@ -139,6 +139,8 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'ENFP',
             'T'
         );
+        $this->assertStableMbtiPreviewContractV1((array) $resp->json('mbti_preview_v1'));
+        $resp->assertJsonPath('mbti_preview_v1.mode', 'module_preview');
         $resp->assertJsonPath('mbti_access_hub_v1.access_state', 'locked')
             ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
             ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
@@ -210,6 +212,8 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'INTJ',
             'A'
         );
+        $this->assertStableMbtiPreviewContractV1((array) $resp->json('mbti_preview_v1'));
+        $resp->assertJsonPath('mbti_preview_v1.mode', 'none');
         $resp->assertJsonPath('mbti_access_hub_v1.access_state', 'ready')
             ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
             ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
@@ -250,6 +254,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'report',
             'mbti_public_summary_v1',
             'mbti_public_projection_v1',
+            'mbti_preview_v1',
             'scale_code',
             'scale_code_legacy',
             'scale_code_v2',
@@ -276,6 +281,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
         $this->assertIsArray($payload['report']);
         $this->assertIsArray($payload['mbti_public_summary_v1']);
         $this->assertIsArray($payload['mbti_public_projection_v1']);
+        $this->assertIsArray($payload['mbti_preview_v1']);
         $this->assertNotSame('', trim((string) $payload['scale_code']));
         $this->assertNotSame('', trim((string) $payload['scale_code_legacy']));
         $this->assertNotSame('', trim((string) $payload['scale_code_v2']));
@@ -283,7 +289,66 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
 
         $this->assertStableCtaShape((array) $payload['cta']);
         $this->assertStableMbtiReportShape((array) $payload['report']);
+        $this->assertStableMbtiPreviewContractV1((array) $payload['mbti_preview_v1']);
         $this->assertStableMbtiAccessHubShape((array) $payload['mbti_access_hub_v1']);
+    }
+
+    /**
+     * @param  array<string,mixed>  $preview
+     */
+    private function assertStableMbtiPreviewContractV1(array $preview): void
+    {
+        foreach (['mode', 'modules', 'sections'] as $key) {
+            $this->assertArrayHasKey($key, $preview);
+        }
+
+        $this->assertContains((string) ($preview['mode'] ?? ''), ['none', 'module_preview']);
+        $this->assertIsArray($preview['modules']);
+        $this->assertIsArray($preview['sections']);
+
+        foreach ((array) $preview['sections'] as $section) {
+            $this->assertIsArray($section);
+            foreach ([
+                'key',
+                'module_code',
+                'has_preview_content',
+                'visible_preview_cards',
+                'has_locked_remainder',
+            ] as $key) {
+                $this->assertArrayHasKey($key, $section);
+            }
+
+            $this->assertIsString($section['key']);
+            $this->assertIsString($section['module_code']);
+            $this->assertIsBool($section['has_preview_content']);
+            $this->assertIsArray($section['visible_preview_cards']);
+            $this->assertIsBool($section['has_locked_remainder']);
+
+            foreach ((array) $section['visible_preview_cards'] as $card) {
+                $this->assertIsArray($card);
+                foreach ([
+                    'id',
+                    'title',
+                    'body',
+                    'bullets',
+                    'tips',
+                    'tags',
+                    'module_code',
+                    'access_level',
+                ] as $key) {
+                    $this->assertArrayHasKey($key, $card);
+                }
+
+                $this->assertIsString($card['id']);
+                $this->assertIsString($card['title']);
+                $this->assertTrue($card['body'] === null || is_string($card['body']));
+                $this->assertIsArray($card['bullets']);
+                $this->assertIsArray($card['tips']);
+                $this->assertIsArray($card['tags']);
+                $this->assertIsString($card['module_code']);
+                $this->assertSame('preview', $card['access_level']);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- add top-level additive `mbti_preview_v1` to the MBTI `/report` response
- build preview sections from `modules_preview` and section card `access_level=preview`
- lock the new DTO shape in the MBTI report HTTP contract regression test

## Checks
- php artisan test --filter=MbtiReportHttpContractRegressionTest