### PR TITLE
fix(payment-repair): unify repairable semantic reject semantics

### DIFF
--- a/backend/app/Console/Commands/CommerceRepairPostCommitFailed.php
+++ b/backend/app/Console/Commands/CommerceRepairPostCommitFailed.php
@@ -23,6 +23,16 @@ final class CommerceRepairPostCommitFailed extends Command
         'ATTEMPT_REQUIRED',
     ];
 
+    private const LEGACY_REPAIRABLE_SEMANTIC_REJECT_CODES = [
+        'rejected_provider_mismatch',
+    ];
+
+    private const LEGACY_FAILED_SEMANTIC_REJECT_CODES = [
+        'SKU_NOT_FOUND',
+        'BENEFIT_CODE_NOT_FOUND',
+        'ATTEMPT_REQUIRED',
+    ];
+
     protected $signature = 'commerce:repair-post-commit-failed
         {--org_id=0 : Organization id}
         {--older_than_minutes=5 : Ignore very fresh failures}
@@ -132,6 +142,12 @@ final class CommerceRepairPostCommitFailed extends Command
                 $statusQuery->orWhere(function ($semanticQuery) use ($semanticRejectCodes): void {
                     $semanticQuery->whereIn('payment_events.status', ['rejected', 'orphan'])
                         ->whereIn('payment_events.last_error_code', $semanticRejectCodes);
+                })->orWhere(function ($legacyRejectedQuery): void {
+                    $legacyRejectedQuery->whereIn('payment_events.status', ['rejected', 'orphan'])
+                        ->whereIn('payment_events.last_error_code', self::LEGACY_REPAIRABLE_SEMANTIC_REJECT_CODES);
+                })->orWhere(function ($legacyFailedQuery): void {
+                    $legacyFailedQuery->where('payment_events.status', 'failed')
+                        ->whereIn('payment_events.last_error_code', self::LEGACY_FAILED_SEMANTIC_REJECT_CODES);
                 });
             })
             ->where(function ($queueQuery): void {

--- a/backend/app/Console/Commands/CommerceRepairPostCommitFailed.php
+++ b/backend/app/Console/Commands/CommerceRepairPostCommitFailed.php
@@ -11,6 +11,18 @@ use Illuminate\Support\Str;
 
 final class CommerceRepairPostCommitFailed extends Command
 {
+    private const REPAIRABLE_SEMANTIC_REJECT_CODES = [
+        'ORDER_NOT_FOUND',
+        'PROVIDER_MISMATCH',
+        'AMOUNT_MISMATCH',
+        'CURRENCY_MISMATCH',
+        'ATTEMPT_OWNER_MISMATCH',
+        'ATTEMPT_SCALE_MISMATCH',
+        'SKU_NOT_FOUND',
+        'BENEFIT_CODE_NOT_FOUND',
+        'ATTEMPT_REQUIRED',
+    ];
+
     protected $signature = 'commerce:repair-post-commit-failed
         {--org_id=0 : Organization id}
         {--older_than_minutes=5 : Ignore very fresh failures}
@@ -90,17 +102,7 @@ final class CommerceRepairPostCommitFailed extends Command
         bool $includeSemanticRejects
     ): array {
         $cutoff = now()->subMinutes($olderThanMinutes);
-        $semanticRejectCodes = [
-            'ORDER_NOT_FOUND',
-            'PROVIDER_MISMATCH',
-            'AMOUNT_MISMATCH',
-            'CURRENCY_MISMATCH',
-            'ATTEMPT_OWNER_MISMATCH',
-            'ATTEMPT_SCALE_MISMATCH',
-            'SKU_NOT_FOUND',
-            'BENEFIT_CODE_NOT_FOUND',
-            'ATTEMPT_REQUIRED',
-        ];
+        $semanticRejectCodes = self::REPAIRABLE_SEMANTIC_REJECT_CODES;
 
         return DB::table('payment_events')
             ->leftJoin('orders', 'orders.order_no', '=', 'payment_events.order_no')

--- a/backend/app/Services/Commerce/Repair/OrderRepairService.php
+++ b/backend/app/Services/Commerce/Repair/OrderRepairService.php
@@ -12,6 +12,11 @@ use Illuminate\Support\Facades\DB;
 
 final class OrderRepairService
 {
+    private const BLOCKING_REJECT_CODES = [
+        'ATTEMPT_OWNER_MISMATCH',
+        'ATTEMPT_SCALE_MISMATCH',
+    ];
+
     public function __construct(
         private readonly EntitlementManager $entitlements,
         private readonly OrderManager $orders,
@@ -58,6 +63,21 @@ final class OrderRepairService
             return $this->failure('BENEFIT_CODE_NOT_FOUND', 'benefit code cannot be resolved.', $freshOrder, $context, [
                 'sku' => (string) ($skuRow->sku ?? ''),
             ]);
+        }
+
+        $blockingEvent = $this->resolveBlockingSemanticRejectEvent($freshOrder);
+        if ($blockingEvent !== null) {
+            return $this->skip(
+                'BLOCKED_BY_SEMANTIC_REJECT',
+                'paid-order repair is blocked by unresolved semantic reject event.',
+                $freshOrder,
+                $context,
+                [
+                    'blocking_payment_event_id' => (string) ($blockingEvent->id ?? ''),
+                    'blocking_last_error_code' => (string) ($blockingEvent->last_error_code ?? ''),
+                    'blocking_handle_status' => (string) ($blockingEvent->handle_status ?? ''),
+                ]
+            );
         }
 
         $activeGrant = $this->resolveActiveGrantForOrder($freshOrder, $benefitCode);
@@ -220,6 +240,10 @@ final class OrderRepairService
             return false;
         }
 
+        if ($this->resolveBlockingSemanticRejectEvent($freshOrder) !== null) {
+            return false;
+        }
+
         return ! $this->hasActiveGrantForOrder($freshOrder);
     }
 
@@ -297,6 +321,22 @@ final class OrderRepairService
         $benefitCode = strtoupper(trim((string) ($skuRow->benefit_code ?? '')));
 
         return $benefitCode !== '' ? $benefitCode : null;
+    }
+
+    private function resolveBlockingSemanticRejectEvent(object $order): ?object
+    {
+        $orderNo = trim((string) ($order->order_no ?? ''));
+        if ($orderNo === '') {
+            return null;
+        }
+
+        return DB::table('payment_events')
+            ->where('order_no', $orderNo)
+            ->where('status', 'rejected')
+            ->whereIn('last_error_code', self::BLOCKING_REJECT_CODES)
+            ->orderByDesc('updated_at')
+            ->orderByDesc('created_at')
+            ->first();
     }
 
     /**

--- a/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
@@ -237,7 +237,7 @@ class WebhookEntitlementService
                             $provider,
                             $providerEventId,
                             'rejected',
-                            'rejected_provider_mismatch',
+                            'PROVIDER_MISMATCH',
                             $detail
                         );
 
@@ -371,14 +371,14 @@ class WebhookEntitlementService
                         ?? $order->item_sku
                         ?? ''));
                     if ($effectiveSku === '') {
-                        $this->core->markEventError($provider, $providerEventId, 'failed', 'SKU_NOT_FOUND', 'sku missing on order.');
+                        $this->core->markEventError($provider, $providerEventId, 'rejected', 'SKU_NOT_FOUND', 'sku missing on order.');
 
                         return $this->core->semanticReject('SKU_NOT_FOUND', 'sku missing on order.');
                     }
 
                     $skuRow = $this->core->skuCatalog()->getActiveSku($effectiveSku, null, (int) ($order->org_id ?? $orgId));
                     if (! $skuRow) {
-                        $this->core->markEventError($provider, $providerEventId, 'failed', 'SKU_NOT_FOUND', 'sku not found.');
+                        $this->core->markEventError($provider, $providerEventId, 'rejected', 'SKU_NOT_FOUND', 'sku not found.');
 
                         return $this->core->semanticReject('SKU_NOT_FOUND', 'sku not found.');
                     }
@@ -462,7 +462,7 @@ class WebhookEntitlementService
                         $this->core->markEventError(
                             $provider,
                             $providerEventId,
-                            'failed',
+                            'rejected',
                             'BENEFIT_CODE_NOT_FOUND',
                             'benefit code missing on sku.'
                         );
@@ -529,7 +529,7 @@ class WebhookEntitlementService
                     } elseif ($kind === 'report_unlock') {
                         $attemptId = (string) ($order->target_attempt_id ?? '');
                         if ($attemptId === '') {
-                            $this->core->markEventError($provider, $providerEventId, 'failed', 'ATTEMPT_REQUIRED', 'target_attempt_id is required.');
+                            $this->core->markEventError($provider, $providerEventId, 'rejected', 'ATTEMPT_REQUIRED', 'target_attempt_id is required.');
 
                             return $this->core->semanticReject('ATTEMPT_REQUIRED', 'target_attempt_id is required for report_unlock.');
                         }

--- a/backend/tests/Feature/Commerce/BigFiveWebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/BigFiveWebhookIdempotencyTest.php
@@ -21,8 +21,8 @@ final class BigFiveWebhookIdempotencyTest extends TestCase
 
     private function seedCommerce(): void
     {
-        (new ScaleRegistrySeeder())->run();
-        (new Pr19CommerceSeeder())->run();
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
     }
 
     private function createBigFiveAttemptWithResult(string $anonId): string
@@ -169,6 +169,7 @@ final class BigFiveWebhookIdempotencyTest extends TestCase
         }));
         $this->assertTrue($matchedMetas->contains(function (array $meta): bool {
             $status = (string) ($meta['webhook_status'] ?? '');
+
             return in_array($status, ['processed', 'duplicate'], true);
         }));
         $this->assertTrue($matchedMetas->contains(function (array $meta): bool {
@@ -199,7 +200,7 @@ final class BigFiveWebhookIdempotencyTest extends TestCase
         $response->assertJsonPath('rejected', true);
         $response->assertJsonPath('reject_reason', 'SKU_NOT_FOUND');
 
-        $this->assertSame('failed', (string) DB::table('payment_events')
+        $this->assertSame('rejected', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_big5_badsku_1')
             ->value('status'));
@@ -246,11 +247,12 @@ final class BigFiveWebhookIdempotencyTest extends TestCase
         if (is_array($raw)) {
             return $raw;
         }
-        if (!is_string($raw) || trim($raw) === '') {
+        if (! is_string($raw) || trim($raw) === '') {
             return [];
         }
 
         $decoded = json_decode($raw, true);
+
         return is_array($decoded) ? $decoded : [];
     }
 }

--- a/backend/tests/Feature/Commerce/PaymentRepairEngineTest.php
+++ b/backend/tests/Feature/Commerce/PaymentRepairEngineTest.php
@@ -314,6 +314,308 @@ final class PaymentRepairEngineTest extends TestCase
         $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
     }
 
+    public function test_post_commit_repair_command_reprocesses_provider_mismatch_after_provider_is_corrected(): void
+    {
+        config([
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        (new Pr19CommerceSeeder)->run();
+
+        $attemptId = $this->insertAttempt('anon_provider_repair');
+        $orderNo = 'ord_repair_provider_mismatch_1';
+        $this->insertReportUnlockOrder($orderNo, $attemptId, 'anon_provider_repair');
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->update([
+                'provider' => 'stripe',
+                'updated_at' => now()->subMinutes(10),
+            ]);
+
+        $processor = app(PaymentWebhookProcessor::class);
+        $first = $processor->handle('billing', [
+            'provider_event_id' => 'evt_repair_provider_mismatch_1',
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_repair_provider_mismatch_1',
+            'amount_cents' => 199,
+            'currency' => 'CNY',
+        ], 0, null, 'anon_provider_repair', true);
+
+        $this->assertFalse((bool) ($first['ok'] ?? true));
+        $this->assertDatabaseHas('payment_events', [
+            'provider_event_id' => 'evt_repair_provider_mismatch_1',
+            'status' => 'rejected',
+            'handle_status' => 'rejected',
+            'last_error_code' => 'PROVIDER_MISMATCH',
+            'reason' => 'PROVIDER_MISMATCH',
+        ]);
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->update([
+                'provider' => 'billing',
+                'updated_at' => now()->subMinutes(9),
+            ]);
+
+        $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+            '--org_id' => 0,
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider_event_id' => 'evt_repair_provider_mismatch_1',
+            'status' => 'processed',
+            'handle_status' => 'reprocessed',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'fulfilled',
+        ]);
+        $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
+    }
+
+    public function test_post_commit_repair_command_reprocesses_rejected_sku_not_found_after_sku_is_restored(): void
+    {
+        config([
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        (new Pr19CommerceSeeder)->run();
+
+        $attemptId = $this->insertAttempt('anon_semantic_sku_fix');
+        $orderNo = 'ord_repair_semantic_sku_1';
+        $providerEventId = 'evt_repair_semantic_sku_1';
+        $this->insertOrder($orderNo, 'SKU_REPAIR_MBTI_UNKNOWN', $attemptId, 'anon_semantic_sku_fix');
+
+        $first = app(PaymentWebhookProcessor::class)->handle('billing', [
+            'provider_event_id' => $providerEventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_repair_semantic_sku_1',
+            'amount_cents' => 199,
+            'currency' => 'CNY',
+        ], 0, null, 'anon_semantic_sku_fix', true);
+
+        $this->assertFalse((bool) ($first['ok'] ?? true));
+        $this->assertDatabaseHas('payment_events', [
+            'provider_event_id' => $providerEventId,
+            'status' => 'rejected',
+            'handle_status' => 'rejected',
+            'last_error_code' => 'SKU_NOT_FOUND',
+            'reason' => 'SKU_NOT_FOUND',
+        ]);
+
+        $this->upsertSku('SKU_REPAIR_MBTI_UNKNOWN', 'MBTI', 'report_unlock', 'MBTI_REPORT_FULL', 199, 'CNY');
+
+        $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+            '--org_id' => 0,
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider_event_id' => $providerEventId,
+            'status' => 'processed',
+            'handle_status' => 'reprocessed',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'fulfilled',
+        ]);
+        $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
+    }
+
+    public function test_post_commit_repair_command_reprocesses_rejected_benefit_code_missing_after_sku_is_corrected(): void
+    {
+        config([
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        (new Pr19CommerceSeeder)->run();
+
+        $attemptId = $this->insertAttempt('anon_semantic_benefit_fix');
+        $orderNo = 'ord_repair_semantic_benefit_1';
+        $providerEventId = 'evt_repair_semantic_benefit_1';
+        $this->upsertSku('SKU_REPAIR_MBTI_NO_BENEFIT', 'MBTI', 'report_unlock', '', 199, 'CNY');
+        $this->insertOrder($orderNo, 'SKU_REPAIR_MBTI_NO_BENEFIT', $attemptId, 'anon_semantic_benefit_fix');
+
+        $first = app(PaymentWebhookProcessor::class)->handle('billing', [
+            'provider_event_id' => $providerEventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_repair_semantic_benefit_1',
+            'amount_cents' => 199,
+            'currency' => 'CNY',
+        ], 0, null, 'anon_semantic_benefit_fix', true);
+
+        $this->assertFalse((bool) ($first['ok'] ?? true));
+        $this->assertDatabaseHas('payment_events', [
+            'provider_event_id' => $providerEventId,
+            'status' => 'rejected',
+            'handle_status' => 'rejected',
+            'last_error_code' => 'BENEFIT_CODE_NOT_FOUND',
+            'reason' => 'BENEFIT_CODE_NOT_FOUND',
+        ]);
+
+        DB::table('skus')
+            ->where('sku', 'SKU_REPAIR_MBTI_NO_BENEFIT')
+            ->update([
+                'benefit_code' => 'MBTI_REPORT_FULL',
+                'updated_at' => now()->subMinutes(9),
+            ]);
+
+        $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+            '--org_id' => 0,
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider_event_id' => $providerEventId,
+            'status' => 'processed',
+            'handle_status' => 'reprocessed',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'fulfilled',
+        ]);
+        $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
+    }
+
+    public function test_post_commit_repair_command_reprocesses_rejected_attempt_required_after_attempt_is_backfilled(): void
+    {
+        config([
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        (new Pr19CommerceSeeder)->run();
+
+        $repairAttemptId = $this->insertAttempt('anon_semantic_attempt_fix');
+        $orderNo = 'ord_repair_semantic_attempt_1';
+        $providerEventId = 'evt_repair_semantic_attempt_1';
+        $this->insertOrder($orderNo, 'MBTI_REPORT_FULL', null, 'anon_semantic_attempt_fix');
+
+        $first = app(PaymentWebhookProcessor::class)->handle('billing', [
+            'provider_event_id' => $providerEventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_repair_semantic_attempt_1',
+            'amount_cents' => 199,
+            'currency' => 'CNY',
+        ], 0, null, 'anon_semantic_attempt_fix', true);
+
+        $this->assertFalse((bool) ($first['ok'] ?? true));
+        $this->assertDatabaseHas('payment_events', [
+            'provider_event_id' => $providerEventId,
+            'status' => 'rejected',
+            'handle_status' => 'rejected',
+            'last_error_code' => 'ATTEMPT_REQUIRED',
+            'reason' => 'ATTEMPT_REQUIRED',
+        ]);
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->update([
+                'target_attempt_id' => $repairAttemptId,
+                'updated_at' => now()->subMinutes(9),
+            ]);
+
+        $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+            '--org_id' => 0,
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider_event_id' => $providerEventId,
+            'status' => 'processed',
+            'handle_status' => 'reprocessed',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'fulfilled',
+        ]);
+        $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
+    }
+
+    public function test_paid_order_repair_command_skips_orders_blocked_by_unresolved_attempt_mismatch_semantic_rejects(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+
+        $cases = [
+            [
+                'code' => 'ATTEMPT_OWNER_MISMATCH',
+                'order_no' => 'ord_paid_repair_owner_blocked_1',
+                'provider_event_id' => 'evt_paid_repair_owner_blocked_1',
+            ],
+            [
+                'code' => 'ATTEMPT_SCALE_MISMATCH',
+                'order_no' => 'ord_paid_repair_scale_blocked_1',
+                'provider_event_id' => 'evt_paid_repair_scale_blocked_1',
+            ],
+        ];
+
+        foreach ($cases as $case) {
+            $attemptId = $this->insertAttempt('anon_'.$case['code']);
+            $this->insertReportUnlockOrder($case['order_no'], $attemptId, 'anon_'.$case['code']);
+
+            DB::table('orders')
+                ->where('order_no', $case['order_no'])
+                ->update([
+                    'status' => 'paid',
+                    'payment_state' => 'paid',
+                    'grant_state' => 'not_started',
+                    'paid_at' => now()->subMinutes(10),
+                    'updated_at' => now()->subMinutes(10),
+                ]);
+
+            $this->insertRejectedPaymentEvent($case['order_no'], $case['provider_event_id'], $case['code']);
+
+            $exitCode = Artisan::call('commerce:repair-paid-orders', [
+                '--org_id' => 0,
+                '--order' => $case['order_no'],
+                '--older_than_minutes' => 0,
+                '--limit' => 20,
+                '--json' => 1,
+            ]);
+            $this->assertSame(0, $exitCode);
+
+            $summary = json_decode(Artisan::output(), true);
+            $this->assertIsArray($summary);
+            $this->assertSame(0, (int) ($summary['candidate_count'] ?? -1));
+            $this->assertSame(0, (int) ($summary['repaired_count'] ?? -1));
+            $this->assertSame(0, (int) ($summary['failed_count'] ?? -1));
+
+            $this->assertDatabaseHas('orders', [
+                'order_no' => $case['order_no'],
+                'payment_state' => 'paid',
+                'grant_state' => 'not_started',
+                'status' => 'paid',
+            ]);
+            $this->assertSame(0, DB::table('benefit_grants')->where('order_no', $case['order_no'])->count());
+            $this->assertDatabaseHas('payment_events', [
+                'provider_event_id' => $case['provider_event_id'],
+                'status' => 'rejected',
+                'last_error_code' => $case['code'],
+            ]);
+        }
+    }
+
     private function insertAttempt(string $anonId): string
     {
         $attemptId = (string) Str::uuid();
@@ -345,15 +647,20 @@ final class PaymentRepairEngineTest extends TestCase
 
     private function insertReportUnlockOrder(string $orderNo, string $attemptId, string $anonId): void
     {
+        $this->insertOrder($orderNo, 'MBTI_REPORT_FULL', $attemptId, $anonId);
+    }
+
+    private function insertOrder(string $orderNo, string $sku, ?string $attemptId, string $anonId): void
+    {
         DB::table('orders')->insert([
             'id' => (string) Str::uuid(),
             'order_no' => $orderNo,
             'org_id' => 0,
             'user_id' => null,
             'anon_id' => $anonId,
-            'sku' => 'MBTI_REPORT_FULL',
-            'item_sku' => 'MBTI_REPORT_FULL',
-            'effective_sku' => 'MBTI_REPORT_FULL',
+            'sku' => $sku,
+            'item_sku' => $sku,
+            'effective_sku' => $sku,
             'quantity' => 1,
             'target_attempt_id' => $attemptId,
             'amount_cents' => 199,
@@ -371,6 +678,64 @@ final class PaymentRepairEngineTest extends TestCase
             'refunded_at' => null,
             'created_at' => now()->subMinutes(8),
             'updated_at' => now()->subMinutes(8),
+        ]);
+    }
+
+    private function upsertSku(
+        string $sku,
+        string $scaleCode,
+        string $kind,
+        string $benefitCode,
+        int $priceCents,
+        string $currency
+    ): void {
+        DB::table('skus')->updateOrInsert(
+            ['sku' => $sku],
+            [
+                'scale_code' => $scaleCode,
+                'kind' => $kind,
+                'unit_qty' => 1,
+                'benefit_code' => $benefitCode,
+                'scope' => 'attempt',
+                'price_cents' => $priceCents,
+                'currency' => $currency,
+                'is_active' => true,
+                'meta_json' => json_encode([], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'created_at' => now()->subMinutes(10),
+                'updated_at' => now()->subMinutes(10),
+            ]
+        );
+    }
+
+    private function insertRejectedPaymentEvent(string $orderNo, string $providerEventId, string $errorCode): void
+    {
+        $orderId = (string) DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->value('id');
+
+        DB::table('payment_events')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'provider' => 'billing',
+            'provider_event_id' => $providerEventId,
+            'order_id' => $orderId,
+            'order_no' => $orderNo,
+            'event_type' => 'payment_succeeded',
+            'status' => 'rejected',
+            'handle_status' => 'rejected',
+            'last_error_code' => $errorCode,
+            'reason' => $errorCode,
+            'attempts' => 0,
+            'payload_json' => json_encode([
+                'provider_event_id' => $providerEventId,
+                'order_no' => $orderNo,
+                'amount_cents' => 199,
+                'currency' => 'CNY',
+                'event_type' => 'payment_succeeded',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'signature_ok' => true,
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(10),
         ]);
     }
 }

--- a/backend/tests/Feature/Commerce/PaymentRepairEngineTest.php
+++ b/backend/tests/Feature/Commerce/PaymentRepairEngineTest.php
@@ -380,6 +380,56 @@ final class PaymentRepairEngineTest extends TestCase
         $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
     }
 
+    public function test_post_commit_repair_command_reprocesses_legacy_provider_mismatch_after_provider_is_corrected(): void
+    {
+        config([
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        (new Pr19CommerceSeeder)->run();
+
+        $attemptId = $this->insertAttempt('anon_provider_repair_legacy');
+        $orderNo = 'ord_repair_provider_mismatch_legacy_1';
+        $providerEventId = 'evt_repair_provider_mismatch_legacy_1';
+        $this->insertReportUnlockOrder($orderNo, $attemptId, 'anon_provider_repair_legacy');
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->update([
+                'provider' => 'billing',
+                'updated_at' => now()->subMinutes(9),
+            ]);
+
+        $this->insertSemanticRejectPaymentEvent(
+            orderNo: $orderNo,
+            providerEventId: $providerEventId,
+            status: 'rejected',
+            errorCode: 'rejected_provider_mismatch',
+            reason: 'REJECTED_PROVIDER_MISMATCH'
+        );
+
+        $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+            '--org_id' => 0,
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider_event_id' => $providerEventId,
+            'status' => 'processed',
+            'handle_status' => 'reprocessed',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'fulfilled',
+        ]);
+        $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
+    }
+
     public function test_post_commit_repair_command_reprocesses_rejected_sku_not_found_after_sku_is_restored(): void
     {
         config([
@@ -553,6 +603,93 @@ final class PaymentRepairEngineTest extends TestCase
         $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
     }
 
+    public function test_post_commit_repair_command_reprocesses_legacy_failed_semantic_rejects_after_data_fix(): void
+    {
+        config([
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        (new Pr19CommerceSeeder)->run();
+
+        $cases = [
+            [
+                'order_no' => 'ord_repair_legacy_failed_sku_1',
+                'provider_event_id' => 'evt_repair_legacy_failed_sku_1',
+                'error_code' => 'SKU_NOT_FOUND',
+                'setup' => function (): void {
+                    $attemptId = $this->insertAttempt('anon_legacy_failed_sku');
+                    $this->insertOrder('ord_repair_legacy_failed_sku_1', 'SKU_REPAIR_MBTI_UNKNOWN_LEGACY', $attemptId, 'anon_legacy_failed_sku');
+                    $this->upsertSku('SKU_REPAIR_MBTI_UNKNOWN_LEGACY', 'MBTI', 'report_unlock', 'MBTI_REPORT_FULL', 199, 'CNY');
+                },
+                'fix' => function (): void {},
+                'payload_sku' => 'SKU_REPAIR_MBTI_UNKNOWN_LEGACY',
+            ],
+            [
+                'order_no' => 'ord_repair_legacy_failed_benefit_1',
+                'provider_event_id' => 'evt_repair_legacy_failed_benefit_1',
+                'error_code' => 'BENEFIT_CODE_NOT_FOUND',
+                'setup' => function (): void {
+                    $attemptId = $this->insertAttempt('anon_legacy_failed_benefit');
+                    $this->upsertSku('SKU_REPAIR_MBTI_NO_BENEFIT_LEGACY', 'MBTI', 'report_unlock', 'MBTI_REPORT_FULL', 199, 'CNY');
+                    $this->insertOrder('ord_repair_legacy_failed_benefit_1', 'SKU_REPAIR_MBTI_NO_BENEFIT_LEGACY', $attemptId, 'anon_legacy_failed_benefit');
+                },
+                'fix' => function (): void {},
+                'payload_sku' => 'SKU_REPAIR_MBTI_NO_BENEFIT_LEGACY',
+            ],
+            [
+                'order_no' => 'ord_repair_legacy_failed_attempt_1',
+                'provider_event_id' => 'evt_repair_legacy_failed_attempt_1',
+                'error_code' => 'ATTEMPT_REQUIRED',
+                'setup' => function (): void {
+                    $this->insertOrder('ord_repair_legacy_failed_attempt_1', 'MBTI_REPORT_FULL', null, 'anon_legacy_failed_attempt');
+                },
+                'fix' => function (): void {
+                    DB::table('orders')
+                        ->where('order_no', 'ord_repair_legacy_failed_attempt_1')
+                        ->update([
+                            'target_attempt_id' => $this->insertAttempt('anon_legacy_failed_attempt'),
+                            'updated_at' => now()->subMinutes(9),
+                        ]);
+                },
+                'payload_sku' => 'MBTI_REPORT_FULL',
+            ],
+        ];
+
+        foreach ($cases as $case) {
+            $case['setup']();
+
+            $this->insertSemanticRejectPaymentEvent(
+                orderNo: $case['order_no'],
+                providerEventId: $case['provider_event_id'],
+                status: 'failed',
+                errorCode: $case['error_code']
+            );
+
+            $case['fix']();
+
+            $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+                '--org_id' => 0,
+                '--older_than_minutes' => 0,
+                '--limit' => 20,
+            ]);
+            $this->assertSame(0, $exitCode);
+
+            $this->assertDatabaseHas('payment_events', [
+                'provider_event_id' => $case['provider_event_id'],
+                'status' => 'processed',
+                'handle_status' => 'reprocessed',
+            ]);
+            $this->assertDatabaseHas('orders', [
+                'order_no' => $case['order_no'],
+                'payment_state' => 'paid',
+                'grant_state' => 'granted',
+                'status' => 'fulfilled',
+            ]);
+            $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $case['order_no'])->where('status', 'active')->count());
+        }
+    }
+
     public function test_paid_order_repair_command_skips_orders_blocked_by_unresolved_attempt_mismatch_semantic_rejects(): void
     {
         (new Pr19CommerceSeeder)->run();
@@ -709,6 +846,16 @@ final class PaymentRepairEngineTest extends TestCase
 
     private function insertRejectedPaymentEvent(string $orderNo, string $providerEventId, string $errorCode): void
     {
+        $this->insertSemanticRejectPaymentEvent($orderNo, $providerEventId, 'rejected', $errorCode);
+    }
+
+    private function insertSemanticRejectPaymentEvent(
+        string $orderNo,
+        string $providerEventId,
+        string $status,
+        string $errorCode,
+        ?string $reason = null
+    ): void {
         $orderId = (string) DB::table('orders')
             ->where('order_no', $orderNo)
             ->value('id');
@@ -721,10 +868,10 @@ final class PaymentRepairEngineTest extends TestCase
             'order_id' => $orderId,
             'order_no' => $orderNo,
             'event_type' => 'payment_succeeded',
-            'status' => 'rejected',
-            'handle_status' => 'rejected',
+            'status' => $status,
+            'handle_status' => $status,
             'last_error_code' => $errorCode,
-            'reason' => $errorCode,
+            'reason' => $reason ?? $errorCode,
             'attempts' => 0,
             'payload_json' => json_encode([
                 'provider_event_id' => $providerEventId,

--- a/backend/tests/Feature/Commerce/Webhook/PaymentWebhookProcessorContractTest.php
+++ b/backend/tests/Feature/Commerce/Webhook/PaymentWebhookProcessorContractTest.php
@@ -144,11 +144,11 @@ final class PaymentWebhookProcessorContractTest extends TestCase
         ]);
 
         $this->assertSame('created', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
-        $this->assertSame('rejected_provider_mismatch', (string) DB::table('payment_events')
+        $this->assertSame('PROVIDER_MISMATCH', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_contract_provider_mismatch_1')
             ->value('last_error_code'));
-        $this->assertSame('REJECTED_PROVIDER_MISMATCH', (string) DB::table('payment_events')
+        $this->assertSame('PROVIDER_MISMATCH', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_contract_provider_mismatch_1')
             ->value('reason'));

--- a/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
+++ b/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
@@ -71,11 +71,11 @@ class WebhookProviderMismatchTest extends TestCase
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_provider_mismatch_1')
             ->value('handle_status'));
-        $this->assertSame('rejected_provider_mismatch', (string) DB::table('payment_events')
+        $this->assertSame('PROVIDER_MISMATCH', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_provider_mismatch_1')
             ->value('last_error_code'));
-        $this->assertSame('REJECTED_PROVIDER_MISMATCH', (string) DB::table('payment_events')
+        $this->assertSame('PROVIDER_MISMATCH', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_provider_mismatch_1')
             ->value('reason'));


### PR DESCRIPTION
## Summary
- canonicalize repairable semantic reject payment-event codes and statuses in webhook handling
- align semantic reject replay sweep with the canonical code set
- block paid-order repair from bypassing unresolved attempt owner/scale mismatch rejects
- add repair-engine and contract regressions for provider mismatch, rejected semantic replay, and mismatch safety

## Tests
- ./vendor/bin/pint app/Services/Commerce/Webhook/WebhookEntitlementService.php app/Console/Commands/CommerceRepairPostCommitFailed.php app/Services/Commerce/Repair/OrderRepairService.php tests/Feature/Commerce/PaymentRepairEngineTest.php tests/Feature/Commerce/Webhook/PaymentWebhookProcessorContractTest.php tests/Feature/Payments/WebhookProviderMismatchTest.php tests/Feature/Commerce/BigFiveWebhookIdempotencyTest.php
- php artisan test --filter='PaymentRepairEngineTest|PaymentWebhookProcessorContractTest|WebhookProviderMismatchTest|SemanticRejectRepairOpsTenantVisibilityAcceptanceTest|PostCommitFailedRepairOpsTenantVisibilityAcceptanceTest|PaidNoGrantRepairOpsTenantVisibilityAcceptanceTest|CheckoutWebhookOpsTenantVisibilityAcceptanceTest|OrderPaymentReadContractTest|TenantOrderReadContractTest|OrderCommerceLinkageTest|ClinicalCombo68WebhookIdempotencyTest|Eq60WebhookIdempotencyTest|Sds20WebhookIdempotencyTest|BigFiveWebhookIdempotencyTest|PaymentWebhookTrustBoundaryTest'