### PR TITLE
fix(ops): add login tracing and autofill sync

### DIFF
--- a/backend/app/Filament/Ops/Pages/OpsLogin.php
+++ b/backend/app/Filament/Ops/Pages/OpsLogin.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Filament\Ops\Pages;
+
+use App\Services\Ops\OpsDistributedLimiter;
+use App\Services\Ops\OpsLoginAudit;
+use App\Services\Ops\OpsLoginTracer;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Component;
+use Filament\Http\Responses\Auth\Contracts\LoginResponse;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Pages\Auth\Login as BaseLogin;
+
+class OpsLogin extends BaseLogin
+{
+    protected static string $view = 'filament.ops.pages.auth.login';
+
+    public function authenticate(): ?LoginResponse
+    {
+        $email = (string) data_get($this->data, 'email', '');
+        $trace = OpsLoginTracer::context(request(), $email);
+
+        OpsLoginTracer::start($trace);
+
+        try {
+            $this->rateLimit(5);
+        } catch (TooManyRequestsException $exception) {
+            $this->getRateLimitedNotification($exception)?->send();
+
+            OpsLoginAudit::fail($trace, 'rate_limited', [
+                'seconds_until_available' => $exception->secondsUntilAvailable,
+                'minutes_until_available' => $exception->minutesUntilAvailable,
+            ]);
+
+            return null;
+        }
+
+        $data = $this->form->getState();
+
+        if (! Filament::auth()->attempt($this->getCredentialsFromFormData($data), $data['remember'] ?? false)) {
+            OpsLoginAudit::fail($trace, 'invalid_credentials');
+
+            $this->throwFailureValidationException();
+        }
+
+        $user = Filament::auth()->user();
+
+        if (
+            ($user instanceof FilamentUser) &&
+            (! $user->canAccessPanel(Filament::getCurrentPanel()))
+        ) {
+            Filament::auth()->logout();
+
+            OpsLoginAudit::fail($trace, 'blocked', [
+                'user_id' => method_exists($user, 'getAuthIdentifier') ? $user->getAuthIdentifier() : null,
+            ]);
+
+            $this->throwFailureValidationException();
+        }
+
+        session()->regenerate();
+
+        $this->clearDistributedLoginLimiters($data);
+
+        OpsLoginTracer::success($trace, [
+            'user_id' => method_exists($user, 'getAuthIdentifier') ? $user->getAuthIdentifier() : null,
+        ]);
+
+        return app(LoginResponse::class);
+    }
+
+    protected function getEmailFormComponent(): Component
+    {
+        /** @var Component $component */
+        $component = parent::getEmailFormComponent();
+
+        return $component
+            ->autocomplete('username')
+            ->extraInputAttributes([
+                'autocapitalize' => 'none',
+                'tabindex' => 1,
+            ]);
+    }
+
+    protected function getPasswordFormComponent(): Component
+    {
+        /** @var Component $component */
+        $component = parent::getPasswordFormComponent();
+
+        return $component
+            ->autocomplete('current-password')
+            ->extraInputAttributes([
+                'tabindex' => 2,
+            ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function clearDistributedLoginLimiters(array $data): void
+    {
+        $ip = (string) (request()->ip() ?? 'unknown');
+        $email = trim((string) ($data['email'] ?? 'anonymous'));
+
+        OpsDistributedLimiter::clear('ops:login:ip:'.$ip);
+        OpsDistributedLimiter::clear('ops:login:user:'.$email);
+    }
+}

--- a/backend/app/Providers/Filament/AdminPanelProvider.php
+++ b/backend/app/Providers/Filament/AdminPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Ops\Pages\OpsDashboard;
+use App\Filament\Ops\Pages\OpsLogin;
 use App\Http\Middleware\BindOpsLoginResponse;
 use App\Http\Middleware\EnsureAdminTotpVerified;
 use App\Http\Middleware\OpsAccessControl;
@@ -31,7 +32,7 @@ class AdminPanelProvider extends PanelProvider
         return $panel
             ->id('ops')
             ->path('ops')
-            ->login()
+            ->login(OpsLogin::class)
             ->authGuard((string) config('admin.guard', 'admin'))
             ->brandName('Fermat Ops')
             ->colors([

--- a/backend/app/Services/Ops/OpsLoginAudit.php
+++ b/backend/app/Services/Ops/OpsLoginAudit.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Illuminate\Support\Facades\Log;
+
+class OpsLoginAudit
+{
+    /**
+     * @param  array<string, mixed>  $trace
+     * @param  array<string, mixed>  $extra
+     */
+    public static function fail(array $trace, string $reason, array $extra = []): void
+    {
+        Log::channel('stack')->warning('OPS_LOGIN_FAIL', [
+            ...$trace,
+            'reason' => $reason,
+            ...$extra,
+        ]);
+    }
+}

--- a/backend/app/Services/Ops/OpsLoginTracer.php
+++ b/backend/app/Services/Ops/OpsLoginTracer.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class OpsLoginTracer
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function context(Request $request, ?string $email = null): array
+    {
+        $requestId = trim((string) $request->headers->get('X-Request-Id', ''));
+
+        return [
+            'trace_id' => (string) Str::uuid(),
+            'request_id' => $requestId !== '' ? $requestId : (string) Str::uuid(),
+            'ip' => (string) ($request->ip() ?? 'unknown'),
+            'ua' => trim((string) ($request->userAgent() ?? '')),
+            'email' => self::maskEmail($email),
+            'timestamp' => now()->toISOString(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @param  array<string, mixed>  $extra
+     */
+    public static function start(array $context, array $extra = []): void
+    {
+        Log::channel('stack')->info('OPS_LOGIN_TRACE_START', [
+            ...$context,
+            ...$extra,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @param  array<string, mixed>  $extra
+     */
+    public static function success(array $context, array $extra = []): void
+    {
+        Log::channel('stack')->info('OPS_LOGIN_SUCCESS', [
+            ...$context,
+            ...$extra,
+        ]);
+    }
+
+    private static function maskEmail(?string $email): ?string
+    {
+        $value = strtolower(trim((string) $email));
+
+        if ($value === '' || ! str_contains($value, '@')) {
+            return null;
+        }
+
+        [$local, $domain] = explode('@', $value, 2);
+        $maskedLocal = strlen($local) <= 2
+            ? substr($local, 0, 1).'*'
+            : substr($local, 0, 2).str_repeat('*', max(1, strlen($local) - 2));
+
+        return $maskedLocal.'@'.$domain;
+    }
+}

--- a/backend/resources/views/filament/ops/pages/auth/login.blade.php
+++ b/backend/resources/views/filament/ops/pages/auth/login.blade.php
@@ -1,0 +1,65 @@
+<x-filament-panels::page.simple>
+    @if (filament()->hasRegistration())
+        <x-slot name="subheading">
+            {{ __('filament-panels::pages/auth/login.actions.register.before') }}
+
+            {{ $this->registerAction }}
+        </x-slot>
+    @endif
+
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE, scopes: $this->getRenderHookScopes()) }}
+
+    <form
+        id="form"
+        method="post"
+        wire:submit="authenticate"
+        novalidate
+        x-data="{ isProcessing: false }"
+        x-init="
+            const syncAutofill = () => {
+                const emailInput = $el.querySelector('input[autocomplete=\'username\'], input[type=\'email\'], input[name=\'email\']')
+                const passwordInput = $el.querySelector('input[autocomplete=\'current-password\'], input[type=\'password\'], input[name=\'password\']')
+
+                if (emailInput && emailInput.value) {
+                    $wire.set('data.email', emailInput.value)
+                }
+
+                if (passwordInput && passwordInput.value) {
+                    $wire.set('data.password', passwordInput.value)
+                }
+            }
+
+            setTimeout(syncAutofill, 300)
+            setTimeout(syncAutofill, 900)
+        "
+        x-on:submit="
+            if (isProcessing) {
+                $event.preventDefault()
+                return
+            }
+
+            const emailInput = $el.querySelector('input[autocomplete=\'username\'], input[type=\'email\'], input[name=\'email\']')
+            const passwordInput = $el.querySelector('input[autocomplete=\'current-password\'], input[type=\'password\'], input[name=\'password\']')
+
+            if (emailInput && emailInput.value) {
+                $wire.set('data.email', emailInput.value)
+            }
+
+            if (passwordInput && passwordInput.value) {
+                $wire.set('data.password', passwordInput.value)
+            }
+        "
+        x-on:form-processing-started="isProcessing = true"
+        x-on:form-processing-finished="isProcessing = false"
+        class="fi-form grid gap-y-6"
+    >
+        {{ $this->form }}
+
+        <x-filament-panels::form.actions
+            :actions="$this->getCachedFormActions()"
+            :full-width="$this->hasFullWidthFormActions()"
+        />
+    </form>
+
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::AUTH_LOGIN_FORM_AFTER, scopes: $this->getRenderHookScopes()) }}
+</x-filament-panels::page.simple>

--- a/backend/tests/Feature/Ops/OpsLoginPageTest.php
+++ b/backend/tests/Feature/Ops/OpsLoginPageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class OpsLoginPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ops_login_page_disables_browser_validation_and_uses_browser_friendly_autocomplete(): void
+    {
+        config()->set('admin.panel_enabled', true);
+
+        $this->get('/ops/login')
+            ->assertOk()
+            ->assertSee('novalidate', false)
+            ->assertSee('autocomplete="username"', false)
+            ->assertSee('autocomplete="current-password"', false);
+    }
+}


### PR DESCRIPTION
## Summary
- override the Ops login page with browser-safe novalidate form markup
- sync browser autofill values into Livewire before submit
- add structured login trace and failure audit logs

## Tests
- cd backend && php artisan test tests/Feature/Ops/OpsLoginPageTest.php