### PR TITLE
fix(ops-access): unify org visibility rules and RBAC boundaries

### DIFF
--- a/backend/app/Filament/Ops/Livewire/CurrentOrgSwitcher.php
+++ b/backend/app/Filament/Ops/Livewire/CurrentOrgSwitcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Livewire;
 
+use App\Services\Ops\OrgVisibilityResolver;
 use Illuminate\Support\Facades\DB;
 use Livewire\Component;
 
@@ -27,7 +28,9 @@ class CurrentOrgSwitcher extends Component
             return;
         }
 
-        $exists = DB::table('organizations')->where('id', $orgId)->exists();
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+        $exists = app(OrgVisibilityResolver::class)->isVisibleOrganization($user, $orgId);
         if (! $exists) {
             return;
         }
@@ -62,7 +65,11 @@ class CurrentOrgSwitcher extends Component
             $this->currentOrgId = (int) $rawOrgId;
         }
 
-        $this->organizations = DB::table('organizations')
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        $this->organizations = app(OrgVisibilityResolver::class)
+            ->visibleOrganizationsQuery($user)
             ->select(['id', 'name'])
             ->orderBy('name')
             ->limit(50)
@@ -73,7 +80,7 @@ class CurrentOrgSwitcher extends Component
             ])
             ->all();
 
-        if ($this->currentOrgId > 0) {
+        if ($this->currentOrgId > 0 && app(OrgVisibilityResolver::class)->isVisibleOrganization($user, $this->currentOrgId)) {
             $row = DB::table('organizations')
                 ->where('id', $this->currentOrgId)
                 ->first(['name']);

--- a/backend/app/Filament/Ops/Pages/DeliveryTools.php
+++ b/backend/app/Filament/Ops/Pages/DeliveryTools.php
@@ -57,8 +57,28 @@ class DeliveryTools extends Page
 
     public string $statusMessage = '';
 
+    private function canRequestAction(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_OWNER)
+                || $user->hasPermission(PermissionNames::ADMIN_APPROVAL_REVIEW)
+                || $user->hasPermission(PermissionNames::ADMIN_OPS_WRITE)
+            );
+    }
+
     public function requestAction(): void
     {
+        if (! $this->canRequestAction()) {
+            $this->statusMessage = 'permission denied.';
+
+            return;
+        }
+
         $orgId = max(0, (int) app(OrgContext::class)->orgId());
         $orderNo = trim($this->orderNo);
         $reason = trim($this->reason);

--- a/backend/app/Filament/Ops/Pages/GlobalSearchPage.php
+++ b/backend/app/Filament/Ops/Pages/GlobalSearchPage.php
@@ -82,8 +82,8 @@ class GlobalSearchPage extends Page
         return is_object($user)
             && method_exists($user, 'hasPermission')
             && (
-                $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
-                || $user->hasPermission(PermissionNames::ADMIN_GLOBAL_SEARCH)
+                $user->hasPermission(PermissionNames::ADMIN_GLOBAL_SEARCH)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
             );
     }
 }

--- a/backend/app/Filament/Ops/Pages/SecureLink.php
+++ b/backend/app/Filament/Ops/Pages/SecureLink.php
@@ -56,8 +56,29 @@ class SecureLink extends Page
 
     public string $statusMessage = '';
 
