### PR TITLE
[codex] fix(ops-assets): harden compiled theme + filament asset release chain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -285,3 +285,82 @@ jobs:
           done
           echo "Auth guest contract check failed"
           exit 1
+
+      - name: Ops asset smoke (post deploy)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "$TARGET" in
+            production)
+              OPS_HOST="ops.fermatmind.com"
+              ;;
+            staging)
+              OPS_HOST="staging.fermatmind.com"
+              ;;
+            *)
+              echo "invalid TARGET=$TARGET"
+              exit 2
+              ;;
+          esac
+
+          LOGIN_URL="https://${OPS_HOST}/ops/login"
+          THEME_URL="https://${OPS_HOST}/css/filament/ops/theme.css"
+          APP_CSS_URL="https://${OPS_HOST}/css/filament/filament/app.css"
+          FORMS_URL="https://${OPS_HOST}/css/filament/forms/forms.css"
+          SUPPORT_URL="https://${OPS_HOST}/css/filament/support/support.css"
+          APP_JS_URL="https://${OPS_HOST}/js/filament/filament/app.js"
+
+          ssh_remote() {
+            ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=10 \
+              -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "$1"
+          }
+
+          assert_http_200() {
+            local url="$1"
+            ssh_remote "curl -fsSI --resolve '${OPS_HOST}:443:127.0.0.1' '${url}' >/dev/null"
+          }
+
+          retry() {
+            local label="$1"
+            local attempts="$2"
+            shift 2
+
+            for i in $(seq 1 "$attempts"); do
+              if "$@"; then
+                return 0
+              fi
+              sleep 2
+            done
+
+            echo "${label} failed"
+            return 1
+          }
+
+          echo "Ops login smoke: $LOGIN_URL"
+          retry "Ops login smoke" 5 assert_http_200 "$LOGIN_URL"
+
+          echo "Ops asset smoke: $THEME_URL"
+          retry "Ops theme smoke" 5 assert_http_200 "$THEME_URL"
+
+          echo "Ops asset smoke: $APP_CSS_URL"
+          retry "Ops app.css smoke" 5 assert_http_200 "$APP_CSS_URL"
+
+          echo "Ops asset smoke: $FORMS_URL"
+          retry "Ops forms.css smoke" 5 assert_http_200 "$FORMS_URL"
+
+          echo "Ops asset smoke: $SUPPORT_URL"
+          retry "Ops support.css smoke" 5 assert_http_200 "$SUPPORT_URL"
+
+          echo "Ops asset smoke: $APP_JS_URL"
+          retry "Ops app.js smoke" 5 assert_http_200 "$APP_JS_URL"
+
+          echo "Ops theme content assertion"
+          retry "Ops theme content assertion" 5 ssh_remote "if curl -fsS --resolve '${OPS_HOST}:443:127.0.0.1' '${THEME_URL}' | grep -Eq '@tailwind|@config|vendor/filament/filament/resources/css/base\\.css'; then exit 1; fi"
+
+          echo "Ops login reference assertion"
+          retry "Ops theme reference assertion" 5 ssh_remote "curl -fsS --resolve '${OPS_HOST}:443:127.0.0.1' '${LOGIN_URL}' | grep -q 'css/filament/ops/theme.css'"
+          retry "Ops app.css reference assertion" 5 ssh_remote "curl -fsS --resolve '${OPS_HOST}:443:127.0.0.1' '${LOGIN_URL}' | grep -q 'css/filament/filament/app.css'"
+          retry "Ops forms.css reference assertion" 5 ssh_remote "curl -fsS --resolve '${OPS_HOST}:443:127.0.0.1' '${LOGIN_URL}' | grep -q 'css/filament/forms/forms.css'"
+          retry "Ops support.css reference assertion" 5 ssh_remote "curl -fsS --resolve '${OPS_HOST}:443:127.0.0.1' '${LOGIN_URL}' | grep -q 'css/filament/support/support.css'"
+          retry "Ops app.js reference assertion" 5 ssh_remote "curl -fsS --resolve '${OPS_HOST}:443:127.0.0.1' '${LOGIN_URL}' | grep -q 'js/filament/filament/app.js'"

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -91,31 +91,56 @@ cd /opt/fap-api/backend
 # 2) 安装后端依赖
 composer install --no-dev --optimize-autoloader
 
