### PR TITLE
test(payment-ops): add mismatch family visibility acceptance

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -798,8 +798,6 @@ class CommerceController extends Controller
         if ($description === '') {
             $description = 'FermatMind Order';
         }
-        $paymentAttempt = $this->createPaymentAttemptForOrder($order, $normalizedProvider, $scene);
-
         $payAction = $this->resolveCheckoutPayAction(
             $normalizedProvider,
             $orderNo,
@@ -834,6 +832,11 @@ class CommerceController extends Controller
         }
 
         $presented = $this->presentCheckoutPayAction($normalizedProvider, $payAction);
+        if (! is_array($presented['pay'] ?? null) && $this->trimNullableString($presented['checkout_url'] ?? null) === null) {
+            return $this->decoratePaymentPayloadForRecovery($presented, $paymentRecoveryToken);
+        }
+
+        $paymentAttempt = $this->createPaymentAttemptForOrder($order, $normalizedProvider, $scene);
         $this->orders->markPaymentPending(
             $orderNo,
             (int) ($order->org_id ?? 0),

--- a/backend/tests/Feature/Commerce/PostPaidAttemptMismatchRepairOpsTenantVisibilityAcceptanceTest.php
+++ b/backend/tests/Feature/Commerce/PostPaidAttemptMismatchRepairOpsTenantVisibilityAcceptanceTest.php
@@ -1,0 +1,685 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Filament\Ops\Resources\OrderResource\Support\OrderLinkageSupport;
+use App\Filament\Tenant\Resources\OrderResource as TenantOrderResource;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Models\TenantUser;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use ReflectionMethod;
+use Tests\Concerns\SignedBillingWebhook;
+use Tests\TestCase;
+
+final class PostPaidAttemptMismatchRepairOpsTenantVisibilityAcceptanceTest extends TestCase
+{
+    use RefreshDatabase;
+    use SignedBillingWebhook;
+
+    public function test_attempt_owner_mismatch_repair_converges_consistently_in_lookup_ops_and_tenant(): void
+    {
+        $this->seedCommerceCatalog();
+
+        config([
+            'payments.providers.billing.enabled' => true,
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        $tenant = $this->createTenantOrgUserToken();
+        $this->grantScaleForOrg($tenant['org_id'], 'MBTI');
+
+        $wrongOwnerUserId = (string) DB::table('users')->insertGetId([
+            'name' => 'Attempt Owner Mismatch User',
+            'email' => 'attempt-owner-mismatch@example.com',
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $tenant['org_id'],
+            'user_id' => (int) $wrongOwnerUserId,
+            'role' => 'member',
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $wrongAttemptId = $this->createMbtiAttemptWithResult(
+            orgId: $tenant['org_id'],
+            userId: $wrongOwnerUserId,
+            anonId: 'anon_wrong_owner_'.$wrongOwnerUserId,
+        );
+
+        $checkout = $this->withHeaders([
+            'Authorization' => 'Bearer '.$tenant['token'],
+            'X-Org-Id' => (string) $tenant['org_id'],
+        ])->postJson('/api/v0.3/orders/checkout', [
+            'attempt_id' => $wrongAttemptId,
+            'sku' => 'MBTI_REPORT_FULL',
+            'provider' => 'billing',
+            'email' => $tenant['email'],
+        ]);
+
+        $checkout->assertOk();
+        $checkout->assertJsonPath('ok', true);
+
+        $orderNo = (string) $checkout->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        $createdOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($createdOrder);
+
+        $providerEventId = 'evt_owner_mismatch_'.$orderNo;
+        $webhook = $this->postSignedBillingWebhook([
+            'provider_event_id' => $providerEventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_'.$orderNo,
+            'amount_cents' => (int) ($createdOrder->amount_cents ?? 0),
+            'currency' => (string) ($createdOrder->currency ?? 'CNY'),
+            'event_type' => 'payment_succeeded',
+        ]);
+
+        $webhook->assertStatus(200);
+        $webhook->assertJsonPath('ok', false);
+        $webhook->assertJsonPath('rejected', true);
+        $webhook->assertJsonPath('acknowledged', true);
+        $webhook->assertJsonPath('reject_reason', 'ATTEMPT_OWNER_MISMATCH');
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider' => 'billing',
+            'provider_event_id' => $providerEventId,
+            'status' => 'rejected',
+            'handle_status' => 'rejected',
+            'last_error_code' => 'ATTEMPT_OWNER_MISMATCH',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'org_id' => $tenant['org_id'],
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'status' => 'paid',
+        ]);
+        $this->assertSame(
+            0,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+
+        $preRepairLookup = $this->lookupForTenant($tenant['token'], $orderNo, $tenant['email']);
+        $preRepairLookup->assertOk();
+        $preRepairLookup->assertJsonPath('ok', true);
+        $preRepairLookup->assertJsonPath('order_no', $orderNo);
+        $preRepairLookup->assertJsonPath('attempt_id', $wrongAttemptId);
+        $preRepairLookup->assertJsonPath('status', 'paid');
+        $preRepairLookup->assertJsonPath('payment_state', 'paid');
+        $preRepairLookup->assertJsonPath('grant_state', 'not_started');
+        $preRepairLookup->assertJsonPath('latest_payment_attempt.state', 'paid');
+
+        $this->assertOpsState(
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedUnlockStatus: 'paid_no_grant',
+            expectedWebhookStatus: 'rejected',
+            expectedRawStatus: 'paid',
+        );
+
+        $this->assertTenantState(
+            tenant: $tenant,
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedGrantStatus: null,
+            expectedUnlockStatus: 'paid_no_grant',
+            expectedRawStatus: 'paid',
+        );
+
+        $this->assertPaidOrderRepairBlocked($tenant['org_id'], $orderNo);
+        $this->assertDatabaseHas('payment_events', [
+            'provider' => 'billing',
+            'provider_event_id' => $providerEventId,
+            'status' => 'rejected',
+            'last_error_code' => 'ATTEMPT_OWNER_MISMATCH',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'status' => 'paid',
+        ]);
+
+        DB::table('attempts')
+            ->where('id', $wrongAttemptId)
+            ->update([
+                'user_id' => (string) $tenant['user_id'],
+                'anon_id' => $tenant['anon_id'],
+                'updated_at' => now()->subMinutes(9),
+            ]);
+
+        $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+            '--org_id' => $tenant['org_id'],
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+            '--include_semantic_rejects' => 1,
+            '--json' => 1,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider' => 'billing',
+            'provider_event_id' => $providerEventId,
+            'status' => 'processed',
+            'handle_status' => 'reprocessed',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'org_id' => $tenant['org_id'],
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'fulfilled',
+        ]);
+        $this->assertSame(
+            1,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+
+        $repairedLookup = $this->lookupForTenant($tenant['token'], $orderNo, $tenant['email']);
+        $repairedLookup->assertOk();
+        $repairedLookup->assertJsonPath('ok', true);
+        $repairedLookup->assertJsonPath('order_no', $orderNo);
+        $repairedLookup->assertJsonPath('attempt_id', $wrongAttemptId);
+        $repairedLookup->assertJsonPath('status', 'paid');
+        $repairedLookup->assertJsonPath('payment_state', 'paid');
+        $repairedLookup->assertJsonPath('grant_state', 'granted');
+        $repairedLookup->assertJsonPath('latest_payment_attempt.state', 'paid');
+
+        $this->assertOpsState(
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedUnlockStatus: 'unlocked',
+            expectedWebhookStatus: 'processed',
+            expectedRawStatus: 'fulfilled',
+        );
+
+        $this->assertTenantState(
+            tenant: $tenant,
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedGrantStatus: 'active',
+            expectedUnlockStatus: 'unlocked',
+            expectedRawStatus: 'fulfilled',
+        );
+    }
+
+    public function test_attempt_scale_mismatch_repair_converges_consistently_in_lookup_ops_and_tenant(): void
+    {
+        $this->seedCommerceCatalog();
+
+        config([
+            'payments.providers.billing.enabled' => true,
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        $tenant = $this->createTenantOrgUserToken();
+        $this->grantScaleForOrg($tenant['org_id'], 'MBTI');
+        $this->grantScaleForOrg($tenant['org_id'], 'SDS_20');
+
+        $wrongAttemptId = $this->createMbtiAttemptWithResult(
+            orgId: $tenant['org_id'],
+            userId: (string) $tenant['user_id'],
+            anonId: $tenant['anon_id'],
+        );
+        $correctAttemptId = $this->createSdsAttemptWithResult(
+            orgId: $tenant['org_id'],
+            userId: (string) $tenant['user_id'],
+            anonId: $tenant['anon_id'],
+        );
+
+        $checkout = $this->withHeaders([
+            'Authorization' => 'Bearer '.$tenant['token'],
+            'X-Org-Id' => (string) $tenant['org_id'],
+        ])->postJson('/api/v0.3/orders/checkout', [
+            'attempt_id' => $wrongAttemptId,
+            'sku' => 'SKU_SDS_20_FULL_299',
+            'provider' => 'billing',
+            'email' => $tenant['email'],
+        ]);
+
+        $checkout->assertOk();
+        $checkout->assertJsonPath('ok', true);
+
+        $orderNo = (string) $checkout->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        $createdOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($createdOrder);
+
+        $providerEventId = 'evt_scale_mismatch_'.$orderNo;
+        $webhook = $this->postSignedBillingWebhook([
+            'provider_event_id' => $providerEventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_'.$orderNo,
+            'amount_cents' => (int) ($createdOrder->amount_cents ?? 0),
+            'currency' => (string) ($createdOrder->currency ?? 'CNY'),
+            'event_type' => 'payment_succeeded',
+        ]);
+
+        $webhook->assertStatus(200);
+        $webhook->assertJsonPath('ok', false);
+        $webhook->assertJsonPath('rejected', true);
+        $webhook->assertJsonPath('acknowledged', true);
+        $webhook->assertJsonPath('reject_reason', 'ATTEMPT_SCALE_MISMATCH');
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider' => 'billing',
+            'provider_event_id' => $providerEventId,
+            'status' => 'rejected',
+            'handle_status' => 'rejected',
+            'last_error_code' => 'ATTEMPT_SCALE_MISMATCH',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'org_id' => $tenant['org_id'],
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'status' => 'paid',
+            'target_attempt_id' => $wrongAttemptId,
+        ]);
+        $this->assertSame(
+            0,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+
+        $preRepairLookup = $this->lookupForTenant($tenant['token'], $orderNo, $tenant['email']);
+        $preRepairLookup->assertOk();
+        $preRepairLookup->assertJsonPath('ok', true);
+        $preRepairLookup->assertJsonPath('order_no', $orderNo);
+        $preRepairLookup->assertJsonPath('attempt_id', $wrongAttemptId);
+        $preRepairLookup->assertJsonPath('status', 'paid');
+        $preRepairLookup->assertJsonPath('payment_state', 'paid');
+        $preRepairLookup->assertJsonPath('grant_state', 'not_started');
+        $preRepairLookup->assertJsonPath('latest_payment_attempt.state', 'paid');
+
+        $this->assertOpsState(
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedUnlockStatus: 'paid_no_grant',
+            expectedWebhookStatus: 'rejected',
+            expectedRawStatus: 'paid',
+        );
+
+        $this->assertTenantState(
+            tenant: $tenant,
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedGrantStatus: null,
+            expectedUnlockStatus: 'paid_no_grant',
+            expectedRawStatus: 'paid',
+        );
+
+        $this->assertPaidOrderRepairBlocked($tenant['org_id'], $orderNo);
+        $this->assertDatabaseHas('payment_events', [
+            'provider' => 'billing',
+            'provider_event_id' => $providerEventId,
+            'status' => 'rejected',
+            'last_error_code' => 'ATTEMPT_SCALE_MISMATCH',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'status' => 'paid',
+            'target_attempt_id' => $wrongAttemptId,
+        ]);
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->update([
+                'target_attempt_id' => $correctAttemptId,
+                'updated_at' => now()->subMinutes(9),
+            ]);
+
+        $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+            '--org_id' => $tenant['org_id'],
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+            '--include_semantic_rejects' => 1,
+            '--json' => 1,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider' => 'billing',
+            'provider_event_id' => $providerEventId,
+            'status' => 'processed',
+            'handle_status' => 'reprocessed',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'org_id' => $tenant['org_id'],
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'fulfilled',
+            'target_attempt_id' => $correctAttemptId,
+        ]);
+        $this->assertSame(
+            1,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+
+        $repairedLookup = $this->lookupForTenant($tenant['token'], $orderNo, $tenant['email']);
+        $repairedLookup->assertOk();
+        $repairedLookup->assertJsonPath('ok', true);
+        $repairedLookup->assertJsonPath('order_no', $orderNo);
+        $repairedLookup->assertJsonPath('attempt_id', $correctAttemptId);
+        $repairedLookup->assertJsonPath('status', 'paid');
+        $repairedLookup->assertJsonPath('payment_state', 'paid');
+        $repairedLookup->assertJsonPath('grant_state', 'granted');
+        $repairedLookup->assertJsonPath('latest_payment_attempt.state', 'paid');
+
+        $this->assertOpsState(
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedUnlockStatus: 'unlocked',
+            expectedWebhookStatus: 'processed',
+            expectedRawStatus: 'fulfilled',
+        );
+
+        $this->assertTenantState(
+            tenant: $tenant,
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedGrantStatus: 'active',
+            expectedUnlockStatus: 'unlocked',
+            expectedRawStatus: 'fulfilled',
+        );
+    }
+
+    private function assertPaidOrderRepairBlocked(int $orgId, string $orderNo): void
+    {
+        $exitCode = Artisan::call('commerce:repair-paid-orders', [
+            '--org_id' => $orgId,
+            '--order' => $orderNo,
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+            '--json' => 1,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $summary = json_decode(Artisan::output(), true);
+        $this->assertIsArray($summary);
+        $this->assertSame(0, (int) ($summary['candidate_count'] ?? -1));
+        $this->assertSame(0, (int) ($summary['repaired_count'] ?? -1));
+        $this->assertSame(0, (int) ($summary['failed_count'] ?? -1));
+    }
+
+    private function lookupForTenant(string $token, string $orderNo, string $email)
+    {
+        return $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => $email,
+        ]);
+    }
+
+    private function assertOpsState(
+        string $orderNo,
+        string $expectedPaymentStatus,
+        string $expectedUnlockStatus,
+        string $expectedWebhookStatus,
+        string $expectedRawStatus
+    ): void {
+        $record = app(OrderLinkageSupport::class)
+            ->query()
+            ->where('orders.order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($record);
+
+        $support = app(OrderLinkageSupport::class);
+        $this->assertSame($expectedPaymentStatus, $support->paymentStatus($record)['label']);
+        $this->assertSame($expectedUnlockStatus, $support->unlockStatus($record)['label']);
+        $this->assertSame($expectedWebhookStatus, $support->webhookStatus($record)['label']);
+        $this->assertSame($expectedRawStatus, strtolower(trim((string) ($record->status ?? ''))));
+    }
+
+    /**
+     * @param  array{org_id:int,user_id:int,token:string,anon_id:string,email:string}  $tenant
+     */
+    private function assertTenantState(
+        array $tenant,
+        string $orderNo,
+        string $expectedPaymentStatus,
+        ?string $expectedGrantStatus,
+        string $expectedUnlockStatus,
+        string $expectedRawStatus
+    ): void {
+        $this->bootstrapTenantContext($tenant['org_id'], $tenant['user_id']);
+        $this->actingAs(TenantUser::query()->findOrFail($tenant['user_id']), (string) config('tenant.guard', 'tenant'));
+        request()->attributes->set('org_id', $tenant['org_id']);
+        request()->attributes->set('fm_org_id', $tenant['org_id']);
+        request()->attributes->set('org_context_resolved', true);
+        request()->attributes->set('org_context_kind', \App\Support\OrgContext::KIND_TENANT);
+
+        $record = TenantOrderResource::getEloquentQuery()
+            ->where('order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($record);
+
+        $paymentStatus = $this->tenantResourceMethod('paymentStatus');
+        $grantStatus = $this->tenantResourceMethod('grantStatus');
+        $unlockStatus = $this->tenantResourceMethod('unlockStatus');
+
+        $this->assertSame($expectedPaymentStatus, $paymentStatus->invoke(null, $record)['label']);
+        if ($expectedGrantStatus === null) {
+            $this->assertNotSame('active', $grantStatus->invoke(null, $record)['label']);
+        } else {
+            $this->assertSame($expectedGrantStatus, $grantStatus->invoke(null, $record)['label']);
+        }
+        $this->assertSame($expectedUnlockStatus, $unlockStatus->invoke(null, $record)['label']);
+        $this->assertSame($expectedRawStatus, strtolower(trim((string) ($record->status ?? ''))));
+    }
+
+    private function seedCommerceCatalog(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
+    }
+
+    /**
+     * @return array{org_id:int,user_id:int,token:string,anon_id:string,email:string}
+     */
+    private function createTenantOrgUserToken(): array
+    {
+        $email = 'postpaid-mismatch-tenant@example.com';
+        $userId = (int) DB::table('users')->insertGetId([
+            'name' => 'Postpaid Mismatch Tenant User',
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $orgId = (int) DB::table('organizations')->insertGetId([
+            'name' => 'Postpaid Mismatch Tenant Org',
+            'owner_user_id' => $userId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => 'owner',
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $anonId = 'anon_postpaid_mismatch_'.$userId;
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'org_id' => $orgId,
+            'role' => 'owner',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return [
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'token' => $token,
+            'anon_id' => $anonId,
+            'email' => $email,
+        ];
+    }
+
+    private function createMbtiAttemptWithResult(int $orgId, string $userId, string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $packId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+
+        Attempt::query()->create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(10),
+            'submitted_at' => now()->subMinutes(9),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::query()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => ['EI' => ['a' => 10, 'b' => 10, 'total' => 20]],
+            'scores_pct' => ['EI' => 50],
+            'axis_states' => ['EI' => 'clear'],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createSdsAttemptWithResult(int $orgId, string $userId, string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::query()->create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'scale_code' => 'SDS_20',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 20,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(10),
+            'submitted_at' => now()->subMinutes(9),
+            'pack_id' => 'SDS_20',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'v2.0_Factor_Logic',
+        ]);
+
+        Result::query()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'SDS_20',
+            'scale_version' => 'v0.3',
+            'type_code' => '',
+            'scores_json' => ['sds_total' => 42],
+            'scores_pct' => ['sds_total' => 60],
+            'axis_states' => [],
+            'pack_id' => 'SDS_20',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'v2.0_Factor_Logic',
+            'report_engine_version' => 'v1.0',
+            'is_valid' => true,
+            'computed_at' => now(),
+            'result_json' => [
+                'scale_code' => 'SDS_20',
+                'normed_json' => [
+                    'scale_code' => 'SDS_20',
+                    'quality' => [
+                        'level' => 'A',
+                        'crisis_alert' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        return $attemptId;
+    }
+
+    private function tenantResourceMethod(string $name): ReflectionMethod
+    {
+        $method = new ReflectionMethod(TenantOrderResource::class, $name);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+
+    private function bootstrapTenantContext(int $orgId, int $userId): void
+    {
+        $context = app(\App\Support\OrgContext::class);
+        $context->set($orgId, $userId, 'owner', null, \App\Support\OrgContext::KIND_TENANT);
+        app()->instance(\App\Support\OrgContext::class, $context);
+    }
+}

--- a/backend/tests/Feature/Commerce/PrePaidMismatchRepairOpsTenantVisibilityAcceptanceTest.php
+++ b/backend/tests/Feature/Commerce/PrePaidMismatchRepairOpsTenantVisibilityAcceptanceTest.php
@@ -1,0 +1,454 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Filament\Ops\Resources\OrderResource\Support\OrderLinkageSupport;
+use App\Filament\Tenant\Resources\OrderResource as TenantOrderResource;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Models\TenantUser;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use ReflectionMethod;
+use Tests\Concerns\SignedBillingWebhook;
+use Tests\TestCase;
+
+final class PrePaidMismatchRepairOpsTenantVisibilityAcceptanceTest extends TestCase
+{
+    use RefreshDatabase;
+    use SignedBillingWebhook;
+
+    public function test_amount_mismatch_repair_converges_consistently_in_lookup_ops_and_tenant(): void
+    {
+        $this->runPrePaidMismatchScenario(
+            mismatchCode: 'AMOUNT_MISMATCH',
+            webhookAmountCents: 1,
+            webhookCurrency: 'CNY',
+            repairFix: function (string $orderNo): void {
+                DB::table('orders')
+                    ->where('order_no', $orderNo)
+                    ->update([
+                        'amount_cents' => 1,
+                        'amount_total' => 1,
+                        'updated_at' => now()->subMinutes(9),
+                    ]);
+
+                DB::table('payment_attempts')
+                    ->where('order_no', $orderNo)
+                    ->update([
+                        'amount_expected' => 1,
+                        'updated_at' => now()->subMinutes(9),
+                    ]);
+            }
+        );
+    }
+
+    public function test_currency_mismatch_repair_converges_consistently_in_lookup_ops_and_tenant(): void
+    {
+        $this->runPrePaidMismatchScenario(
+            mismatchCode: 'CURRENCY_MISMATCH',
+            webhookAmountCents: null,
+            webhookCurrency: 'USD',
+            repairFix: function (string $orderNo): void {
+                DB::table('orders')
+                    ->where('order_no', $orderNo)
+                    ->update([
+                        'currency' => 'USD',
+                        'updated_at' => now()->subMinutes(9),
+                    ]);
+
+                DB::table('payment_attempts')
+                    ->where('order_no', $orderNo)
+                    ->update([
+                        'currency' => 'USD',
+                        'updated_at' => now()->subMinutes(9),
+                    ]);
+            }
+        );
+    }
+
+    private function runPrePaidMismatchScenario(
+        string $mismatchCode,
+        ?int $webhookAmountCents,
+        string $webhookCurrency,
+        callable $repairFix
+    ): void {
+        $this->seedCommerceCatalog();
+
+        config([
+            'payments.providers.billing.enabled' => true,
+            'queue.default' => 'sync',
+            'queue.connections.database.driver' => 'sync',
+        ]);
+
+        $tenant = $this->createTenantOrgUserToken();
+        $this->grantScaleForOrg($tenant['org_id'], 'MBTI');
+
+        $attemptId = $this->createMbtiAttemptWithResult(
+            orgId: $tenant['org_id'],
+            userId: (string) $tenant['user_id'],
+            anonId: $tenant['anon_id'],
+        );
+
+        $checkout = $this->withHeaders([
+            'Authorization' => 'Bearer '.$tenant['token'],
+            'X-Org-Id' => (string) $tenant['org_id'],
+        ])->postJson('/api/v0.3/orders/checkout', [
+            'attempt_id' => $attemptId,
+            'sku' => 'MBTI_REPORT_FULL',
+            'provider' => 'billing',
+            'email' => $tenant['email'],
+        ]);
+
+        $checkout->assertOk();
+        $checkout->assertJsonPath('ok', true);
+        $checkout->assertJsonPath('status', 'pending');
+        $checkout->assertJsonPath('payment_state', 'pending');
+        $checkout->assertJsonPath('grant_state', 'not_started');
+
+        $orderNo = (string) $checkout->json('order_no');
+        $this->assertNotSame('', $orderNo);
+        $createdOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($createdOrder);
+
+        $providerEventId = 'evt_'.Str::lower($mismatchCode).'_'.$orderNo;
+        $webhook = $this->postSignedBillingWebhook([
+            'provider_event_id' => $providerEventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_'.$orderNo,
+            'amount_cents' => $webhookAmountCents ?? (int) ($createdOrder->amount_cents ?? 0),
+            'currency' => $webhookCurrency,
+            'event_type' => 'payment_succeeded',
+        ]);
+
+        $webhook->assertStatus(200);
+        $webhook->assertJsonPath('ok', false);
+        $webhook->assertJsonPath('rejected', true);
+        $webhook->assertJsonPath('acknowledged', true);
+        $webhook->assertJsonPath('reject_reason', $mismatchCode);
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider' => 'billing',
+            'provider_event_id' => $providerEventId,
+            'status' => 'rejected',
+            'handle_status' => 'rejected',
+            'last_error_code' => $mismatchCode,
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'org_id' => $tenant['org_id'],
+            'payment_state' => 'pending',
+            'grant_state' => 'not_started',
+            'status' => 'pending',
+        ]);
+        $this->assertSame(
+            0,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+
+        $preRepairLookup = $this->lookupForTenant($tenant['token'], $orderNo, $tenant['email']);
+        $preRepairLookup->assertOk();
+        $preRepairLookup->assertJsonPath('ok', true);
+        $preRepairLookup->assertJsonPath('order_no', $orderNo);
+        $preRepairLookup->assertJsonPath('attempt_id', $attemptId);
+        $preRepairLookup->assertJsonPath('status', 'pending');
+        $preRepairLookup->assertJsonPath('payment_state', 'pending');
+        $preRepairLookup->assertJsonPath('grant_state', 'not_started');
+
+        $this->assertOpsState(
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'pending',
+            expectedUnlockStatus: 'pending',
+            expectedWebhookStatus: 'rejected',
+            expectedRawStatus: 'pending',
+        );
+
+        $this->assertTenantState(
+            tenant: $tenant,
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'pending',
+            expectedGrantStatus: null,
+            expectedUnlockStatus: 'pending',
+            expectedRawStatus: 'pending',
+        );
+
+        $repairFix($orderNo);
+
+        $exitCode = Artisan::call('commerce:repair-post-commit-failed', [
+            '--org_id' => $tenant['org_id'],
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+            '--include_semantic_rejects' => 1,
+            '--json' => 1,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $this->assertDatabaseHas('payment_events', [
+            'provider' => 'billing',
+            'provider_event_id' => $providerEventId,
+            'status' => 'processed',
+            'handle_status' => 'reprocessed',
+        ]);
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'org_id' => $tenant['org_id'],
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'fulfilled',
+        ]);
+        $this->assertSame(
+            1,
+            DB::table('benefit_grants')
+                ->where('org_id', $tenant['org_id'])
+                ->where('order_no', $orderNo)
+                ->where('status', 'active')
+                ->count()
+        );
+
+        $repairedLookup = $this->lookupForTenant($tenant['token'], $orderNo, $tenant['email']);
+        $repairedLookup->assertOk();
+        $repairedLookup->assertJsonPath('ok', true);
+        $repairedLookup->assertJsonPath('order_no', $orderNo);
+        $repairedLookup->assertJsonPath('attempt_id', $attemptId);
+        $repairedLookup->assertJsonPath('status', 'paid');
+        $repairedLookup->assertJsonPath('payment_state', 'paid');
+        $repairedLookup->assertJsonPath('grant_state', 'granted');
+        $repairedLookup->assertJsonPath('latest_payment_attempt.state', 'paid');
+
+        $this->assertOpsState(
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedUnlockStatus: 'unlocked',
+            expectedWebhookStatus: 'processed',
+            expectedRawStatus: 'fulfilled',
+        );
+
+        $this->assertTenantState(
+            tenant: $tenant,
+            orderNo: $orderNo,
+            expectedPaymentStatus: 'paid',
+            expectedGrantStatus: 'active',
+            expectedUnlockStatus: 'unlocked',
+            expectedRawStatus: 'fulfilled',
+        );
+    }
+
+    private function lookupForTenant(string $token, string $orderNo, string $email)
+    {
+        return $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => $email,
+        ]);
+    }
+
+    private function assertOpsState(
+        string $orderNo,
+        string $expectedPaymentStatus,
+        string $expectedUnlockStatus,
+        string $expectedWebhookStatus,
+        string $expectedRawStatus
+    ): void {
+        $record = app(OrderLinkageSupport::class)
+            ->query()
+            ->where('orders.order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($record);
+
+        $support = app(OrderLinkageSupport::class);
+        $this->assertSame($expectedPaymentStatus, $support->paymentStatus($record)['label']);
+        $this->assertSame($expectedUnlockStatus, $support->unlockStatus($record)['label']);
+        $this->assertSame($expectedWebhookStatus, $support->webhookStatus($record)['label']);
+        $this->assertSame($expectedRawStatus, strtolower(trim((string) ($record->status ?? ''))));
+    }
+
+    /**
+     * @param  array{org_id:int,user_id:int,token:string,anon_id:string,email:string}  $tenant
+     */
+    private function assertTenantState(
+        array $tenant,
+        string $orderNo,
+        string $expectedPaymentStatus,
+        ?string $expectedGrantStatus,
+        string $expectedUnlockStatus,
+        string $expectedRawStatus
+    ): void {
+        $this->bootstrapTenantContext($tenant['org_id'], $tenant['user_id']);
+        $this->actingAs(TenantUser::query()->findOrFail($tenant['user_id']), (string) config('tenant.guard', 'tenant'));
+        request()->attributes->set('org_id', $tenant['org_id']);
+        request()->attributes->set('fm_org_id', $tenant['org_id']);
+        request()->attributes->set('org_context_resolved', true);
+        request()->attributes->set('org_context_kind', \App\Support\OrgContext::KIND_TENANT);
+
+        $record = TenantOrderResource::getEloquentQuery()
+            ->where('order_no', $orderNo)
+            ->first();
+
+        $this->assertNotNull($record);
+
+        $paymentStatus = $this->tenantResourceMethod('paymentStatus');
+        $grantStatus = $this->tenantResourceMethod('grantStatus');
+        $unlockStatus = $this->tenantResourceMethod('unlockStatus');
+
+        $this->assertSame($expectedPaymentStatus, $paymentStatus->invoke(null, $record)['label']);
+        if ($expectedGrantStatus === null) {
+            $this->assertNotSame('active', $grantStatus->invoke(null, $record)['label']);
+        } else {
+            $this->assertSame($expectedGrantStatus, $grantStatus->invoke(null, $record)['label']);
+        }
+        $this->assertSame($expectedUnlockStatus, $unlockStatus->invoke(null, $record)['label']);
+        $this->assertSame($expectedRawStatus, strtolower(trim((string) ($record->status ?? ''))));
+    }
+
+    private function seedCommerceCatalog(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
+    }
+
+    /**
+     * @return array{org_id:int,user_id:int,token:string,anon_id:string,email:string}
+     */
+    private function createTenantOrgUserToken(): array
+    {
+        $email = 'prepaid-mismatch-tenant@example.com';
+        $userId = (int) DB::table('users')->insertGetId([
+            'name' => 'Prepaid Mismatch Tenant User',
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $orgId = (int) DB::table('organizations')->insertGetId([
+            'name' => 'Prepaid Mismatch Tenant Org',
+            'owner_user_id' => $userId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => 'owner',
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $anonId = 'anon_prepaid_mismatch_'.$userId;
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'org_id' => $orgId,
+            'role' => 'owner',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return [
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'token' => $token,
+            'anon_id' => $anonId,
+            'email' => $email,
+        ];
+    }
+
+    private function createMbtiAttemptWithResult(int $orgId, string $userId, string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $packId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+
+        Attempt::query()->create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(10),
+            'submitted_at' => now()->subMinutes(9),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::query()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function tenantResourceMethod(string $name): ReflectionMethod
+    {
+        $method = new ReflectionMethod(TenantOrderResource::class, $name);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+
+    private function bootstrapTenantContext(int $orgId, int $userId): void
+    {
+        $context = app(\App\Support\OrgContext::class);
+        $context->set($orgId, $userId, 'owner', null, \App\Support\OrgContext::KIND_TENANT);
+        app()->instance(\App\Support\OrgContext::class, $context);
+    }
+}


### PR DESCRIPTION
## Summary
- add pre-paid mismatch visibility acceptance for amount and currency mismatch replay repair
- add post-paid attempt mismatch visibility acceptance for owner and scale mismatch replay repair
- prevent pending lookup from creating a fresh payment attempt when there is no actionable payment payload, so pre-paid mismatch replay surfaces the repaired latest payment attempt consistently

## Tests
- cd backend && ./vendor/bin/pint app/Http/Controllers/API/V0_3/CommerceController.php tests/Feature/Commerce/PrePaidMismatchRepairOpsTenantVisibilityAcceptanceTest.php tests/Feature/Commerce/PostPaidAttemptMismatchRepairOpsTenantVisibilityAcceptanceTest.php
- cd backend && php artisan test tests/Feature/Commerce/PrePaidMismatchRepairOpsTenantVisibilityAcceptanceTest.php
- cd backend && php artisan test tests/Feature/Commerce/PostPaidAttemptMismatchRepairOpsTenantVisibilityAcceptanceTest.php
- cd backend && php artisan test --filter='PaymentRepairEngineTest|PaymentWebhookProcessorContractTest|PaymentWebhookTrustBoundaryTest|ClinicalCombo68WebhookIdempotencyTest|Sds20WebhookIdempotencyTest|CheckoutWebhookOpsTenantVisibilityAcceptanceTest|PostCommitFailedRepairOpsTenantVisibilityAcceptanceTest|SemanticRejectRepairOpsTenantVisibilityAcceptanceTest|OrderPaymentReadContractTest|TenantOrderReadContractTest|OrderCommerceLinkageTest'
