### PR TITLE
fix(ops): close remaining access and entry gaps

### DIFF
--- a/backend/app/Http/Middleware/OpsAccessControl.php
+++ b/backend/app/Http/Middleware/OpsAccessControl.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Services\Ops\OpsAlertService;
+use App\Services\Ops\OpsAuditLogger;
+use App\Services\Ops\OpsDistributedLimiter;
+use App\Services\Ops\OpsIpBlacklist;
+use App\Services\Ops\OpsRiskEngine;
+use App\Support\Ops\OpsSecurityEvent;
 use Closure;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class OpsAccessControl
 {
@@ -19,76 +26,338 @@ class OpsAccessControl
             return $next($request);
         }
 
-        if (str_starts_with($routeName, 'filament.ops.auth.')) {
+        $config = $this->accessControlConfig();
+
+        if (! $config['enabled'] || $config['emergency_disable']) {
             return $next($request);
         }
 
-        if (
-            $routeName === 'filament.ops.auth.login'
-            && $request->isMethod('post')
-            && ! app()->environment(['local', 'testing', 'ci'])
-        ) {
-            $key = 'ops:admin-login:'.($request->ip() ?? 'unknown');
-            $maxAttempts = max(1, (int) config('ops.security.admin_login_max_attempts', 5));
+        try {
+            $routeKey = $routeName !== '' ? $routeName : $request->path();
+            $admin = $this->adminUser();
 
-            if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
-                return response()->json([
-                    'ok' => false,
-                    'error_code' => 'RATE_LIMITED',
-                    'message' => 'Too many failed login attempts.',
-                ], 429);
-            }
-        }
+            OpsAuditLogger::log('ACCESS', [
+                'user_id' => $admin?->getAuthIdentifier(),
+                'route' => $routeName,
+                'path' => $request->path(),
+                'ip' => $request->ip(),
+                'host' => $request->getHost(),
+            ]);
 
-        if (! app()->environment(['local', 'testing', 'ci'])) {
-            $allowedHost = trim((string) config('ops.allowed_host', ''));
-            if ($allowedHost !== '') {
-                $requestHost = trim((string) $request->getHost());
-                if ($allowedHost !== '' && ! str_contains($requestHost, $allowedHost)) {
-                    if (app()->environment('production')) {
-                        Log::warning('OPS_ACCESS_DEBUG', [
+            OpsSecurityEvent::emit('ACCESS', [
+                'route' => $routeName,
+                'path' => $request->path(),
+                'ip' => $request->ip(),
+                'host' => $request->getHost(),
+                'user_id' => $admin?->getAuthIdentifier(),
+            ]);
+
+            if (str_starts_with($routeName, 'filament.ops.auth.')) {
+                if (
+                    $routeName === 'filament.ops.auth.login'
+                    && $request->isMethod('post')
+                    && ! app()->environment(['local', 'testing', 'ci'])
+                ) {
+                    if (OpsIpBlacklist::isBlocked((string) $request->ip())) {
+                        OpsSecurityEvent::emit('IP_BLACKLIST_BLOCKED', [
+                            'ip' => $request->ip(),
                             'route' => $routeName,
                             'host' => $request->getHost(),
-                            'ip' => $request->ip(),
                         ]);
+
+                        return response()->json([
+                            'ok' => false,
+                            'error_code' => 'RATE_LIMITED',
+                            'message' => 'Too many attempts',
+                        ], 429);
                     }
 
-                    Log::warning('OPS_ACCESS_HOST_BLOCKED', [
-                        'request_host' => $requestHost,
-                        'allowed_host' => $allowedHost,
-                        'path' => $request->path(),
+                    $loginIpKey = 'ops:login:ip:'.($request->ip() ?? 'unknown');
+                    $loginRouteKey = 'ops:login:route:'.$routeKey;
+                    $identifier = trim((string) ($request->input('email') ?? $request->input('username') ?? 'anonymous'));
+                    $loginUserKey = 'ops:login:user:'.$identifier;
+                    $maxAttempts = max(1, (int) ($config['rate_limit']['login'] ?? $config['admin_login_max_attempts']));
+
+                    $decaySeconds = max(60, (int) config('ops.security.admin_login_decay_seconds', 300));
+                    $ipCount = OpsDistributedLimiter::hit($loginIpKey, $decaySeconds);
+                    $routeCount = OpsDistributedLimiter::hit($loginRouteKey, $decaySeconds);
+                    $userCount = OpsDistributedLimiter::hit($loginUserKey, $decaySeconds);
+
+                    if (
+                        $ipCount > $maxAttempts
+                        || $routeCount > $maxAttempts
+                        || $userCount > $maxAttempts
+                        || OpsDistributedLimiter::tooMany($loginIpKey, $maxAttempts)
+                        || OpsDistributedLimiter::tooMany($loginRouteKey, $maxAttempts)
+                        || OpsDistributedLimiter::tooMany($loginUserKey, $maxAttempts)
+                    ) {
+                        OpsSecurityEvent::emit('LOGIN_RATE_LIMIT', [
+                            'ip' => $request->ip(),
+                            'route' => $routeName,
+                            'identifier' => $identifier,
+                            'count_ip' => $ipCount,
+                            'count_route' => $routeCount,
+                            'count_user' => $userCount,
+                        ]);
+
+                        OpsAlertService::send('🚨 Ops login attack: '.((string) $request->ip()));
+                        OpsIpBlacklist::block((string) $request->ip());
+
+                        return response()->json([
+                            'ok' => false,
+                            'error_code' => 'RATE_LIMITED',
+                            'message' => 'Too many attempts',
+                        ], 429);
+                    }
+
+                    if ((bool) ($config['risk']['enabled'] ?? true)) {
+                        $risk = OpsRiskEngine::evaluate([
+                            'ip_reputation' => $this->isTrustedIp((string) $request->ip(), $config) ? 'trusted' : 'untrusted',
+                            'failed_login_count' => OpsDistributedLimiter::attempts($loginIpKey),
+                            'external_risk_score' => 0,
+                        ]);
+
+                        if ($risk['level'] === 'HIGH') {
+                            OpsSecurityEvent::emit('HIGH_RISK_ACCESS', [
+                                'route' => $routeName,
+                                'ip' => $request->ip(),
+                                'score' => $risk['score'],
+                                'level' => $risk['level'],
+                            ]);
+                        }
+                    }
+                }
+
+                OpsSecurityEvent::emit('PASS', [
+                    'route' => $routeName,
+                    'ip' => $request->ip(),
+                    'host' => $request->getHost(),
+                ]);
+
+                return $next($request);
+            }
+
+            if (! app()->environment(['local', 'testing', 'ci'])) {
+                if (OpsIpBlacklist::isBlocked((string) $request->ip())) {
+                    OpsSecurityEvent::emit('IP_BLACKLIST_BLOCKED', [
+                        'ip' => $request->ip(),
+                        'route' => $routeName,
+                        'host' => $request->getHost(),
                     ]);
 
-                    abort(403, 'Ops console is not available on this host.');
+                    return response('Blocked IP', 403);
+                }
+
+                $globalLimit = max(1, (int) ($config['rate_limit']['global'] ?? 100));
+                $globalIpKey = 'ops:global:ip:'.$routeKey.':'.($request->ip() ?? 'unknown');
+                $globalIpCount = OpsDistributedLimiter::hit($globalIpKey, 60);
+                if ($globalIpCount > $globalLimit || OpsDistributedLimiter::tooMany($globalIpKey, $globalLimit)) {
+                    OpsSecurityEvent::emit('GLOBAL_RATE_LIMIT', [
+                        'route' => $routeName,
+                        'ip' => $request->ip(),
+                        'count' => $globalIpCount,
+                    ]);
+
+                    return response()->json([
+                        'ok' => false,
+                        'error_code' => 'RATE_LIMITED',
+                        'message' => 'Too many requests',
+                    ], 429);
+                }
+
+                if ($admin !== null) {
+                    $globalUserKey = 'ops:global:user:'.$routeKey.':'.$admin->getAuthIdentifier();
+                    $globalUserCount = OpsDistributedLimiter::hit($globalUserKey, 60);
+                    if ($globalUserCount > $globalLimit || OpsDistributedLimiter::tooMany($globalUserKey, $globalLimit)) {
+                        OpsSecurityEvent::emit('GLOBAL_RATE_LIMIT', [
+                            'route' => $routeName,
+                            'ip' => $request->ip(),
+                            'user_id' => $admin->getAuthIdentifier(),
+                            'count' => $globalUserCount,
+                        ]);
+
+                        return response()->json([
+                            'ok' => false,
+                            'error_code' => 'RATE_LIMITED',
+                            'message' => 'Too many requests',
+                        ], 429);
+                    }
                 }
             }
 
-            $allowlist = array_values(array_filter(array_map(
+            if (! app()->environment(['local', 'testing', 'ci'])) {
+                $allowedHost = trim((string) $config['allowed_host']);
+                if ($allowedHost !== '') {
+                    $host = trim((string) $request->getHost());
+
+                    if (! str_contains($host, $allowedHost)) {
+                        OpsSecurityEvent::emit('HOST_BLOCKED', [
+                            'host' => $host,
+                            'allowed' => $allowedHost,
+                            'route' => $routeName,
+                            'ip' => $request->ip(),
+                        ]);
+
+                        return response('Ops console is not available on this host.', 403);
+                    }
+                }
+
+                $allowlist = array_values(array_filter(array_map(
+                    static fn ($value): string => trim((string) $value),
+                    (array) $config['ip_allowlist']
+                )));
+
+                if (! empty($allowlist) && ! in_array((string) $request->ip(), $allowlist, true)) {
+                    OpsSecurityEvent::emit('IP_BLOCKED', [
+                        'ip' => $request->ip(),
+                        'route' => $routeName,
+                        'host' => $request->getHost(),
+                    ]);
+
+                    return response('Ops console IP is not allowlisted.', 403);
+                }
+            }
+
+            if ($this->isSensitiveRoute($routeName, $request->path())) {
+                OpsAuditLogger::log('SENSITIVE_ACTION', [
+                    'user_id' => $admin?->getAuthIdentifier(),
+                    'route' => $routeName,
+                    'path' => $request->path(),
+                    'ip' => $request->ip(),
+                ]);
+
+                if (! $this->hasSensitiveActionPermission($admin)) {
+                    OpsSecurityEvent::emit('UNAUTHORIZED_ACTION', [
+                        'user_id' => $admin?->getAuthIdentifier(),
+                        'route' => $routeName,
+                        'path' => $request->path(),
+                        'ip' => $request->ip(),
+                    ]);
+
+                    return response('Forbidden', 403);
+                }
+            }
+
+            if ((bool) ($config['risk']['enabled'] ?? true)) {
+                $risk = OpsRiskEngine::evaluate([
+                    'ip_reputation' => $this->isTrustedIp((string) $request->ip(), $config) ? 'trusted' : 'untrusted',
+                    'failed_login_count' => 0,
+                    'external_risk_score' => 0,
+                ]);
+
+                if ($risk['level'] === 'HIGH') {
+                    OpsSecurityEvent::emit('HIGH_RISK_ACCESS', [
+                        'route' => $routeName,
+                        'ip' => $request->ip(),
+                        'score' => $risk['score'],
+                        'level' => $risk['level'],
+                        'user_id' => $admin?->getAuthIdentifier(),
+                    ]);
+                }
+            }
+
+            OpsSecurityEvent::emit('PASS', [
+                'route' => $routeName,
+                'ip' => $request->ip(),
+                'host' => $request->getHost(),
+                'user_id' => $admin?->getAuthIdentifier(),
+            ]);
+
+            return $next($request);
+        } catch (Throwable $e) {
+            OpsSecurityEvent::emit('FAIL_OPEN', [
+                'route' => $routeName,
+                'host' => $request->getHost(),
+                'ip' => $request->ip(),
+                'error' => $e->getMessage(),
+            ]);
+
+            if ($config['fail_open']) {
+                return $next($request);
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @return array{
+     *     enabled: bool,
+     *     fail_open: bool,
+     *     emergency_disable: bool,
+     *     allowed_host: string,
+     *     ip_allowlist: array<int, string>,
+     *     admin_login_max_attempts: int,
+     *     audit_log: bool,
+     *     rate_limit: array{login: int, global: int},
+     *     risk: array{enabled: bool}
+     * }
+     */
+    private function accessControlConfig(): array
+    {
+        /** @var array<string, mixed> $config */
+        $config = (array) config('ops.access_control', []);
+
+        return [
+            'enabled' => (bool) ($config['enabled'] ?? true),
+            'fail_open' => (bool) ($config['fail_open'] ?? true),
+            'emergency_disable' => (bool) ($config['emergency_disable'] ?? false),
+            'allowed_host' => trim((string) ($config['allowed_host'] ?? '')),
+            'ip_allowlist' => array_values(array_filter(array_map(
                 static fn ($value): string => trim((string) $value),
-                (array) config('ops.ip_allowlist', [])
-            )));
+                (array) ($config['ip_allowlist'] ?? [])
+            ))),
+            'admin_login_max_attempts' => max(1, (int) ($config['admin_login_max_attempts'] ?? 5)),
+            'audit_log' => (bool) ($config['audit_log'] ?? true),
+            'rate_limit' => [
+                'login' => max(1, (int) data_get($config, 'rate_limit.login', $config['admin_login_max_attempts'] ?? 5)),
+                'global' => max(1, (int) data_get($config, 'rate_limit.global', 100)),
+            ],
+            'risk' => [
+                'enabled' => (bool) data_get($config, 'risk.enabled', true),
+            ],
+        ];
+    }
 
-            if (! empty($allowlist)) {
-                $ip = (string) $request->ip();
-                if (! in_array($ip, $allowlist, true)) {
-                    if (app()->environment('production')) {
-                        Log::warning('OPS_ACCESS_DEBUG', [
-                            'route' => $routeName,
-                            'host' => $request->getHost(),
-                            'ip' => $request->ip(),
-                        ]);
-                    }
+    /**
+     * @param  array{
+     *     ip_allowlist: array<int, string>
+     * }  $config
+     */
+    private function isTrustedIp(string $ip, array $config): bool
+    {
+        $allowlist = array_values(array_filter(array_map(
+            static fn ($value): string => trim((string) $value),
+            (array) ($config['ip_allowlist'] ?? [])
+        )));
 
-                    Log::warning('OPS_ACCESS_IP_BLOCKED', [
-                        'ip' => $ip,
-                        'path' => $request->path(),
-                    ]);
+        return $allowlist !== [] && in_array($ip, $allowlist, true);
+    }
 
-                    abort(403, 'Ops console IP is not allowlisted.');
-                }
+    private function isSensitiveRoute(string $routeName, string $path): bool
+    {
+        $haystack = strtolower($routeName.' '.$path);
+        foreach (['delivery-tools', 'secure-link', 'refund', 'grant', 'reprocess'] as $keyword) {
+            if (str_contains($haystack, $keyword)) {
+                return true;
             }
         }
 
-        return $next($request);
+        return false;
+    }
+
+    private function hasSensitiveActionPermission(?Authenticatable $user): bool
+    {
+        return $user !== null
+            && method_exists($user, 'hasPermission')
+            && ($user->hasPermission('admin.ops.write') || $user->hasPermission('admin.owner'));
+    }
+
+    private function adminUser(): ?Authenticatable
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = Auth::guard($guard)->user();
+
+        return $user instanceof Authenticatable ? $user : null;
     }
 }

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -27,6 +27,7 @@ use App\Services\Content\ContentPack;
 use App\Services\Content\ContentPacksIndex;
 use App\Services\Content\ContentStore;
 use App\Services\ContentPackResolver;
+use App\Services\Ops\OpsDistributedLimiter;
 use App\Support\Logging\RedactProcessor;
 use App\Support\OrgContext;
 use App\Support\Security\ExternalKmsPiiEnvelopeAdapter;
@@ -524,6 +525,13 @@ class AppServiceProvider extends ServiceProvider
             $ip = request()?->ip() ?? 'unknown';
             $key = 'ops:admin-login:'.$ip;
             RateLimiter::clear($key);
+
+            $routeName = (string) optional(request()?->route())->getName();
+            $routeKey = $routeName !== '' ? $routeName : 'filament.ops.auth.login';
+            $identifier = trim((string) (request()?->input('email') ?? request()?->input('username') ?? 'anonymous'));
+            OpsDistributedLimiter::clear('ops:login:ip:'.$ip);
+            OpsDistributedLimiter::clear('ops:login:route:'.$routeKey);
+            OpsDistributedLimiter::clear('ops:login:user:'.$identifier);
 
             $user = $event->user;
             if (is_object($user) && method_exists($user, 'forceFill') && method_exists($user, 'save')) {

--- a/backend/app/Services/Ops/OpsAlertService.php
+++ b/backend/app/Services/Ops/OpsAlertService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Illuminate\Support\Facades\Http;
+
+class OpsAlertService
+{
+    public static function send(string $message): void
+    {
+        $url = trim((string) config('ops.alert.webhook', ''));
+        if ($url === '') {
+            return;
+        }
+
+        Http::post($url, [
+            'text' => $message,
+        ]);
+    }
+}

--- a/backend/app/Services/Ops/OpsAuditLogger.php
+++ b/backend/app/Services/Ops/OpsAuditLogger.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Illuminate\Support\Facades\Log;
+
+class OpsAuditLogger
+{
+    public static function log(string $event, array $data = []): void
+    {
+        Log::channel('stack')->info('OPS_AUDIT_'.$event, [
+            'ts' => now()->toISOString(),
+            ...$data,
+        ]);
+    }
+}

--- a/backend/app/Services/Ops/OpsDistributedLimiter.php
+++ b/backend/app/Services/Ops/OpsDistributedLimiter.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Illuminate\Support\Facades\Redis;
+
+class OpsDistributedLimiter
+{
+    public static function hit(string $key, int $ttl = 60): int
+    {
+        $count = (int) Redis::incr($key);
+
+        if ($count === 1) {
+            Redis::expire($key, $ttl);
+        }
+
+        return $count;
+    }
+
+    public static function tooMany(string $key, int $max): bool
+    {
+        return (int) Redis::get($key) > $max;
+    }
+
+    public static function attempts(string $key): int
+    {
+        return (int) Redis::get($key);
+    }
+
+    public static function clear(string $key): void
+    {
+        Redis::del($key);
+    }
+}

--- a/backend/app/Services/Ops/OpsIpBlacklist.php
+++ b/backend/app/Services/Ops/OpsIpBlacklist.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Illuminate\Support\Facades\Redis;
+
+class OpsIpBlacklist
+{
+    public static function isBlocked(string $ip): bool
+    {
+        return (bool) Redis::sismember('ops:ip:blacklist', $ip);
+    }
+
+    public static function block(string $ip): void
+    {
+        Redis::sadd('ops:ip:blacklist', $ip);
+    }
+}

--- a/backend/app/Services/Ops/OpsRiskEngine.php
+++ b/backend/app/Services/Ops/OpsRiskEngine.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+class OpsRiskEngine
+{
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array{score: int, level: string}
+     */
+    public static function evaluate(array $context): array
+    {
+        $risk = 0;
+
+        if (($context['ip_reputation'] ?? 'untrusted') !== 'trusted') {
+            $risk += 10;
+        }
+
+        if ((int) ($context['failed_login_count'] ?? 0) > 3) {
+            $risk += 30;
+        }
+
+        $risk += max(0, (int) ($context['external_risk_score'] ?? 0));
+
+        return [
+            'score' => $risk,
+            'level' => $risk > 50 ? 'HIGH' : 'LOW',
+        ];
+    }
+}

--- a/backend/app/Support/Ops/OpsSecurityEvent.php
+++ b/backend/app/Support/Ops/OpsSecurityEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Ops;
+
+use Illuminate\Support\Facades\Log;
+
+class OpsSecurityEvent
+{
+    public static function emit(string $type, array $data = []): void
+    {
+        Log::channel('stack')->warning('OPS_SECURITY_'.$type, [
+            'timestamp' => now()->toISOString(),
+            ...$data,
+        ]);
+    }
+}

--- a/backend/config/ops.php
+++ b/backend/config/ops.php
@@ -1,12 +1,37 @@
 <?php
 
-return [
-    'allowed_host' => env('OPS_ALLOWED_HOST', ''),
+$opsIpAllowlist = array_values(array_filter(array_map(
+    static fn (string $value): string => trim($value),
+    explode(',', (string) env('OPS_IP_ALLOWLIST', ''))
+)));
 
-    'ip_allowlist' => array_values(array_filter(array_map(
-        static fn (string $value): string => trim($value),
-        explode(',', (string) env('OPS_IP_ALLOWLIST', ''))
-    ))),
+$opsAccessControl = [
+    'enabled' => (bool) env('OPS_ACCESS_CONTROL_ENABLED', true),
+    'fail_open' => (bool) env('OPS_ACCESS_FAIL_OPEN', true),
+    'emergency_disable' => (bool) env('OPS_EMERGENCY_DISABLE', false),
+    'allowed_host' => env('OPS_ALLOWED_HOST', ''),
+    'ip_allowlist' => $opsIpAllowlist,
+    'admin_login_max_attempts' => (int) env('OPS_ADMIN_LOGIN_MAX_ATTEMPTS', 5),
+    'audit_log' => true,
+    'rate_limit' => [
+        'login' => (int) env('OPS_LOGIN_RATE_LIMIT', (int) env('OPS_ADMIN_LOGIN_MAX_ATTEMPTS', 5)),
+        'global' => (int) env('OPS_GLOBAL_RATE_LIMIT', 100),
+    ],
+    'risk' => [
+        'enabled' => (bool) env('OPS_RISK_ENGINE_ENABLED', true),
+    ],
+];
+
+return [
+    'allowed_host' => $opsAccessControl['allowed_host'],
+
+    'ip_allowlist' => $opsAccessControl['ip_allowlist'],
+
+    'access_control' => $opsAccessControl,
+
+    'alert' => [
+        'webhook' => env('OPS_ALERT_WEBHOOK'),
+    ],
 
     'go_live_gate' => [
         // enabled_only: only validate providers that are enabled in payments.providers.*
@@ -28,7 +53,7 @@ return [
     ],
 
     'security' => [
-        'admin_login_max_attempts' => (int) env('OPS_ADMIN_LOGIN_MAX_ATTEMPTS', 5),
+        'admin_login_max_attempts' => $opsAccessControl['admin_login_max_attempts'],
         'admin_login_decay_seconds' => (int) env('OPS_ADMIN_LOGIN_DECAY_SECONDS', 300),
     ],
 

--- a/backend/resources/views/filament/ops/pages/delivery-tools.blade.php
+++ b/backend/resources/views/filament/ops/pages/delivery-tools.blade.php
@@ -1,31 +1,67 @@
 <x-filament-panels::page>
-    <div class="space-y-4">
-        <div class="grid gap-3 md:grid-cols-2">
-            <input
-                type="text"
-                wire:model.defer="orderNo"
-                placeholder="order_no"
-                class="block w-full rounded-lg border-gray-300 shadow-sm"
-            />
-            <select wire:model.defer="tool" class="block w-full rounded-lg border-gray-300 shadow-sm">
-                <option value="regenerate_report">Regenerate Report</option>
-                <option value="resend_delivery">Resend Delivery</option>
-            </select>
-        </div>
+    <div class="ops-shell-page">
+        <x-filament-ops::ops-section
+            eyebrow="Support tools"
+            title="Delivery tools"
+            description="Request an approval-backed recovery action for a single order inside the active organization context."
+        >
+            <x-filament-ops::ops-toolbar>
+                <div class="ops-page-grid ops-page-grid--2">
+                    <div class="ops-control-stack">
+                        <label class="ops-control-label" for="ops-delivery-order-no">Order number</label>
+                        <input
+                            id="ops-delivery-order-no"
+                            type="text"
+                            wire:model.defer="orderNo"
+                            placeholder="order_no"
+                            class="ops-input"
+                        />
+                    </div>
 
-        <textarea
-            wire:model.defer="reason"
-            rows="4"
-            placeholder="reason"
-            class="block w-full rounded-lg border-gray-300 shadow-sm"
-        ></textarea>
+                    <div class="ops-control-stack">
+                        <label class="ops-control-label" for="ops-delivery-tool">Tool</label>
+                        <select id="ops-delivery-tool" wire:model.defer="tool" class="ops-input">
+                            <option value="regenerate_report">Regenerate Report</option>
+                            <option value="resend_delivery">Resend Delivery</option>
+                        </select>
+                    </div>
+                </div>
 
-        <x-filament::button wire:click="requestAction">Request</x-filament::button>
+                <div class="ops-control-stack">
+                    <label class="ops-control-label" for="ops-delivery-reason">Reason</label>
+                    <textarea
+                        id="ops-delivery-reason"
+                        wire:model.defer="reason"
+                        rows="4"
+                        placeholder="reason"
+                        class="ops-input"
+                    ></textarea>
+                    <p class="ops-control-hint">The request creates an approval record, it does not directly execute the action.</p>
+                </div>
 
-        @if ($statusMessage !== '')
-            <div class="rounded-lg border border-gray-200 bg-white p-3 text-sm">
-                {{ $statusMessage }}
-            </div>
-        @endif
+                <x-slot name="actions">
+                    <x-filament::button wire:click="requestAction">Request</x-filament::button>
+                </x-slot>
+            </x-filament-ops::ops-toolbar>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Request status"
+            description="Current submission outcome for the last action attempt."
+        >
+            @if ($statusMessage !== '')
+                <x-filament-ops::ops-result-card
+                    title="Latest status"
+                    :meta="$statusMessage"
+                />
+            @else
+                <x-filament-ops::ops-empty-state
+                    eyebrow="Delivery tools"
+                    icon="heroicon-o-truck"
+                    title="No request submitted yet"
+                    description="Fill in the order number, choose a tool, and provide a reason to create an approval request."
+                />
+            @endif
+        </x-filament-ops::ops-section>
     </div>
 </x-filament-panels::page>

--- a/backend/resources/views/filament/ops/pages/global-search-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/global-search-page.blade.php
@@ -8,67 +8,54 @@
     @endphp
 
     <div class="ops-shell-page">
-        <x-filament::section>
-            <div class="ops-workbench-toolbar ops-workbench-toolbar--split">
-                <div class="ops-workbench-toolbar__main">
-                    <div class="ops-shell-inline-intro">
-                        <span class="ops-shell-inline-intro__eyebrow">Support workspace</span>
-                        <p class="ops-shell-inline-intro__meta">
-                            Jump directly to orders, attempts, shares, or user records without leaving the current ops context.
-                        </p>
-                    </div>
-
-                    <div class="ops-control-stack">
-                        <label class="ops-control-label" for="ops-global-search-input">Search by order_no / attempt_id / share_id / user_email</label>
-                        <input
-                            id="ops-global-search-input"
-                            type="text"
-                            wire:model.defer="query"
-                            placeholder="ord_..., attempt..., share..., email"
-                            class="ops-input"
-                        />
-                        <p class="ops-control-hint">The search stays read-only here. Open a result to continue in its native workspace.</p>
-                    </div>
+        <x-filament-ops::ops-section
+            eyebrow="Support workspace"
+            title="Global search"
+            description="Jump directly to orders, attempts, shares, or user records without leaving the current Ops shell."
+        >
+            <x-filament-ops::ops-toolbar>
+                <div class="ops-control-stack">
+                    <label class="ops-control-label" for="ops-global-search-input">Search by order_no / attempt_id / share_id / user_email</label>
+                    <input
+                        id="ops-global-search-input"
+                        type="text"
+                        wire:model.defer="query"
+                        placeholder="ord_..., attempt..., share..., email"
+                        class="ops-input"
+                    />
+                    <p class="ops-control-hint">The search stays read-only here. Open a result to continue in its native workspace.</p>
                 </div>
 
-                <div class="ops-workbench-toolbar__actions">
+                <x-slot name="actions">
                     <x-filament::button color="primary" wire:click="runSearch">
                         Search
                     </x-filament::button>
-                </div>
-            </div>
-        </x-filament::section>
+                </x-slot>
+            </x-filament-ops::ops-toolbar>
+        </x-filament-ops::ops-section>
 
-        <x-filament::section>
-            <div class="ops-results-header">
-                <div>
-                    <h3 class="ops-results-header__title">Results</h3>
-                    <p class="ops-results-header__meta">Shared result cards keep support actions readable even when records come from different domains.</p>
-                </div>
+        <x-filament-ops::ops-section
+            title="Results"
+            description="Shared result cards keep support actions readable even when records come from different domains."
+        >
+            <x-slot name="actions">
                 <span class="ops-results-header__meta">{{ $elapsedMs }} ms</span>
-            </div>
+            </x-slot>
 
-            <div class="ops-card-list mt-4">
+            <div class="ops-card-list">
                 @forelse ($items as $item)
-                    <div class="ops-result-card">
-                        <div class="ops-result-card__header">
-                            <div>
-                                <p class="ops-result-card__title">{{ (string) ($item['label'] ?? '-') }}</p>
-                                <p class="ops-result-card__meta">
-                                    {{ (string) ($item['type'] ?? '-') }}
-                                    @if ((int) ($item['org_id'] ?? 0) > 0)
-                                        | org={{ (int) ($item['org_id'] ?? 0) }}
-                                    @endif
-                                    | {{ (string) ($item['subtitle'] ?? '') }}
-                                </p>
-                            </div>
+                    <x-filament-ops::ops-result-card
+                        :title="(string) ($item['label'] ?? '-')"
+                        :meta="(string) ($item['type'] ?? '-') . (((int) ($item['org_id'] ?? 0) > 0) ? ' | org='.(int) ($item['org_id'] ?? 0) : '') . (((string) ($item['subtitle'] ?? '')) !== '' ? ' | '.(string) ($item['subtitle'] ?? '') : '')"
+                    >
+                        <x-slot name="actions">
                             <x-filament::button size="xs" color="gray" tag="a" href="{{ (string) ($item['url'] ?? '/ops') }}">
                                 Open
                             </x-filament::button>
-                        </div>
-                    </div>
+                        </x-slot>
+                    </x-filament-ops::ops-result-card>
                 @empty
-                    <x-filament.ops.shared.empty-state
+                    <x-filament-ops::ops-empty-state
                         eyebrow="Support search"
                         icon="heroicon-o-magnifying-glass"
                         :title="$emptyTitle"
@@ -76,6 +63,6 @@
                     />
                 @endforelse
             </div>
-        </x-filament::section>
+        </x-filament-ops::ops-section>
     </div>
 </x-filament-panels::page>

--- a/backend/resources/views/filament/ops/pages/queue-monitor.blade.php
+++ b/backend/resources/views/filament/ops/pages/queue-monitor.blade.php
@@ -1,43 +1,60 @@
 <x-filament-panels::page>
-    <div class="space-y-4">
-        <div class="flex items-center gap-3">
-            <x-filament::button wire:click="refresh">Refresh</x-filament::button>
-            @if ($statusMessage !== '')
-                <span class="text-sm text-gray-600">{{ $statusMessage }}</span>
-            @endif
-        </div>
+    <div class="ops-shell-page">
+        <x-filament-ops::ops-section
+            eyebrow="SRE controls"
+            title="Queue monitor"
+            description="Inspect failed jobs and retry individual records without leaving the Ops shell."
+        >
+            <x-filament-ops::ops-toolbar :split="false">
+                <x-slot name="actions">
+                    <div class="ops-toolbar-inline">
+                        <x-filament::button wire:click="refresh">Refresh</x-filament::button>
+                    </div>
+                </x-slot>
+            </x-filament-ops::ops-toolbar>
+        </x-filament-ops::ops-section>
 
-        <div class="overflow-x-auto rounded-lg border">
-            <table class="min-w-full divide-y divide-gray-200 text-xs">
-                <thead class="bg-gray-50">
+        <x-filament-ops::ops-section
+            title="Failed jobs"
+            description="Latest failed queue jobs across the current runtime with direct retry controls."
+        >
+            @if ($statusMessage !== '')
+                <x-slot name="actions">
+                    <span class="ops-results-header__meta">{{ $statusMessage }}</span>
+                </x-slot>
+            @endif
+
+            <x-filament-ops::ops-table
+                :has-rows="$failedJobs !== []"
+                empty-description="There are currently no failed jobs in the queue backlog."
+                empty-eyebrow="Queue monitor"
+                empty-icon="heroicon-o-queue-list"
+                empty-title="No failed jobs"
+            >
+                <x-slot name="head">
                     <tr>
-                        <th class="px-3 py-2 text-left">ID</th>
-                        <th class="px-3 py-2 text-left">Connection</th>
-                        <th class="px-3 py-2 text-left">Queue</th>
-                        <th class="px-3 py-2 text-left">Failed At</th>
-                        <th class="px-3 py-2 text-left">Exception</th>
-                        <th class="px-3 py-2 text-left">Action</th>
+                        <th>ID</th>
+                        <th>Connection</th>
+                        <th>Queue</th>
+                        <th>Failed At</th>
+                        <th>Exception</th>
+                        <th>Action</th>
                     </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-100 bg-white">
-                    @forelse ($failedJobs as $job)
-                        <tr>
-                            <td class="px-3 py-2">{{ $job['id'] }}</td>
-                            <td class="px-3 py-2">{{ $job['connection'] }}</td>
-                            <td class="px-3 py-2">{{ $job['queue'] }}</td>
-                            <td class="px-3 py-2">{{ $job['failed_at'] }}</td>
-                            <td class="px-3 py-2">{{ $job['exception'] }}</td>
-                            <td class="px-3 py-2">
-                                <x-filament::button size="xs" wire:click="retry({{ $job['id'] }})">Retry</x-filament::button>
-                            </td>
-                        </tr>
-                    @empty
-                        <tr>
-                            <td colspan="6" class="px-3 py-4 text-center text-gray-500">No failed jobs.</td>
-                        </tr>
-                    @endforelse
-                </tbody>
-            </table>
-        </div>
+                </x-slot>
+
+                @foreach ($failedJobs as $job)
+                    <tr>
+                        <td>{{ $job['id'] }}</td>
+                        <td>{{ $job['connection'] }}</td>
+                        <td>{{ $job['queue'] }}</td>
+                        <td>{{ $job['failed_at'] }}</td>
+                        <td>{{ $job['exception'] }}</td>
+                        <td>
+                            <x-filament::button size="xs" wire:click="retry({{ $job['id'] }})">Retry</x-filament::button>
+                        </td>
+                    </tr>
+                @endforeach
+            </x-filament-ops::ops-table>
+        </x-filament-ops::ops-section>
     </div>
 </x-filament-panels::page>

--- a/backend/resources/views/filament/ops/pages/secure-link.blade.php
+++ b/backend/resources/views/filament/ops/pages/secure-link.blade.php
@@ -1,34 +1,64 @@
 <x-filament-panels::page>
-    <div class="space-y-4">
-        <div class="grid gap-3 md:grid-cols-2">
-            <input
-                type="text"
-                wire:model.defer="orderNo"
-                placeholder="order_no"
-                class="block w-full rounded-lg border-gray-300 shadow-sm"
-            />
-            <input
-                type="number"
-                min="1"
-                max="120"
-                wire:model.defer="ttlMinutes"
-                placeholder="ttl_minutes"
-                class="block w-full rounded-lg border-gray-300 shadow-sm"
-            />
-        </div>
+    <div class="ops-shell-page">
+        <x-filament-ops::ops-section
+            eyebrow="Support tools"
+            title="Secure link"
+            description="Generate a short-lived claim URL for a single order inside the active organization context."
+        >
+            <x-filament-ops::ops-toolbar>
+                <div class="ops-page-grid ops-page-grid--2">
+                    <div class="ops-control-stack">
+                        <label class="ops-control-label" for="ops-secure-link-order-no">Order number</label>
+                        <input
+                            id="ops-secure-link-order-no"
+                            type="text"
+                            wire:model.defer="orderNo"
+                            placeholder="order_no"
+                            class="ops-input"
+                        />
+                    </div>
 
-        <x-filament::button wire:click="generate">Generate Secure Link</x-filament::button>
+                    <div class="ops-control-stack">
+                        <label class="ops-control-label" for="ops-secure-link-ttl">TTL minutes</label>
+                        <input
+                            id="ops-secure-link-ttl"
+                            type="number"
+                            min="1"
+                            max="120"
+                            wire:model.defer="ttlMinutes"
+                            placeholder="ttl_minutes"
+                            class="ops-input"
+                        />
+                    </div>
+                </div>
 
-        @if ($statusMessage !== '')
-            <div class="rounded-lg border border-gray-200 bg-white p-3 text-sm">
-                {{ $statusMessage }}
-            </div>
-        @endif
+                <x-slot name="actions">
+                    <x-filament::button wire:click="generate">Generate Secure Link</x-filament::button>
+                </x-slot>
+            </x-filament-ops::ops-toolbar>
+        </x-filament-ops::ops-section>
 
-        @if ($generatedLink !== '')
-            <div class="rounded-lg border p-3 text-sm break-all">
-                <a href="{{ $generatedLink }}" target="_blank" class="text-primary-600 underline">{{ $generatedLink }}</a>
-            </div>
-        @endif
+        <x-filament-ops::ops-section
+            title="Generation result"
+            description="The latest secure-link outcome and the generated URL when available."
+        >
+            @if ($statusMessage !== '' || $generatedLink !== '')
+                <x-filament-ops::ops-result-card
+                    title="Latest status"
+                    :meta="$statusMessage !== '' ? $statusMessage : 'Secure link generated.'"
+                >
+                    @if ($generatedLink !== '')
+                        <a href="{{ $generatedLink }}" target="_blank" class="text-primary-600 underline break-all">{{ $generatedLink }}</a>
+                    @endif
+                </x-filament-ops::ops-result-card>
+            @else
+                <x-filament-ops::ops-empty-state
+                    eyebrow="Secure link"
+                    icon="heroicon-o-key"
+                    title="No secure link generated yet"
+                    description="Provide an order number and TTL to mint a short-lived claim URL."
+                />
+            @endif
+        </x-filament-ops::ops-section>
     </div>
 </x-filament-panels::page>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,13 +1,20 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\SitemapController;
+use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     $requestHost = strtolower((string) request()->getHost());
     $opsAllowedHost = strtolower(trim((string) config('ops.allowed_host', '')));
+    $opsAdminUrlHost = strtolower((string) parse_url((string) config('admin.url', ''), PHP_URL_HOST));
 
-    if (config('admin.panel_enabled') && $opsAllowedHost !== '' && $requestHost === $opsAllowedHost) {
+    $isOpsEntryHost = config('admin.panel_enabled') && (
+        ($opsAllowedHost !== '' && $requestHost === $opsAllowedHost)
+        || ($opsAdminUrlHost !== '' && $requestHost === $opsAdminUrlHost)
+        || str_starts_with($requestHost, 'ops.')
+    );
+
+    if ($isOpsEntryHost) {
         return redirect('/ops');
     }
 
@@ -27,13 +34,13 @@ Route::get('/sitemap.xml', [SitemapController::class, 'index'])
 
 if (config('admin.panel_enabled')) {
     Route::permanentRedirect('/admin', '/ops');
-    Route::get('/admin/{path}', fn (string $path) => redirect('/ops/' . $path, 301))
+    Route::get('/admin/{path}', fn (string $path) => redirect('/ops/'.$path, 301))
         ->where('path', '.*');
 } else {
     Route::get('/admin', fn () => abort(404));
     Route::get('/ops', fn () => abort(404));
 }
 
-if (!config('tenant.panel_enabled')) {
+if (! config('tenant.panel_enabled')) {
     Route::get('/tenant', fn () => abort(404));
 }

--- a/backend/tests/Feature/Ops/OpsAccessControlMiddlewareTest.php
+++ b/backend/tests/Feature/Ops/OpsAccessControlMiddlewareTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Http\Middleware\OpsAccessControl;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Redis;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+final class OpsAccessControlMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_auth_routes_bypass_host_and_ip_blocks(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('ops.access_control.allowed_host', 'ops.example.test');
+        config()->set('ops.access_control.ip_allowlist', ['1.1.1.1']);
+
+        Redis::shouldReceive('sismember')
+            ->never();
+
+        $request = Request::create('/ops/login', 'GET', [], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'blocked.example.test',
+        ]);
+        $route = new Route(['GET'], '/ops/login', static fn (): Response => response('ok'));
+        $route->name('filament.ops.auth.login');
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $response = app(OpsAccessControl::class)->handle(
+            $request,
+            static fn (): Response => response('allowed'),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('allowed', $response->getContent());
+    }
+
+    public function test_login_page_get_is_not_blocked_by_blacklist(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+
+        Redis::shouldReceive('sismember')
+            ->never();
+
+        $request = Request::create('/ops/login', 'GET', [], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'ops.example.test',
+        ]);
+        $route = new Route(['GET'], '/ops/login', static fn (): Response => response('ok'));
+        $route->name('filament.ops.auth.login');
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $response = app(OpsAccessControl::class)->handle(
+            $request,
+            static fn (): Response => response('allowed'),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('allowed', $response->getContent());
+    }
+
+    public function test_login_post_rate_limit_still_applies_for_auth_route(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('ops.access_control.rate_limit.login', 1);
+
+        Redis::shouldReceive('sismember')
+            ->once()
+            ->with('ops:ip:blacklist', '8.8.8.8')
+            ->andReturn(false);
+        Redis::shouldReceive('incr')
+            ->times(3)
+            ->andReturn(2, 1, 1);
+        Redis::shouldReceive('expire')
+            ->times(2)
+            ->andReturnTrue();
+        Redis::shouldReceive('sadd')
+            ->once()
+            ->with('ops:ip:blacklist', '8.8.8.8')
+            ->andReturn(1);
+
+        $request = Request::create('/ops/login', 'POST', [], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'ops.example.test',
+        ]);
+        $route = new Route(['POST'], '/ops/login', static fn (): Response => response('ok'));
+        $route->name('filament.ops.auth.login');
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $response = app(OpsAccessControl::class)->handle(
+            $request,
+            static fn (): Response => response('allowed'),
+        );
+
+        $this->assertSame(429, $response->getStatusCode());
+        $this->assertStringContainsString('RATE_LIMITED', (string) $response->getContent());
+    }
+
+    public function test_non_auth_ops_routes_remain_blocked_by_host_policy(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('ops.access_control.allowed_host', 'ops.example.test');
+        config()->set('ops.access_control.ip_allowlist', []);
+        config()->set('ops.access_control.rate_limit.global', 100);
+
+        Redis::shouldReceive('sismember')
+            ->once()
+            ->with('ops:ip:blacklist', '8.8.8.8')
+            ->andReturn(false);
+        Redis::shouldReceive('incr')
+            ->once()
+            ->andReturn(1);
+        Redis::shouldReceive('expire')
+            ->once()
+            ->andReturnTrue();
+        Redis::shouldReceive('get')
+            ->once()
+            ->andReturn(1);
+
+        $request = Request::create('/ops/orders', 'GET', [], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'blocked.example.test',
+        ]);
+        $route = new Route(['GET'], '/ops/orders', static fn (): Response => response('ok'));
+        $route->name('filament.ops.resources.orders.index');
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $response = app(OpsAccessControl::class)->handle(
+            $request,
+            static fn (): Response => response('allowed'),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_fail_open_allows_request_when_redis_lookup_throws(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('ops.access_control.fail_open', true);
+        config()->set('ops.access_control.allowed_host', 'ops.example.test');
+
+        Redis::shouldReceive('sismember')
+            ->once()
+            ->andThrow(new \RuntimeException('redis unavailable'));
+
+        $request = Request::create('/ops/orders', 'GET', [], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'blocked.example.test',
+        ]);
+        $route = new Route(['GET'], '/ops/orders', static fn (): Response => response('ok'));
+        $route->name('filament.ops.resources.orders.index');
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $response = app(OpsAccessControl::class)->handle(
+            $request,
+            static fn (): Response => response('allowed'),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('allowed', $response->getContent());
+    }
+
+    public function test_emergency_disable_bypasses_access_control(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('ops.access_control.enabled', true);
+        config()->set('ops.access_control.emergency_disable', true);
+        config()->set('ops.access_control.allowed_host', 'ops.example.test');
+        config()->set('ops.access_control.ip_allowlist', ['1.1.1.1']);
+
+        $request = Request::create('/ops/orders', 'GET', [], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'blocked.example.test',
+        ]);
+        $route = new Route(['GET'], '/ops/orders', static fn (): Response => response('ok'));
+        $route->name('filament.ops.resources.orders.index');
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $response = app(OpsAccessControl::class)->handle(
+            $request,
+            static fn (): Response => response('allowed'),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('allowed', $response->getContent());
+    }
+}

--- a/backend/tests/Feature/Ops/OpsEntryContractTest.php
+++ b/backend/tests/Feature/Ops/OpsEntryContractTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class OpsEntryContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ops_host_root_redirects_to_ops_when_host_matches_ops_prefix(): void
+    {
+        config()->set('admin.panel_enabled', true);
+        config()->set('ops.allowed_host', '');
+        config()->set('admin.url', '');
+
+        $this->get('http://ops.example.test/')
+            ->assertRedirect('/ops');
+    }
+
+    public function test_ops_host_root_redirects_to_ops_when_admin_url_host_matches_request_host(): void
+    {
+        config()->set('admin.panel_enabled', true);
+        config()->set('ops.allowed_host', '');
+        config()->set('admin.url', 'https://secure-ops.example.test/ops');
+
+        $this->get('http://secure-ops.example.test/')
+            ->assertRedirect('/ops');
+    }
+
+    public function test_non_ops_host_keeps_welcome_page_contract(): void
+    {
+        config()->set('admin.panel_enabled', true);
+        config()->set('ops.allowed_host', '');
+        config()->set('admin.url', '');
+
+        $this->get('http://www.example.test/')
+            ->assertOk();
+    }
+}

--- a/backend/tests/Feature/Ops/OpsLoginLimiterResetTest.php
+++ b/backend/tests/Feature/Ops/OpsLoginLimiterResetTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Auth\Events\Login;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Redis;
+use Tests\TestCase;
+
+final class OpsLoginLimiterResetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_successful_admin_login_clears_distributed_login_limiter_keys(): void
+    {
+        $request = Request::create('/ops/login', 'POST', [
+            'email' => 'ops@example.test',
+        ], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'ops.example.test',
+        ]);
+        $route = new Route(['POST'], '/ops/login', static fn () => response('ok'));
+        $route->name('filament.ops.auth.login');
+        $request->setRouteResolver(static fn (): Route => $route);
+        $this->app->instance('request', $request);
+
+        Redis::shouldReceive('del')
+            ->once()
+            ->with('ops:login:ip:8.8.8.8')
+            ->andReturn(1);
+        Redis::shouldReceive('del')
+            ->once()
+            ->with('ops:login:route:filament.ops.auth.login')
+            ->andReturn(1);
+        Redis::shouldReceive('del')
+            ->once()
+            ->with('ops:login:user:ops@example.test')
+            ->andReturn(1);
+
+        Event::dispatch(new Login('admin', new class implements Authenticatable
+        {
+            public function getAuthIdentifierName(): string
+            {
+                return 'id';
+            }
+
+            public function getAuthIdentifier(): mixed
+            {
+                return 1;
+            }
+
+            public function getAuthPasswordName(): string
+            {
+                return 'password';
+            }
+
+            public function getAuthPassword(): string
+            {
+                return '';
+            }
+
+            public function getRememberToken(): string
+            {
+                return '';
+            }
+
+            public function setRememberToken($value): void {}
+
+            public function getRememberTokenName(): string
+            {
+                return 'remember_token';
+            }
+        }, false));
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- harden Ops access control with distributed rate limiting, audit/security events, blacklist handling, and login limiter resets
- restore the ops entry-host redirect contract and add regression tests for root-entry and login middleware behavior
- finish design-system migration for remaining custom Ops pages

## Tests
- cd backend && php artisan test tests/Feature/Ops/OpsEntryContractTest.php tests/Feature/Ops/OpsAccessControlMiddlewareTest.php tests/Feature/Ops/OpsLoginLimiterResetTest.php tests/Feature/Ops/OpsAccessBoundaryTest.php tests/Feature/Ops/SelectOrgFlowTest.php
- cd backend && php artisan view:cache
- cd backend && php artisan route:list | rg 'ops/login|ops/delivery-tools|ops/secure-link|ops/global-search|ops/queue-monitor|^  GET\|HEAD  / '
