### PR TITLE
[codex] fix(ops-entry): reconcile / root contract and add ops host smoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -286,6 +286,97 @@ jobs:
           echo "Auth guest contract check failed"
           exit 1
 
+      - name: Ops entry smoke (post deploy)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "$TARGET" in
+            production)
+              OPS_HOST="ops.fermatmind.com"
+              ASSERT_ROOT_REDIRECT="yes"
+              ;;
+            staging)
+              OPS_HOST="staging.fermatmind.com"
+              ASSERT_ROOT_REDIRECT="no"
+              ;;
+            *)
+              echo "invalid TARGET=$TARGET"
+              exit 2
+              ;;
+          esac
+
+          ROOT_URL="https://${OPS_HOST}/"
+          ADMIN_URL="https://${OPS_HOST}/admin"
+          OPS_URL="https://${OPS_HOST}/ops"
+          LOGIN_URL="https://${OPS_HOST}/ops/login"
+
+          ssh_remote() {
+            ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=10 \
+              -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "$1"
+          }
+
+          fetch_headers() {
+            local url="$1"
+            ssh_remote "curl -sSI --max-redirs 0 --resolve '${OPS_HOST}:443:127.0.0.1' '${url}'"
+          }
+
+          assert_redirect() {
+            local url="$1"
+            local expected_relative="$2"
+            local headers
+            local location
+            headers="$(fetch_headers "$url")"
+            printf '%s\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ 30[12] '
+            location="$(printf '%s\n' "$headers" | tr -d '\r' | awk 'BEGIN { IGNORECASE = 1 } /^Location:/ { sub(/^Location:[[:space:]]*/, "", $0); print; exit }')"
+            [ -n "$location" ]
+
+            case "$location" in
+              "$expected_relative"|https://"${OPS_HOST}${expected_relative}")
+                return 0
+                ;;
+            esac
+
+            return 1
+          }
+
+          assert_200() {
+            local url="$1"
+            local headers
+            headers="$(fetch_headers "$url")"
+            printf '%s\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ 200 '
+          }
+
+          retry() {
+            local label="$1"
+            local attempts="$2"
+            shift 2
+
+            for i in $(seq 1 "$attempts"); do
+              if "$@"; then
+                return 0
+              fi
+              sleep 2
+            done
+
+            echo "${label} failed"
+            return 1
+          }
+
+          if [ "$ASSERT_ROOT_REDIRECT" = "yes" ]; then
+            echo "Ops root smoke: $ROOT_URL"
+            retry "Ops root redirect" 5 assert_redirect "$ROOT_URL" "/ops"
+
+            echo "Ops admin alias smoke: $ADMIN_URL"
+            retry "Ops admin redirect" 5 assert_redirect "$ADMIN_URL" "/ops"
+          fi
+
+          echo "Ops panel smoke: $OPS_URL"
+          retry "Ops panel redirect" 5 assert_redirect "$OPS_URL" "/ops/login"
+
+          echo "Ops login smoke: $LOGIN_URL"
+          retry "Ops login 200" 5 assert_200 "$LOGIN_URL"
+
       - name: Ops asset smoke (post deploy)
         shell: bash
         run: |

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -123,6 +123,21 @@ curl -I https://ops.fermatmind.com/css/filament/support/support.css
 curl -I https://ops.fermatmind.com/js/filament/filament/app.js
 ! curl -s https://ops.fermatmind.com/css/filament/ops/theme.css | rg '^@tailwind|@config|vendor/filament/filament/resources/css/base.css'
 