-# 3) 构建前端资源（若发布工件不含构建产物）
+# 3) 生成 Ops 自定义主题（固定 public 路径产物）
+# build 会同时执行 build:app + build:ops-theme；若只需重建 Ops 主题，至少执行 build:ops-theme
 npm ci
 npm run build
 
-# 4) 数据库迁移
+# 4) 发布 Filament core assets（CSS / JS）
+php artisan filament:assets
+
+# 5) 数据库迁移
 php artisan migrate --force
 
-# 5) 缓存与路由缓存
+# 6) 缓存与路由缓存
 php artisan config:cache
 php artisan route:cache
 
-# 6) 基线校验
+# 7) Ops 资产验收
+test -s public/css/filament/ops/theme.css
+test -s public/css/filament/filament/app.css
+test -s public/css/filament/forms/forms.css
+test -s public/css/filament/support/support.css
+test -s public/js/filament/filament/app.js
+! grep -Eq '@tailwind|@config|vendor/filament/filament/resources/css/base.css' public/css/filament/ops/theme.css
+
+# 7.1) 线上 Ops smoke（production 示例）
+curl -I https://ops.fermatmind.com/ops/login
+curl -I https://ops.fermatmind.com/css/filament/ops/theme.css
+curl -I https://ops.fermatmind.com/css/filament/filament/app.css
+curl -I https://ops.fermatmind.com/css/filament/forms/forms.css
+curl -I https://ops.fermatmind.com/css/filament/support/support.css
+curl -I https://ops.fermatmind.com/js/filament/filament/app.js
+! curl -s https://ops.fermatmind.com/css/filament/ops/theme.css | rg '^@tailwind|@config|vendor/filament/filament/resources/css/base.css'
+
+# 8) 基线校验
 php artisan fap:schema:verify
 ```
 
 ### 5.1 Ops Theme Build in Deploy Pipeline
 - 当前 Filament Ops Panel 通过 `->theme(asset('css/filament/ops/theme.css'))` 注册自定义主题。
+- `backend/resources/css/filament/ops/theme.css` 是 Tailwind 源文件，不是可直接在线服务的生产产物。
+- `backend/public/css/filament/ops/theme.css` 是唯一合法的运行时主题文件，必须由 `npm run build` 或 `npm run build:ops-theme` 生成。
 - Deployer 发布时会在 `{{release_path}}/backend` 内执行：
   - `npm ci --no-audit --no-fund`
   - `npm run build:ops-theme`
 - Deployer 还会显式执行 `php artisan filament:assets`，确保 Filament 核心 CSS/JS 被复制到当前 release 的 `backend/public`。
-- 发布链会在切换 symlink 前校验 `backend/public/css/filament/ops/theme.css` 已生成且非空；若缺失，部署会直接失败。
-- 发布链也会校验关键 Filament 资源存在且非空；缺失这些资源会导致 `/ops` 的样式缺失、脚本 404 或 Alpine 初始化报错。
+- 发布链会在切换 symlink 前校验 `backend/public/css/filament/ops/theme.css` 已生成、非空且不包含 raw Tailwind source 签名；若仍含 `@tailwind`、`@config` 或原始 vendor `@import`，部署会直接失败。
+- 发布链也会校验关键 Filament 资源存在且非空，包括 `backend/public/css/filament/filament/app.css`、`backend/public/css/filament/forms/forms.css`、`backend/public/css/filament/support/support.css`、`backend/public/js/filament/filament/app.js` 等；缺失这些资源会导致 `/ops` 的样式缺失、脚本 404 或 Alpine 初始化报错。
 - 这一步是 release 产物构建，不是 shared 配置，也不是将编译产物提交进 git。
 - 若目标主机缺少 `node` / `npm`，或版本低于当前仓库基线（Node 20.19+ / NPM 10+），部署会 fail fast。
+- 禁止继续使用 `cp resources/css/filament/ops/theme.css public/css/filament/ops/theme.css` 作为正式发布方案；这会把源码误当成线上产物。
+- GitHub Actions 在 deploy 后会按 `TARGET` 对应域名执行同一套 Ops smoke；若线上仍在服务 raw source theme，或关键 core assets 404，workflow 会直接失败。
 
 ## 6. Supervisor 队列守护配置（无 Horizon）
 当前基线：使用 Supervisor 常驻 `queue:work`。至少部署以下两个 program。

--- a/deploy.php
+++ b/deploy.php
@@ -127,6 +127,11 @@ task('guard:ops-theme-asset', function () {
     if (! test("[ -s {$asset} ]")) {
         throw new \RuntimeException("ops theme asset missing or empty: {$asset}");
     }
+
+    $rawSourcePattern = '@tailwind|@config|vendor/filament/filament/resources/css/base\\.css';
+    if (test("grep -Eq '{$rawSourcePattern}' {$asset}")) {
+        throw new \RuntimeException("ops theme asset is raw source, not compiled CSS: {$asset}");
+    }
 });
 
 task('guard:filament-assets', function () {


### PR DESCRIPTION
This PR formalizes the Ops asset release chain for the Filament-based Ops panel at `ops.fermatmind.com` without changing routing, auth, HTTPS, or Nginx behavior.

The user-facing failure mode was that Ops could appear partially recovered while still serving an invalid theme artifact. In practice, `public/css/filament/ops/theme.css` could exist and return 200 even when it was just the raw Tailwind source copied from `resources/css/filament/ops/theme.css`. That produced a false sense of deploy success: the page was no longer completely bare, but the compiled theme contract was still broken and visual parity was not restored. Separately, Filament core assets and the custom Ops theme come from two different generation chains, so deployments could also regress into theme-only or core-only partial states.

Root cause was not the panel provider contract. `AdminPanelProvider` already points to the correct runtime path, `asset('css/filament/ops/theme.css')`. The gaps were in release enforcement and verification: deploy only checked that the theme file existed and was non-empty, post-deploy checks only exercised API endpoints, and the manual deploy docs did not state the full dual-chain asset contract clearly enough.

This PR hardens that release chain in three places:

1. `deploy.php`
   - Keeps the existing release build path for the Ops theme (`npm ci --no-audit --no-fund` + `npm run build:ops-theme`).
   - Keeps Filament core asset publication as an explicit deploy step (`php artisan filament:assets`).
   - Upgrades the Ops theme guard from a presence check to a legality check by rejecting raw-source signatures such as `@tailwind`, `@config`, and the uncompiled vendor import path.

2. `.github/workflows/deploy.yml`
   - Adds post-deploy Ops asset smoke coverage for both deploy targets, selecting the correct host from `TARGET`.
   - Verifies `/ops/login`, the compiled Ops theme asset, Filament app CSS, Filament forms/support CSS, and Filament app JS.
   - Verifies that the live theme file is not raw Tailwind source and that the login page references the expected asset chain.
   - Adds retries so transient post-symlink timing does not create a false negative.

3. `README_DEPLOY.md`
   - Documents the single valid runtime contract: `resources/css/filament/ops/theme.css` is source only, while `public/css/filament/ops/theme.css` must be generated by `npm run build` or `npm run build:ops-theme`.
   - Documents that `php artisan filament:assets` is separately required for Filament core CSS/JS.
   - Adds concrete local and remote acceptance commands.
   - Explicitly forbids copying the raw source theme into `public/` as a release tactic.

Validation performed for this PR:

- `php -l deploy.php`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yml'); puts 'deploy.yml OK'"`
- `cd backend && php artisan filament:assets`
- `cd backend && npm ci`
- `cd backend && npm run build`
- Local generated asset checks for:
  - `public/css/filament/ops/theme.css`
  - `public/css/filament/filament/app.css`
  - `public/css/filament/forms/forms.css`
  - `public/css/filament/support/support.css`
  - `public/js/filament/filament/app.js`
- Raw-source rejection check against the generated Ops theme asset.

Non-goals remain unchanged:
- no routing changes
- no auth/guard/provider changes
- no HTTPS/Nginx/DNS changes
- no staging fallback or secondary theme path