+    private function canGenerateSecureLink(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_OWNER)
+                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_GLOBAL_SEARCH)
+            );
+    }
+
     public function generate(): void
     {
+        if (! $this->canGenerateSecureLink()) {
+            $this->statusMessage = 'permission denied.';
+            $this->generatedLink = '';
+
+            return;
+        }
+
         $orgId = max(0, (int) app(OrgContext::class)->orgId());
         $orderNo = trim($this->orderNo);
         if ($orderNo === '') {

--- a/backend/app/Filament/Ops/Pages/SelectOrgPage.php
+++ b/backend/app/Filament/Ops/Pages/SelectOrgPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Pages;
 
+use App\Services\Ops\OrgVisibilityResolver;
 use App\Support\Rbac\PermissionNames;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
@@ -40,6 +41,13 @@ class SelectOrgPage extends Page
         return __('ops.nav.select_org');
     }
 
+    public static function canAccess(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+
+        return app(OrgVisibilityResolver::class)->canSelectOrganizations(auth($guard)->user());
+    }
+
     public function mount(): void
     {
         $this->returnTo = trim((string) request()->query('return_to', ''));
@@ -73,9 +81,9 @@ class SelectOrgPage extends Page
             return;
         }
 
-        $exists = DB::table('organizations')
-            ->where('id', $orgId)
-            ->exists();
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+        $exists = app(OrgVisibilityResolver::class)->isVisibleOrganization($user, $orgId);
 
         if (! $exists) {
             Notification::make()
@@ -203,8 +211,10 @@ class SelectOrgPage extends Page
 
         $search = trim($this->search);
 
-        $query = DB::table('organizations')
-            ->select(['id', 'name', 'status', 'domain', 'updated_at'])
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+        $query = app(OrgVisibilityResolver::class)
+            ->visibleOrganizationsQuery($user)
             ->orderBy('id', 'desc');
 
         if ($search !== '') {
@@ -246,6 +256,15 @@ class SelectOrgPage extends Page
         if (! \App\Support\SchemaBaseline::hasTable('organizations')) {
             $this->currentOrgName = 'No Org Selected';
             $this->currentOrgId = 0;
+
+            return;
+        }
+
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+        if (! app(OrgVisibilityResolver::class)->isVisibleOrganization($user, $this->currentOrgId)) {
+            $this->currentOrgId = 0;
+            $this->currentOrgName = 'No Org Selected';
 
             return;
         }

--- a/backend/app/Filament/Ops/Resources/AdminApprovalResource.php
+++ b/backend/app/Filament/Ops/Resources/AdminApprovalResource.php
@@ -10,6 +10,7 @@ use App\Filament\Shared\BaseTenantResource;
 use App\Jobs\ExecuteApprovalJob;
 use App\Models\AdminApproval;
 use App\Services\Audit\AuditLogger;
+use App\Support\OrgContext;
 use App\Support\Rbac\PermissionNames;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -39,7 +40,13 @@ class AdminApprovalResource extends BaseTenantResource
             return null;
         }
 
+        $orgId = max(0, (int) app(OrgContext::class)->orgId());
+        if ($orgId <= 0) {
+            return null;
+        }
+
         $count = (int) DB::table('admin_approvals')
+            ->where('org_id', $orgId)
             ->where('status', AdminApproval::STATUS_PENDING)
             ->count();
 

--- a/backend/app/Filament/Ops/Resources/AttemptResource.php
+++ b/backend/app/Filament/Ops/Resources/AttemptResource.php
@@ -265,7 +265,6 @@ class AttemptResource extends Resource
             && method_exists($user, 'hasPermission')
             && (
                 $user->hasPermission(PermissionNames::ADMIN_MENU_SUPPORT)
-                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
                 || $user->hasPermission(PermissionNames::ADMIN_OWNER)
             );
     }

--- a/backend/app/Filament/Ops/Resources/OrderResource.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource.php
@@ -392,7 +392,6 @@ class OrderResource extends \App\Filament\Shared\BaseTenantResource
             && (
                 $user->hasPermission(PermissionNames::ADMIN_MENU_COMMERCE)
                 || $user->hasPermission(PermissionNames::ADMIN_MENU_SUPPORT)
-                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
                 || $user->hasPermission(PermissionNames::ADMIN_OWNER)
             );
     }

--- a/backend/app/Filament/Ops/Resources/OrganizationResource.php
+++ b/backend/app/Filament/Ops/Resources/OrganizationResource.php
@@ -7,12 +7,14 @@ namespace App\Filament\Ops\Resources;
 use App\Filament\Ops\Resources\OrganizationResource\Pages;
 use App\Filament\Ops\Support\StatusBadge;
 use App\Models\Organization;
+use App\Services\Ops\OrgVisibilityResolver;
 use App\Support\Rbac\PermissionNames;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class OrganizationResource extends Resource
 {
@@ -104,6 +106,14 @@ class OrganizationResource extends Resource
                 Tables\Actions\EditAction::make(),
             ])
             ->bulkActions([]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $guard = (string) config('admin.guard', 'admin');
+
+        return app(OrgVisibilityResolver::class)
+            ->applyEloquentVisibility(parent::getEloquentQuery(), auth($guard)->user());
     }
 
     public static function getPages(): array

