### PR TITLE
test(payment-ops): add paid_no_grant repair visibility acceptance

### DIFF
--- a/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
@@ -1198,7 +1198,7 @@ final class OrderLinkageSupport
 
     private function benefitField(string $column): QueryBuilder
     {
-        return DB::table('benefit_grants')
+        $query = DB::table('benefit_grants')
             ->select($column)
             ->where(function (QueryBuilder $builder): void {
                 $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
@@ -1207,11 +1207,15 @@ final class OrderLinkageSupport
             ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
             ->orderByRaw('coalesce(updated_at, created_at) desc')
             ->limit(1);
+
+        $this->applyExpectedBenefitFilter($query);
+
+        return $query;
     }
 
     private function activeBenefitExistsField(): QueryBuilder
     {
-        return DB::table('benefit_grants')
+        $query = DB::table('benefit_grants')
             ->selectRaw('1')
             ->where('benefit_grants.status', 'active')
             ->where(function (QueryBuilder $builder): void {
@@ -1219,6 +1223,43 @@ final class OrderLinkageSupport
                     ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
             })
             ->limit(1);
+
+        $this->applyExpectedBenefitFilter($query);
+
+        return $query;
+    }
+
+    private function expectedBenefitCodeField(): ?QueryBuilder
+    {
+        if (! SchemaBaseline::hasTable('skus')) {
+            return null;
+        }
+
+        return DB::table('skus')
+            ->selectRaw('upper(coalesce(benefit_code, \'\'))')
+            ->where('is_active', true)
+            ->whereRaw("upper(coalesce(skus.sku, '')) = upper(coalesce(nullif(orders.item_sku, ''), orders.sku, ''))")
+            ->limit(1);
+    }
+
+    private function applyExpectedBenefitFilter(QueryBuilder $query): void
+    {
+        $expectedA = $this->expectedBenefitCodeField();
+        $expectedB = $this->expectedBenefitCodeField();
+
+        if ($expectedA === null || $expectedB === null) {
+            return;
+        }
+
+        $query->where(function (QueryBuilder $builder) use ($expectedA, $expectedB): void {
+            $builder->whereRaw(
+                'coalesce(('.$expectedA->toSql()."), '') = ''",
+                $expectedA->getBindings()
+            )->orWhereRaw(
+                "upper(coalesce(benefit_grants.benefit_code, '')) = (".$expectedB->toSql().')',
+                $expectedB->getBindings()
+            );
+        });
     }
 
     private function snapshotField(string $column): QueryBuilder

--- a/backend/app/Filament/Tenant/Resources/OrderResource.php
+++ b/backend/app/Filament/Tenant/Resources/OrderResource.php
@@ -7,10 +7,10 @@ namespace App\Filament\Tenant\Resources;
 use App\Filament\Shared\BaseTenantResource;
 use App\Filament\Tenant\Resources\OrderResource\Pages;
 use App\Models\Order;
+use Filament\Forms\Form;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
-use Filament\Forms\Form;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -124,21 +124,29 @@ class OrderResource extends BaseTenantResource
 
     private static function latestBenefitStatusField(): QueryBuilder
     {
-        return DB::table('benefit_grants')
+        $query = DB::table('benefit_grants')
             ->select('status')
             ->whereColumn('benefit_grants.order_no', 'orders.order_no')
             ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
             ->orderByRaw('coalesce(updated_at, created_at) desc')
             ->limit(1);
+
+        self::applyExpectedBenefitFilter($query);
+
+        return $query;
     }
 
     private static function activeBenefitExistsField(): QueryBuilder
     {
-        return DB::table('benefit_grants')
+        $query = DB::table('benefit_grants')
             ->selectRaw('1')
             ->whereColumn('benefit_grants.order_no', 'orders.order_no')
             ->where('benefit_grants.status', 'active')
             ->limit(1);
+
+        self::applyExpectedBenefitFilter($query);
+
+        return $query;
     }
 
     /**
@@ -206,6 +214,39 @@ class OrderResource extends BaseTenantResource
             Order::PAYMENT_STATE_EXPIRED,
             Order::PAYMENT_STATE_REFUNDED,
         ], true) ? $state : '';
+    }
+
+    private static function expectedBenefitCodeField(): ?QueryBuilder
+    {
+        if (! Schema::hasTable('skus')) {
+            return null;
+        }
+
+        return DB::table('skus')
+            ->selectRaw('upper(coalesce(benefit_code, \'\'))')
+            ->where('is_active', true)
+            ->whereRaw("upper(coalesce(skus.sku, '')) = upper(coalesce(nullif(orders.item_sku, ''), orders.sku, ''))")
+            ->limit(1);
+    }
+
+    private static function applyExpectedBenefitFilter(QueryBuilder $query): void
+    {
+        $expectedA = self::expectedBenefitCodeField();
+        $expectedB = self::expectedBenefitCodeField();
+
+        if ($expectedA === null || $expectedB === null) {
+            return;
+        }
+
+        $query->where(function (QueryBuilder $builder) use ($expectedA, $expectedB): void {
+            $builder->whereRaw(
+                'coalesce(('.$expectedA->toSql()."), '') = ''",
+                $expectedA->getBindings()
+            )->orWhereRaw(
+                "upper(coalesce(benefit_grants.benefit_code, '')) = (".$expectedB->toSql().')',
+                $expectedB->getBindings()
+            );
+        });
     }
 
     private static function statusColor(string $status): string

--- a/backend/tests/Feature/Commerce/PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest.php
+++ b/backend/tests/Feature/Commerce/PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest.php
@@ -146,6 +146,13 @@ final class PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest extends TestCase
         ]);
         $this->assertSame(0, $exitCode);
 
+        $secondExitCode = Artisan::call('commerce:repair-paid-orders', [
+            '--org_id' => $tenant['org_id'],
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+        ]);
+        $this->assertSame(0, $secondExitCode);
+
         $repairedOrder = DB::table('orders')->where('order_no', $orderNo)->first();
         $this->assertNotNull($repairedOrder);
         $this->assertSame('paid', (string) ($repairedOrder->payment_state ?? ''));
@@ -166,6 +173,15 @@ final class PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest extends TestCase
             'benefit_code' => 'MBTI_REPORT_FULL',
             'status' => 'active',
         ]);
+        $this->assertSame(
+            1,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('benefit_code', 'MBTI_REPORT_FULL')
+                ->where('status', 'active')
+                ->count()
+        );
 
         $lookup = $this->postJson('/api/v0.3/orders/lookup', [
             'order_no' => $orderNo,
@@ -244,6 +260,124 @@ final class PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest extends TestCase
         $this->assertContains('latest_benefit_status', $componentNames);
         $this->assertContains('unlock_status', $componentNames);
         $this->assertContains('status', $componentNames);
+    }
+
+    public function test_paid_no_grant_visibility_ignores_unrelated_active_grant_until_correct_benefit_is_repaired(): void
+    {
+        $this->seedCommerceCatalog();
+
+        $tenant = $this->createTenantOrgUserToken();
+        $this->grantScaleForOrg($tenant['org_id'], 'MBTI');
+
+        $attemptId = $this->createMbtiAttemptWithResult(
+            orgId: $tenant['org_id'],
+            userId: (string) $tenant['user_id'],
+            anonId: $tenant['anon_id'],
+        );
+
+        config([
+            'payments.providers.billing.enabled' => true,
+        ]);
+
+        $checkout = $this->withHeaders([
+            'Authorization' => 'Bearer '.$tenant['token'],
+            'X-Org-Id' => (string) $tenant['org_id'],
+        ])->postJson('/api/v0.3/orders/checkout', [
+            'attempt_id' => $attemptId,
+            'sku' => 'MBTI_REPORT_FULL',
+            'provider' => 'billing',
+            'email' => $tenant['email'],
+        ]);
+
+        $checkout->assertOk();
+
+        $orderNo = (string) $checkout->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        $this->promoteOrderToPaidNoGrant($tenant['org_id'], $orderNo);
+        $this->insertActiveGrant(
+            orgId: $tenant['org_id'],
+            attemptId: $attemptId,
+            orderNo: $orderNo,
+            benefitCode: 'OTHER_BENEFIT',
+            benefitRef: 'wrong_'.$orderNo,
+        );
+
+        $opsRecord = app(OrderLinkageSupport::class)
+            ->query()
+            ->where('orders.order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($opsRecord);
+
+        $opsSupport = app(OrderLinkageSupport::class);
+        $this->assertSame('paid', $opsSupport->paymentStatus($opsRecord)['label']);
+        $this->assertSame('paid_no_grant', $opsSupport->unlockStatus($opsRecord)['label']);
+        $this->assertSame('missing', $opsSupport->webhookStatus($opsRecord)['label']);
+
+        $this->bootstrapTenantContext($tenant['org_id'], $tenant['user_id']);
+        $this->actingAs(TenantUser::query()->findOrFail($tenant['user_id']), (string) config('tenant.guard', 'tenant'));
+        request()->attributes->set('org_id', $tenant['org_id']);
+        request()->attributes->set('fm_org_id', $tenant['org_id']);
+        request()->attributes->set('org_context_resolved', true);
+        request()->attributes->set('org_context_kind', \App\Support\OrgContext::KIND_TENANT);
+
+        $tenantRecord = TenantOrderResource::getEloquentQuery()
+            ->where('order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($tenantRecord);
+
+        $tenantPayment = $this->tenantResourceMethod('paymentStatus');
+        $tenantGrant = $this->tenantResourceMethod('grantStatus');
+        $tenantUnlock = $this->tenantResourceMethod('unlockStatus');
+
+        $this->assertSame('paid', $tenantPayment->invoke(null, $tenantRecord)['label']);
+        $this->assertSame('missing', $tenantGrant->invoke(null, $tenantRecord)['label']);
+        $this->assertSame('paid_no_grant', $tenantUnlock->invoke(null, $tenantRecord)['label']);
+
+        $exitCode = Artisan::call('commerce:repair-paid-orders', [
+            '--org_id' => $tenant['org_id'],
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $this->assertSame(
+            2,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+        $this->assertSame(
+            1,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('benefit_code', 'MBTI_REPORT_FULL')
+                ->where('status', 'active')
+                ->count()
+        );
+
+        $repairedOpsRecord = app(OrderLinkageSupport::class)
+            ->query()
+            ->where('orders.order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($repairedOpsRecord);
+        $this->assertSame('paid', $opsSupport->paymentStatus($repairedOpsRecord)['label']);
+        $this->assertSame('unlocked', $opsSupport->unlockStatus($repairedOpsRecord)['label']);
+
+        $repairedTenantRecord = TenantOrderResource::getEloquentQuery()
+            ->where('order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($repairedTenantRecord);
+        $this->assertSame('paid', $tenantPayment->invoke(null, $repairedTenantRecord)['label']);
+        $this->assertSame('active', $tenantGrant->invoke(null, $repairedTenantRecord)['label']);
+        $this->assertSame('unlocked', $tenantUnlock->invoke(null, $repairedTenantRecord)['label']);
     }
 
     private function seedCommerceCatalog(): void
@@ -396,6 +530,33 @@ final class PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest extends TestCase
                 'finalized_at' => $timestamp,
                 'updated_at' => $timestamp,
             ]);
+    }
+
+    private function insertActiveGrant(
+        int $orgId,
+        string $attemptId,
+        string $orderNo,
+        string $benefitCode,
+        string $benefitRef
+    ): void {
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'user_id' => null,
+            'benefit_code' => $benefitCode,
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'status' => 'active',
+            'benefit_type' => 'report_unlock',
+            'benefit_ref' => $benefitRef,
+            'order_no' => $orderNo,
+            'source_order_id' => (string) Str::uuid(),
+            'source_event_id' => null,
+            'expires_at' => null,
+            'meta_json' => null,
+            'created_at' => now()->subMinutes(9),
+            'updated_at' => now()->subMinutes(9),
+        ]);
     }
 
     private function tenantResourceMethod(string $name): ReflectionMethod

--- a/backend/tests/Feature/Commerce/PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest.php
+++ b/backend/tests/Feature/Commerce/PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest.php
@@ -1,0 +1,415 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Filament\Ops\Resources\OrderResource\Pages\ListOrders as OpsListOrders;
+use App\Filament\Ops\Resources\OrderResource\Support\OrderLinkageSupport;
+use App\Filament\Tenant\Resources\OrderResource as TenantOrderResource;
+use App\Models\Attempt;
+use App\Models\Order;
+use App\Models\Result;
+use App\Models\TenantUser;
+use App\Support\Rbac\PermissionNames;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Filament\Facades\Filament;
+use Filament\Infolists\Components\Component;
+use Filament\Infolists\Infolist;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use ReflectionMethod;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_paid_no_grant_repair_converges_consistently_in_lookup_ops_and_tenant(): void
+    {
+        $this->seedCommerceCatalog();
+
+        $tenant = $this->createTenantOrgUserToken();
+        $this->grantScaleForOrg($tenant['org_id'], 'MBTI');
+
+        $attemptId = $this->createMbtiAttemptWithResult(
+            orgId: $tenant['org_id'],
+            userId: (string) $tenant['user_id'],
+            anonId: $tenant['anon_id'],
+        );
+
+        config([
+            'payments.providers.billing.enabled' => true,
+        ]);
+
+        $checkout = $this->withHeaders([
+            'Authorization' => 'Bearer '.$tenant['token'],
+            'X-Org-Id' => (string) $tenant['org_id'],
+        ])->postJson('/api/v0.3/orders/checkout', [
+            'attempt_id' => $attemptId,
+            'sku' => 'MBTI_REPORT_FULL',
+            'provider' => 'billing',
+            'email' => $tenant['email'],
+        ]);
+
+        $checkout->assertOk();
+        $checkout->assertJsonPath('ok', true);
+        $checkout->assertJsonPath('attempt_id', $attemptId);
+        $checkout->assertJsonPath('status', 'pending');
+        $checkout->assertJsonPath('payment_state', 'pending');
+        $checkout->assertJsonPath('grant_state', 'not_started');
+
+        $orderNo = (string) $checkout->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        $this->promoteOrderToPaidNoGrant($tenant['org_id'], $orderNo);
+
+        $preRepairOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($preRepairOrder);
+        $this->assertSame($tenant['org_id'], (int) ($preRepairOrder->org_id ?? 0));
+        $this->assertSame('paid', (string) ($preRepairOrder->payment_state ?? ''));
+        $this->assertSame('not_started', (string) ($preRepairOrder->grant_state ?? ''));
+        $this->assertSame('paid', (string) ($preRepairOrder->status ?? ''));
+        $this->assertSame(
+            0,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+        $this->assertSame(
+            0,
+            DB::table('payment_events')
+                ->where('order_no', $orderNo)
+                ->count()
+        );
+
+        $preRepairOpsRecord = app(OrderLinkageSupport::class)
+            ->query()
+            ->where('orders.order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($preRepairOpsRecord);
+
+        $opsSupport = app(OrderLinkageSupport::class);
+        $preRepairOpsPayment = $opsSupport->paymentStatus($preRepairOpsRecord);
+        $preRepairOpsUnlock = $opsSupport->unlockStatus($preRepairOpsRecord);
+        $preRepairOpsWebhook = $opsSupport->webhookStatus($preRepairOpsRecord);
+
+        $this->assertSame('paid', $preRepairOpsPayment['label']);
+        $this->assertSame('paid_no_grant', $preRepairOpsUnlock['label']);
+        $this->assertSame('missing', $preRepairOpsWebhook['label']);
+        $this->assertNotSame($preRepairOpsPayment['label'], $preRepairOpsWebhook['label']);
+
+        $this->bootstrapTenantContext($tenant['org_id'], $tenant['user_id']);
+        $this->actingAs(TenantUser::query()->findOrFail($tenant['user_id']), (string) config('tenant.guard', 'tenant'));
+        request()->attributes->set('org_id', $tenant['org_id']);
+        request()->attributes->set('fm_org_id', $tenant['org_id']);
+        request()->attributes->set('org_context_resolved', true);
+        request()->attributes->set('org_context_kind', \App\Support\OrgContext::KIND_TENANT);
+
+        $preRepairTenantRecord = TenantOrderResource::getEloquentQuery()
+            ->where('order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($preRepairTenantRecord);
+
+        $tenantPayment = $this->tenantResourceMethod('paymentStatus');
+        $tenantGrant = $this->tenantResourceMethod('grantStatus');
+        $tenantUnlock = $this->tenantResourceMethod('unlockStatus');
+
+        $this->assertSame('paid', $tenantPayment->invoke(null, $preRepairTenantRecord)['label']);
+        $this->assertNotSame('active', $tenantGrant->invoke(null, $preRepairTenantRecord)['label']);
+        $this->assertSame('missing', $tenantGrant->invoke(null, $preRepairTenantRecord)['label']);
+        $this->assertSame('paid_no_grant', $tenantUnlock->invoke(null, $preRepairTenantRecord)['label']);
+        $this->assertSame('paid', (string) ($preRepairTenantRecord->status ?? ''));
+
+        $exitCode = Artisan::call('commerce:repair-paid-orders', [
+            '--org_id' => $tenant['org_id'],
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $repairedOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($repairedOrder);
+        $this->assertSame('paid', (string) ($repairedOrder->payment_state ?? ''));
+        $this->assertSame('granted', (string) ($repairedOrder->grant_state ?? ''));
+        $this->assertSame('fulfilled', (string) ($repairedOrder->status ?? ''));
+        $this->assertSame(
+            1,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+        $this->assertDatabaseHas('benefit_grants', [
+            'org_id' => $tenant['org_id'],
+            'order_no' => $orderNo,
+            'attempt_id' => $attemptId,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'status' => 'active',
+        ]);
+
+        $lookup = $this->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => $tenant['email'],
+        ]);
+
+        $lookup->assertOk();
+        $lookup->assertJsonPath('ok', true);
+        $lookup->assertJsonPath('order_no', $orderNo);
+        $lookup->assertJsonPath('attempt_id', $attemptId);
+        $lookup->assertJsonPath('status', 'paid');
+        $lookup->assertJsonPath('payment_state', 'paid');
+        $lookup->assertJsonPath('grant_state', 'granted');
+
+        $repairedOpsRecord = app(OrderLinkageSupport::class)
+            ->query()
+            ->where('orders.order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($repairedOpsRecord);
+
+        $repairedOpsPayment = $opsSupport->paymentStatus($repairedOpsRecord);
+        $repairedOpsUnlock = $opsSupport->unlockStatus($repairedOpsRecord);
+        $repairedOpsWebhook = $opsSupport->webhookStatus($repairedOpsRecord);
+
+        $this->assertSame('paid', $repairedOpsPayment['label']);
+        $this->assertSame('unlocked', $repairedOpsUnlock['label']);
+        $this->assertSame('missing', $repairedOpsWebhook['label']);
+        $this->assertSame('fulfilled', strtolower(trim((string) ($repairedOpsRecord->status ?? ''))));
+        $this->assertNotSame($repairedOpsPayment['label'], $repairedOpsWebhook['label']);
+
+        $opsOrder = Order::query()->where('order_no', $orderNo)->firstOrFail();
+        $opsAdmin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Paid No Grant Acceptance Ops Org');
+
+        session($this->opsSession($opsAdmin, $selectedOrg));
+        $this->actingAs($opsAdmin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(OpsListOrders::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$opsOrder])
+            ->assertTableColumnExists('payment_state')
+            ->assertTableColumnExists('latest_payment_status')
+            ->assertTableColumnExists('unlock_status');
+
+        $this->bootstrapTenantContext($tenant['org_id'], $tenant['user_id']);
+        $this->actingAs(TenantUser::query()->findOrFail($tenant['user_id']), (string) config('tenant.guard', 'tenant'));
+        request()->attributes->set('org_id', $tenant['org_id']);
+        request()->attributes->set('fm_org_id', $tenant['org_id']);
+        request()->attributes->set('org_context_resolved', true);
+        request()->attributes->set('org_context_kind', \App\Support\OrgContext::KIND_TENANT);
+
+        $repairedTenantRecord = TenantOrderResource::getEloquentQuery()
+            ->where('order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($repairedTenantRecord);
+        $this->assertSame('paid', $tenantPayment->invoke(null, $repairedTenantRecord)['label']);
+        $this->assertSame('active', $tenantGrant->invoke(null, $repairedTenantRecord)['label']);
+        $this->assertSame('unlocked', $tenantUnlock->invoke(null, $repairedTenantRecord)['label']);
+        $this->assertSame('fulfilled', (string) ($repairedTenantRecord->status ?? ''));
+
+        $infolist = TenantOrderResource::infolist(Infolist::make()->record($repairedTenantRecord));
+        $componentNames = array_map(
+            static fn (Component $component): string => (string) $component->getName(),
+            array_values(array_filter(
+                $infolist->getFlatComponents(),
+                static fn ($component): bool => $component instanceof Component && method_exists($component, 'getName')
+            ))
+        );
+
+        $this->assertContains('payment_state', $componentNames);
+        $this->assertContains('latest_benefit_status', $componentNames);
+        $this->assertContains('unlock_status', $componentNames);
+        $this->assertContains('status', $componentNames);
+    }
+
+    private function seedCommerceCatalog(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
+    }
+
+    /**
+     * @return array{org_id:int,user_id:int,token:string,anon_id:string,email:string}
+     */
+    private function createTenantOrgUserToken(): array
+    {
+        $userId = (int) DB::table('users')->insertGetId([
+            'name' => 'Paid No Grant Tenant User',
+            'email' => 'paid-no-grant-repair-tenant@example.com',
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $orgId = (int) DB::table('organizations')->insertGetId([
+            'name' => 'Paid No Grant Tenant Org',
+            'owner_user_id' => $userId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => 'owner',
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $anonId = 'anon_paid_no_grant_'.$userId;
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'org_id' => $orgId,
+            'role' => 'owner',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return [
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'token' => $token,
+            'anon_id' => $anonId,
+            'email' => 'paid-no-grant-repair-tenant@example.com',
+        ];
+    }
+
+    private function createMbtiAttemptWithResult(int $orgId, string $userId, string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $packId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+
+        Attempt::query()->create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(10),
+            'submitted_at' => now()->subMinutes(9),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::query()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function promoteOrderToPaidNoGrant(int $orgId, string $orderNo): void
+    {
+        $timestamp = now()->subMinutes(10);
+
+        DB::table('orders')
+            ->where('org_id', $orgId)
+            ->where('order_no', $orderNo)
+            ->update([
+                'status' => 'paid',
+                'payment_state' => 'paid',
+                'grant_state' => 'not_started',
+                'paid_at' => $timestamp,
+                'fulfilled_at' => null,
+                'updated_at' => $timestamp,
+            ]);
+
+        DB::table('payment_attempts')
+            ->where('org_id', $orgId)
+            ->where('order_no', $orderNo)
+            ->update([
+                'state' => 'paid',
+                'callback_received_at' => $timestamp,
+                'verified_at' => $timestamp,
+                'finalized_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ]);
+    }
+
+    private function tenantResourceMethod(string $name): ReflectionMethod
+    {
+        $method = new ReflectionMethod(TenantOrderResource::class, $name);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+
+    private function bootstrapTenantContext(int $orgId, int $userId): void
+    {
+        $context = app(\App\Support\OrgContext::class);
+        $context->set($orgId, $userId, 'owner', null, \App\Support\OrgContext::KIND_TENANT);
+        app()->instance(\App\Support\OrgContext::class, $context);
+    }
+}


### PR DESCRIPTION
## Summary
- add a paid_no_grant repair visibility acceptance test for a real tenant order
- verify canonical DB truth before and after `commerce:repair-paid-orders`
- verify the same `order_no` converges consistently in public lookup, Ops, and Tenant reads

## Tests
- ./vendor/bin/pint tests/Feature/Commerce/PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest.php
- php artisan test tests/Feature/Commerce/PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest.php
- php artisan test --filter='PaymentRepairEngineTest|PaidNoGrantCompensationVisibilityTest|CheckoutWebhookOpsTenantVisibilityAcceptanceTest|OrderPaymentReadContractTest|TenantOrderReadContractTest|OrderCommerceLinkageTest'