### PR TITLE
[codex] docs(ops-bootstrap): codify first admin / first org bootstrap

### DIFF
--- a/backend/resources/views/filament/ops/pages/organizations-import-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/organizations-import-page.blade.php
@@ -9,7 +9,7 @@
                 <x-filament::button color="primary" tag="a" href="/ops/select-org">
                     Back to Select Org
                 </x-filament::button>
-                <x-filament::button color="gray" tag="a" href="/docs/04-ops/admin-ops-runbook.md" target="_blank">
+                <x-filament::button color="gray" tag="a" href="/docs/04-ops/ops-bootstrap.md" target="_blank">
                     Open Runbook
                 </x-filament::button>
             </div>

--- a/docs/04-ops/admin-console.md
+++ b/docs/04-ops/admin-console.md
@@ -23,17 +23,21 @@
 | Analyst | admin.events.read, admin.audit.read, admin.funnel.read |
 
 ## 登录方式
-- 初始化：`php artisan admin:bootstrap-owner --email=owner@example.com --password=owner12345 --name=Owner`
-- 打开：`/admin`（默认 `http://127.0.0.1:18010/admin`）
+- 首次 bootstrap：优先参考 `docs/04-ops/ops-bootstrap.md`
+- 官方首个管理员命令：`php artisan admin:bootstrap-owner --email=owner@example.com --password='ChangeMe123!' --name='Owner'`
+- 正确登录模型：`App\Models\AdminUser`，不要用 `App\Models\User`
+- 打开：`/ops/login`（默认 `http://127.0.0.1:18010/ops/login`）
 - 备用：API Token 访问 `/api/v0.3/admin/*`（Header：`X-FAP-Admin-Token`）
 - 开关：`FAP_ADMIN_PANEL_ENABLED=true|false`
 
 ## 常用路径
-- UI：`/admin`
+- UI：`/ops`
+- Login：`/ops/login`
+- Select Org：`/ops/select-org`
 - API：`/api/v0.3/admin/*`
 
 ## 截图位点（待补）
-- Admin 登录页（/admin）
+- Admin 登录页（/ops/login）
 - Admin Users 列表 + 禁用弹窗
 - Roles 权限勾选页
 - Audit Logs 过滤 + 导出按钮
@@ -42,6 +46,7 @@
 - Widgets：HealthzStatusWidget、FunnelWidget
 
 ## 本机手动验收要点
-- 浏览器打开 `http://127.0.0.1:18010/admin` 登录 Owner
+- 浏览器打开 `http://127.0.0.1:18010/ops/login` 登录 Owner
+- 首次登录/无 org 状态下应进入 `Select Org`
 - HealthzStatusWidget 与 FunnelWidget 正常显示；无数据时显示 “no data”
 - ContentReleaseResource 可看到发布记录，Probe 可执行并写入 audit_logs

--- a/docs/04-ops/admin-ops-runbook.md
+++ b/docs/04-ops/admin-ops-runbook.md
@@ -1,5 +1,12 @@
 # Admin Ops Runbook
 
+## Bootstrap
+
+- 首个 Ops 管理员与首个 org 的正式 bootstrap/runbook 请先看：`docs/04-ops/ops-bootstrap.md`
+- 当前正确登录入口是 `/ops/login`
+- 不要把 `App\Models\User` 当成 Ops 登录账号
+- 不要把 `/ops/organizations-import` 当成已自动化完成的 org import 流程
+
 ## 健康检查（Healthz Snapshot）
 1) API：`GET /api/v0.3/admin/healthz/snapshot`
 2) 预期：返回最新 `ops_healthz_snapshots` 记录，`ok=true` 为绿色
@@ -21,5 +28,4 @@
 ## 常见故障
 - Token 不匹配：检查 `FAP_ADMIN_TOKEN` 与请求 Header（`X-FAP-Admin-Token`）
 - Admin 用户被禁用：在 Admin Users 中启用或重新 bootstrap
-- 会话失效：重新登录 /admin，或改用 token 调用 API
-
+- 会话失效：重新登录 `/ops/login`，或改用 token 调用 API