--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource.php
@@ -261,7 +261,6 @@ class ReportSnapshotResource extends Resource
             && method_exists($user, 'hasPermission')
             && (
                 $user->hasPermission(PermissionNames::ADMIN_MENU_SUPPORT)
-                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
                 || $user->hasPermission(PermissionNames::ADMIN_OWNER)
             );
     }

--- a/backend/app/Filament/Ops/Resources/ResultResource.php
+++ b/backend/app/Filament/Ops/Resources/ResultResource.php
@@ -262,7 +262,6 @@ class ResultResource extends Resource
             && method_exists($user, 'hasPermission')
             && (
                 $user->hasPermission(PermissionNames::ADMIN_MENU_SUPPORT)
-                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
                 || $user->hasPermission(PermissionNames::ADMIN_OWNER)
             );
     }

--- a/backend/app/Http/Middleware/RequireOpsOrgSelected.php
+++ b/backend/app/Http/Middleware/RequireOpsOrgSelected.php
@@ -25,6 +25,7 @@ class RequireOpsOrgSelected
         'filament.ops.pages.go-live-gate',
         'filament.ops.pages.health-checks',
         'filament.ops.pages.queue-monitor',
+        'filament.ops.pages.global-search',
     ];
 
     /**
@@ -36,6 +37,10 @@ class RequireOpsOrgSelected
         'filament.ops.resources.permissions.',
         'filament.ops.resources.organizations.',
         'filament.ops.resources.deploys.',
+        'filament.ops.resources.orders.',
+        'filament.ops.resources.attempts.',
+        'filament.ops.resources.results.',
+        'filament.ops.resources.reports.',
     ];
 
     /**
@@ -46,14 +51,12 @@ class RequireOpsOrgSelected
         'filament.ops.pages.delivery-tools',
         'filament.ops.pages.secure-link',
         'filament.ops.pages.webhook-monitor',
-        'filament.ops.pages.global-search',
     ];
 
     /**
      * @var list<string>
      */
     private array $orgScopedResourcePrefixes = [
-        'filament.ops.resources.orders.',
         'filament.ops.resources.payment-events.',
         'filament.ops.resources.benefit-grants.',
         'filament.ops.resources.skus.',
@@ -107,7 +110,7 @@ class RequireOpsOrgSelected
         $request->session()->flash('ops_org_required_message', '需要先选择组织后再访问该模块。');
 
         return redirect()->route('filament.ops.pages.select-org', [
-            'return_to' => '/' . ltrim($request->path(), '/'),
+            'return_to' => '/'.ltrim($request->path(), '/'),
         ]);
     }
 }

