### PR TITLE
fix(payment-repair): close tenant post-commit replay gap

### DIFF
--- a/backend/app/Console/Commands/CommerceRepairPostCommitFailed.php
+++ b/backend/app/Console/Commands/CommerceRepairPostCommitFailed.php
@@ -41,12 +41,15 @@ final class CommerceRepairPostCommitFailed extends Command
         ];
 
         foreach ($events as $event) {
+            $effectiveOrgId = $this->resolveEffectiveOrgId($event, $orgId);
+
             $summary['results'][] = [
                 'payment_event_id' => (string) ($event->id ?? ''),
                 'provider_event_id' => (string) ($event->provider_event_id ?? ''),
                 'order_no' => (string) ($event->order_no ?? ''),
                 'status' => (string) ($event->status ?? ''),
                 'last_error_code' => (string) ($event->last_error_code ?? ''),
+                'effective_org_id' => $effectiveOrgId,
             ];
 
             if ($dryRun) {
@@ -55,15 +58,15 @@ final class CommerceRepairPostCommitFailed extends Command
 
             DB::table('payment_events')
                 ->where('id', (string) ($event->id ?? ''))
-                ->where('org_id', (int) ($event->org_id ?? $orgId))
                 ->update([
+                    'org_id' => $effectiveOrgId,
                     'handle_status' => 'queued',
                     'updated_at' => now(),
                 ]);
 
             ReprocessPaymentEventJob::dispatch(
                 (string) ($event->id ?? ''),
-                (int) ($event->org_id ?? $orgId),
+                $effectiveOrgId,
                 'scheduled_payment_repair',
                 (string) Str::uuid(),
             );
@@ -100,26 +103,40 @@ final class CommerceRepairPostCommitFailed extends Command
         ];
 
         return DB::table('payment_events')
-            ->where('org_id', $orgId)
-            ->where('updated_at', '<=', $cutoff)
-            ->where('attempts', '<', $maxAttempts)
+            ->leftJoin('orders', 'orders.order_no', '=', 'payment_events.order_no')
+            ->select('payment_events.*')
+            ->selectRaw('coalesce(nullif(payment_events.org_id, 0), orders.org_id, 0) as effective_org_id')
+            ->where(function ($orgScope) use ($orgId): void {
+                $orgScope
+                    ->where('payment_events.org_id', $orgId)
+                    ->orWhere(function ($scopedQuery) use ($orgId): void {
+                        $scopedQuery
+                            ->where(function ($orgQuery): void {
+                                $orgQuery->whereNull('payment_events.org_id')
+                                    ->orWhere('payment_events.org_id', 0);
+                            })
+                            ->where('orders.org_id', $orgId);
+                    });
+            })
+            ->where('payment_events.updated_at', '<=', $cutoff)
+            ->where('payment_events.attempts', '<', $maxAttempts)
             ->where(function ($statusQuery) use ($includeSemanticRejects, $semanticRejectCodes): void {
-                $statusQuery->where('status', 'post_commit_failed');
+                $statusQuery->where('payment_events.status', 'post_commit_failed');
 
                 if (! $includeSemanticRejects) {
                     return;
                 }
 
                 $statusQuery->orWhere(function ($semanticQuery) use ($semanticRejectCodes): void {
-                    $semanticQuery->whereIn('status', ['rejected', 'orphan'])
-                        ->whereIn('last_error_code', $semanticRejectCodes);
+                    $semanticQuery->whereIn('payment_events.status', ['rejected', 'orphan'])
+                        ->whereIn('payment_events.last_error_code', $semanticRejectCodes);
                 });
             })
             ->where(function ($queueQuery): void {
-                $queueQuery->whereNull('handle_status')
-                    ->orWhere('handle_status', '!=', 'queued');
+                $queueQuery->whereNull('payment_events.handle_status')
+                    ->orWhere('payment_events.handle_status', '!=', 'queued');
             })
-            ->orderBy('updated_at')
+            ->orderBy('payment_events.updated_at')
             ->limit($limit)
             ->get()
             ->all();
@@ -149,5 +166,20 @@ final class CommerceRepairPostCommitFailed extends Command
         }
 
         return in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function resolveEffectiveOrgId(object $event, int $fallbackOrgId): int