--- a/docs/04-ops/ops-bootstrap.md
+++ b/docs/04-ops/ops-bootstrap.md
@@ -1,0 +1,266 @@
+# Ops Bootstrap Runbook
+
+## Purpose
+
+This runbook defines the current repo-backed bootstrap path for:
+
+- the first Ops login account
+- the first owner-ready Ops admin
+- the first org-selected, actually usable Ops session
+
+This document only describes the current repository truth. It does not invent new bootstrap commands, onboarding UI, seed flows, or tenant-side ownership semantics that do not exist in code today.
+
+## Scope
+
+In scope:
+
+- first Ops admin bootstrap
+- first login flow
+- first org creation path
+- first org selection path
+- minimum acceptance checks
+
+Out of scope:
+
+- deploy / asset / entry runbooks
+- auth or provider rewrites
+- tenant-side ownership/member semantics redesign
+- organization import automation
+
+## Preflight
+
+Before running bootstrap:
+
+1. Migrations must already be applied.
+2. The Ops panel must be enabled with `FAP_ADMIN_PANEL_ENABLED=true`.
+3. The correct Ops login URL is `/ops/login`.
+4. Host/IP restrictions for Ops access must already allow your environment.
+
+Minimum repo checks:
+
+```bash
+cd backend
+php artisan list | rg 'admin:bootstrap-owner'
+php artisan route:list | rg 'ops|select-org|organizations-import|two-factor-challenge|admin-users|organizations'
+```
+
+## Correct Login Model
+
+The first Ops login account must be an `App\Models\AdminUser`.
+
+Do not use:
+
+- `App\Models\User`
+- `App\Models\TenantUser`
+- `php artisan db:seed` as an Ops bootstrap substitute
+
+Why:
+
+- Ops panel auth uses the `admin` guard and the `admin_users` provider.
+- `TenantUser` only applies to the tenant panel, not the Ops panel.
+- The default `DatabaseSeeder` creates a `User`, which is not an Ops login account.
+
+## Bootstrap States
+
+This repo currently has three different bootstrap states. Do not collapse them into one:
+
+1. `login-capable admin`
+   - A valid `AdminUser` exists.
+   - The account is active.
+   - The account is not locked.
+   - The password is set.
+   - This state is enough to log into `/ops/login`.
+
+2. `owner-ready admin`
+   - The `AdminUser` also has initialized RBAC state.
+   - The account has the roles and permissions needed to manage Ops bootstrap screens.
+   - This is the intended result of `admin:bootstrap-owner`.
+
+3. `org-selected usable Ops session`
+   - The admin has logged in successfully.
+   - An organization exists.
+   - An organization has been selected in the Ops session.
+   - This is the minimum state for org-scoped Ops workflows.
+
+Logging in successfully does not mean Ops is fully usable.
+
+## First Admin: Official Bootstrap Path
+
+The official first-admin path is:
+
+```bash
+cd backend
+php artisan admin:bootstrap-owner --email=owner@example.com --password='ChangeMe123!' --name='Owner'
+```
+
+What this command does today:
+
+- creates or updates an `AdminUser`
+- sets:
+  - `name`
+  - `email`
+  - `password`
+  - `is_active = 1`
+- initializes permissions
+- initializes default roles
+- grants:
+  - `OpsAdmin`
+  - `Owner`
+
+What this command does not do:
+
+- create a tenant-side `users` record
+- create an organization
+- create an `organization_members` row
+- establish tenant-side `owner_user_id` semantics
+
+## First Admin: Minimum Login-Capable Conditions
+
+The minimum login-capable Ops admin is an `AdminUser` with:
+
+- `name`
+- `email`
+- `password`
+- `is_active = 1`
+- `locked_until = null` or not in the future
+
+Notes:
+
+- Roles and permissions are not the raw login gate.
+- Roles and permissions do matter for what can be managed after login.
+- `failed_login_count` can remain at its default value.
+- `totp_enabled_at` may remain `null` for first login.
+
+## First Login Flow
+
+Use:
+
+```text
+/ops/login
+```
+
+Current flow:
+
+1. Submit valid `AdminUser` credentials at `/ops/login`.
+2. If TOTP is enabled for that admin, the session is redirected to:
+
+```text
+/ops/two-factor-challenge
+```
+
+3. Otherwise, or after successful TOTP verification, the session is redirected to:
+
+```text
+/ops/select-org
+```
+
+This is expected. First login lands in org selection, not directly in a fully usable org-scoped workspace.
+
+## No-Org State vs Usable State
+
+Current no-org state:
+
+- login works
+- dashboard works
+- select-org works
+- the following pages/resources remain accessible without org selection:
+  - dashboard
+  - select-org
+  - admin-users
+  - roles
+  - permissions
+  - organizations
+  - deploys
+  - organizations-import
+  - go-live-gate
+  - health-checks
+  - queue-monitor
+
+Current org-scoped state:
+
+- many content, commerce, support, and runtime pages require an org to be selected
+- if no org is selected, middleware redirects those requests back to `/ops/select-org`
+
+Practical rule:
+
+- `login success` means the account is valid
+- `usable Ops` starts only after an org exists and has been selected
+
+## First Org: Current Supported Path
+
+There is no repo-backed first-org artisan bootstrap command today.
+
+The current supported first-org path is manual creation inside Ops UI:
+
+1. Log in at `/ops/login`.
+2. Complete TOTP if required.
+3. Go to `/ops/select-org`.
+4. Create an organization from the existing UI entry point.
+
+Current supported creation entry points:
+
+- `/ops/select-org`
+- `/ops/organizations/create`
+
+Current supported selection step:
+
+- choose the org from `/ops/select-org`
+
+## Important Boundary: Org Creation Is Not Tenant Ownership Bootstrap
+
+Be explicit about the current boundary:
+
+- creating an org in Ops UI does not mean the `AdminUser` becomes a tenant-side owner/member
+- current Ops-side org creation does not establish `organization_members` for the admin
+- current Ops-side org creation does not establish tenant-side `owner_user_id` semantics for an actual tenant user
+
+Do not document those semantics as if they are already wired up.
+
+## Unsupported Or Non-Official Bootstrap Paths
+
+Do not treat any of the following as the official first bootstrap path:
+
+- creating `App\Models\User` and expecting Ops login to work
+- creating `App\Models\TenantUser` and expecting Ops login to work
+- `php artisan db:seed`
+- the default `DatabaseSeeder`
+- tenant API org creation as the first Ops bootstrap path
+- `/ops/organizations-import` as an automated import solution
+
+The current import page is only a placeholder. It is not an automated org bootstrap pipeline.
+
+## Minimum Acceptance Checks
+
+After first-admin bootstrap:
+
+```bash
+cd backend
+php artisan list | rg 'admin:bootstrap-owner'
+php artisan route:list | rg 'ops|select-org|organizations-import|two-factor-challenge|admin-users|organizations'
+php -l app/Console/Commands/AdminBootstrapOwner.php
+php -l app/Models/AdminUser.php
+php -l app/Http/Responses/Auth/OpsLoginResponse.php
+php -l app/Http/Middleware/RequireOpsOrgSelected.php
+```
+
+Host-level smoke:
+
+```bash
+curl -I https://ops.fermatmind.com/ops/login
+curl -I https://ops.fermatmind.com/ops
+curl -I https://staging.fermatmind.com/ops/login
+```
+
+Repo-context checks:
+
+```bash
+cd backend
+php artisan tinker --execute="dump(config('auth.guards.admin')); dump(config('auth.providers.admin_users'));"
+php artisan tinker --execute="dump(config('admin.panel_enabled')); dump(config('admin.url'));"
+```
+
+## Operational Notes
+
+- Prefer `admin:bootstrap-owner` over ad-hoc tinker for first-admin bootstrap because the command is repo-backed and initializes RBAC.
+- If production recovery ever requires manual intervention beyond this runbook, document that separately as an exception flow. Do not replace this runbook with “just use tinker”.
+- If a future PR adds a real first-org command or import automation, update this runbook then. Do not pre-document it now.