--- a/backend/app/Services/Ops/OrgVisibilityResolver.php
+++ b/backend/app/Services/Ops/OrgVisibilityResolver.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
+
+final class OrgVisibilityResolver
+{
+    /**
+     * @return list<string>
+     */
+    private function selectablePermissions(): array
+    {
+        return PermissionNames::all();
+    }
+
+    public function canSelectOrganizations(mixed $user): bool
+    {
+        return $this->hasAnyPermission($user, $this->selectablePermissions());
+    }
+
+    public function canManageOrganizations(mixed $user): bool
+    {
+        return $this->hasAnyPermission($user, [
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_ORG_MANAGE,
+        ]);
+    }
+
+    public function applyTableVisibility(QueryBuilder $query, mixed $user, string $qualifiedIdColumn = 'id'): QueryBuilder
+    {
+        if (! $this->canSelectOrganizations($user)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query;
+    }
+
+    public function applyEloquentVisibility(EloquentBuilder $query, mixed $user, string $qualifiedIdColumn = 'id'): EloquentBuilder
+    {
+        if (! $this->canSelectOrganizations($user)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query;
+    }
+
+    public function visibleOrganizationsQuery(mixed $user): QueryBuilder
+    {
+        return $this->applyTableVisibility(
+            DB::table('organizations')->select(['id', 'name', 'status', 'domain', 'updated_at']),
+            $user
+        );
+    }
+
+    public function isVisibleOrganization(mixed $user, int $orgId): bool
+    {
+        if ($orgId <= 0) {
+            return false;
+        }
+
+        return $this->visibleOrganizationsQuery($user)
+            ->where('id', $orgId)
+            ->exists();
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function hasAnyPermission(mixed $user, array $permissions): bool
+    {
+        if (! is_object($user) || ! method_exists($user, 'hasPermission')) {
+            return false;
+        }
+
+        foreach ($permissions as $permission) {
+            if ($user->hasPermission($permission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/tests/Feature/Ops/OpsAccessBoundaryTest.php
+++ b/backend/tests/Feature/Ops/OpsAccessBoundaryTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Pages\DeliveryTools;
+use App\Filament\Ops\Pages\SecureLink;
+use App\Models\AdminApproval;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\Feature\Ops\Support\InteractsWithCommerceOpsWorkbench;
+use Tests\TestCase;
+
+final class OpsAccessBoundaryTest extends TestCase
+{
+    use InteractsWithCommerceOpsWorkbench;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_cross_org_explorer_pages_open_without_org_context_but_org_scoped_pages_still_redirect(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_GLOBAL_SEARCH,
+            PermissionNames::ADMIN_OPS_READ,
+            PermissionNames::ADMIN_MENU_COMMERCE,
+        ]);
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/orders')
+            ->assertOk();
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/attempts')
+            ->assertOk();
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/results')
+            ->assertOk();
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/reports')
+            ->assertOk();
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/global-search')
+            ->assertOk();
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/payment-events')
+            ->assertRedirect('/ops/select-org?return_to=%2Fops%2Fpayment-events');
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/order-lookup')
+            ->assertRedirect('/ops/select-org?return_to=%2Fops%2Forder-lookup');
+    }
+
+    public function test_cross_org_explorers_no_longer_allow_plain_ops_read_without_support_or_commerce_menu(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/orders')
+            ->assertForbidden();
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/attempts')
+            ->assertForbidden();
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/results')
+            ->assertForbidden();
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/reports')
+            ->assertForbidden();
+    }
+
+    public function test_select_org_requires_real_ops_access_capability(): void
+    {
+        $admin = $this->createAdminWithPermissions([]);
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/select-org')
+            ->assertForbidden();
+    }
+
+    public function test_delivery_tools_request_requires_elevated_action_permission(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+        ]);
+        $selectedOrg = $this->createOrganization('Delivery Action Org');
+        $chain = $this->seedCommerceOpsChain((int) $selectedOrg->id, 'ord_delivery_action_001');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->bindOpsOrgContext((int) $selectedOrg->id);
+
+        Livewire::test(DeliveryTools::class)
+            ->set('orderNo', $chain['order_no'])
+            ->set('reason', 'Need regeneration')
+            ->call('requestAction')
+            ->assertSet('statusMessage', 'permission denied.');
+
+        $this->assertDatabaseCount('admin_approvals', 0);
+    }
+
+    public function test_delivery_tools_request_allows_support_reviewer_role(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+        ]);
+        $selectedOrg = $this->createOrganization('Delivery Reviewer Org');
+        $chain = $this->seedCommerceOpsChain((int) $selectedOrg->id, 'ord_delivery_action_002');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->bindOpsOrgContext((int) $selectedOrg->id);
+
+        Livewire::test(DeliveryTools::class)
+            ->set('orderNo', $chain['order_no'])
+            ->set('reason', 'Need regeneration')
+            ->call('requestAction')
+            ->assertSet('statusMessage', fn (string $message): bool => $message !== '' && $message !== 'permission denied.');
+
+        $this->assertDatabaseHas('admin_approvals', [
+            'org_id' => (int) $selectedOrg->id,
+            'type' => AdminApproval::TYPE_MANUAL_GRANT,
+            'status' => AdminApproval::STATUS_PENDING,
+        ]);
+    }
+
+    public function test_secure_link_generation_requires_more_than_support_menu_only(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+        ]);
+        $selectedOrg = $this->createOrganization('Secure Link Org');
+        $chain = $this->seedCommerceOpsChain((int) $selectedOrg->id, 'ord_secure_link_001');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->bindOpsOrgContext((int) $selectedOrg->id);
+
+        Livewire::test(SecureLink::class)
+            ->set('orderNo', $chain['order_no'])
+            ->call('generate')
+            ->assertSet('statusMessage', 'permission denied.')
+            ->assertSet('generatedLink', '');
+    }
+
+    private function bindOpsOrgContext(int $orgId): void
+    {
+        $context = new OrgContext;
+        $context->set($orgId, null, 'admin');
+
+        $this->app->instance(OrgContext::class, $context);
+    }
+}