+# 7.2) 入口契约 smoke
+# production: 根入口必须跳到 /ops
+curl -sSI --max-redirs 0 https://ops.fermatmind.com/ | rg '^HTTP/[0-9.]+ 30[12] '
+curl -sSI --max-redirs 0 https://ops.fermatmind.com/ | rg '^Location: (/ops|https://ops\.fermatmind\.com/ops)\r?$'
+curl -sSI --max-redirs 0 https://ops.fermatmind.com/admin | rg '^HTTP/[0-9.]+ 30[12] '
+curl -sSI --max-redirs 0 https://ops.fermatmind.com/admin | rg '^Location: (/ops|https://ops\.fermatmind\.com/ops)\r?$'
+curl -sSI --max-redirs 0 https://ops.fermatmind.com/ops | rg '^HTTP/[0-9.]+ 30[12] '
+curl -sSI --max-redirs 0 https://ops.fermatmind.com/ops | rg '^Location: (/ops/login|https://ops\.fermatmind\.com/ops/login)\r?$'
+curl -sSI https://ops.fermatmind.com/ops/login | rg '^HTTP/[0-9.]+ 200 '
+
+# staging: 不强制要求 / -> /ops，只验证 /ops 与 /ops/login
+curl -sSI --max-redirs 0 https://staging.fermatmind.com/ops | rg '^HTTP/[0-9.]+ 30[12] '
+curl -sSI --max-redirs 0 https://staging.fermatmind.com/ops | rg '^Location: (/ops/login|https://staging\.fermatmind\.com/ops/login)\r?$'
+curl -sSI https://staging.fermatmind.com/ops/login | rg '^HTTP/[0-9.]+ 200 '
+
 # 8) 基线校验
 php artisan fap:schema:verify
 ```
@@ -137,10 +152,12 @@ php artisan fap:schema:verify
 - Deployer 还会显式执行 `php artisan filament:assets`，确保 Filament 核心 CSS/JS 被复制到当前 release 的 `backend/public`。
 - 发布链会在切换 symlink 前校验 `backend/public/css/filament/ops/theme.css` 已生成、非空且不包含 raw Tailwind source 签名；若仍含 `@tailwind`、`@config` 或原始 vendor `@import`，部署会直接失败。
 - 发布链也会校验关键 Filament 资源存在且非空，包括 `backend/public/css/filament/filament/app.css`、`backend/public/css/filament/forms/forms.css`、`backend/public/css/filament/support/support.css`、`backend/public/js/filament/filament/app.js` 等；缺失这些资源会导致 `/ops` 的样式缺失、脚本 404 或 Alpine 初始化报错。
+- production Ops host 的根入口契约是 `https://ops.fermatmind.com/ -> /ops`；这条契约由仓库路由显式表达，并在 deploy/workflow/manual smoke 中验收。
+- staging 不共享这条根入口契约；`https://staging.fermatmind.com/` 仍按前台站点处理，entry smoke 只覆盖 `/ops` 与 `/ops/login`。
 - 这一步是 release 产物构建，不是 shared 配置，也不是将编译产物提交进 git。
 - 若目标主机缺少 `node` / `npm`，或版本低于当前仓库基线（Node 20.19+ / NPM 10+），部署会 fail fast。
 - 禁止继续使用 `cp resources/css/filament/ops/theme.css public/css/filament/ops/theme.css` 作为正式发布方案；这会把源码误当成线上产物。
-- GitHub Actions 在 deploy 后会按 `TARGET` 对应域名执行同一套 Ops smoke；若线上仍在服务 raw source theme，或关键 core assets 404，workflow 会直接失败。
+- GitHub Actions 在 deploy 后会按 `TARGET` 对应域名执行对应的 entry smoke 与 asset smoke；production 额外断言 `/ -> /ops` 与 `/admin -> /ops`，staging 不共享这条根入口契约。
 
 ## 6. Supervisor 队列守护配置（无 Horizon）
 当前基线：使用 Supervisor 常驻 `queue:work`。至少部署以下两个 program。

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -4,6 +4,13 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\SitemapController;
 
 Route::get('/', function () {
+    $requestHost = strtolower((string) request()->getHost());
+    $opsAllowedHost = strtolower(trim((string) config('ops.allowed_host', '')));
+
+    if (config('admin.panel_enabled') && $opsAllowedHost !== '' && $requestHost === $opsAllowedHost) {
+        return redirect('/ops');
+    }
+
     return view('welcome');
 });
 

