### PR TITLE
fix(ops-entry): handle lowercase location headers in smoke

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -126,16 +126,16 @@ curl -I https://ops.fermatmind.com/js/filament/filament/app.js
 # 7.2) 入口契约 smoke
 # production: 根入口必须跳到 /ops
 curl -sSI --max-redirs 0 https://ops.fermatmind.com/ | rg '^HTTP/[0-9.]+ 30[12] '
-curl -sSI --max-redirs 0 https://ops.fermatmind.com/ | rg '^Location: (/ops|https://ops\.fermatmind\.com/ops)\r?$'
+curl -sSI --max-redirs 0 https://ops.fermatmind.com/ | rg -i '^Location: (/ops|https://ops\.fermatmind\.com/ops)\r?$'
 curl -sSI --max-redirs 0 https://ops.fermatmind.com/admin | rg '^HTTP/[0-9.]+ 30[12] '
-curl -sSI --max-redirs 0 https://ops.fermatmind.com/admin | rg '^Location: (/ops|https://ops\.fermatmind\.com/ops)\r?$'
+curl -sSI --max-redirs 0 https://ops.fermatmind.com/admin | rg -i '^Location: (/ops|https://ops\.fermatmind\.com/ops)\r?$'
 curl -sSI --max-redirs 0 https://ops.fermatmind.com/ops | rg '^HTTP/[0-9.]+ 30[12] '
-curl -sSI --max-redirs 0 https://ops.fermatmind.com/ops | rg '^Location: (/ops/login|https://ops\.fermatmind\.com/ops/login)\r?$'
+curl -sSI --max-redirs 0 https://ops.fermatmind.com/ops | rg -i '^Location: (/ops/login|https://ops\.fermatmind\.com/ops/login)\r?$'
 curl -sSI https://ops.fermatmind.com/ops/login | rg '^HTTP/[0-9.]+ 200 '
 
 # staging: 不强制要求 / -> /ops，只验证 /ops 与 /ops/login
 curl -sSI --max-redirs 0 https://staging.fermatmind.com/ops | rg '^HTTP/[0-9.]+ 30[12] '
-curl -sSI --max-redirs 0 https://staging.fermatmind.com/ops | rg '^Location: (/ops/login|https://staging\.fermatmind\.com/ops/login)\r?$'
+curl -sSI --max-redirs 0 https://staging.fermatmind.com/ops | rg -i '^Location: (/ops/login|https://staging\.fermatmind\.com/ops/login)\r?$'
 curl -sSI https://staging.fermatmind.com/ops/login | rg '^HTTP/[0-9.]+ 200 '
 
 # 8) 基线校验

--- a/deploy.php
+++ b/deploy.php
@@ -302,14 +302,19 @@ task('healthcheck:ops-entry-contract', function () {
         return run("curl -sSI --max-redirs 0 --resolve {$host}:443:127.0.0.1 {$url}");
     };
 
-    $assertRedirect = static function (string $url, string $expectedPattern, string $label) use ($fetchHeaders): void {
+    $assertRedirect = static function (string $url, string $expectedRelative, string $expectedAbsolute, string $label) use ($fetchHeaders): void {
         $headers = $fetchHeaders($url);
 
         if (! preg_match('/^HTTP\\/[0-9.]+ 30[12]\\b/m', $headers)) {
             throw new \RuntimeException("{$label} did not return a 301/302 redirect");
         }
 
-        if (! preg_match($expectedPattern, $headers)) {
+        if (! preg_match('/^Location:\\s*(.+)\\r?$/mi', $headers, $matches)) {
+            throw new \RuntimeException("{$label} redirect response did not include a Location header");
+        }
+
+        $location = trim((string) ($matches[1] ?? ''));
+        if ($location !== $expectedRelative && $location !== $expectedAbsolute) {
             throw new \RuntimeException("{$label} redirect target did not match expected location");
         }
     };
@@ -322,21 +327,22 @@ task('healthcheck:ops-entry-contract', function () {
         }
     };
 
-    $quotedHost = preg_quote($host, '/');
-
     $assertRedirect(
         "https://{$host}/",
-        '/^Location:\\s*(?:\\/ops|https:\\/\\/' . $quotedHost . '\\/ops)\\r?$/mi',
+        '/ops',
+        "https://{$host}/ops",
         'ops host root'
     );
     $assertRedirect(
         "https://{$host}/admin",
-        '/^Location:\\s*(?:\\/ops|https:\\/\\/' . $quotedHost . '\\/ops)\\r?$/mi',
+        '/ops',
+        "https://{$host}/ops",
         'ops host admin alias'
     );
     $assertRedirect(
         "https://{$host}/ops",
-        '/^Location:\\s*(?:\\/ops\\/login|https:\\/\\/' . $quotedHost . '\\/ops\\/login)\\r?$/mi',
+        '/ops/login',
+        "https://{$host}/ops/login",
         'ops panel root'
     );
     $assertStatus(


### PR DESCRIPTION
## Summary
- make deploy entry smoke parse `Location` headers case-insensitively before comparing redirect targets
- make README entry smoke commands accept lowercase `location:` headers from HTTP/2 responses
- keep the scope limited to residual entry-smoke hardening

## Tests
- `php -l deploy.php`
- `curl -sSI --max-redirs 0 https://staging.fermatmind.com/ops | rg -i '^Location: (/ops/login|https://staging\.fermatmind\.com/ops/login)\r?$'`
- PHP snippet validating both `Location:` and `location:` redirect header forms pass the deploy matcher
