### PR TITLE
[codex] Unify paid-order read contract across Ops and Tenant

### DIFF
--- a/backend/app/Filament/Ops/Resources/OrderResource.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource.php
@@ -114,7 +114,10 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                     ->badge()
                     ->color(fn (Order $record): string => $support->orderStatus($record)['state']),
                 Tables\Columns\TextColumn::make('payment_state')
+                    ->label('Payment status')
+                    ->state(fn (Order $record): string => $support->paymentStatus($record)['label'])
                     ->badge()
+                    ->color(fn (Order $record): string => $support->paymentStatus($record)['state'])
                     ->toggleable(),
                 Tables\Columns\TextColumn::make('grant_state')
                     ->badge()
@@ -152,12 +155,12 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                     ->badge()
                     ->color(fn (Order $record): string => $support->compensationStatus($record)['state']),
                 Tables\Columns\TextColumn::make('latest_payment_status')
-                    ->label('Payment status')
-                    ->state(fn (Order $record): string => $support->paymentStatus($record)['label'])
+                    ->label('Webhook status')
+                    ->state(fn (Order $record): string => $support->webhookStatus($record)['label'])
                     ->badge()
-                    ->color(fn (Order $record): string => $support->paymentStatus($record)['state']),
+                    ->color(fn (Order $record): string => $support->webhookStatus($record)['state']),
                 Tables\Columns\TextColumn::make('latest_handle_status')
-                    ->label('Handle status')
+                    ->label('Webhook handle status')
                     ->badge()
                     ->toggleable(),
                 Tables\Columns\TextColumn::make('latest_benefit_status')
@@ -268,8 +271,6 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                     ->options(fn (): array => $support->distinctOrderOptions('provider')),
                 Tables\Filters\SelectFilter::make('channel')
                     ->options(fn (): array => $support->distinctOrderOptions('channel')),
-                Tables\Filters\SelectFilter::make('payment_state')
-                    ->options(fn (): array => $support->distinctOrderOptions('payment_state')),
                 Tables\Filters\SelectFilter::make('grant_state')
                     ->options(fn (): array => $support->distinctOrderOptions('grant_state')),
                 Tables\Filters\SelectFilter::make('commerce_exception_filter')
@@ -326,6 +327,12 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
                     ->options(fn (): array => $support->distinctPaymentStatusOptions())
                     ->query(function (Builder $query, array $data) use ($support): void {
                         $support->applyPaymentStatusFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('webhook_status_filter')
+                    ->label('Webhook status')
+                    ->options(fn (): array => $support->distinctWebhookStatusOptions())
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyWebhookStatusFilter($query, $data['value'] ?? null);
                     }),
                 Tables\Filters\SelectFilter::make('unlock_status_filter')
                     ->label('Unlock status')