--- a/deploy.php
+++ b/deploy.php
@@ -75,6 +75,7 @@ host('production')
     ->setPort((int)(getenv('DEPLOY_PORT_PROD') ?: 22))
     ->set('deploy_path', getenv('DEPLOY_PATH_PROD') ?: '/var/www/fap-api')
     ->set('healthcheck_host', getenv('HEALTHCHECK_HOST_PROD') ?: 'fermatmind.com')
+    ->set('ops_entry_host', getenv('OPS_ENTRY_HOST_PROD') ?: 'ops.fermatmind.com')
     ->set('nginx_site', '/etc/nginx/sites-enabled/fap-api')
     ->set('php_fpm_service', getenv('PHP_FPM_SERVICE_PROD') ?: 'php8.4-fpm');
 
@@ -84,6 +85,7 @@ host('staging')
     ->setPort((int)(getenv('DEPLOY_PORT_STG') ?: 22))
     ->set('deploy_path', getenv('DEPLOY_PATH_STG') ?: '/var/www/fap-api-staging')
     ->set('healthcheck_host', getenv('HEALTHCHECK_HOST_STG') ?: 'staging.fermatmind.com')
+    ->set('ops_entry_host', getenv('OPS_ENTRY_HOST_STG') ?: '')
     ->set('nginx_site', '/etc/nginx/sites-enabled/fap-api-staging')
     ->set('php_fpm_service', getenv('PHP_FPM_SERVICE_STG') ?: 'php8.4-fpm');
 
@@ -288,6 +290,62 @@ task('healthcheck:auth-guest-contract', function () {
     run($cmd);
 });
 