+    {
+        $effectiveOrgId = (int) ($event->effective_org_id ?? 0);
+        if ($effectiveOrgId > 0) {
+            return $effectiveOrgId;
+        }
+
+        $eventOrgId = (int) ($event->org_id ?? 0);
+        if ($eventOrgId > 0) {
+            return $eventOrgId;
+        }
+
+        return $fallbackOrgId;
     }
 }

--- a/backend/app/Jobs/Commerce/ReprocessPaymentEventJob.php
+++ b/backend/app/Jobs/Commerce/ReprocessPaymentEventJob.php
@@ -39,40 +39,32 @@ class ReprocessPaymentEventJob implements ShouldQueue
     {
         $event = DB::table('payment_events')
             ->where('id', $this->paymentEventId)
-            ->where('org_id', $this->orgId)
             ->first();
 
         if (! $event) {
             return;
         }
 
+        $effectiveOrgId = $this->resolveEffectiveOrgId($event);
+
         $provider = strtolower(trim((string) ($event->provider ?? '')));
         $payload = $this->decodePayload($event->payload_json ?? null);
         if ($provider === '' || $payload === []) {
-            $this->markFailed($event, 'INVALID_EVENT_PAYLOAD', 'provider/payload missing');
+            $this->markFailed($event, $effectiveOrgId, 'INVALID_EVENT_PAYLOAD', 'provider/payload missing');
 
             return;
         }
 
         $signatureOk = (bool) ($event->signature_ok ?? false);
         $originalStatus = strtolower(trim((string) ($event->status ?? '')));
-        $result = $processor->handle(
-            $provider,
-            $payload,
-            $this->orgId,
-            null,
-            null,
-            $signatureOk,
-            [],
-            (string) ($event->payload_sha256 ?? ''),
-            (int) ($event->payload_size_bytes ?? -1),
-        );
+        $result = $processor->process($provider, $payload, $signatureOk);
 
         if (($result['ok'] ?? false) === true) {
-            $repair = $this->repairOrderIfNeeded($event, $orderRepair);
+            $repair = $this->repairOrderIfNeeded($event, $orderRepair, $effectiveOrgId);
             if (($repair['ok'] ?? true) !== true) {
                 $this->markFailed(
                     $event,
+                    $effectiveOrgId,
                     (string) ($repair['error'] ?? 'ORDER_REPAIR_FAILED'),
                     (string) ($repair['message'] ?? 'order repair failed after payment-event reprocess.'),
                     $this->retryableStatus($originalStatus)
@@ -84,6 +76,7 @@ class ReprocessPaymentEventJob implements ShouldQueue
             DB::table('payment_events')
                 ->where('id', $this->paymentEventId)
                 ->update([
+                    'org_id' => $effectiveOrgId,
                     'status' => 'processed',
                     'handle_status' => ($result['duplicate'] ?? false) ? 'duplicate' : 'reprocessed',
                     'last_error_code' => null,
@@ -94,6 +87,7 @@ class ReprocessPaymentEventJob implements ShouldQueue
                 ]);
 
             $this->writeAudit(
+                orgId: $effectiveOrgId,
                 action: 'reprocess_payment_event_executed',
                 targetType: 'PaymentEvent',
                 targetId: (string) $event->id,
@@ -114,7 +108,7 @@ class ReprocessPaymentEventJob implements ShouldQueue
         $errorCode = (string) ($result['error_code'] ?? $result['error'] ?? 'REPROCESS_FAILED');
         $message = (string) ($result['message'] ?? 'reprocess failed.');
 
-        $this->markFailed($event, $errorCode, $message, $this->retryableStatus($originalStatus));
+        $this->markFailed($event, $effectiveOrgId, $errorCode, $message, $this->retryableStatus($originalStatus));
     }
 
     /**
@@ -136,11 +130,12 @@ class ReprocessPaymentEventJob implements ShouldQueue
         return [];
     }
 
-    private function markFailed(object $event, string $errorCode, string $message, ?string $preserveStatus = null): void
+    private function markFailed(object $event, int $orgId, string $errorCode, string $message, ?string $preserveStatus = null): void
     {
         DB::table('payment_events')
             ->where('id', (string) $event->id)
             ->update([
+                'org_id' => $orgId,
                 'status' => $preserveStatus ?? 'failed',
                 'handle_status' => 'reprocess_failed',
                 'last_error_code' => $errorCode,
@@ -150,6 +145,7 @@ class ReprocessPaymentEventJob implements ShouldQueue
             ]);
 
         $this->writeAudit(
+            orgId: $orgId,
             action: 'reprocess_payment_event_failed',
             targetType: 'PaymentEvent',
             targetId: (string) $event->id,
@@ -165,18 +161,18 @@ class ReprocessPaymentEventJob implements ShouldQueue
         );
     }
 
-    private function writeAudit(string $action, string $targetType, string $targetId, string $orderNo, array $meta): void
+    private function writeAudit(int $orgId, string $action, string $targetType, string $targetId, string $orderNo, array $meta): void
     {
         $reason = trim((string) ($meta['reason'] ?? 'reprocess_payment_event'));
         DB::table('audit_logs')->insert([
-            'org_id' => $this->orgId,
+            'org_id' => $orgId,
             'actor_admin_id' => null,
             'action' => $action,
             'target_type' => $targetType,
             'target_id' => $targetId,
             'meta_json' => json_encode(array_merge([
                 'actor' => 'system',
-                'org_id' => $this->orgId,
+                'org_id' => $orgId,
                 'order_no' => $orderNo,
                 'correlation_id' => $this->correlationId,
             ], $meta), JSON_UNESCAPED_UNICODE),
@@ -192,7 +188,7 @@ class ReprocessPaymentEventJob implements ShouldQueue
     /**
      * @return array<string,mixed>
      */
-    private function repairOrderIfNeeded(object $event, OrderRepairService $orderRepair): array
+    private function repairOrderIfNeeded(object $event, OrderRepairService $orderRepair, int $orgId): array
     {
         $orderNo = trim((string) ($event->order_no ?? ''));
         if ($orderNo === '') {
@@ -200,7 +196,7 @@ class ReprocessPaymentEventJob implements ShouldQueue
         }
 
         $order = DB::table('orders')
-            ->where('org_id', $this->orgId)
+            ->where('org_id', $orgId)
             ->where('order_no', $orderNo)
             ->first();
 
@@ -218,6 +214,27 @@ class ReprocessPaymentEventJob implements ShouldQueue
             'correlation_id' => $this->correlationId,
             'payment_event_id' => (string) ($event->id ?? ''),
         ]);
+    }
+
+    private function resolveEffectiveOrgId(object $event): int
+    {
+        $orderNo = trim((string) ($event->order_no ?? ''));
+        if ($orderNo !== '') {
+            $resolvedOrgId = DB::table('orders')
+                ->where('order_no', $orderNo)
+                ->value('org_id');
+
+            if ($resolvedOrgId !== null && (int) $resolvedOrgId > 0) {
+                return (int) $resolvedOrgId;
+            }
+        }
+
+        $eventOrgId = (int) ($event->org_id ?? 0);
+        if ($eventOrgId > 0) {
+            return $eventOrgId;
+        }
+
+        return $this->orgId;
     }
 
     private function retryableStatus(string $status): ?string

--- a/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
@@ -117,6 +117,7 @@ class WebhookEntitlementService
                 ) {
                     $insertSeed = [
                         'id' => (string) Str::uuid(),
+                        'org_id' => $orgId,
                         'provider' => $provider,
                         'provider_event_id' => $providerEventId,
                         'order_id' => (string) Str::uuid(),
@@ -172,6 +173,7 @@ class WebhookEntitlementService
                     $attempts = $attempts > 0 ? $attempts + 1 : 1;
 
                     $baseRow = [
+                        'org_id' => $orgId,
                         'provider' => $provider,
                         'provider_event_id' => $providerEventId,
                         'order_id' => $eventRow->order_id ?? ($insertSeed['order_id'] ?? (string) Str::uuid()),
@@ -250,6 +252,7 @@ class WebhookEntitlementService
                     $orderMeta = $this->core->resolveOrderMeta($orgId, $orderNo, $order);
                     $normalizedSkuMeta = $this->core->normalizeOrderSkuMeta($order);
                     $this->core->updatePaymentEvent($provider, $providerEventId, [
+                        'org_id' => (int) ($order->org_id ?? $orgId),
                         'order_id' => $order->id ?? null,
                         'event_type' => $eventType,
                         'signature_ok' => $signatureOk,

--- a/backend/tests/Feature/Commerce/PostCommitFailedRepairOpsTenantVisibilityAcceptanceTest.php
+++ b/backend/tests/Feature/Commerce/PostCommitFailedRepairOpsTenantVisibilityAcceptanceTest.php
@@ -1,0 +1,409 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Filament\Ops\Resources\OrderResource\Pages\ListOrders as OpsListOrders;
+use App\Filament\Ops\Resources\OrderResource\Support\OrderLinkageSupport;
+use App\Filament\Tenant\Resources\OrderResource as TenantOrderResource;
+use App\Models\Attempt;
+use App\Models\Order;
+use App\Models\Result;
+use App\Models\TenantUser;
+use App\Services\Report\ReportSnapshotStore;
+use App\Support\Rbac\PermissionNames;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Filament\Facades\Filament;
+use Filament\Infolists\Components\Component;
+use Filament\Infolists\Infolist;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Mockery;
+use ReflectionMethod;
+use Tests\Concerns\SignedBillingWebhook;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class PostCommitFailedRepairOpsTenantVisibilityAcceptanceTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+    use SignedBillingWebhook;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_post_commit_failed_repair_converges_consistently_in_lookup_ops_and_tenant(): void
+    {
+        $this->seedCommerceCatalog();
+
+        $tenant = $this->createTenantOrgUserToken();
+        $this->grantScaleForOrg($tenant['org_id'], 'MBTI');
+
+        $attemptId = $this->createMbtiAttemptWithResult(
+            orgId: $tenant['org_id'],
+            userId: (string) $tenant['user_id'],
+            anonId: $tenant['anon_id'],
+        );
+
+        config([
+            'payments.providers.billing.enabled' => true,
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        $realSnapshotStore = app(ReportSnapshotStore::class);
+        $snapshotStore = Mockery::mock(ReportSnapshotStore::class)->makePartial();
+        $seedCalls = 0;
+        $snapshotStore->shouldReceive('seedPendingSnapshot')
+            ->twice()
+            ->andReturnUsing(function (int $orgId, string $attemptIdArg, ?string $orderNoArg, array $meta) use (&$seedCalls, $realSnapshotStore): void {
+                $seedCalls++;
+                if ($seedCalls === 1) {
+                    throw new \RuntimeException('simulated_post_commit_failure');
+                }
+
+                $realSnapshotStore->seedPendingSnapshot($orgId, $attemptIdArg, $orderNoArg, $meta);
+            });
+        $this->app->instance(ReportSnapshotStore::class, $snapshotStore);
+
+        $checkout = $this->withHeaders([
+            'Authorization' => 'Bearer '.$tenant['token'],
+            'X-Org-Id' => (string) $tenant['org_id'],
+        ])->postJson('/api/v0.3/orders/checkout', [
+            'attempt_id' => $attemptId,
+            'sku' => 'MBTI_REPORT_FULL',
+            'provider' => 'billing',
+            'email' => $tenant['email'],
+        ]);
+
+        $checkout->assertOk();
+        $checkout->assertJsonPath('ok', true);
+        $checkout->assertJsonPath('attempt_id', $attemptId);
+        $checkout->assertJsonPath('status', 'pending');
+        $checkout->assertJsonPath('payment_state', 'pending');
+        $checkout->assertJsonPath('grant_state', 'not_started');
+
+        $orderNo = (string) $checkout->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        $createdOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($createdOrder);
+        $this->assertSame($tenant['org_id'], (int) ($createdOrder->org_id ?? 0));
+
+        $providerEventId = 'evt_post_commit_'.$orderNo;
+        $webhook = $this->postSignedBillingWebhook([
+            'provider_event_id' => $providerEventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_post_commit_'.$orderNo,
+            'amount_cents' => (int) ($createdOrder->amount_cents ?? 0),
+            'currency' => (string) ($createdOrder->currency ?? 'CNY'),
+        ]);
+
+        $webhook->assertStatus(500);
+        $webhook->assertJsonPath('ok', false);
+
+        $failedOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $failedEvent = DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', $providerEventId)
+            ->first();
+
+        $this->assertNotNull($failedOrder);
+        $this->assertNotNull($failedEvent);
+        $this->assertSame('paid', (string) ($failedOrder->payment_state ?? ''));
+        $this->assertSame('granted', (string) ($failedOrder->grant_state ?? ''));
+        $this->assertSame('fulfilled', (string) ($failedOrder->status ?? ''));
+        $this->assertSame($tenant['org_id'], (int) ($failedEvent->org_id ?? 0));
+        $this->assertSame('post_commit_failed', (string) ($failedEvent->status ?? ''));
+        $this->assertSame(
+            1,
+            DB::table('benefit_grants')
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+        $this->assertSame(
+            0,
+            DB::table('report_snapshots')
+                ->where('attempt_id', $attemptId)
+                ->count()
+        );
+
+        $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+            '--org_id' => $tenant['org_id'],
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+            '--json' => 1,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $repairedOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $repairedEvent = DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', $providerEventId)
+            ->first();
+
+        $this->assertNotNull($repairedOrder);
+        $this->assertNotNull($repairedEvent);
+        $this->assertSame('paid', (string) ($repairedOrder->payment_state ?? ''));
+        $this->assertSame('granted', (string) ($repairedOrder->grant_state ?? ''));
+        $this->assertSame('fulfilled', (string) ($repairedOrder->status ?? ''));
+        $this->assertSame($tenant['org_id'], (int) ($repairedEvent->org_id ?? 0));
+        $this->assertSame('processed', (string) ($repairedEvent->status ?? ''));
+        $this->assertSame('reprocessed', (string) ($repairedEvent->handle_status ?? ''));
+        $this->assertSame(
+            1,
+            DB::table('benefit_grants')
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+        $this->assertSame(
+            1,
+            DB::table('report_snapshots')
+                ->where('attempt_id', $attemptId)
+                ->count()
+        );
+
+        $lookup = $this->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => $tenant['email'],
+        ]);
+
+        $lookup->assertOk();
+        $lookup->assertJsonPath('ok', true);
+        $lookup->assertJsonPath('order_no', $orderNo);
+        $lookup->assertJsonPath('attempt_id', $attemptId);
+        $lookup->assertJsonPath('status', 'paid');
+        $lookup->assertJsonPath('payment_state', 'paid');
+        $lookup->assertJsonPath('grant_state', 'granted');
+        $lookup->assertJsonPath('latest_payment_attempt.state', 'paid');
+
+        $opsRecord = app(OrderLinkageSupport::class)
+            ->query()
+            ->where('orders.order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($opsRecord);
+
+        $opsSupport = app(OrderLinkageSupport::class);
+        $opsPayment = $opsSupport->paymentStatus($opsRecord);
+        $opsUnlock = $opsSupport->unlockStatus($opsRecord);
+        $opsWebhook = $opsSupport->webhookStatus($opsRecord);
+
+        $this->assertSame('paid', $opsPayment['label']);
+        $this->assertSame('unlocked', $opsUnlock['label']);
+        $this->assertSame('processed', $opsWebhook['label']);
+        $this->assertSame('fulfilled', strtolower(trim((string) ($opsRecord->status ?? ''))));
+        $this->assertNotSame($opsPayment['label'], $opsWebhook['label']);
+
+        $opsOrder = Order::query()->where('order_no', $orderNo)->firstOrFail();
+        $opsAdmin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Post Commit Repair Ops Org');
+
+        session($this->opsSession($opsAdmin, $selectedOrg));
+        $this->actingAs($opsAdmin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(OpsListOrders::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$opsOrder])
+            ->assertTableColumnExists('payment_state')
+            ->assertTableColumnExists('latest_payment_status')
+            ->assertTableColumnExists('unlock_status');
+
+        $this->bootstrapTenantContext($tenant['org_id'], $tenant['user_id']);
+        $this->actingAs(TenantUser::query()->findOrFail($tenant['user_id']), (string) config('tenant.guard', 'tenant'));
+        request()->attributes->set('org_id', $tenant['org_id']);
+        request()->attributes->set('fm_org_id', $tenant['org_id']);
+        request()->attributes->set('org_context_resolved', true);
+        request()->attributes->set('org_context_kind', \App\Support\OrgContext::KIND_TENANT);
+
+        $tenantRecord = TenantOrderResource::getEloquentQuery()
+            ->where('order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($tenantRecord);
+
+        $tenantPayment = $this->tenantResourceMethod('paymentStatus');
+        $tenantGrant = $this->tenantResourceMethod('grantStatus');
+        $tenantUnlock = $this->tenantResourceMethod('unlockStatus');
+
+        $this->assertSame('paid', $tenantPayment->invoke(null, $tenantRecord)['label']);
+        $this->assertSame('active', $tenantGrant->invoke(null, $tenantRecord)['label']);
+        $this->assertSame('unlocked', $tenantUnlock->invoke(null, $tenantRecord)['label']);
+        $this->assertSame('fulfilled', (string) ($tenantRecord->status ?? ''));
+
+        $infolist = TenantOrderResource::infolist(Infolist::make()->record($tenantRecord));
+        $componentNames = array_map(
+            static fn (Component $component): string => (string) $component->getName(),
+            array_values(array_filter(
+                $infolist->getFlatComponents(),
+                static fn ($component): bool => $component instanceof Component && method_exists($component, 'getName')
+            ))
+        );
+
+        $this->assertContains('payment_state', $componentNames);
+        $this->assertContains('latest_benefit_status', $componentNames);
+        $this->assertContains('unlock_status', $componentNames);
+        $this->assertContains('status', $componentNames);
+    }
+
+    private function seedCommerceCatalog(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
+    }
+
+    /**
+     * @return array{org_id:int,user_id:int,token:string,anon_id:string,email:string}
+     */
+    private function createTenantOrgUserToken(): array
+    {
+        $userId = (int) DB::table('users')->insertGetId([
+            'name' => 'Post Commit Tenant User',
+            'email' => 'post-commit-repair-tenant@example.com',
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $orgId = (int) DB::table('organizations')->insertGetId([
+            'name' => 'Post Commit Tenant Org',
+            'owner_user_id' => $userId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => 'owner',
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $anonId = 'anon_post_commit_'.$userId;
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'org_id' => $orgId,
+            'role' => 'owner',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return [
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'token' => $token,
+            'anon_id' => $anonId,
+            'email' => 'post-commit-repair-tenant@example.com',
+        ];
+    }
+
+    private function createMbtiAttemptWithResult(int $orgId, string $userId, string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $packId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+
+        Attempt::query()->create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(10),
+            'submitted_at' => now()->subMinutes(9),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::query()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function tenantResourceMethod(string $name): ReflectionMethod
+    {
+        $method = new ReflectionMethod(TenantOrderResource::class, $name);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+
+    private function bootstrapTenantContext(int $orgId, int $userId): void
+    {
+        $context = app(\App\Support\OrgContext::class);
+        $context->set($orgId, $userId, 'owner', null, \App\Support\OrgContext::KIND_TENANT);
+        app()->instance(\App\Support\OrgContext::class, $context);
+    }
+}


### PR DESCRIPTION
## Summary
- write the real org_id onto payment_events during webhook handling for tenant orders
- resolve the effective org for post-commit repair candidate selection and reprocess execution
- add a post_commit_failed -> repair -> lookup/ops/tenant visibility acceptance test

## Tests
- ./vendor/bin/pint app/Services/Commerce/Webhook/WebhookEntitlementService.php app/Console/Commands/CommerceRepairPostCommitFailed.php app/Jobs/Commerce/ReprocessPaymentEventJob.php tests/Feature/Commerce/PostCommitFailedRepairOpsTenantVisibilityAcceptanceTest.php
- php artisan test tests/Feature/Commerce/PostCommitFailedRepairOpsTenantVisibilityAcceptanceTest.php
- php artisan test --filter=\PaymentRepairEngineTest|CheckoutWebhookOpsTenantVisibilityAcceptanceTest|OrderPaymentReadContractTest|TenantOrderReadContractTest|OrderCommerceLinkageTest'