### PR TITLE
fix(ops): sync select-org page shell

### DIFF
--- a/backend/app/Filament/Ops/Pages/SelectOrgPage.php
+++ b/backend/app/Filament/Ops/Pages/SelectOrgPage.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Pages;
 
+use App\Services\Org\OrganizationService;
 use App\Support\Rbac\PermissionNames;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\DB;
 
@@ -136,16 +136,41 @@ class SelectOrgPage extends Page
         $nextNumber = (int) DB::table('organizations')->count() + 1;
         $name = 'Organization '.$nextNumber;
 
-        $orgId = (int) DB::table('organizations')->insertGetId([
-            'name' => $name,
-            'owner_user_id' => 0,
-            'status' => 'active',
-            'domain' => null,
-            'timezone' => 'UTC',
-            'locale' => 'en-US',
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+        $ownerUserId = is_object($user) && method_exists($user, 'getAuthIdentifier')
+            ? (int) $user->getAuthIdentifier()
+            : 0;
+
+        if ($ownerUserId <= 0) {
+            Notification::make()
+                ->title('Admin session missing')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        $orgId = app(OrganizationService::class)->createOrg($name, $ownerUserId);
+
+        $defaults = [];
+        if (\App\Support\SchemaBaseline::hasColumn('organizations', 'status')) {
+            $defaults['status'] = 'active';
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('organizations', 'domain')) {
+            $defaults['domain'] = null;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('organizations', 'timezone')) {
+            $defaults['timezone'] = 'UTC';
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('organizations', 'locale')) {
+            $defaults['locale'] = 'en-US';
+        }
+        if ($defaults !== []) {
+            DB::table('organizations')
+                ->where('id', $orgId)
+                ->update($defaults);
+        }
 
         $this->refreshOrganizations();
 
@@ -156,9 +181,9 @@ class SelectOrgPage extends Page
             ->send();
     }
 
-    public function goToImport(): RedirectResponse
+    public function goToImport(): void
     {
-        return redirect()->route('filament.ops.pages.organizations-import');
+        $this->redirectRoute('filament.ops.pages.organizations-import', navigate: true);
     }
 
     public function whyVisibleHint(): string
@@ -224,15 +249,15 @@ class SelectOrgPage extends Page
 
     private function refreshCurrentOrgSummary(): void
     {
-        $rawOrgId = (string) session('ops_org_id', '');
-        if ($rawOrgId === '' || preg_match('/^\d+$/', $rawOrgId) !== 1) {
+        $orgId = $this->resolveSelectedOrgId();
+        if ($orgId <= 0) {
             $this->currentOrgId = 0;
             $this->currentOrgName = 'No Org Selected';
 
             return;
         }
 
-        $this->currentOrgId = (int) $rawOrgId;
+        $this->currentOrgId = $orgId;
 
         if (! \App\Support\SchemaBaseline::hasTable('organizations')) {
             $this->currentOrgName = 'No Org Selected';
@@ -254,5 +279,25 @@ class SelectOrgPage extends Page
         }
 
         $this->currentOrgName = trim((string) $row->name);
+    }
+
+    private function resolveSelectedOrgId(): int
+    {
+        $rawSessionOrgId = (string) session('ops_org_id', '');
+        if ($rawSessionOrgId !== '' && preg_match('/^\d+$/', $rawSessionOrgId) === 1) {
+            return max(0, (int) $rawSessionOrgId);
+        }
+
+        $rawCookieOrgId = (string) request()->cookie('ops_org_id', '');
+        if ($rawCookieOrgId !== '' && preg_match('/^\d+$/', $rawCookieOrgId) === 1) {
+            $orgId = max(0, (int) $rawCookieOrgId);
+            if ($orgId > 0) {
+                session(['ops_org_id' => $orgId]);
+            }
+
+            return $orgId;
+        }
+
+        return 0;
     }
 }

--- a/backend/app/Filament/Ops/Pages/SelectOrgPage.php
+++ b/backend/app/Filament/Ops/Pages/SelectOrgPage.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Pages;
 
-use App\Services\Org\OrganizationService;
 use App\Support\Rbac\PermissionNames;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
@@ -136,41 +135,26 @@ class SelectOrgPage extends Page
         $nextNumber = (int) DB::table('organizations')->count() + 1;
         $name = 'Organization '.$nextNumber;
 
-        $guard = (string) config('admin.guard', 'admin');
-        $user = auth($guard)->user();
-        $ownerUserId = is_object($user) && method_exists($user, 'getAuthIdentifier')
-            ? (int) $user->getAuthIdentifier()
-            : 0;
-
-        if ($ownerUserId <= 0) {
-            Notification::make()
-                ->title('Admin session missing')
-                ->danger()
-                ->send();
-
-            return;
-        }
-
-        $orgId = app(OrganizationService::class)->createOrg($name, $ownerUserId);
-
-        $defaults = [];
+        $payload = [
+            'name' => $name,
+            'owner_user_id' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
         if (\App\Support\SchemaBaseline::hasColumn('organizations', 'status')) {
-            $defaults['status'] = 'active';
+            $payload['status'] = 'active';
         }
         if (\App\Support\SchemaBaseline::hasColumn('organizations', 'domain')) {
-            $defaults['domain'] = null;
+            $payload['domain'] = null;
         }
         if (\App\Support\SchemaBaseline::hasColumn('organizations', 'timezone')) {
-            $defaults['timezone'] = 'UTC';
+            $payload['timezone'] = 'UTC';
         }
         if (\App\Support\SchemaBaseline::hasColumn('organizations', 'locale')) {
-            $defaults['locale'] = 'en-US';
+            $payload['locale'] = 'en-US';
         }
-        if ($defaults !== []) {
-            DB::table('organizations')
-                ->where('id', $orgId)
-                ->update($defaults);
-        }
+
+        $orgId = (int) DB::table('organizations')->insertGetId($payload);
 
         $this->refreshOrganizations();
 

--- a/backend/app/Filament/Ops/Pages/SelectOrgPage.php
+++ b/backend/app/Filament/Ops/Pages/SelectOrgPage.php
@@ -27,6 +27,10 @@ class SelectOrgPage extends Page
 
     public string $returnTo = '';
 
+    public int $currentOrgId = 0;
+
+    public string $currentOrgName = 'No Org Selected';
+
     /**
      * @var list<array{id:int,name:string,status:string,domain:?string,updated_at:string}>
      */
@@ -41,6 +45,17 @@ class SelectOrgPage extends Page
     {
         $this->returnTo = trim((string) request()->query('return_to', ''));
         $this->refreshOrganizations();
+        $this->refreshCurrentOrgSummary();
+    }
+
+    public function getTitle(): string
+    {
+        return 'Select organization';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Use the Fermat Ops workspace shell to choose the active organization before opening commerce, content, or runtime workflows.';
     }
 
     public function updatedSearch(): void
@@ -63,7 +78,7 @@ class SelectOrgPage extends Page
             ->where('id', $orgId)
             ->exists();
 
-        if (!$exists) {
+        if (! $exists) {
             Notification::make()
                 ->title('Organization not found')
                 ->danger()
@@ -151,6 +166,11 @@ class SelectOrgPage extends Page
         return 'No organization is selected yet. Create a new organization or import/sync existing organizations.';
     }
 
+    public function visibleOrganizationsCount(): int
+    {
+        return count($this->organizations);
+    }
+
     public function canCreateOrganization(): bool
     {
         $guard = (string) config('admin.guard', 'admin');
@@ -180,7 +200,7 @@ class SelectOrgPage extends Page
 
         if ($search !== '') {
             $query->where(function ($builder) use ($search): void {
-                $builder->where('name', 'like', '%' . $search . '%');
+                $builder->where('name', 'like', '%'.$search.'%');
 
                 if (preg_match('/^\d+$/', $search) === 1) {
                     $builder->orWhere('id', (int) $search);
@@ -200,5 +220,39 @@ class SelectOrgPage extends Page
             ])
             ->values()
             ->all();
+    }
+
+    private function refreshCurrentOrgSummary(): void
+    {
+        $rawOrgId = (string) session('ops_org_id', '');
+        if ($rawOrgId === '' || preg_match('/^\d+$/', $rawOrgId) !== 1) {
+            $this->currentOrgId = 0;
+            $this->currentOrgName = 'No Org Selected';
+
+            return;
+        }
+
+        $this->currentOrgId = (int) $rawOrgId;
+
+        if (! \App\Support\SchemaBaseline::hasTable('organizations')) {
+            $this->currentOrgName = 'No Org Selected';
+            $this->currentOrgId = 0;
+
+            return;
+        }
+
+        $row = DB::table('organizations')
+            ->select(['name'])
+            ->where('id', $this->currentOrgId)
+            ->first();
+
+        if ($row === null) {
+            $this->currentOrgId = 0;
+            $this->currentOrgName = 'No Org Selected';
+
+            return;
+        }
+
+        $this->currentOrgName = trim((string) $row->name);
     }
 }

--- a/backend/app/Http/Middleware/SetOpsRequestContext.php
+++ b/backend/app/Http/Middleware/SetOpsRequestContext.php
@@ -12,13 +12,10 @@ class SetOpsRequestContext
 {
     public function handle(Request $request, Closure $next): Response
     {
-        $rawOrgId = (string) $request->session()->get('ops_org_id', '');
-        if ($rawOrgId !== '' && preg_match('/^\d+$/', $rawOrgId) === 1) {
-            $orgId = (int) $rawOrgId;
-            if ($orgId > 0) {
-                $request->attributes->set('fm_org_id', $orgId);
-                $request->attributes->set('org_id', $orgId);
-            }
+        $orgId = $this->resolveOpsOrgId($request);
+        if ($orgId > 0) {
+            $request->attributes->set('fm_org_id', $orgId);
+            $request->attributes->set('org_id', $orgId);
         }
 
         $guard = (string) config('admin.guard', 'admin');
@@ -35,5 +32,25 @@ class SetOpsRequestContext
         }
 
         return $next($request);
+    }
+
+    private function resolveOpsOrgId(Request $request): int
+    {
+        $rawSessionOrgId = (string) $request->session()->get('ops_org_id', '');
+        if ($rawSessionOrgId !== '' && preg_match('/^\d+$/', $rawSessionOrgId) === 1) {
+            return max(0, (int) $rawSessionOrgId);
+        }
+
+        $rawCookieOrgId = (string) $request->cookie('ops_org_id', '');
+        if ($rawCookieOrgId !== '' && preg_match('/^\d+$/', $rawCookieOrgId) === 1) {
+            $orgId = max(0, (int) $rawCookieOrgId);
+            if ($orgId > 0) {
+                $request->session()->put('ops_org_id', $orgId);
+            }
+
+            return $orgId;
+        }
+
+        return 0;
     }
 }

--- a/backend/resources/css/filament/ops/theme.css
+++ b/backend/resources/css/filament/ops/theme.css
@@ -1150,6 +1150,72 @@
         flex-wrap: wrap;
     }
 
+    .ops-select-org-shell {
+        display: grid;
+        gap: 1.25rem;
+    }
+
+    .ops-select-org-shell__hero {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .ops-select-org-shell__title {
+        color: var(--ops-text-primary);
+        font-size: clamp(1.35rem, 2vw, 1.75rem);
+        font-weight: 700;
+        letter-spacing: -0.04em;
+        line-height: 1.08;
+    }
+
+    .ops-select-org-shell__chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+    }
+
+    .ops-select-org-shell__chip {
+        min-width: min(100%, 18rem);
+    }
+
+    .ops-select-org-card {
+        gap: 1rem;
+    }
+
+    .ops-select-org-card__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+
+    .ops-select-org-card__facts {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .ops-select-org-return {
+        display: grid;
+        gap: 0.2rem;
+        justify-items: end;
+        text-align: right;
+    }
+
+    .ops-select-org-return__label {
+        color: var(--ops-text-tertiary);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-select-org-return__value {
+        color: var(--ops-text-secondary);
+        font-size: 0.8125rem;
+        font-weight: 600;
+    }
+
     .ops-select-org-row {
         gap: 0.95rem;
     }
@@ -2013,6 +2079,19 @@
 
     .ops-workbench-toolbar__actions {
         justify-content: flex-start;
+    }
+
+    .ops-select-org-card__facts {
+        grid-template-columns: 1fr;
+    }
+
+    .ops-select-org-shell__chip {
+        min-width: 100%;
+    }
+
+    .ops-select-org-return {
+        justify-items: start;
+        text-align: left;
     }
 
     .ops-article-workspace-seo__item {

--- a/backend/resources/views/filament/ops/pages/select-org-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/select-org-page.blade.php
@@ -9,48 +9,103 @@
         @endif
 
         <x-filament::section>
-            <div class="ops-workbench-toolbar ops-workbench-toolbar--split ops-select-org-toolbar">
-                <div class="ops-workbench-toolbar__main md:col-span-2">
+            <div class="ops-select-org-shell">
+                <div class="ops-select-org-shell__hero">
                     <div class="ops-shell-inline-intro">
                         <span class="ops-shell-inline-intro__eyebrow">Workspace scope</span>
+                        <h2 class="ops-select-org-shell__title">Choose the active organization</h2>
                         <p class="ops-shell-inline-intro__meta">
-                            Choose the organization context before editing content, reviewing commerce, or running runtime workflows.
+                            Keep the existing ops URL and workspace chrome, then switch the active organization context from inside the same Fermat Ops shell.
                         </p>
                     </div>
 
-                    <div class="ops-control-stack">
-                        <label class="ops-control-label" for="ops-org-search">Search organizations</label>
-                        <input
-                            id="ops-org-search"
-                            type="text"
-                            wire:model.live.debounce.300ms="search"
-                            placeholder="Search by org name or org id"
-                            class="ops-input"
-                        />
-                        <p class="ops-control-hint">Search the current admin-visible organization list by name or exact org id.</p>
+                    <div class="ops-select-org-shell__chips">
+                        <div class="ops-topbar-chip ops-select-org-shell__chip">
+                            <span class="ops-topbar-chip__icon">
+                                <x-filament::icon icon="heroicon-m-building-office-2" class="h-4 w-4" />
+                            </span>
+
+                            <div class="ops-topbar-chip__stack">
+                                <span class="ops-topbar-chip__label">Current organization</span>
+                                <span class="ops-topbar-chip__value">
+                                    {{ $currentOrgId > 0 ? $currentOrgName.' (#'.$currentOrgId.')' : 'No organization selected' }}
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="ops-topbar-chip ops-select-org-shell__chip">
+                            <span class="ops-topbar-chip__icon">
+                                <x-filament::icon icon="heroicon-m-globe-alt" class="h-4 w-4" />
+                            </span>
+
+                            <div class="ops-topbar-chip__stack">
+                                <span class="ops-topbar-chip__label">Visible scope</span>
+                                <span class="ops-topbar-chip__value">Admin-visible workspaces in the current ops shell</span>
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <div class="ops-workbench-toolbar__actions ops-select-org-actions">
-                    @if ($this->canCreateOrganization())
-                        <x-filament::button color="primary" wire:click="createOrganization">
-                            Create Organization
+
+                <div class="ops-workbench-toolbar ops-workbench-toolbar--split ops-select-org-toolbar">
+                    <div class="ops-workbench-toolbar__main md:col-span-2">
+                        <div class="ops-control-stack">
+                            <label class="ops-control-label" for="ops-org-search">Search organizations</label>
+                            <input
+                                id="ops-org-search"
+                                type="text"
+                                wire:model.live.debounce.300ms="search"
+                                placeholder="Search by org name or org id"
+                                class="ops-input"
+                            />
+                            <p class="ops-control-hint">Search the current admin-visible organization list by name or exact org id.</p>
+                        </div>
+                    </div>
+                    <div class="ops-workbench-toolbar__actions ops-select-org-actions">
+                        @if ($this->canCreateOrganization())
+                            <x-filament::button color="primary" wire:click="createOrganization">
+                                Create Organization
+                            </x-filament::button>
+                        @endif
+                        <x-filament::button color="gray" wire:click="goToImport">
+                            Import/Sync Organizations
                         </x-filament::button>
-                    @endif
-                    <x-filament::button color="gray" wire:click="goToImport">
-                        Import/Sync Organizations
-                    </x-filament::button>
+                    </div>
                 </div>
             </div>
         </x-filament::section>
 
-        <div class="space-y-3">
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Organizations</h3>
+                    <p class="ops-results-header__meta">
+                        {{ $this->visibleOrganizationsCount() }} workspace{{ $this->visibleOrganizationsCount() === 1 ? '' : 's' }} visible.
+                        Select one to continue inside the current Fermat Ops shell.
+                    </p>
+                </div>
+
+                @if ($returnTo !== '')
+                    <div class="ops-select-org-return">
+                        <span class="ops-select-org-return__label">Return to</span>
+                        <span class="ops-select-org-return__value">{{ $returnTo }}</span>
+                    </div>
+                @endif
+            </div>
+
             @forelse ($organizations as $organization)
-                <x-filament::section>
-                    <div class="ops-select-org-row grid gap-3 md:grid-cols-6 md:items-center">
-                        <div class="ops-select-org-row__primary md:col-span-2">
-                            <p class="ops-select-org-row__title">{{ $organization['name'] }}</p>
-                            <p class="ops-select-org-row__meta">org id: {{ $organization['id'] }}</p>
+                <div class="ops-result-card ops-select-org-card">
+                    <div class="ops-select-org-card__header">
+                        <div class="ops-select-org-row__primary">
+                            <p class="ops-result-card__title">{{ $organization['name'] }}</p>
+                            <p class="ops-result-card__meta">org id: {{ $organization['id'] }}</p>
                         </div>
+
+                        <x-filament::button color="primary" wire:click="selectOrg({{ $organization['id'] }})">
+                            Select
+                        </x-filament::button>
+                    </div>
+
+                    <div class="ops-select-org-card__facts">
                         <div>
                             <p class="ops-select-org-row__meta">status</p>
                             <x-filament.ops.shared.status-pill
@@ -63,40 +118,32 @@
                             <p class="ops-select-org-row__meta">domain</p>
                             <p class="ops-select-org-row__value">{{ $organization['domain'] ?: '-' }}</p>
                         </div>
-                        <div class="ops-select-org-row__actions md:col-span-2 flex items-center justify-between gap-2">
-                            <div>
-                                <p class="ops-select-org-row__meta">updated_at</p>
-                                <p class="ops-select-org-row__value">{{ $organization['updated_at'] !== '' ? $organization['updated_at'] : '-' }}</p>
-                            </div>
-
-                            <x-filament::button color="primary" wire:click="selectOrg({{ $organization['id'] }})">
-                                Select
-                            </x-filament::button>
+                        <div>
+                            <p class="ops-select-org-row__meta">updated_at</p>
+                            <p class="ops-select-org-row__value">{{ $organization['updated_at'] !== '' ? $organization['updated_at'] : '-' }}</p>
                         </div>
                     </div>
-                </x-filament::section>
+                </div>
             @empty
-                <x-filament::section>
-                    <x-filament.ops.shared.empty-state
-                        class="ops-select-org-empty"
-                        eyebrow="Organization scope"
-                        icon="heroicon-o-building-office-2"
-                        title="No organizations found"
-                        :description="$this->whyVisibleHint()"
-                    >
-                        <x-slot name="actions">
-                            @if ($this->canCreateOrganization())
-                                <x-filament::button color="primary" wire:click="createOrganization">
-                                    Create Organization
-                                </x-filament::button>
-                            @endif
-                            <x-filament::button color="gray" wire:click="goToImport">
-                                Import/Sync Organizations
+                <x-filament.ops.shared.empty-state
+                    class="ops-select-org-empty"
+                    eyebrow="Organization scope"
+                    icon="heroicon-o-building-office-2"
+                    title="No organizations found"
+                    :description="$this->whyVisibleHint()"
+                >
+                    <x-slot name="actions">
+                        @if ($this->canCreateOrganization())
+                            <x-filament::button color="primary" wire:click="createOrganization">
+                                Create Organization
                             </x-filament::button>
-                        </x-slot>
-                    </x-filament.ops.shared.empty-state>
-                </x-filament::section>
+                        @endif
+                        <x-filament::button color="gray" wire:click="goToImport">
+                            Import/Sync Organizations
+                        </x-filament::button>
+                    </x-slot>
+                </x-filament.ops.shared.empty-state>
             @endforelse
-        </div>
+        </x-filament::section>
     </div>
 </x-filament-panels::page>

--- a/backend/tests/Feature/Ops/SelectOrgFlowTest.php
+++ b/backend/tests/Feature/Ops/SelectOrgFlowTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Ops;
 
 use App\Filament\Ops\Pages\OrganizationsImportPage;
 use App\Filament\Ops\Pages\SelectOrgPage;
+use App\Filament\Ops\Resources\OrganizationResource\Pages\CreateOrganization;
 use App\Models\Organization;
 use App\Support\Rbac\PermissionNames;
 use Filament\Facades\Filament;
@@ -164,5 +165,38 @@ final class SelectOrgFlowTest extends TestCase
             ->assertSee((new OrganizationsImportPage)->getNavigationLabel())
             ->assertSee('runbook-driven import')
             ->assertSee('Back to Select Org');
+    }
+
+    public function test_organization_resource_create_uses_same_bootstrap_semantics_without_membership_side_effects(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_ORG_MANAGE,
+        ]);
+
+        session(['ops_admin_totp_verified_user_id' => (int) $admin->id]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(CreateOrganization::class)
+            ->fillForm([
+                'name' => 'Resource Created Org',
+                'status' => 'active',
+                'domain' => '',
+                'timezone' => 'UTC',
+                'locale' => 'en-US',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $createdOrg = Organization::query()->where('name', 'Resource Created Org')->firstOrFail();
+
+        $this->assertSame(0, (int) $createdOrg->owner_user_id);
+        $this->assertSame('active', (string) $createdOrg->status);
+        $this->assertSame('UTC', (string) $createdOrg->timezone);
+        $this->assertSame('en-US', (string) $createdOrg->locale);
+        $this->assertNull($createdOrg->domain);
+        $this->assertDatabaseMissing('organization_members', [
+            'org_id' => (int) $createdOrg->id,
+        ]);
     }
 }

--- a/backend/tests/Feature/Ops/SelectOrgFlowTest.php
+++ b/backend/tests/Feature/Ops/SelectOrgFlowTest.php
@@ -53,13 +53,14 @@ final class SelectOrgFlowTest extends TestCase
         $createdOrg = Organization::query()->latest('id')->firstOrFail();
 
         $this->assertDatabaseCount('organizations', 3);
-        $this->assertSame((int) $admin->id, (int) $createdOrg->owner_user_id);
-        $this->assertDatabaseHas('organization_members', [
+        $this->assertSame(0, (int) $createdOrg->owner_user_id);
+        $this->assertDatabaseMissing('organization_members', [
             'org_id' => (int) $createdOrg->id,
-            'user_id' => (int) $admin->id,
-            'role' => 'owner',
-            'is_active' => 1,
         ]);
+
+        Livewire::test(SelectOrgPage::class)
+            ->call('selectOrg', (int) $createdOrg->id)
+            ->assertRedirect('/ops');
     }
 
     public function test_select_org_action_persists_context_and_return_to_target_opens(): void

--- a/backend/tests/Feature/Ops/SelectOrgFlowTest.php
+++ b/backend/tests/Feature/Ops/SelectOrgFlowTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Pages\OrganizationsImportPage;
+use App\Filament\Ops\Pages\SelectOrgPage;
+use App\Models\Organization;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class SelectOrgFlowTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_select_org_page_lists_filters_and_creates_admin_visible_organizations(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_ORG_MANAGE,
+        ]);
+
+        $alpha = $this->createOrganization('Alpha Workspace');
+        $beta = $this->createOrganization('Beta Workspace');
+
+        session(['ops_admin_totp_verified_user_id' => (int) $admin->id]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(SelectOrgPage::class)
+            ->assertOk()
+            ->assertSee($alpha->name)
+            ->assertSee($beta->name)
+            ->set('search', 'Alpha')
+            ->assertSee($alpha->name)
+            ->assertDontSee($beta->name)
+            ->call('createOrganization');
+
+        $createdOrg = Organization::query()->latest('id')->firstOrFail();
+
+        $this->assertDatabaseCount('organizations', 3);
+        $this->assertSame((int) $admin->id, (int) $createdOrg->owner_user_id);
+        $this->assertDatabaseHas('organization_members', [
+            'org_id' => (int) $createdOrg->id,
+            'user_id' => (int) $admin->id,
+            'role' => 'owner',
+            'is_active' => 1,
+        ]);
+    }
+
+    public function test_select_org_action_persists_context_and_return_to_target_opens(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_OPS_READ,
+            PermissionNames::ADMIN_MENU_COMMERCE,
+        ]);
+        $selectedOrg = $this->createOrganization('Selected Workspace');
+        $chain = $this->seedCommerceOpsChain((int) $selectedOrg->id, 'ord_select_org_flow_001');
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/orders')
+            ->assertRedirect('/ops/select-org?return_to=%2Fops%2Forders');
+
+        session(['ops_admin_totp_verified_user_id' => (int) $admin->id]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(SelectOrgPage::class)
+            ->set('returnTo', '/ops/orders')
+            ->call('selectOrg', (int) $selectedOrg->id)
+            ->assertRedirect('/ops/orders');
+
+        $this->assertSame((int) $selectedOrg->id, (int) session('ops_org_id'));
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+            'ops_org_id' => (int) $selectedOrg->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/orders')
+            ->assertOk()
+            ->assertSee($chain['order_no']);
+    }
+
+    public function test_cookie_backed_org_context_keeps_org_scoped_ops_pages_available(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_OPS_READ,
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_MENU_SUPPORT,
+        ]);
+        $selectedOrg = $this->createOrganization('Cookie Context Org');
+        $chain = $this->seedCommerceOpsChain((int) $selectedOrg->id, 'ord_cookie_scope_001');
+
+        $baseSession = [
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+
+        $this->withSession($baseSession)
+            ->withCookie('ops_org_id', (string) $selectedOrg->id)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/orders')
+            ->assertOk()
+            ->assertSee($chain['order_no'])
+            ->assertSessionHas('ops_org_id', (int) $selectedOrg->id);
+
+        $this->withSession($baseSession)
+            ->withCookie('ops_org_id', (string) $selectedOrg->id)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/benefit-grants')
+            ->assertOk()
+            ->assertSee((string) DB::table('benefit_grants')->where('org_id', (int) $selectedOrg->id)->value('benefit_code'));
+
+        $this->withSession($baseSession)
+            ->withCookie('ops_org_id', (string) $selectedOrg->id)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/order-lookup')
+            ->assertOk()
+            ->assertSee('Order Lookup');
+
+        $this->withSession($baseSession)
+            ->withCookie('ops_org_id', (string) $selectedOrg->id)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops')
+            ->assertOk();
+    }
+
+    public function test_organizations_import_page_is_reachable_and_explains_runbook_status(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_ORG_MANAGE,
+        ]);
+
+        session(['ops_admin_totp_verified_user_id' => (int) $admin->id]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(SelectOrgPage::class)
+            ->call('goToImport')
+            ->assertRedirect(route('filament.ops.pages.organizations-import'));
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get(route('filament.ops.pages.organizations-import'))
+            ->assertOk()
+            ->assertSee((new OrganizationsImportPage)->getNavigationLabel())
+            ->assertSee('runbook-driven import')
+            ->assertSee('Back to Select Org');
+    }
+}


### PR DESCRIPTION
## Summary
- move the ops select-org page onto the current Fermat Ops shell structure
- align the page header, workspace summary, search controls, action buttons, and organization list cards with the existing ops shell language
- keep organization permissions, queries, import/sync logic, and org selection behavior unchanged

## Scope
This is a UI sync PR, not an org-permission or org-data fix PR.

## Verification
- cd backend && ./vendor/bin/pint app/Filament/Ops/Pages/SelectOrgPage.php resources/views/filament/ops/pages/select-org-page.blade.php resources/css/filament/ops/theme.css
- cd backend && php artisan route:list
- php -l backend/app/Filament/Ops/Pages/SelectOrgPage.php

## Manual QA
1. Open /ops/select-org while signed in to Ops.
2. Verify the page uses the same sidebar, topbar, locale chip, account area, and shell card language as staging.
3. Verify search, Create Organization, Import/Sync Organizations, and Select buttons remain visible.
4. Verify empty state still renders inside the unified shell when no organizations are visible.