+task('healthcheck:ops-entry-contract', function () {
+    $host = trim((string) get('ops_entry_host', ''));
+
+    if ($host === '') {
+        writeln('<comment>Skip ops entry contract smoke (ops_entry_host not configured)</comment>');
+        return;
+    }
+
+    $fetchHeaders = static function (string $url) use ($host): string {
+        return run("curl -sSI --max-redirs 0 --resolve {$host}:443:127.0.0.1 {$url}");
+    };
+
+    $assertRedirect = static function (string $url, string $expectedPattern, string $label) use ($fetchHeaders): void {
+        $headers = $fetchHeaders($url);
+
+        if (! preg_match('/^HTTP\\/[0-9.]+ 30[12]\\b/m', $headers)) {
+            throw new \RuntimeException("{$label} did not return a 301/302 redirect");
+        }
+
+        if (! preg_match($expectedPattern, $headers)) {
+            throw new \RuntimeException("{$label} redirect target did not match expected location");
+        }
+    };
+
+    $assertStatus = static function (string $url, int $status, string $label) use ($fetchHeaders): void {
+        $headers = $fetchHeaders($url);
+
+        if (! preg_match('/^HTTP\\/[0-9.]+ ' . $status . '\\b/m', $headers)) {
+            throw new \RuntimeException("{$label} did not return HTTP {$status}");
+        }
+    };
+
+    $quotedHost = preg_quote($host, '/');
+
+    $assertRedirect(
+        "https://{$host}/",
+        '/^Location:\\s*(?:\\/ops|https:\\/\\/' . $quotedHost . '\\/ops)\\r?$/mi',
+        'ops host root'
+    );
+    $assertRedirect(
+        "https://{$host}/admin",
+        '/^Location:\\s*(?:\\/ops|https:\\/\\/' . $quotedHost . '\\/ops)\\r?$/mi',
+        'ops host admin alias'
+    );
+    $assertRedirect(
+        "https://{$host}/ops",
+        '/^Location:\\s*(?:\\/ops\\/login|https:\\/\\/' . $quotedHost . '\\/ops\\/login)\\r?$/mi',
+        'ops panel root'
+    );
+    $assertStatus(
+        "https://{$host}/ops/login",
+        200,
+        'ops login page'
+    );
+});
+
 /**
  * ======================================================
  * Seed shared content_packages
@@ -326,5 +384,6 @@ after('deploy:symlink', 'reload:php-fpm');
 after('deploy:symlink', 'reload:nginx');
 after('deploy:symlink', 'healthcheck:public');
 after('deploy:symlink', 'healthcheck:auth-guest-contract');
+after('deploy:symlink', 'healthcheck:ops-entry-contract');
 
 after('deploy:failed', 'deploy:unlock');


### PR DESCRIPTION
This PR formalizes the Ops host entry contract for `ops.fermatmind.com` and adds entry-chain smoke checks so deploy success is no longer inferred only from API health or asset availability.

Before this change, the production live behavior for the Ops host root was `https://ops.fermatmind.com/ -> /ops`, but repo truth still served the generic `welcome` page on `/`. That meant the most user-visible entrypoint could drift out of sync with the repository while deploys still passed. The panel path itself was already stable through Filament (`/ops` and `/ops/login`), but there was no single repo-backed statement of the production root contract and no deploy-time assertion for redirect semantics.

This PR closes that gap in four places:

1. `backend/routes/web.php`
   - Makes the root route host-aware and repo-backed for the dedicated Ops host.
   - The redirect now derives from `config('ops.allowed_host')` rather than a hardcoded hostname, so route behavior stays aligned with the existing host restriction config already used by `OpsAccessControl`.
   - This keeps the production Ops host contract explicit without changing staging `/` or the main site `/`.

2. `deploy.php`
   - Adds a dedicated Ops entry contract healthcheck for the production Ops host.
   - Verifies:
     - `/ -> /ops`
     - `/admin -> /ops`
     - `/ops -> /ops/login`
     - `/ops/login -> 200`
   - Hooks the check into the post-symlink healthcheck sequence, alongside the existing API-level checks.

3. `.github/workflows/deploy.yml`
   - Adds post-deploy entry smoke with environment-specific behavior.
   - Production validates `/`, `/admin`, `/ops`, and `/ops/login`.
   - Staging validates `/ops` and `/ops/login` only, intentionally not asserting `staging / -> /ops`.
   - The redirect matcher now parses the `Location` header value directly and accepts both relative and absolute redirect forms, avoiding false failures against the live absolute redirect shape.

4. `README_DEPLOY.md`
   - Documents the manual entry-smoke commands.
   - Makes the production vs staging contract split explicit so operators do not incorrectly generalize the root redirect to every host.

Validation performed for this PR:

- `php -l backend/routes/web.php`
- `php -l deploy.php`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yml'); puts 'deploy.yml OK'"`
- `cd backend && php artisan route:list | rg 'GET\|HEAD\s+/\s|GET\|HEAD\s+ops\s|GET\|HEAD\s+ops/login\s|ANY\s+admin\s'`
- Laravel kernel simulation with `FAP_ADMIN_PANEL_ENABLED=true` and `OPS_ALLOWED_HOST=ops.fermatmind.com` confirmed `ops.fermatmind.com /` returns `302` with `Location: https://ops.fermatmind.com/ops`.
- Laravel kernel simulation with `OPS_ALLOWED_HOST=` confirmed the same host no longer redirects, proving the new route behavior is derived from config instead of a literal hostname.
- Header parsing checks for relative and absolute `Location` forms used by the workflow matcher.
- Live baseline curl checks confirmed the current production and staging entry chains still match the intended contract.

Non-goals remain unchanged:
- no auth/model/provider changes
- no asset/theme/build/publish changes
- no HTTPS/Nginx/DNS changes
- no shared `bootstrap/cache` lifecycle治理 in this PR