--- a/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
@@ -271,6 +271,28 @@ final class OrderLinkageSupport
      */
     public function distinctPaymentStatusOptions(): array
     {
+        if (! SchemaBaseline::hasColumn('orders', 'payment_state')) {
+            return [];
+        }
+
+        return collect([
+            Order::PAYMENT_STATE_CREATED,
+            Order::PAYMENT_STATE_PENDING,
+            Order::PAYMENT_STATE_PAID,
+            Order::PAYMENT_STATE_FAILED,
+            Order::PAYMENT_STATE_CANCELED,
+            Order::PAYMENT_STATE_EXPIRED,
+            Order::PAYMENT_STATE_REFUNDED,
+        ])
+            ->mapWithKeys(fn (string $value): array => [$value => $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctWebhookStatusOptions(): array
+    {
         if (! SchemaBaseline::hasTable('payment_events') || ! SchemaBaseline::hasColumn('payment_events', 'status')) {
             return [];
         }
@@ -512,17 +534,30 @@ final class OrderLinkageSupport
      */
     public function applyPaymentStatusFilter(Builder $query, ?string $value): void
     {
-        $paymentStatus = trim((string) $value);
-        if ($paymentStatus === '' || ! SchemaBaseline::hasTable('payment_events')) {
+        $paymentState = strtolower(trim((string) $value));
+        if ($paymentState === '' || ! SchemaBaseline::hasColumn('orders', 'payment_state')) {
             return;
         }
 
-        $query->whereExists(function (QueryBuilder $paymentQuery) use ($paymentStatus): void {
+        $query->where('orders.payment_state', $paymentState);
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyWebhookStatusFilter(Builder $query, ?string $value): void
+    {
+        $webhookStatus = trim((string) $value);
+        if ($webhookStatus === '' || ! SchemaBaseline::hasTable('payment_events')) {
+            return;
+        }
+
+        $query->whereExists(function (QueryBuilder $paymentQuery) use ($webhookStatus): void {
             $paymentQuery
                 ->selectRaw('1')
                 ->from('payment_events')
                 ->whereColumn('payment_events.order_no', 'orders.order_no')
-                ->where('payment_events.status', $paymentStatus);
+                ->where('payment_events.status', $webhookStatus);
         });
     }
 
@@ -592,6 +627,7 @@ final class OrderLinkageSupport
         if ($value) {
             $query
                 ->where($this->paidLikeOrderClause())
+                ->whereExists($this->activeBenefitExistsQuery())
                 ->whereExists($this->snapshotReadyExistsQuery());
 
             return;
@@ -600,6 +636,7 @@ final class OrderLinkageSupport
         $query->where(function (Builder $builder): void {
             $builder
                 ->where($this->notPaidLikeOrderClause())
+                ->orWhereNotExists($this->activeBenefitExistsQuery())
                 ->orWhereNotExists($this->snapshotReadyExistsQuery());
         });
     }
@@ -643,6 +680,7 @@ final class OrderLinkageSupport
             'delivered' => $query->whereExists($this->deliveryEmailExistsQuery()),
             'ready' => $query
                 ->where($this->paidLikeOrderClause())
+                ->whereExists($this->activeBenefitExistsQuery())
                 ->whereNotExists($this->deliveryEmailExistsQuery())
                 ->whereExists($this->snapshotReadyExistsQuery()),
             'failed' => $query->where(function (Builder $builder): void {
@@ -656,6 +694,7 @@ final class OrderLinkageSupport
                 ->whereNotExists($this->deliveryEmailExistsQuery())
                 ->where(function (Builder $builder): void {
                     $builder->where($this->notPaidLikeOrderClause())
+                        ->orWhereNotExists($this->activeBenefitExistsQuery())
                         ->orWhereNotExists($this->snapshotReadyExistsQuery());
                 }),
             default => null,
@@ -676,6 +715,19 @@ final class OrderLinkageSupport
      * @return array{label:string,state:string}
      */
     public function paymentStatus(object $order): array
+    {
+        $status = $this->resolvedPaymentStateValue($order);
+        if ($status === '') {
+            return ['label' => 'missing', 'state' => 'gray'];
+        }
+
+        return ['label' => $status, 'state' => $this->statusState($status)];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function webhookStatus(object $order): array
     {
         $status = trim((string) ($order->latest_payment_status ?? ''));
         if ($status === '') {
@@ -741,15 +793,17 @@ final class OrderLinkageSupport
      */
     public function unlockStatus(object $order): array
     {
+        $paymentState = $this->resolvedPaymentStateValue($order);
+
         if ($this->hasActiveBenefitGrant($order)) {
             return ['label' => 'unlocked', 'state' => 'success'];
         }
 
-        if ($this->isRefundedLike((string) ($order->status ?? ''))) {
+        if ($paymentState === Order::PAYMENT_STATE_REFUNDED) {
             return ['label' => 'refunded', 'state' => 'danger'];
         }
 
-        if ($this->isPaidLike((string) ($order->status ?? '')) || $this->isPaidLike((string) ($order->latest_payment_status ?? ''))) {
+        if ($paymentState === Order::PAYMENT_STATE_PAID) {
             return ['label' => 'paid_no_grant', 'state' => 'warning'];
         }
 
@@ -1358,45 +1412,36 @@ final class OrderLinkageSupport
     private function paidLikeOrderClause(): \Closure
     {
         return function (Builder|QueryBuilder $builder): void {
-            $builder->where(function (Builder|QueryBuilder $nested): void {
-                $nested
-                    ->whereRaw("lower(coalesce(orders.status, '')) in (?, ?, ?, ?)", ['paid', 'fulfilled', 'complete', 'completed'])
-                    ->orWhereNotNull('orders.paid_at');
-            });
+            $builder->where('orders.payment_state', Order::PAYMENT_STATE_PAID);
         };
     }
 
     private function refundedLikeOrderClause(): \Closure
     {
         return function (Builder|QueryBuilder $builder): void {
-            $builder->where(function (Builder|QueryBuilder $nested): void {
-                $nested
-                    ->whereRaw("lower(coalesce(orders.status, '')) like ?", ['%refund%']);
-
-                if (SchemaBaseline::hasColumn('orders', 'refunded_at')) {
-                    $nested->orWhereNotNull('orders.refunded_at');
-                }
-            });
+            $builder->where('orders.payment_state', Order::PAYMENT_STATE_REFUNDED);
         };
     }
 
     private function notPaidLikeOrderClause(): \Closure
     {
         return function (Builder|QueryBuilder $builder): void {
-            $builder
-                ->whereRaw("lower(coalesce(orders.status, '')) not in (?, ?, ?, ?)", ['paid', 'fulfilled', 'complete', 'completed'])
-                ->whereNull('orders.paid_at');
+            $builder->where(function (Builder|QueryBuilder $nested): void {
+                $nested
+                    ->whereNull('orders.payment_state')
+                    ->orWhere('orders.payment_state', '!=', Order::PAYMENT_STATE_PAID);
+            });
         };
     }
 
     private function notRefundedLikeOrderClause(): \Closure
     {
         return function (Builder|QueryBuilder $builder): void {
-            $builder->whereRaw("lower(coalesce(orders.status, '')) not like ?", ['%refund%']);
-
-            if (SchemaBaseline::hasColumn('orders', 'refunded_at')) {
-                $builder->whereNull('orders.refunded_at');
-            }
+            $builder->where(function (Builder|QueryBuilder $nested): void {
+                $nested
+                    ->whereNull('orders.payment_state')
+                    ->orWhere('orders.payment_state', '!=', Order::PAYMENT_STATE_REFUNDED);
+            });
         };
     }
 
@@ -1735,18 +1780,17 @@ final class OrderLinkageSupport
 
     private function resolvedPaymentStateValue(object $order): string
     {
-        return Order::normalizePaymentState(
-            (string) ($order->payment_state ?? ''),
-            (string) ($order->status ?? '')
-        );
-    }
+        $state = strtolower(trim((string) ($order->payment_state ?? '')));
 
-    private function resolvedGrantStateValue(object $order): string
-    {
-        return Order::normalizeGrantState(
-            (string) ($order->grant_state ?? ''),
-            (string) ($order->status ?? '')
-        );
+        return in_array($state, [
+            Order::PAYMENT_STATE_CREATED,
+            Order::PAYMENT_STATE_PENDING,
+            Order::PAYMENT_STATE_PAID,
+            Order::PAYMENT_STATE_FAILED,
+            Order::PAYMENT_STATE_CANCELED,
+            Order::PAYMENT_STATE_EXPIRED,
+            Order::PAYMENT_STATE_REFUNDED,
+        ], true) ? $state : '';
     }
 
     private function latestPaymentAttemptState(object $order): string
@@ -1757,7 +1801,6 @@ final class OrderLinkageSupport
     private function matchesException(string $key, object $order): bool
     {
         $paymentState = $this->resolvedPaymentStateValue($order);
-        $grantState = $this->resolvedGrantStateValue($order);
         $attemptState = $this->latestPaymentAttemptState($order);
         $hasAttempt = (int) ($order->payment_attempts_count ?? 0) > 0;
         $hasActiveGrant = $this->hasActiveBenefitGrant($order);
@@ -1774,7 +1817,6 @@ final class OrderLinkageSupport
             'callback_missing' => in_array($paymentState, [Order::PAYMENT_STATE_CREATED, Order::PAYMENT_STATE_PENDING], true)
                 && in_array($attemptState, [PaymentAttempt::STATE_CALLBACK_RECEIVED, PaymentAttempt::STATE_VERIFIED], true),
             'paid_no_grant' => $paymentState === Order::PAYMENT_STATE_PAID
-                && $grantState !== Order::GRANT_STATE_GRANTED
                 && ! $hasActiveGrant,
             'grant_without_paid' => $hasActiveGrant
                 && ! in_array($paymentState, [Order::PAYMENT_STATE_PAID, Order::PAYMENT_STATE_REFUNDED], true),
@@ -1839,7 +1881,8 @@ final class OrderLinkageSupport
         $snapshotStatus = strtolower(trim((string) ($order->latest_snapshot_status ?? '')));
 
         return $this->resolvedAttemptId($order) !== null
-            && ($this->isPaidLike((string) ($order->status ?? '')) || $this->isPaidLike((string) ($order->latest_payment_status ?? '')))
+            && $this->resolvedPaymentStateValue($order) === Order::PAYMENT_STATE_PAID
+            && $this->hasActiveBenefitGrant($order)
             && in_array($snapshotStatus, ['ready', 'full', 'completed'], true);
     }
 
@@ -1857,19 +1900,9 @@ final class OrderLinkageSupport
             $status === '' => 'gray',
             in_array($status, ['paid', 'fulfilled', 'active', 'ready', 'full', 'completed', 'processed', 'handled', 'succeeded'], true) => 'success',
             in_array($status, ['pending', 'queued', 'running', 'processing', 'initiated', 'provider_created', 'client_presented', 'callback_received', 'verified'], true) => 'warning',
-            in_array($status, ['failed', 'error', 'revoked', 'expired', 'invalid', 'refunded'], true) => 'danger',
+            in_array($status, ['failed', 'error', 'revoked', 'expired', 'invalid', 'refunded', 'canceled', 'cancelled'], true) => 'danger',
             default => 'gray',
         };
-    }
-
-    private function isPaidLike(?string $status): bool
-    {
-        return in_array(strtolower(trim((string) $status)), ['paid', 'fulfilled', 'complete', 'completed', 'succeeded'], true);
-    }
-
-    private function isRefundedLike(?string $status): bool
-    {
-        return str_contains(strtolower(trim((string) $status)), 'refund');
     }
 
     private function contactEmailHash(string $candidate): ?string

--- a/backend/app/Filament/Tenant/Resources/OrderResource.php
+++ b/backend/app/Filament/Tenant/Resources/OrderResource.php
@@ -7,9 +7,16 @@ namespace App\Filament\Tenant\Resources;
 use App\Filament\Shared\BaseTenantResource;
 use App\Filament\Tenant\Resources\OrderResource\Pages;
 use App\Models\Order;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
 use Filament\Forms\Form;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class OrderResource extends BaseTenantResource
 {
@@ -24,12 +31,41 @@ class OrderResource extends BaseTenantResource
         return $form->schema([]);
     }
 
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery()
+            ->select('orders.*');
+
+        if (! Schema::hasTable('benefit_grants')) {
+            return $query;
+        }
+
+        return $query
+            ->selectSub(self::latestBenefitStatusField(), 'latest_benefit_status')
+            ->selectSub(self::activeBenefitExistsField(), 'has_active_benefit_grant');
+    }
+
     public static function table(Table $table): Table
     {
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('order_no')->searchable()->copyable(),
-                Tables\Columns\TextColumn::make('status')->badge()->sortable(),
+                Tables\Columns\TextColumn::make('payment_state')
+                    ->label('Payment status')
+                    ->state(fn (Order $record): string => self::paymentStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => self::paymentStatus($record)['state'])
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('unlock_status')
+                    ->label('Unlock status')
+                    ->state(fn (Order $record): string => self::unlockStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => self::unlockStatus($record)['state']),
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Lifecycle status')
+                    ->badge()
+                    ->color(fn (Order $record): string => self::statusColor((string) ($record->status ?? '')))
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('amount_cents')->label('Amount')->numeric()->sortable(),
                 Tables\Columns\TextColumn::make('currency'),
                 Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable(),
@@ -47,5 +83,138 @@ class OrderResource extends BaseTenantResource
             'index' => Pages\ListOrders::route('/'),
             'view' => Pages\ViewOrder::route('/{record}'),
         ];
+    }
+
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Section::make('Order')
+                    ->schema([
+                        TextEntry::make('order_no')
+                            ->label('Order no'),
+                        TextEntry::make('payment_state')
+                            ->label('Payment status')
+                            ->state(fn (Order $record): string => self::paymentStatus($record)['label'])
+                            ->badge()
+                            ->color(fn (Order $record): string => self::paymentStatus($record)['state']),
+                        TextEntry::make('latest_benefit_status')
+                            ->label('Grant status')
+                            ->state(fn (Order $record): string => self::grantStatus($record)['label'])
+                            ->badge()
+                            ->color(fn (Order $record): string => self::grantStatus($record)['state']),
+                        TextEntry::make('unlock_status')
+                            ->label('Unlock status')
+                            ->state(fn (Order $record): string => self::unlockStatus($record)['label'])
+                            ->badge()
+                            ->color(fn (Order $record): string => self::unlockStatus($record)['state']),
+                        TextEntry::make('status')
+                            ->label('Lifecycle status')
+                            ->badge()
+                            ->color(fn (Order $record): string => self::statusColor((string) ($record->status ?? ''))),
+                        TextEntry::make('amount_cents')
+                            ->label('Amount'),
+                        TextEntry::make('currency'),
+                        TextEntry::make('created_at')
+                            ->dateTime(),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    private static function latestBenefitStatusField(): QueryBuilder
+    {
+        return DB::table('benefit_grants')
+            ->select('status')
+            ->whereColumn('benefit_grants.order_no', 'orders.order_no')
+            ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private static function activeBenefitExistsField(): QueryBuilder
+    {
+        return DB::table('benefit_grants')
+            ->selectRaw('1')
+            ->whereColumn('benefit_grants.order_no', 'orders.order_no')
+            ->where('benefit_grants.status', 'active')
+            ->limit(1);
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    private static function paymentStatus(Order $record): array
+    {
+        $state = self::paymentStateValue($record);
+
+        return [
+            'label' => $state !== '' ? $state : 'missing',
+            'state' => self::statusColor($state),
+        ];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    private static function grantStatus(Order $record): array
+    {
+        if (self::hasActiveBenefitGrant($record)) {
+            return ['label' => 'active', 'state' => 'success'];
+        }
+
+        $latest = strtolower(trim((string) ($record->latest_benefit_status ?? '')));
+        if ($latest !== '') {
+            return ['label' => $latest, 'state' => self::statusColor($latest)];
+        }
+
+        return ['label' => 'missing', 'state' => 'gray'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    private static function unlockStatus(Order $record): array
+    {
+        if (self::hasActiveBenefitGrant($record)) {
+            return ['label' => 'unlocked', 'state' => 'success'];
+        }
+
+        return match (self::paymentStateValue($record)) {
+            Order::PAYMENT_STATE_PAID => ['label' => 'paid_no_grant', 'state' => 'warning'],
+            Order::PAYMENT_STATE_REFUNDED => ['label' => 'refunded', 'state' => 'danger'],
+            default => ['label' => 'pending', 'state' => 'gray'],
+        };
+    }
+
+    private static function hasActiveBenefitGrant(Order $record): bool
+    {
+        return (bool) ($record->has_active_benefit_grant ?? false)
+            || strtolower(trim((string) ($record->latest_benefit_status ?? ''))) === 'active';
+    }
+
+    private static function paymentStateValue(Order $record): string
+    {
+        $state = strtolower(trim((string) ($record->payment_state ?? '')));
+
+        return in_array($state, [
+            Order::PAYMENT_STATE_CREATED,
+            Order::PAYMENT_STATE_PENDING,
+            Order::PAYMENT_STATE_PAID,
+            Order::PAYMENT_STATE_FAILED,
+            Order::PAYMENT_STATE_CANCELED,
+            Order::PAYMENT_STATE_EXPIRED,
+            Order::PAYMENT_STATE_REFUNDED,
+        ], true) ? $state : '';
+    }
+
+    private static function statusColor(string $status): string
+    {
+        return match (strtolower(trim($status))) {
+            'paid', 'fulfilled', 'active', 'ready', 'full', 'completed', 'processed' => 'success',
+            'pending', 'created', 'queued', 'processing' => 'warning',
+            'failed', 'error', 'canceled', 'cancelled', 'expired', 'revoked', 'refunded' => 'danger',
+            default => 'gray',
+        };
     }
 }

--- a/backend/tests/Feature/Ops/OrderPaymentReadContractTest.php
+++ b/backend/tests/Feature/Ops/OrderPaymentReadContractTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\OrderResource\Support\OrderLinkageSupport;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class OrderPaymentReadContractTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    public function test_ops_support_separates_payment_truth_from_webhook_diagnostics(): void
+    {
+        $chain = $this->seedCommerceOpsChain(orgId: 72, orderNo: 'ord_ops_paid_event_failed', options: [
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'status' => 'fulfilled',
+            'with_grant' => false,
+            'payment_event_status' => 'post_commit_failed',
+            'payment_event_handle_status' => 'post_commit_failed',
+        ]);
+
+        $record = app(OrderLinkageSupport::class)
+            ->query()
+            ->where('orders.order_no', $chain['order_no'])
+            ->first();
+
+        $this->assertNotNull($record);
+
+        $support = app(OrderLinkageSupport::class);
+        $this->assertSame('paid', $support->paymentStatus($record)['label']);
+        $this->assertSame('post_commit_failed', $support->webhookStatus($record)['label']);
+        $this->assertSame('paid_no_grant', $support->unlockStatus($record)['label']);
+    }
+
+    public function test_paid_success_filter_only_uses_payment_state(): void
+    {
+        $paid = $this->seedCommerceOpsChain(orgId: 74, orderNo: 'ord_ops_paid_truth', options: [
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'pending',
+        ]);
+        $fulfilledButUnpaid = $this->seedCommerceOpsChain(orgId: 74, orderNo: 'ord_ops_fulfilled_but_failed', options: [
+            'payment_state' => 'failed',
+            'grant_state' => 'not_started',
+            'status' => 'fulfilled',
+            'with_grant' => false,
+            'payment_event_status' => 'processed',
+        ]);
+
+        $support = app(OrderLinkageSupport::class);
+        $query = $support->query();
+        $support->applyPaidSuccessFilter($query, true);
+        $orderNos = $query->pluck('order_no')->all();
+
+        $this->assertContains($paid['order_no'], $orderNos);
+        $this->assertNotContains($fulfilledButUnpaid['order_no'], $orderNos);
+    }
+
+    public function test_ops_payment_truth_does_not_fallback_from_lifecycle_status(): void
+    {
+        $chain = $this->seedCommerceOpsChain(orgId: 75, orderNo: 'ord_ops_fulfilled_failed_payment_state', options: [
+            'payment_state' => 'failed',
+            'grant_state' => 'not_started',
+            'status' => 'fulfilled',
+            'with_grant' => false,
+            'payment_event_status' => 'processed',
+        ]);
+
+        $record = app(OrderLinkageSupport::class)
+            ->query()
+            ->where('orders.order_no', $chain['order_no'])
+            ->first();
+
+        $this->assertNotNull($record);
+
+        $support = app(OrderLinkageSupport::class);
+        $this->assertSame('failed', $support->paymentStatus($record)['label']);
+        $this->assertSame('pending', $support->unlockStatus($record)['label']);
+        $this->assertSame('clear', $support->primaryException($record)['label']);
+    }
+}

--- a/backend/tests/Feature/Tenant/TenantOrderReadContractTest.php
+++ b/backend/tests/Feature/Tenant/TenantOrderReadContractTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenant;
+
+use App\Filament\Tenant\Resources\OrderResource;
+use App\Models\Order;
+use App\Models\TenantUser;
+use App\Support\OrgContext;
+use Filament\Infolists\Components\Component;
+use Filament\Infolists\Infolist;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use ReflectionMethod;
+use Tests\TestCase;
+
+final class TenantOrderReadContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tenant_orders_list_uses_payment_state_and_unlock_truth(): void
+    {
+        $tenant = $this->createTenantUserWithOrg();
+        $paidUnlocked = $this->insertOrder($tenant['org_id'], 'ord_tenant_paid_unlocked', 'fulfilled', 'paid');
+        $paidNoGrant = $this->insertOrder($tenant['org_id'], 'ord_tenant_paid_no_grant', 'fulfilled', 'paid');
+
+        $this->insertActiveGrant($tenant['org_id'], (string) $paidUnlocked->order_no);
+        $this->bootstrapTenantContext($tenant['org_id'], (int) $tenant['user']->id);
+
+        $records = OrderResource::getEloquentQuery()
+            ->whereIn('order_no', [(string) $paidUnlocked->order_no, (string) $paidNoGrant->order_no])
+            ->orderBy('order_no')
+            ->get()
+            ->keyBy('order_no');
+
+        $this->assertArrayHasKey((string) $paidUnlocked->order_no, $records->all());
+        $this->assertArrayHasKey((string) $paidNoGrant->order_no, $records->all());
+
+        $paymentStatus = $this->resourceMethod('paymentStatus');
+        $unlockStatus = $this->resourceMethod('unlockStatus');
+
+        $this->assertSame('paid', $paymentStatus->invoke(null, $records[$paidUnlocked->order_no])['label']);
+        $this->assertSame('unlocked', $unlockStatus->invoke(null, $records[$paidUnlocked->order_no])['label']);
+        $this->assertSame('paid', $paymentStatus->invoke(null, $records[$paidNoGrant->order_no])['label']);
+        $this->assertSame('paid_no_grant', $unlockStatus->invoke(null, $records[$paidNoGrant->order_no])['label']);
+    }
+
+    public function test_tenant_order_detail_shows_payment_grant_and_lifecycle_truths(): void
+    {
+        $tenant = $this->createTenantUserWithOrg();
+        $order = $this->insertOrder($tenant['org_id'], 'ord_tenant_detail_paid_no_grant', 'fulfilled', 'paid');
+        $this->bootstrapTenantContext($tenant['org_id'], (int) $tenant['user']->id);
+
+        $record = OrderResource::getEloquentQuery()
+            ->whereKey($order->getKey())
+            ->first();
+
+        $this->assertNotNull($record);
+
+        $infolist = OrderResource::infolist(Infolist::make()->record($record));
+        $componentNames = array_map(
+            static fn (Component $component): string => (string) $component->getName(),
+            array_values(array_filter(
+                $infolist->getFlatComponents(),
+                static fn ($component): bool => $component instanceof Component && method_exists($component, 'getName')
+            ))
+        );
+
+        $this->assertContains('payment_state', $componentNames);
+        $this->assertContains('latest_benefit_status', $componentNames);
+        $this->assertContains('unlock_status', $componentNames);
+        $this->assertContains('status', $componentNames);
+
+        $paymentStatus = $this->resourceMethod('paymentStatus');
+        $grantStatus = $this->resourceMethod('grantStatus');
+        $unlockStatus = $this->resourceMethod('unlockStatus');
+
+        $this->assertSame('paid', $paymentStatus->invoke(null, $record)['label']);
+        $this->assertSame('missing', $grantStatus->invoke(null, $record)['label']);
+        $this->assertSame('paid_no_grant', $unlockStatus->invoke(null, $record)['label']);
+        $this->assertSame('fulfilled', (string) ($record->status ?? ''));
+    }
+
+    public function test_tenant_payment_truth_does_not_fallback_from_lifecycle_status(): void
+    {
+        $tenant = $this->createTenantUserWithOrg();
+        $order = $this->insertOrder($tenant['org_id'], 'ord_tenant_fulfilled_failed_payment_state', 'fulfilled', 'failed');
+        $this->bootstrapTenantContext($tenant['org_id'], (int) $tenant['user']->id);
+
+        $record = OrderResource::getEloquentQuery()
+            ->whereKey($order->getKey())
+            ->first();
+
+        $this->assertNotNull($record);
+
+        $paymentStatus = $this->resourceMethod('paymentStatus');
+        $unlockStatus = $this->resourceMethod('unlockStatus');
+
+        $this->assertSame('failed', $paymentStatus->invoke(null, $record)['label']);
+        $this->assertSame('pending', $unlockStatus->invoke(null, $record)['label']);
+        $this->assertSame('fulfilled', (string) ($record->status ?? ''));
+    }
+
+    /**
+     * @return array{user:TenantUser,org_id:int}
+     */
+    private function createTenantUserWithOrg(): array
+    {
+        $user = TenantUser::query()->create([
+            'name' => 'Tenant Commerce User',
+            'email' => 'tenant-commerce-'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+        ]);
+
+        $orgId = (int) DB::table('organizations')->insertGetId([
+            'name' => 'Tenant Commerce Org',
+            'owner_user_id' => (int) $user->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => (int) $user->id,
+            'role' => 'owner',
+            'is_active' => 1,
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return ['user' => $user, 'org_id' => $orgId];
+    }
+
+    private function insertOrder(int $orgId, string $orderNo, string $status, ?string $paymentState): Order
+    {
+        $orderId = (string) Str::uuid();
+
+        DB::table('orders')->insert([
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => $orgId,
+            'user_id' => null,
+            'anon_id' => 'anon_'.$orderNo,
+            'sku' => 'MBTI_REPORT_FULL',
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'target_attempt_id' => null,
+            'amount_cents' => 299,
+            'amount_total' => 299,
+            'amount_refunded' => 0,
+            'currency' => 'CNY',
+            'status' => $status,
+            'payment_state' => $paymentState,
+            'grant_state' => 'not_started',
+            'provider' => 'billing',
+            'channel' => 'web',
+            'provider_app' => null,
+            'provider_order_id' => null,
+            'external_trade_no' => null,
+            'provider_trade_no' => null,
+            'paid_at' => now()->subMinutes(5),
+            'fulfilled_at' => strtolower($status) === 'fulfilled' ? now()->subMinutes(4) : null,
+            'refunded_at' => null,
+            'created_at' => now()->subHour(),
+            'updated_at' => now()->subMinutes(3),
+        ]);
+
+        return Order::query()->findOrFail($orderId);
+    }
+
+    private function insertActiveGrant(int $orgId, string $orderNo): void
+    {
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'user_id' => null,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'attempt',
+            'attempt_id' => null,
+            'status' => 'active',
+            'expires_at' => null,
+            'benefit_type' => 'report_unlock',
+            'benefit_ref' => 'grant_'.$orderNo,
+            'order_no' => $orderNo,
+            'source_order_id' => (string) Str::uuid(),
+            'source_event_id' => (string) Str::uuid(),
+            'meta_json' => null,
+            'created_at' => now()->subMinutes(4),
+            'updated_at' => now()->subMinutes(4),
+        ]);
+    }
+
+    private function resourceMethod(string $name): ReflectionMethod
+    {
+        $method = new ReflectionMethod(OrderResource::class, $name);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+
+    private function bootstrapTenantContext(int $orgId, int $userId): void
+    {
+        $context = app(OrgContext::class);
+        $context->set($orgId, $userId, 'owner', null, OrgContext::KIND_TENANT);
+        app()->instance(OrgContext::class, $context);
+    }
+}


### PR DESCRIPTION
## Summary
This PR unifies the paid-order read contract across Ops and Tenant/CMS so the backend UI no longer uses conflicting signals to decide whether an order was successfully paid.

The bug was entirely in the read layer. Ops was mixing `orders.payment_state` with `payment_events.status`, while Tenant/CMS was still reading `orders.status` as if it were payment truth. That made the same order appear paid in one backend surface and failed or incomplete in another, especially for cases like `payment_state=paid` with `payment_events.status=post_commit_failed`, or `status=fulfilled` with a non-paid payment state.

## Root cause
The repository had three competing read paths for "payment success":
- `orders.status` in Tenant/CMS
- `payment_events.status` in Ops `Payment status`
- `orders.payment_state` as the actual canonical payment truth

It also had helper logic that still tolerated lifecycle-based fallback semantics, which meant `fulfilled` could leak into payment-success interpretation even though the intended contract was already `orders.payment_state='paid'`.

## Fix
This PR changes only the read layer.

- Ops `Payment status` now reads `orders.payment_state`.
- Ops event diagnostics are explicitly renamed to `Webhook status` and kept separate from payment truth.
- Ops paid filters, unlock helpers, PDF readiness checks, and related read helpers now key off `orders.payment_state` and active benefit grants rather than lifecycle or webhook fallback.
- Tenant/CMS order list/detail now expose `Payment status`, `Grant status`, `Unlock status`, and `Lifecycle status` separately.
- Tenant/CMS no longer treats `orders.status` as payment-success truth.
- Added contract tests to prove:
  - paid orders remain paid even if webhook diagnostics failed post-commit
  - fulfilled orders do not display as paid unless `payment_state='paid'`
  - unlock truth comes from active `benefit_grants`

## Validation
Ran focused read-contract regression checks:
- `php artisan test --filter=OrderPaymentReadContractTest`
- `php artisan test --filter=TenantOrderReadContractTest`
- `php artisan test --filter=OrderCommerceLinkageTest`

## Scope boundary
This PR does not change:
- webhook processing
- order state transitions
- benefit grant writes
- compensation/reconciliation
- database schema
- public `/orders/*` API write path
