### PR TITLE
[codex] fix(deploy-cache): defer bootstrap clear until vendors

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -429,7 +429,7 @@ before('deploy:prepare', 'ensure:phpredis');
 before('deploy:shared', 'fap:seed_shared_content_packages');
 
 after('deploy:update_code', 'ensure:node-toolchain');
-after('deploy:prepare', 'bootstrap-cache:clear-release');
+after('deploy:vendors', 'bootstrap-cache:clear-release');
 
 after('deploy:shared', 'ensure:shared-perms');
 after('deploy:shared', 'ensure:healthz-deps');


### PR DESCRIPTION
## Summary
This PR fixes the current staging deploy failure caused by the `bootstrap-cache:clear-release` hook running before `deploy:vendors`.

## Problem
`bootstrap-cache:clear-release` resolves Laravel bootstrap cache paths by requiring `backend/vendor/autoload.php`. On staging deploy, that task was wired to run after `deploy:prepare`, which is too early in the Deployer lifecycle. At that point the release does not yet have vendor dependencies installed, so the task fatals with:

- `require(vendor/autoload.php): Failed to open stream`
- `Failed opening required 'vendor/autoload.php'`

## Root cause
The hook timing was wrong, not the task body itself. The task assumes vendor autoloading is already available, but the hook was attached before `deploy:vendors`.

## Fix
Move the hook from:
- `after('deploy:prepare', 'bootstrap-cache:clear-release')`

to:
- `after('deploy:vendors', 'bootstrap-cache:clear-release')`

This preserves the existing task implementation and only corrects the execution point so the required autoload file exists before Laravel path resolution runs.

## Validation
- `php -l deploy.php`
- checked the diff to confirm only the hook timing changed

## Scope
This PR does not change:
- the clear/rebuild task bodies
- rollback handling
- README or workflow logic
- any other deploy tasks
