### PR TITLE
fix(deploy-cache): repair release runtime perms before healthchecks

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -296,6 +296,16 @@ task('ensure:shared-perms', function () {
     run("find {$base}/shared/content_packages -type f -exec chmod 664 {} \\;");
 });
 
+task('ensure:release-runtime-perms', function () {
+    $owner = currentHost()->getRemoteUser() ?: 'ubuntu';
+    $cacheDir = '{{release_path}}/backend/bootstrap/cache';
+
+    run("mkdir -p {$cacheDir}");
+    run("sudo -n /usr/bin/chown -R {$owner}:www-data {$cacheDir}");
+    run("find {$cacheDir} -type d -exec chmod 2775 {} \\;");
+    run("find {$cacheDir} -type f -exec chmod 664 {} \\;");
+});
+
 /**
  * ======================================================
  * runtime dirs（healthz 依赖）
@@ -443,6 +453,7 @@ after('deploy:vendors', 'build:ops-theme');
 after('build:ops-theme', 'guard:ops-theme-asset');
 after('guard:ops-theme-asset', 'artisan:filament:assets');
 after('artisan:filament:assets', 'guard:filament-assets');
+after('artisan:migrate', 'ensure:release-runtime-perms');
 
 after('deploy:symlink', 'reload:php-fpm');
 after('deploy:symlink', 'reload:nginx');


### PR DESCRIPTION
## Summary
- add a release-local runtime permissions repair task for `backend/bootstrap/cache`
- run it after `artisan:migrate` and before public healthchecks
- keep the fix scoped to `deploy.php` only

## Root cause
Staging deploys started failing post-symlink healthchecks because `backend/bootstrap/cache` is release-local again and the new release directory was not writable by the PHP-FPM runtime user/group. The app recovered immediately once that directory was repaired to a `www-data`-writable state.

## Tests
- `php -l deploy.php`
- `rg -n "ensure:release-runtime-perms|bootstrap/cache|www-data|artisan:migrate|healthcheck:public" deploy.php`