--- a/backend/tests/Feature/Ops/SelectOrgFlowTest.php
+++ b/backend/tests/Feature/Ops/SelectOrgFlowTest.php
@@ -77,16 +77,16 @@ final class SelectOrgFlowTest extends TestCase
         $this->withSession([
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
         ])->actingAs($admin, (string) config('admin.guard', 'admin'))
-            ->get('/ops/orders')
-            ->assertRedirect('/ops/select-org?return_to=%2Fops%2Forders');
+            ->get('/ops/payment-events')
+            ->assertRedirect('/ops/select-org?return_to=%2Fops%2Fpayment-events');
 
         session(['ops_admin_totp_verified_user_id' => (int) $admin->id]);
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));
 
         Livewire::test(SelectOrgPage::class)
-            ->set('returnTo', '/ops/orders')
+            ->set('returnTo', '/ops/payment-events')
             ->call('selectOrg', (int) $selectedOrg->id)
-            ->assertRedirect('/ops/orders');
+            ->assertRedirect('/ops/payment-events');
 
         $this->assertSame((int) $selectedOrg->id, (int) session('ops_org_id'));
 
@@ -94,7 +94,7 @@ final class SelectOrgFlowTest extends TestCase
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
             'ops_org_id' => (int) $selectedOrg->id,
         ])->actingAs($admin, (string) config('admin.guard', 'admin'))
-            ->get('/ops/orders')
+            ->get('/ops/payment-events')
             ->assertOk()
             ->assertSee($chain['order_no']);
     }


### PR DESCRIPTION
## Summary
- centralize Ops org visibility into a resolver used by select-org, org switcher, and organizations resource
- reclassify cross-org support explorers so they no longer require selected org and no longer allow plain admin.ops.read access
- tighten risky support actions and scope approvals navigation badge to current org
- add focused Ops access boundary coverage and update select-org flow coverage

## Tests
- cd backend && ./vendor/bin/pint app/Services/Ops/OrgVisibilityResolver.php app/Filament/Ops/Pages/SelectOrgPage.php app/Filament/Ops/Livewire/CurrentOrgSwitcher.php app/Filament/Ops/Resources/OrganizationResource.php app/Http/Middleware/RequireOpsOrgSelected.php app/Filament/Ops/Resources/OrderResource.php app/Filament/Ops/Resources/AttemptResource.php app/Filament/Ops/Resources/ResultResource.php app/Filament/Ops/Resources/ReportSnapshotResource.php app/Filament/Ops/Pages/GlobalSearchPage.php app/Filament/Ops/Pages/DeliveryTools.php app/Filament/Ops/Pages/SecureLink.php app/Filament/Ops/Resources/AdminApprovalResource.php tests/Feature/Ops/OpsAccessBoundaryTest.php tests/Feature/Ops/SelectOrgFlowTest.php
- cd backend && php artisan test tests/Feature/Ops/OpsAccessBoundaryTest.php tests/Feature/Ops/SelectOrgFlowTest.php
- cd backend && php artisan test --filter='CurrentOrgSwitcherComponentTest|OrderCommerceLinkageTest|AttemptsExplorerTest|ResultsExplorerTest|ReportPdfCenterTest|PaymentAttemptResourceTest'
- cd backend && php artisan route:list | rg 'ops/(select-org|organizations|orders|attempts|results|reports|payment-events|benefit-grants|order-lookup|webhook-monitor|global-search|delivery-tools|secure-link)'