### PR DESCRIPTION
## Summary
This PR codifies the current repo-backed Ops bootstrap path for the first admin and first organization, without changing any PHP business logic.

It adds a dedicated bootstrap runbook and updates the existing Ops docs/UI pointer so operators stop relying on stale `/admin` guidance, the wrong login model, or non-existent organization bootstrap automation.

## Problem
The repo already had a real first-admin bootstrap command and a working `/ops/login -> /ops/select-org` flow, but the documentation was fragmented and partially stale.

That left several high-risk misunderstandings in circulation:
- treating `App\Models\User` as the Ops login account
- treating "can log in" as equivalent to "can actually use Ops"
- treating `db:seed`, tenant API org creation, or the import placeholder as official first-org bootstrap paths
- continuing to follow `/admin`-based docs after the Ops entry contract had moved to `/ops`

## Root cause
The current repo truth lived across multiple places:
- `admin:bootstrap-owner` in the console layer
- `AdminUser` vs `TenantUser` model split
- Filament login response and org-selection middleware
- Select Org UI and Organizations resource

But there was no single current runbook that tied those pieces together and stated the limits honestly.

## Fix
This PR adds a dedicated `docs/04-ops/ops-bootstrap.md` runbook and updates the existing Ops docs to point at it.

The new runbook explicitly defines:
- the only correct Ops login model: `App\Models\AdminUser`
- the official first-admin command: `php artisan admin:bootstrap-owner ...`
- the difference between `login-capable admin`, `owner-ready admin`, and `org-selected usable Ops session`
- the actual first-login flow: `/ops/login` -> optional `/ops/two-factor-challenge` -> `/ops/select-org`
- the current first-org path: manual creation in existing Ops UI
- the current no-org allowlist before org selection
- the current boundaries that must not be over-documented, especially tenant-side owner/member semantics and import automation

It also updates the import placeholder so the in-product "Open Runbook" button points directly to the new bootstrap runbook.

## Validation
I only ran static/repo-backed validation for this docs PR:
- confirmed `admin:bootstrap-owner` exists in `php artisan list`
- confirmed `/ops/login`, `/ops/select-org`, `/ops/organizations-import`, `/ops/two-factor-challenge`, `/ops/admin-users`, and `/ops/organizations` exist in `php artisan route:list`
- confirmed the referenced PHP files parse cleanly with `php -l`
- diff-checked that only the intended docs/UI pointer files are included in this PR

## Scope notes
This PR does not:
- change auth/provider/model behavior
- add a first-org artisan command
- change org ownership/member semantics
- change assets, entry, deploy, or HTTPS behavior
