### PR TITLE
feat(cms): build editorial workflow and assignment system

### DIFF
--- a/backend/app/Filament/Ops/Pages/ContentReleasePage.php
+++ b/backend/app/Filament/Ops/Pages/ContentReleasePage.php
@@ -9,6 +9,7 @@ use App\Filament\Ops\Resources\CareerGuideResource;
 use App\Filament\Ops\Resources\CareerJobResource;
 use App\Filament\Ops\Support\ContentAccess;
 use App\Filament\Ops\Support\EditorialReviewAudit;
+use App\Filament\Ops\Support\EditorialReviewChecklist;
 use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
@@ -301,6 +302,12 @@ class ContentReleasePage extends Page
 
         $decision = EditorialReviewAudit::latestState($type, $record);
 
-        return $decision['state'] ?? EditorialReviewAudit::STATE_NEEDS_ATTENTION;
+        if (is_array($decision) && ($decision['state'] ?? null) !== null) {
+            return (string) $decision['state'];
+        }
+
+        return EditorialReviewChecklist::missing($type, $record) === []
+            ? EditorialReviewAudit::STATE_READY
+            : EditorialReviewAudit::STATE_NEEDS_ATTENTION;
     }
 }

--- a/backend/app/Filament/Ops/Pages/ContentReleasePage.php
+++ b/backend/app/Filament/Ops/Pages/ContentReleasePage.php
@@ -300,13 +300,20 @@ class ContentReleasePage extends Page
             return EditorialReviewAudit::STATE_APPROVED;
         }
 
+        $checklistReady = EditorialReviewChecklist::missing($type, $record) === [];
         $decision = EditorialReviewAudit::latestState($type, $record);
 
         if (is_array($decision) && ($decision['state'] ?? null) !== null) {
-            return (string) $decision['state'];
+            $state = (string) $decision['state'];
+
+            if ($state === EditorialReviewAudit::STATE_READY && ! $checklistReady) {
+                return EditorialReviewAudit::STATE_NEEDS_ATTENTION;
+            }
+
+            return $state;
         }
 
-        return EditorialReviewChecklist::missing($type, $record) === []
+        return $checklistReady
             ? EditorialReviewAudit::STATE_READY
             : EditorialReviewAudit::STATE_NEEDS_ATTENTION;
     }

--- a/backend/app/Filament/Ops/Pages/EditorialReviewPage.php
+++ b/backend/app/Filament/Ops/Pages/EditorialReviewPage.php
@@ -10,6 +10,7 @@ use App\Filament\Ops\Resources\CareerJobResource;
 use App\Filament\Ops\Support\ContentAccess;
 use App\Filament\Ops\Support\EditorialReviewAudit;
 use App\Filament\Ops\Support\EditorialReviewChecklist;
+use App\Models\AdminUser;
 use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
@@ -38,12 +39,25 @@ class EditorialReviewPage extends Page
     /** @var list<array<string, mixed>> */
     public array $reviewItems = [];
 
+    /** @var array<string, string> */
+    public array $ownerAssignments = [];
+
+    /** @var array<string, string> */
+    public array $reviewerAssignments = [];
+
+    /** @var array<int, string> */
+    public array $ownerOptions = [];
+
+    /** @var array<int, string> */
+    public array $reviewerOptions = [];
+
     public string $typeFilter = 'all';
 
     public string $reviewStateFilter = 'all';
 
     public function mount(): void
     {
+        $this->loadAssignmentOptions();
         $this->refreshReviewSurface();
     }
 
@@ -57,13 +71,94 @@ class EditorialReviewPage extends Page
         $this->refreshReviewSurface();
     }
 
+    public function assignOwnerItem(string $type, int $id): void
+    {
+        if (! ContentAccess::canAssignOwner()) {
+            throw new AuthorizationException('You do not have permission to assign an owner.');
+        }
+
+        $record = $this->resolveRecord($type, $id);
+        $selection = trim((string) ($this->ownerAssignments[$this->workflowKey($type, $id)] ?? ''));
+        $ownerAdminId = (int) $selection;
+
+        if ($ownerAdminId <= 0) {
+            throw new AuthorizationException('Select an owner before saving the assignment.');
+        }
+
+        EditorialReviewAudit::assignOwner($ownerAdminId, $type, $record);
+
+        Notification::make()
+            ->title('Owner assigned')
+            ->success()
+            ->send();
+
+        $this->refreshReviewSurface();
+    }
+
+    public function assignReviewerItem(string $type, int $id): void
+    {
+        if (! ContentAccess::canAssignReviewer()) {
+            throw new AuthorizationException('You do not have permission to assign a reviewer.');
+        }
+
+        $record = $this->resolveRecord($type, $id);
+        $selection = trim((string) ($this->reviewerAssignments[$this->workflowKey($type, $id)] ?? ''));
+        $reviewerAdminId = (int) $selection;
+
+        if ($reviewerAdminId <= 0) {
+            throw new AuthorizationException('Select a reviewer before saving the assignment.');
+        }
+
+        EditorialReviewAudit::assignReviewer($reviewerAdminId, $type, $record);
+
+        Notification::make()
+            ->title('Reviewer assigned')
+            ->success()
+            ->send();
+
+        $this->refreshReviewSurface();
+    }
+
+    public function submitItem(string $type, int $id): void
+    {
+        $record = $this->resolveRecord($type, $id);
+        $missing = EditorialReviewChecklist::missing($type, $record);
+        $snapshot = EditorialReviewAudit::latestState($type, $record);
+
+        if ($missing !== []) {
+            throw new AuthorizationException('Fix the checklist gaps before submitting for review.');
+        }
+
+        if ((int) ($snapshot['owner_admin_user_id'] ?? 0) <= 0 || (int) ($snapshot['reviewer_admin_user_id'] ?? 0) <= 0) {
+            throw new AuthorizationException('Assign both an owner and a reviewer before submitting for review.');
+        }
+
+        if (! $this->canSubmitForReview($snapshot)) {
+            throw new AuthorizationException('You do not have permission to submit this record for review.');
+        }
+
+        EditorialReviewAudit::submit($type, $record);
+
+        Notification::make()
+            ->title('Sent to review')
+            ->success()
+            ->send();
+
+        $this->refreshReviewSurface();
+    }
+
     public function approveItem(string $type, int $id): void
     {
         $record = $this->resolveRecord($type, $id);
         $missing = EditorialReviewChecklist::missing($type, $record);
+        $snapshot = EditorialReviewAudit::latestState($type, $record);
 
         if ($missing !== []) {
             throw new AuthorizationException('You cannot approve a record with review checklist gaps.');
+        }
+
+        if (! $this->canDecideReview($snapshot)) {
+            throw new AuthorizationException('You are not the assigned reviewer for this record.');
         }
 
         EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, $type, $record);
@@ -79,6 +174,11 @@ class EditorialReviewPage extends Page
     public function requestChangesItem(string $type, int $id): void
     {
         $record = $this->resolveRecord($type, $id);
+        $snapshot = EditorialReviewAudit::latestState($type, $record);
+
+        if (! $this->canDecideReview($snapshot)) {
+            throw new AuthorizationException('You are not the assigned reviewer for this record.');
+        }
 
         EditorialReviewAudit::mark(EditorialReviewAudit::STATE_CHANGES_REQUESTED, $type, $record);
 
@@ -93,6 +193,11 @@ class EditorialReviewPage extends Page
     public function rejectItem(string $type, int $id): void
     {
         $record = $this->resolveRecord($type, $id);
+        $snapshot = EditorialReviewAudit::latestState($type, $record);
+
+        if (! $this->canDecideReview($snapshot)) {
+            throw new AuthorizationException('You are not the assigned reviewer for this record.');
+        }
 
         EditorialReviewAudit::mark(EditorialReviewAudit::STATE_REJECTED, $type, $record);
 
@@ -116,11 +221,13 @@ class EditorialReviewPage extends Page
 
     public static function canAccess(): bool
     {
-        return ContentAccess::canRelease();
+        return ContentAccess::canOpenWorkflow();
     }
 
     private function refreshReviewSurface(): void
     {
+        $this->loadAssignmentOptions();
+
         $currentOrgIds = $this->currentOrgIds();
 
         $articles = Article::query()
@@ -163,8 +270,11 @@ class EditorialReviewPage extends Page
         }
 
         $readyCount = $allItems->where('review_state', EditorialReviewAudit::STATE_READY)->count();
+        $inReviewCount = $allItems->where('review_state', EditorialReviewAudit::STATE_IN_REVIEW)->count();
         $approvedCount = $allItems->where('review_state', EditorialReviewAudit::STATE_APPROVED)->count();
         $attentionCount = $allItems->where('review_state', EditorialReviewAudit::STATE_NEEDS_ATTENTION)->count();
+
+        $this->hydrateAssignmentSelections($allItems->all());
 
         $this->reviewItems = $filteredItems
             ->sortByDesc('updated_at_sort')
@@ -180,7 +290,12 @@ class EditorialReviewPage extends Page
             [
                 'label' => 'Ready for release review',
                 'value' => (string) $readyCount,
-                'hint' => 'Draft records that satisfy the current checklist and are ready for an explicit approval decision.',
+                'hint' => 'Checklist-clean drafts that have not yet been formally submitted into the reviewer queue.',
+            ],
+            [
+                'label' => 'Currently in review',
+                'value' => (string) $inReviewCount,
+                'hint' => 'Draft records actively assigned and submitted to a reviewer.',
             ],
             [
                 'label' => 'Approved for release',
@@ -221,7 +336,8 @@ class EditorialReviewPage extends Page
     private function reviewRowForArticle(Article $record): array
     {
         $missing = EditorialReviewChecklist::missing('article', $record);
-        $reviewState = $this->resolveReviewState('article', $record, $missing === []);
+        $snapshot = EditorialReviewAudit::latestState('article', $record);
+        $reviewState = $this->resolveReviewState($snapshot, $missing === []);
 
         return $this->reviewRow(
             type: 'article',
@@ -230,6 +346,10 @@ class EditorialReviewPage extends Page
             title: (string) $record->title,
             locale: (string) $record->locale,
             reviewState: $reviewState,
+            ownerAdminId: (int) ($snapshot['owner_admin_user_id'] ?? 0),
+            ownerLabel: (string) ($snapshot['owner_label'] ?? ''),
+            reviewerAdminId: (int) ($snapshot['reviewer_admin_user_id'] ?? 0),
+            reviewerLabel: (string) ($snapshot['reviewer_label'] ?? ''),
             checklistLabel: $missing === [] ? 'Content + SEO ready' : 'Missing: '.implode(', ', $missing),
             updatedAt: optional($record->updated_at)?->toDateTimeString() ?? 'Unknown',
             editUrl: ArticleResource::getUrl('edit', ['record' => $record]),
@@ -242,7 +362,8 @@ class EditorialReviewPage extends Page
     private function reviewRowForGuide(CareerGuide $record): array
     {
         $missing = EditorialReviewChecklist::missing('guide', $record);
-        $reviewState = $this->resolveReviewState('guide', $record, $missing === []);
+        $snapshot = EditorialReviewAudit::latestState('guide', $record);
+        $reviewState = $this->resolveReviewState($snapshot, $missing === []);
 
         return $this->reviewRow(
             type: 'guide',
@@ -251,6 +372,10 @@ class EditorialReviewPage extends Page
             title: (string) $record->title,
             locale: (string) $record->locale,
             reviewState: $reviewState,
+            ownerAdminId: (int) ($snapshot['owner_admin_user_id'] ?? 0),
+            ownerLabel: (string) ($snapshot['owner_label'] ?? ''),
+            reviewerAdminId: (int) ($snapshot['reviewer_admin_user_id'] ?? 0),
+            reviewerLabel: (string) ($snapshot['reviewer_label'] ?? ''),
             checklistLabel: $missing === [] ? 'Content + SEO ready' : 'Missing: '.implode(', ', $missing),
             updatedAt: optional($record->updated_at)?->toDateTimeString() ?? 'Unknown',
             editUrl: CareerGuideResource::getUrl('edit', ['record' => $record]),
@@ -263,7 +388,8 @@ class EditorialReviewPage extends Page
     private function reviewRowForJob(CareerJob $record): array
     {
         $missing = EditorialReviewChecklist::missing('job', $record);
-        $reviewState = $this->resolveReviewState('job', $record, $missing === []);
+        $snapshot = EditorialReviewAudit::latestState('job', $record);
+        $reviewState = $this->resolveReviewState($snapshot, $missing === []);
 
         return $this->reviewRow(
             type: 'job',
@@ -272,6 +398,10 @@ class EditorialReviewPage extends Page
             title: (string) $record->title,
             locale: (string) $record->locale,
             reviewState: $reviewState,
+            ownerAdminId: (int) ($snapshot['owner_admin_user_id'] ?? 0),
+            ownerLabel: (string) ($snapshot['owner_label'] ?? ''),
+            reviewerAdminId: (int) ($snapshot['reviewer_admin_user_id'] ?? 0),
+            reviewerLabel: (string) ($snapshot['reviewer_label'] ?? ''),
             checklistLabel: $missing === [] ? 'Content + SEO ready' : 'Missing: '.implode(', ', $missing),
             updatedAt: optional($record->updated_at)?->toDateTimeString() ?? 'Unknown',
             editUrl: CareerJobResource::getUrl('edit', ['record' => $record]),
@@ -288,21 +418,45 @@ class EditorialReviewPage extends Page
         string $title,
         string $locale,
         string $reviewState,
+        int $ownerAdminId,
+        string $ownerLabel,
+        int $reviewerAdminId,
+        string $reviewerLabel,
         string $checklistLabel,
         string $updatedAt,
         string $editUrl,
     ): array {
+        $workflowKey = $this->workflowKey($type, $id);
+
         return [
             'type' => $type,
             'id' => $id,
+            'workflow_key' => $workflowKey,
             'type_label' => $typeLabel,
             'title' => $title !== '' ? $title : 'Untitled',
             'locale' => $locale !== '' ? $locale : 'Unknown',
             'review_state' => $reviewState,
+            'owner_admin_user_id' => $ownerAdminId > 0 ? $ownerAdminId : null,
+            'owner_label' => $ownerLabel !== '' ? $ownerLabel : 'Unassigned',
+            'reviewer_admin_user_id' => $reviewerAdminId > 0 ? $reviewerAdminId : null,
+            'reviewer_label' => $reviewerLabel !== '' ? $reviewerLabel : 'Unassigned',
             'checklist_label' => $checklistLabel,
             'updated_at' => $updatedAt,
             'updated_at_sort' => strtotime($updatedAt) ?: 0,
             'edit_url' => $editUrl,
+            'can_assign_owner' => ContentAccess::canAssignOwner(),
+            'can_assign_reviewer' => ContentAccess::canAssignReviewer(),
+            'can_submit' => ($reviewState === EditorialReviewAudit::STATE_READY || $reviewState === EditorialReviewAudit::STATE_CHANGES_REQUESTED)
+                && $ownerAdminId > 0
+                && $reviewerAdminId > 0
+                && $this->canSubmitForReview([
+                    'owner_admin_user_id' => $ownerAdminId,
+                    'reviewer_admin_user_id' => $reviewerAdminId,
+                ]),
+            'can_decide' => $reviewState === EditorialReviewAudit::STATE_IN_REVIEW
+                && $this->canDecideReview([
+                    'reviewer_admin_user_id' => $reviewerAdminId,
+                ]),
         ];
     }
 
@@ -313,6 +467,7 @@ class EditorialReviewPage extends Page
             'guide' => 'Career Guide',
             'job' => 'Career Job',
             EditorialReviewAudit::STATE_READY => EditorialReviewAudit::label(EditorialReviewAudit::STATE_READY),
+            EditorialReviewAudit::STATE_IN_REVIEW => EditorialReviewAudit::label(EditorialReviewAudit::STATE_IN_REVIEW),
             EditorialReviewAudit::STATE_APPROVED => EditorialReviewAudit::label(EditorialReviewAudit::STATE_APPROVED),
             EditorialReviewAudit::STATE_CHANGES_REQUESTED => EditorialReviewAudit::label(EditorialReviewAudit::STATE_CHANGES_REQUESTED),
             EditorialReviewAudit::STATE_REJECTED => EditorialReviewAudit::label(EditorialReviewAudit::STATE_REJECTED),
@@ -321,20 +476,21 @@ class EditorialReviewPage extends Page
         };
     }
 
-    private function resolveReviewState(string $type, object $record, bool $checklistReady): string
+    /**
+     * @param  array<string, mixed>|null  $snapshot
+     */
+    private function resolveReviewState(?array $snapshot, bool $checklistReady): string
     {
         if (! $checklistReady) {
             return EditorialReviewAudit::STATE_NEEDS_ATTENTION;
         }
 
-        $decision = EditorialReviewAudit::latestState($type, $record);
-
-        return $decision['state'] ?? EditorialReviewAudit::STATE_READY;
+        return (string) ($snapshot['state'] ?? EditorialReviewAudit::STATE_READY);
     }
 
     private function resolveRecord(string $type, int $id): object
     {
-        if (! ContentAccess::canRelease()) {
+        if (! ContentAccess::canOpenWorkflow()) {
             throw new AuthorizationException('You do not have permission to review content.');
         }
 
@@ -344,5 +500,91 @@ class EditorialReviewPage extends Page
             'job' => CareerJob::query()->withoutGlobalScopes()->where('org_id', 0)->findOrFail($id),
             default => throw new AuthorizationException('Unsupported review type.'),
         };
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function hydrateAssignmentSelections(array $items): void
+    {
+        foreach ($items as $item) {
+            $this->ownerAssignments[$item['workflow_key']] = (string) ($item['owner_admin_user_id'] ?? '');
+            $this->reviewerAssignments[$item['workflow_key']] = (string) ($item['reviewer_admin_user_id'] ?? '');
+        }
+    }
+
+    private function loadAssignmentOptions(): void
+    {
+        $admins = AdminUser::query()
+            ->where('is_active', 1)
+            ->orderBy('name')
+            ->orderBy('email')
+            ->get();
+
+        $this->ownerOptions = $admins
+            ->filter(fn (AdminUser $admin): bool => $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_CONTENT_WRITE)
+                || $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_OWNER))
+            ->mapWithKeys(fn (AdminUser $admin): array => [(int) $admin->id => trim($admin->name !== '' ? $admin->name : $admin->email)])
+            ->all();
+
+        $this->reviewerOptions = $admins
+            ->filter(fn (AdminUser $admin): bool => $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_APPROVAL_REVIEW)
+                || $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_CONTENT_RELEASE)
+                || $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_OWNER))
+            ->mapWithKeys(fn (AdminUser $admin): array => [(int) $admin->id => trim($admin->name !== '' ? $admin->name : $admin->email)])
+            ->all();
+    }
+
+    private function workflowKey(string $type, int $id): string
+    {
+        return $type.'_'.$id;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $snapshot
+     */
+    private function canSubmitForReview(?array $snapshot): bool
+    {
+        if (ContentAccess::isOwner()) {
+            return true;
+        }
+
+        if (! ContentAccess::canOpenWorkflow()) {
+            return false;
+        }
+
+        $actorId = $this->actorAdminId();
+
+        return $actorId > 0 && $actorId === (int) ($snapshot['owner_admin_user_id'] ?? 0);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $snapshot
+     */
+    private function canDecideReview(?array $snapshot): bool
+    {
+        if (ContentAccess::isOwner()) {
+            return true;
+        }
+
+        if (! ContentAccess::canReview()) {
+            return false;
+        }
+
+        $actorId = $this->actorAdminId();
+
+        return $actorId > 0 && $actorId === (int) ($snapshot['reviewer_admin_user_id'] ?? 0);
+    }
+
+    private function actorAdminId(): int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user) && is_numeric(data_get($user, 'id'))
+            ? (int) data_get($user, 'id')
+            : 0;
     }
 }

--- a/backend/app/Filament/Ops/Support/ContentAccess.php
+++ b/backend/app/Filament/Ops/Support/ContentAccess.php
@@ -37,6 +37,38 @@ final class ContentAccess
         ]);
     }
 
+    public static function canReview(): bool
+    {
+        return self::hasAnyPermission([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+            PermissionNames::ADMIN_CONTENT_PUBLISH,
+            PermissionNames::ADMIN_OWNER,
+        ]);
+    }
+
+    public static function canOpenWorkflow(): bool
+    {
+        return self::canWrite() || self::canReview();
+    }
+
+    public static function canAssignOwner(): bool
+    {
+        return self::canWrite() || self::canReview();
+    }
+
+    public static function canAssignReviewer(): bool
+    {
+        return self::canReview();
+    }
+
+    public static function isOwner(): bool
+    {
+        return self::hasAnyPermission([
+            PermissionNames::ADMIN_OWNER,
+        ]);
+    }
+
     /**
      * @param  list<string>  $permissions
      */

--- a/backend/app/Filament/Ops/Support/EditorialReviewAudit.php
+++ b/backend/app/Filament/Ops/Support/EditorialReviewAudit.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Support;
 
-use App\Models\AuditLog;
+use App\Models\AdminUser;
+use App\Models\EditorialReview;
 use App\Services\Audit\AuditLogger;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 final class EditorialReviewAudit
 {
     public const STATE_READY = 'ready';
+
+    public const STATE_IN_REVIEW = 'in_review';
 
     public const STATE_APPROVED = 'approved';
 
@@ -19,6 +23,69 @@ final class EditorialReviewAudit
     public const STATE_REJECTED = 'rejected';
 
     public const STATE_NEEDS_ATTENTION = 'needs_attention';
+
+    public static function assignOwner(int $ownerAdminId, string $type, object $record): EditorialReview
+    {
+        $workflow = self::workflowFor($type, $record);
+        $workflow->owner_admin_user_id = $ownerAdminId;
+        $workflow->last_transition_at = now();
+        $workflow->save();
+
+        self::log(
+            action: 'editorial_review_owner_assigned',
+            type: $type,
+            record: $record,
+            meta: [
+                'owner_admin_user_id' => $ownerAdminId,
+                'owner_label' => self::adminLabel($ownerAdminId),
+            ],
+        );
+
+        return $workflow;
+    }
+
+    public static function assignReviewer(int $reviewerAdminId, string $type, object $record): EditorialReview
+    {
+        $workflow = self::workflowFor($type, $record);
+        $workflow->reviewer_admin_user_id = $reviewerAdminId;
+        $workflow->last_transition_at = now();
+        $workflow->save();
+
+        self::log(
+            action: 'editorial_review_reviewer_assigned',
+            type: $type,
+            record: $record,
+            meta: [
+                'reviewer_admin_user_id' => $reviewerAdminId,
+                'reviewer_label' => self::adminLabel($reviewerAdminId),
+            ],
+        );
+
+        return $workflow;
+    }
+
+    public static function submit(string $type, object $record): EditorialReview
+    {
+        $workflow = self::workflowFor($type, $record);
+        $actorAdminId = self::actorAdminId();
+
+        $workflow->workflow_state = self::STATE_IN_REVIEW;
+        $workflow->submitted_by_admin_user_id = $actorAdminId;
+        $workflow->submitted_at = now();
+        $workflow->last_transition_at = now();
+        $workflow->save();
+
+        self::log(
+            action: 'editorial_review_submitted',
+            type: $type,
+            record: $record,
+            meta: [
+                'workflow_state' => self::STATE_IN_REVIEW,
+            ],
+        );
+
+        return $workflow;
+    }
 
     public static function mark(string $decision, string $type, object $record): void
     {
@@ -29,6 +96,164 @@ final class EditorialReviewAudit
             default => throw new \InvalidArgumentException('Unsupported review decision.'),
         };
 
+        $workflow = self::workflowFor($type, $record);
+        $workflow->workflow_state = $decision;
+        $workflow->reviewed_by_admin_user_id = self::actorAdminId();
+        $workflow->reviewed_at = now();
+        $workflow->last_transition_at = now();
+        $workflow->save();
+
+        self::log(
+            action: $action,
+            type: $type,
+            record: $record,
+            meta: [
+                'decision' => $decision,
+                'workflow_state' => $decision,
+            ],
+        );
+    }
+
+    /**
+     * @return array{state:string,label:string,reviewed_at:string,owner_admin_user_id:int|null,owner_label:string,reviewer_admin_user_id:int|null,reviewer_label:string}|null
+     */
+    public static function latestState(string $type, object $record): ?array
+    {
+        $workflow = self::query()
+            ->with(['owner', 'reviewer'])
+            ->where('content_type', self::targetType($type))
+            ->where('content_id', (int) data_get($record, 'id'))
+            ->first();
+
+        if (! $workflow instanceof EditorialReview) {
+            return null;
+        }
+
+        $updatedAt = data_get($record, 'updated_at');
+        if (
+            $updatedAt instanceof \DateTimeInterface
+            && $workflow->last_transition_at instanceof \DateTimeInterface
+            && $workflow->last_transition_at < $updatedAt
+        ) {
+            return [
+                'state' => self::STATE_READY,
+                'label' => self::label(self::STATE_READY),
+                'reviewed_at' => optional($workflow->reviewed_at)?->toDateTimeString() ?? 'Unknown',
+                'owner_admin_user_id' => $workflow->owner_admin_user_id,
+                'owner_label' => trim((string) optional($workflow->owner)->name),
+                'reviewer_admin_user_id' => $workflow->reviewer_admin_user_id,
+                'reviewer_label' => trim((string) optional($workflow->reviewer)->name),
+            ];
+        }
+
+        return [
+            'state' => (string) $workflow->workflow_state,
+            'label' => self::label((string) $workflow->workflow_state),
+            'reviewed_at' => optional($workflow->reviewed_at ?? $workflow->submitted_at)?->toDateTimeString() ?? 'Unknown',
+            'owner_admin_user_id' => $workflow->owner_admin_user_id,
+            'owner_label' => trim((string) optional($workflow->owner)->name),
+            'reviewer_admin_user_id' => $workflow->reviewer_admin_user_id,
+            'reviewer_label' => trim((string) optional($workflow->reviewer)->name),
+        ];
+    }
+
+    public static function label(string $state): string
+    {
+        return match ($state) {
+            self::STATE_IN_REVIEW => 'In review',
+            self::STATE_APPROVED => 'Approved',
+            self::STATE_CHANGES_REQUESTED => 'Changes requested',
+            self::STATE_REJECTED => 'Rejected',
+            self::STATE_NEEDS_ATTENTION => 'Needs attention',
+            default => 'Ready',
+        };
+    }
+
+    public static function isAssignedReviewer(string $type, object $record, ?int $adminUserId = null): bool
+    {
+        $snapshot = self::latestState($type, $record);
+        $adminUserId ??= self::actorAdminId();
+
+        return $adminUserId > 0
+            && (int) ($snapshot['reviewer_admin_user_id'] ?? 0) === $adminUserId;
+    }
+
+    public static function isAssignedOwner(string $type, object $record, ?int $adminUserId = null): bool
+    {
+        $snapshot = self::latestState($type, $record);
+        $adminUserId ??= self::actorAdminId();
+
+        return $adminUserId > 0
+            && (int) ($snapshot['owner_admin_user_id'] ?? 0) === $adminUserId;
+    }
+
+    public static function resetStateAfterEdit(string $type, object $record): void
+    {
+        $workflow = self::query()
+            ->where('content_type', self::targetType($type))
+            ->where('content_id', (int) data_get($record, 'id'))
+            ->first();
+
+        if (! $workflow instanceof EditorialReview) {
+            return;
+        }
+
+        $workflow->workflow_state = self::STATE_READY;
+        $workflow->save();
+    }
+
+    private static function targetType(string $type): string
+    {
+        return match ($type) {
+            'article' => 'article',
+            'guide' => 'career_guide',
+            'job' => 'career_job',
+            default => 'content',
+        };
+    }
+
+    private static function workflowFor(string $type, object $record): EditorialReview
+    {
+        /** @var EditorialReview|null $workflow */
+        $workflow = self::query()
+            ->where('content_type', self::targetType($type))
+            ->where('content_id', (int) data_get($record, 'id'))
+            ->first();
+
+        if ($workflow instanceof EditorialReview) {
+            return $workflow;
+        }
+
+        return EditorialReview::withoutGlobalScopes()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => max(0, (int) data_get($record, 'org_id', 0)),
+            'content_type' => self::targetType($type),
+            'content_id' => (int) data_get($record, 'id'),
+            'workflow_state' => self::STATE_READY,
+            'last_transition_at' => now(),
+        ]);
+    }
+
+    private static function query()
+    {
+        return EditorialReview::withoutGlobalScopes();
+    }
+
+    private static function actorAdminId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $actor = auth($guard)->user();
+
+        return is_object($actor) && is_numeric(data_get($actor, 'id'))
+            ? (int) data_get($actor, 'id')
+            : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    private static function log(string $action, string $type, object $record, array $meta = []): void
+    {
         $guard = (string) config('admin.guard', 'admin');
         $actor = auth($guard)->user();
         $request = app()->bound('request') && request() instanceof Request
@@ -40,74 +265,25 @@ final class EditorialReviewAudit
             $action,
             self::targetType($type),
             (string) data_get($record, 'id'),
-            [
+            array_merge([
                 'title' => trim((string) data_get($record, 'title', '')),
                 'locale' => trim((string) data_get($record, 'locale', '')),
-                'decision' => $decision,
                 'actor_email' => is_object($actor) ? trim((string) data_get($actor, 'email', '')) : '',
-            ],
+            ], $meta),
             reason: 'cms_editorial_review',
             result: 'success',
         );
     }
 
-    /**
-     * @return array{state:string,label:string,reviewed_at:string}|null
-     */
-    public static function latestState(string $type, object $record): ?array
+    private static function adminLabel(int $adminUserId): string
     {
-        $row = AuditLog::query()
-            ->whereIn('action', [
-                'editorial_review_approved',
-                'editorial_review_changes_requested',
-                'editorial_review_rejected',
-            ])
-            ->where('target_type', self::targetType($type))
-            ->where('target_id', (string) data_get($record, 'id'))
-            ->latest('created_at')
-            ->first();
+        /** @var AdminUser|null $admin */
+        $admin = AdminUser::query()->find($adminUserId);
 
-        if (! $row instanceof AuditLog) {
-            return null;
+        if (! $admin instanceof AdminUser) {
+            return '';
         }
 
-        $updatedAt = data_get($record, 'updated_at');
-        if ($updatedAt instanceof \DateTimeInterface && $row->created_at instanceof \DateTimeInterface && $row->created_at < $updatedAt) {
-            return null;
-        }
-
-        $state = match ($row->action) {
-            'editorial_review_approved' => self::STATE_APPROVED,
-            'editorial_review_changes_requested' => self::STATE_CHANGES_REQUESTED,
-            'editorial_review_rejected' => self::STATE_REJECTED,
-            default => self::STATE_READY,
-        };
-
-        return [
-            'state' => $state,
-            'label' => self::label($state),
-            'reviewed_at' => optional($row->created_at)?->toDateTimeString() ?? 'Unknown',
-        ];
-    }
-
-    public static function label(string $state): string
-    {
-        return match ($state) {
-            self::STATE_APPROVED => 'Approved',
-            self::STATE_CHANGES_REQUESTED => 'Changes requested',
-            self::STATE_REJECTED => 'Rejected',
-            self::STATE_NEEDS_ATTENTION => 'Needs attention',
-            default => 'Ready',
-        };
-    }
-
-    private static function targetType(string $type): string
-    {
-        return match ($type) {
-            'article' => 'article',
-            'guide' => 'career_guide',
-            'job' => 'career_job',
-            default => 'content',
-        };
+        return trim($admin->name !== '' ? $admin->name : $admin->email);
     }
 }

--- a/backend/app/Filament/Ops/Support/EditorialReviewAudit.php
+++ b/backend/app/Filament/Ops/Support/EditorialReviewAudit.php
@@ -7,6 +7,7 @@ namespace App\Filament\Ops\Support;
 use App\Models\AdminUser;
 use App\Models\EditorialReview;
 use App\Services\Audit\AuditLogger;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -26,8 +27,19 @@ final class EditorialReviewAudit
 
     public static function assignOwner(int $ownerAdminId, string $type, object $record): EditorialReview
     {
+        if (! ContentAccess::canAssignOwner()) {
+            throw new AuthorizationException('You do not have permission to assign an owner.');
+        }
+
+        $owner = self::resolveOwnerCandidate($ownerAdminId);
         $workflow = self::workflowFor($type, $record);
+
+        if ((int) $workflow->owner_admin_user_id === $ownerAdminId) {
+            return $workflow;
+        }
+
         $workflow->owner_admin_user_id = $ownerAdminId;
+        self::resetWorkflowState($workflow);
         $workflow->last_transition_at = now();
         $workflow->save();
 
@@ -37,7 +49,7 @@ final class EditorialReviewAudit
             record: $record,
             meta: [
                 'owner_admin_user_id' => $ownerAdminId,
-                'owner_label' => self::adminLabel($ownerAdminId),
+                'owner_label' => trim($owner->name !== '' ? $owner->name : $owner->email),
             ],
         );
 
@@ -46,8 +58,19 @@ final class EditorialReviewAudit
 
     public static function assignReviewer(int $reviewerAdminId, string $type, object $record): EditorialReview
     {
+        if (! ContentAccess::canAssignReviewer()) {
+            throw new AuthorizationException('You do not have permission to assign a reviewer.');
+        }
+
+        $reviewer = self::resolveReviewerCandidate($reviewerAdminId);
         $workflow = self::workflowFor($type, $record);
+
+        if ((int) $workflow->reviewer_admin_user_id === $reviewerAdminId) {
+            return $workflow;
+        }
+
         $workflow->reviewer_admin_user_id = $reviewerAdminId;
+        self::resetWorkflowState($workflow);
         $workflow->last_transition_at = now();
         $workflow->save();
 
@@ -57,7 +80,7 @@ final class EditorialReviewAudit
             record: $record,
             meta: [
                 'reviewer_admin_user_id' => $reviewerAdminId,
-                'reviewer_label' => self::adminLabel($reviewerAdminId),
+                'reviewer_label' => trim($reviewer->name !== '' ? $reviewer->name : $reviewer->email),
             ],
         );
 
@@ -67,11 +90,13 @@ final class EditorialReviewAudit
     public static function submit(string $type, object $record): EditorialReview
     {
         $workflow = self::workflowFor($type, $record);
-        $actorAdminId = self::actorAdminId();
+        self::assertCanSubmit($workflow, $type, $record);
 
         $workflow->workflow_state = self::STATE_IN_REVIEW;
-        $workflow->submitted_by_admin_user_id = $actorAdminId;
+        $workflow->submitted_by_admin_user_id = self::actorAdminId();
         $workflow->submitted_at = now();
+        $workflow->reviewed_by_admin_user_id = null;
+        $workflow->reviewed_at = null;
         $workflow->last_transition_at = now();
         $workflow->save();
 
@@ -89,6 +114,9 @@ final class EditorialReviewAudit
 
     public static function mark(string $decision, string $type, object $record): void
     {
+        $workflow = self::workflowFor($type, $record);
+        self::assertCanMark($workflow, $decision, $type, $record);
+
         $action = match ($decision) {
             self::STATE_APPROVED => 'editorial_review_approved',
             self::STATE_CHANGES_REQUESTED => 'editorial_review_changes_requested',
@@ -96,7 +124,6 @@ final class EditorialReviewAudit
             default => throw new \InvalidArgumentException('Unsupported review decision.'),
         };
 
-        $workflow = self::workflowFor($type, $record);
         $workflow->workflow_state = $decision;
         $workflow->reviewed_by_admin_user_id = self::actorAdminId();
         $workflow->reviewed_at = now();
@@ -198,7 +225,8 @@ final class EditorialReviewAudit
             return;
         }
 
-        $workflow->workflow_state = self::STATE_READY;
+        self::resetWorkflowState($workflow);
+        $workflow->last_transition_at = now();
         $workflow->save();
     }
 
@@ -239,6 +267,69 @@ final class EditorialReviewAudit
         return EditorialReview::withoutGlobalScopes();
     }
 
+    private static function assertCanSubmit(EditorialReview $workflow, string $type, object $record): void
+    {
+        if ((int) $workflow->owner_admin_user_id <= 0 || (int) $workflow->reviewer_admin_user_id <= 0) {
+            throw new AuthorizationException('Assign both an owner and reviewer before submitting for review.');
+        }
+
+        if (EditorialReviewChecklist::missing($type, $record) !== []) {
+            throw new AuthorizationException('Fix the review checklist gaps before submitting for review.');
+        }
+
+        if ($workflow->workflow_state === self::STATE_IN_REVIEW && ! self::hasNewerEdits($workflow, $record)) {
+            throw new AuthorizationException('This record is already in review.');
+        }
+
+        if ($workflow->workflow_state === self::STATE_APPROVED && ! self::hasNewerEdits($workflow, $record)) {
+            throw new AuthorizationException('This record is already approved and has no newer edits to resubmit.');
+        }
+
+        if (! ContentAccess::isOwner() && self::actorAdminId() !== (int) $workflow->owner_admin_user_id) {
+            throw new AuthorizationException('Only the assigned owner can submit this record for review.');
+        }
+    }
+
+    private static function assertCanMark(EditorialReview $workflow, string $decision, string $type, object $record): void
+    {
+        if (self::hasNewerEdits($workflow, $record)) {
+            throw new AuthorizationException('This record changed after submission and must be resubmitted before review can continue.');
+        }
+
+        if ($workflow->workflow_state !== self::STATE_IN_REVIEW) {
+            throw new AuthorizationException('This record is not currently in review.');
+        }
+
+        $actorAdminId = self::actorAdminId();
+        $isAssignedReviewer = $actorAdminId !== null && $actorAdminId === (int) $workflow->reviewer_admin_user_id;
+
+        if (! ContentAccess::isOwner() && (! ContentAccess::canReview() || ! $isAssignedReviewer)) {
+            throw new AuthorizationException('Only the assigned reviewer can decide this record.');
+        }
+
+        if ($decision === self::STATE_APPROVED && EditorialReviewChecklist::missing($type, $record) !== []) {
+            throw new AuthorizationException('A record with checklist gaps cannot be approved.');
+        }
+    }
+
+    private static function hasNewerEdits(EditorialReview $workflow, object $record): bool
+    {
+        $updatedAt = data_get($record, 'updated_at');
+
+        return $updatedAt instanceof \DateTimeInterface
+            && $workflow->last_transition_at instanceof \DateTimeInterface
+            && $workflow->last_transition_at < $updatedAt;
+    }
+
+    private static function resetWorkflowState(EditorialReview $workflow): void
+    {
+        $workflow->workflow_state = self::STATE_READY;
+        $workflow->submitted_by_admin_user_id = null;
+        $workflow->reviewed_by_admin_user_id = null;
+        $workflow->submitted_at = null;
+        $workflow->reviewed_at = null;
+    }
+
     private static function actorAdminId(): ?int
     {
         $guard = (string) config('admin.guard', 'admin');
@@ -275,15 +366,44 @@ final class EditorialReviewAudit
         );
     }
 
-    private static function adminLabel(int $adminUserId): string
+    private static function resolveOwnerCandidate(int $adminUserId): AdminUser
     {
         /** @var AdminUser|null $admin */
         $admin = AdminUser::query()->find($adminUserId);
 
         if (! $admin instanceof AdminUser) {
-            return '';
+            throw new AuthorizationException('The selected owner does not exist.');
         }
 
-        return trim($admin->name !== '' ? $admin->name : $admin->email);
+        if (
+            ! $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_CONTENT_WRITE)
+            && ! $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_CONTENT_PUBLISH)
+            && ! $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_OWNER)
+        ) {
+            throw new AuthorizationException('The selected owner cannot own editorial records.');
+        }
+
+        return $admin;
+    }
+
+    private static function resolveReviewerCandidate(int $adminUserId): AdminUser
+    {
+        /** @var AdminUser|null $admin */
+        $admin = AdminUser::query()->find($adminUserId);
+
+        if (! $admin instanceof AdminUser) {
+            throw new AuthorizationException('The selected reviewer does not exist.');
+        }
+
+        if (
+            ! $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_APPROVAL_REVIEW)
+            && ! $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_CONTENT_RELEASE)
+            && ! $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_CONTENT_PUBLISH)
+            && ! $admin->hasPermission(\App\Support\Rbac\PermissionNames::ADMIN_OWNER)
+        ) {
+            throw new AuthorizationException('The selected reviewer cannot review editorial records.');
+        }
+
+        return $admin;
     }
 }

--- a/backend/app/Models/EditorialReview.php
+++ b/backend/app/Models/EditorialReview.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EditorialReview extends Model
+{
+    use HasOrgScope;
+    use HasUuids;
+
+    public const STATE_DRAFTING = 'drafting';
+
+    public const STATE_IN_REVIEW = 'in_review';
+
+    public const STATE_CHANGES_REQUESTED = 'changes_requested';
+
+    public const STATE_APPROVED = 'approved';
+
+    public const STATE_REJECTED = 'rejected';
+
+    protected $table = 'editorial_reviews';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'org_id',
+        'content_type',
+        'content_id',
+        'workflow_state',
+        'owner_admin_user_id',
+        'reviewer_admin_user_id',
+        'submitted_by_admin_user_id',
+        'reviewed_by_admin_user_id',
+        'submitted_at',
+        'reviewed_at',
+        'last_transition_at',
+        'note',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'content_id' => 'integer',
+        'owner_admin_user_id' => 'integer',
+        'reviewer_admin_user_id' => 'integer',
+        'submitted_by_admin_user_id' => 'integer',
+        'reviewed_by_admin_user_id' => 'integer',
+        'submitted_at' => 'datetime',
+        'reviewed_at' => 'datetime',
+        'last_transition_at' => 'datetime',
+    ];
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(AdminUser::class, 'owner_admin_user_id');
+    }
+
+    public function reviewer(): BelongsTo
+    {
+        return $this->belongsTo(AdminUser::class, 'reviewer_admin_user_id');
+    }
+
+    public function submittedBy(): BelongsTo
+    {
+        return $this->belongsTo(AdminUser::class, 'submitted_by_admin_user_id');
+    }
+
+    public function reviewedBy(): BelongsTo
+    {
+        return $this->belongsTo(AdminUser::class, 'reviewed_by_admin_user_id');
+    }
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return self::allowOrgZeroWithResolvedContext();
+    }
+}

--- a/backend/database/migrations/2026_03_29_120000_create_editorial_reviews_table.php
+++ b/backend/database/migrations/2026_03_29_120000_create_editorial_reviews_table.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'editorial_reviews';
+
+    private const CONTENT_UNIQUE = 'editorial_reviews_content_unique';
+
+    private const ORG_STATE_UPDATED_INDEX = 'editorial_reviews_org_state_updated_idx';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('content_type', 32);
+                $table->unsignedBigInteger('content_id');
+                $table->string('workflow_state', 32)->default('drafting');
+                $table->unsignedBigInteger('owner_admin_user_id')->nullable();
+                $table->unsignedBigInteger('reviewer_admin_user_id')->nullable();
+                $table->unsignedBigInteger('submitted_by_admin_user_id')->nullable();
+                $table->unsignedBigInteger('reviewed_by_admin_user_id')->nullable();
+                $table->timestamp('submitted_at')->nullable();
+                $table->timestamp('reviewed_at')->nullable();
+                $table->timestamp('last_transition_at')->nullable();
+                $table->string('note', 255)->nullable();
+                $table->timestamps();
+
+                $table->unique(['content_type', 'content_id'], self::CONTENT_UNIQUE);
+                $table->index(['org_id', 'workflow_state', 'updated_at'], self::ORG_STATE_UPDATED_INDEX);
+                $table->index('owner_admin_user_id', 'editorial_reviews_owner_idx');
+                $table->index('reviewer_admin_user_id', 'editorial_reviews_reviewer_idx');
+            });
+
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            if (! Schema::hasColumn(self::TABLE, 'org_id')) {
+                $table->unsignedBigInteger('org_id')->default(0);
+            }
+            if (! Schema::hasColumn(self::TABLE, 'content_type')) {
+                $table->string('content_type', 32)->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'content_id')) {
+                $table->unsignedBigInteger('content_id')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'workflow_state')) {
+                $table->string('workflow_state', 32)->default('drafting');
+            }
+            if (! Schema::hasColumn(self::TABLE, 'owner_admin_user_id')) {
+                $table->unsignedBigInteger('owner_admin_user_id')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'reviewer_admin_user_id')) {
+                $table->unsignedBigInteger('reviewer_admin_user_id')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'submitted_by_admin_user_id')) {
+                $table->unsignedBigInteger('submitted_by_admin_user_id')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'reviewed_by_admin_user_id')) {
+                $table->unsignedBigInteger('reviewed_by_admin_user_id')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'submitted_at')) {
+                $table->timestamp('submitted_at')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'reviewed_at')) {
+                $table->timestamp('reviewed_at')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'last_transition_at')) {
+                $table->timestamp('last_transition_at')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'note')) {
+                $table->string('note', 255)->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
+        });
+
+        if (
+            Schema::hasColumn(self::TABLE, 'content_type')
+            && Schema::hasColumn(self::TABLE, 'content_id')
+            && ! SchemaIndex::indexExists(self::TABLE, self::CONTENT_UNIQUE)
+        ) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->unique(['content_type', 'content_id'], self::CONTENT_UNIQUE);
+            });
+        }
+
+        if (
+            Schema::hasColumn(self::TABLE, 'org_id')
+            && Schema::hasColumn(self::TABLE, 'workflow_state')
+            && Schema::hasColumn(self::TABLE, 'updated_at')
+            && ! SchemaIndex::indexExists(self::TABLE, self::ORG_STATE_UPDATED_INDEX)
+        ) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->index(['org_id', 'workflow_state', 'updated_at'], self::ORG_STATE_UPDATED_INDEX);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+    }
+};

--- a/backend/resources/views/filament/ops/pages/content-release.blade.php
+++ b/backend/resources/views/filament/ops/pages/content-release.blade.php
@@ -8,7 +8,7 @@
             <x-filament-ops::ops-toolbar>
                 <div class="ops-control-stack">
                     <span class="ops-control-label">Release review</span>
-                    <p class="ops-control-hint">This workspace is the lightweight review surface for Phase 1. There is no workflow engine yet, so <code>content_release</code> is the approval boundary and a successful action follows the current public publish contract.</p>
+                    <p class="ops-control-hint">Only records that have completed owner assignment, reviewer assignment, formal submission, and approval can publish from this queue.</p>
                 </div>
 
                 <x-slot name="actions">
@@ -105,7 +105,7 @@
                         </td>
                         <td class="ops-table__status">
                             <x-filament.ops.shared.status-pill
-                                :state="match ($item['review_state']) { 'approved' => 'success', 'ready' => 'info', 'changes_requested' => 'warning', 'rejected' => 'danger', default => 'warning' }"
+                                :state="match ($item['review_state']) { 'approved' => 'success', 'ready' => 'info', 'in_review' => 'info', 'changes_requested' => 'warning', 'rejected' => 'danger', default => 'warning' }"
                                 :label="\App\Filament\Ops\Support\EditorialReviewAudit::label($item['review_state'])"
                             />
                         </td>
@@ -129,7 +129,7 @@
                                     </x-filament::button>
                                 @elseif ($item['status'] === 'draft')
                                     <x-filament::button size="xs" color="warning" disabled>
-                                        Needs Approval
+                                        Needs Workflow
                                     </x-filament::button>
                                 @else
                                     <x-filament::button size="xs" color="success" disabled>

--- a/backend/resources/views/filament/ops/pages/editorial-review.blade.php
+++ b/backend/resources/views/filament/ops/pages/editorial-review.blade.php
@@ -3,12 +3,12 @@
         <x-filament-ops::ops-section
             eyebrow="Editorial review"
             title="Editorial review"
-            description="Review draft editorial records against a lightweight readiness checklist before handing them into the publish queue."
+            description="Route draft editorial records through owner assignment, reviewer assignment, explicit submission, and recorded approval decisions before they enter the publish queue."
         >
             <x-filament-ops::ops-toolbar>
                 <div class="ops-control-stack">
                     <span class="ops-control-label">Approval boundary</span>
-                    <p class="ops-control-hint"><code>content_release</code> remains the approval boundary. This page now persists lightweight approval decisions in audit logs without introducing a workflow engine or schema change.</p>
+                    <p class="ops-control-hint"><code>content_write</code> drives ownership, <code>admin.approval.review</code> or <code>content_release</code> handles formal review, and every transition is persisted into both workflow state and audit logs.</p>
                 </div>
 
                 <x-slot name="actions">
@@ -56,6 +56,7 @@
                             <select id="editorial-review-state" wire:model.live="reviewStateFilter" class="ops-input">
                                 <option value="all">All</option>
                                 <option value="ready">Ready</option>
+                                <option value="in_review">In review</option>
                                 <option value="approved">Approved</option>
                                 <option value="changes_requested">Changes requested</option>
                                 <option value="rejected">Rejected</option>
@@ -77,6 +78,8 @@
                         <th>Type</th>
                         <th>Title</th>
                         <th>Review state</th>
+                        <th>Owner</th>
+                        <th>Reviewer</th>
                         <th>Checklist</th>
                         <th>Locale</th>
                         <th>Updated</th>
@@ -90,36 +93,81 @@
                         <td>{{ $item['title'] }}</td>
                         <td class="ops-table__status">
                             <x-filament.ops.shared.status-pill
-                                :state="match ($item['review_state']) { 'approved' => 'success', 'ready' => 'info', 'changes_requested' => 'warning', 'rejected' => 'danger', default => 'warning' }"
+                                :state="match ($item['review_state']) { 'approved' => 'success', 'ready' => 'info', 'in_review' => 'info', 'changes_requested' => 'warning', 'rejected' => 'danger', default => 'warning' }"
                                 :label="\App\Filament\Ops\Support\EditorialReviewAudit::label($item['review_state'])"
                             />
                         </td>
+                        <td>{{ $item['owner_label'] }}</td>
+                        <td>{{ $item['reviewer_label'] }}</td>
                         <td>{{ $item['checklist_label'] }}</td>
                         <td>{{ $item['locale'] }}</td>
                         <td>{{ $item['updated_at'] }}</td>
                         <td>
-                            <div class="ops-toolbar-inline">
-                                <x-filament::button size="xs" color="gray" tag="a" href="{{ $item['edit_url'] }}">
-                                    Open
-                                </x-filament::button>
-                                @if ($item['review_state'] === 'ready' || $item['review_state'] === 'changes_requested')
-                                    <x-filament::button size="xs" color="success" type="button" wire:click="approveItem('{{ $item['type'] }}', {{ $item['id'] }})">
-                                        Approve
+                            <div class="ops-control-stack">
+                                <div class="ops-toolbar-inline">
+                                    <x-filament::button size="xs" color="gray" tag="a" href="{{ $item['edit_url'] }}">
+                                        Open
                                     </x-filament::button>
-                                @endif
-                                @if ($item['review_state'] !== 'rejected')
-                                    <x-filament::button size="xs" color="warning" type="button" wire:click="requestChangesItem('{{ $item['type'] }}', {{ $item['id'] }})">
-                                        Send Back
-                                    </x-filament::button>
-                                    <x-filament::button size="xs" color="danger" type="button" wire:click="rejectItem('{{ $item['type'] }}', {{ $item['id'] }})">
-                                        Reject
-                                    </x-filament::button>
-                                @endif
-                                @if ($item['review_state'] === 'approved')
-                                    <x-filament::button size="xs" color="primary" tag="a" href="{{ \App\Filament\Ops\Pages\ContentReleasePage::getUrl() }}">
-                                        Release Queue
-                                    </x-filament::button>
-                                @endif
+                                    @if ($item['review_state'] === 'approved')
+                                        <x-filament::button size="xs" color="primary" tag="a" href="{{ \App\Filament\Ops\Pages\ContentReleasePage::getUrl() }}">
+                                            Release Queue
+                                        </x-filament::button>
+                                    @endif
+                                </div>
+
+                                <div class="ops-toolbar-inline">
+                                    @if ($item['can_assign_owner'])
+                                        <label class="ops-control-stack" for="owner-{{ $item['workflow_key'] }}">
+                                            <span class="ops-control-label">Owner</span>
+                                            <select id="owner-{{ $item['workflow_key'] }}" wire:model.live="ownerAssignments.{{ $item['workflow_key'] }}" class="ops-input">
+                                                <option value="">Select owner</option>
+                                                @foreach ($ownerOptions as $adminId => $label)
+                                                    <option value="{{ $adminId }}">{{ $label }}</option>
+                                                @endforeach
+                                            </select>
+                                        </label>
+                                        <x-filament::button size="xs" color="gray" type="button" wire:click="assignOwnerItem('{{ $item['type'] }}', {{ $item['id'] }})">
+                                            Save Owner
+                                        </x-filament::button>
+                                    @endif
+
+                                    @if ($item['can_assign_reviewer'])
+                                        <label class="ops-control-stack" for="reviewer-{{ $item['workflow_key'] }}">
+                                            <span class="ops-control-label">Reviewer</span>
+                                            <select id="reviewer-{{ $item['workflow_key'] }}" wire:model.live="reviewerAssignments.{{ $item['workflow_key'] }}" class="ops-input">
+                                                <option value="">Select reviewer</option>
+                                                @foreach ($reviewerOptions as $adminId => $label)
+                                                    <option value="{{ $adminId }}">{{ $label }}</option>
+                                                @endforeach
+                                            </select>
+                                        </label>
+                                        <x-filament::button size="xs" color="gray" type="button" wire:click="assignReviewerItem('{{ $item['type'] }}', {{ $item['id'] }})">
+                                            Save Reviewer
+                                        </x-filament::button>
+                                    @endif
+                                </div>
+
+                                <div class="ops-toolbar-inline">
+                                    @if ($item['can_submit'])
+                                        <x-filament::button size="xs" color="info" type="button" wire:click="submitItem('{{ $item['type'] }}', {{ $item['id'] }})">
+                                            Submit
+                                        </x-filament::button>
+                                    @endif
+                                    @if ($item['can_decide'])
+                                        <x-filament::button size="xs" color="success" type="button" wire:click="approveItem('{{ $item['type'] }}', {{ $item['id'] }})">
+                                            Approve
+                                        </x-filament::button>
+                                        <x-filament::button size="xs" color="warning" type="button" wire:click="requestChangesItem('{{ $item['type'] }}', {{ $item['id'] }})">
+                                            Send Back
+                                        </x-filament::button>
+                                        <x-filament::button size="xs" color="danger" type="button" wire:click="rejectItem('{{ $item['type'] }}', {{ $item['id'] }})">
+                                            Reject
+                                        </x-filament::button>
+                                    @endif
+                                    @if (! $item['can_submit'] && ! $item['can_decide'] && $item['review_state'] !== 'approved')
+                                        <span class="ops-control-hint">Assign owner + reviewer, then submit.</span>
+                                    @endif
+                                </div>
                             </div>
                         </td>
                     </tr>

--- a/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
+++ b/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
@@ -25,6 +25,7 @@ use App\Models\ArticleTag;
 use App\Models\AuditLog;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
+use App\Models\EditorialReview;
 use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Role;
@@ -117,6 +118,38 @@ final class ContentCmsProductLayerTest extends TestCase
         $this->withSession($session)
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->get('/ops/content-release')
+            ->assertForbidden();
+
+        $this->withSession($session)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/editorial-review')
+            ->assertOk()
+            ->assertSee('Editorial review')
+            ->assertSee('Review queue');
+    }
+
+    public function test_approval_review_admin_can_open_editorial_review_but_not_release_surface(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+        ]);
+
+        $session = $this->opsSession((int) $admin->id);
+
+        $this->withSession($session)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/editorial-review')
+            ->assertOk()
+            ->assertSee('Editorial review');
+
+        $this->withSession($session)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-release')
+            ->assertForbidden();
+
+        $this->withSession($session)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/articles/create')
             ->assertForbidden();
     }
 
@@ -447,11 +480,17 @@ final class ContentCmsProductLayerTest extends TestCase
 
     public function test_editorial_review_approvals_are_persisted_and_gate_release_queue(): void
     {
-        $admin = $this->createAdminWithPermissions([
+        $owner = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $reviewer = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+        ]);
+        $publisher = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_RELEASE,
         ]);
 
-        $session = $this->opsSession((int) $admin->id);
+        $session = $this->opsSession((int) $owner->id);
         $selectedOrgId = (int) $session['ops_org_id'];
 
         $article = $this->seedArticle([
@@ -478,16 +517,37 @@ final class ContentCmsProductLayerTest extends TestCase
             'is_indexable' => true,
         ]);
 
-        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
-        app()->instance('request', Request::create('/ops/editorial-review', 'POST'));
+        $this->setOpsContext($selectedOrgId, $owner, '/ops/editorial-review');
+        Livewire::test(EditorialReviewPage::class)
+            ->assertOk()
+            ->set('ownerAssignments.article_'.$article->id, (string) $owner->id)
+            ->call('assignOwnerItem', 'article', (int) $article->id);
 
-        $context = app(OrgContext::class);
-        $context->set($selectedOrgId, (int) $admin->id, 'admin');
-        app()->instance(OrgContext::class, $context);
+        $this->setOpsContext($selectedOrgId, $reviewer, '/ops/editorial-review');
+        Livewire::test(EditorialReviewPage::class)
+            ->assertOk()
+            ->set('reviewerAssignments.article_'.$article->id, (string) $reviewer->id)
+            ->call('assignReviewerItem', 'article', (int) $article->id);
 
+        $this->setOpsContext($selectedOrgId, $owner, '/ops/editorial-review');
+        Livewire::test(EditorialReviewPage::class)
+            ->assertOk()
+            ->call('submitItem', 'article', (int) $article->id);
+
+        $this->setOpsContext($selectedOrgId, $reviewer, '/ops/editorial-review');
         Livewire::test(EditorialReviewPage::class)
             ->assertOk()
             ->call('approveItem', 'article', (int) $article->id);
+
+        $workflow = EditorialReview::withoutGlobalScopes()
+            ->where('content_type', 'article')
+            ->where('content_id', (int) $article->id)
+            ->first();
+
+        $this->assertNotNull($workflow);
+        $this->assertSame((int) $owner->id, (int) $workflow->owner_admin_user_id);
+        $this->assertSame((int) $reviewer->id, (int) $workflow->reviewer_admin_user_id);
+        $this->assertSame(EditorialReview::STATE_APPROVED, (string) $workflow->workflow_state);
 
         $audit = AuditLog::query()
             ->where('action', 'editorial_review_approved')
@@ -497,15 +557,14 @@ final class ContentCmsProductLayerTest extends TestCase
 
         $this->assertNotNull($audit);
 
-        $this->withSession($session)
-            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+        $this->withSession($this->opsSessionForOrg((int) $publisher->id, $selectedOrgId))
+            ->actingAs($publisher, (string) config('admin.guard', 'admin'))
             ->get('/ops/content-release')
             ->assertOk()
             ->assertSee('Approved')
             ->assertSee('Publish');
 
-        app()->instance('request', Request::create('/ops/content-release', 'POST'));
-        app()->instance(OrgContext::class, $context);
+        $this->setOpsContext($selectedOrgId, $publisher, '/ops/content-release');
 
         Livewire::test(ContentReleasePage::class)
             ->assertOk()
@@ -544,11 +603,14 @@ final class ContentCmsProductLayerTest extends TestCase
 
     public function test_editorial_review_can_request_changes_and_reject_records(): void
     {
-        $admin = $this->createAdminWithPermissions([
-            PermissionNames::ADMIN_CONTENT_RELEASE,
+        $owner = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $reviewer = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
         ]);
 
-        $session = $this->opsSession((int) $admin->id);
+        $session = $this->opsSession((int) $owner->id);
 
         $changesRequested = $this->seedArticle([
             'org_id' => (int) $session['ops_org_id'],
@@ -581,24 +643,93 @@ final class ContentCmsProductLayerTest extends TestCase
             ]);
         }
 
-        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
-        app()->instance('request', Request::create('/ops/editorial-review', 'POST'));
+        $this->routeRecordIntoReview((int) $session['ops_org_id'], $owner, $reviewer, 'article', $changesRequested);
+        $this->routeRecordIntoReview((int) $session['ops_org_id'], $owner, $reviewer, 'article', $rejected);
 
-        $context = app(OrgContext::class);
-        $context->set((int) $session['ops_org_id'], (int) $admin->id, 'admin');
-        app()->instance(OrgContext::class, $context);
-
+        $this->setOpsContext((int) $session['ops_org_id'], $reviewer, '/ops/editorial-review');
         Livewire::test(EditorialReviewPage::class)
             ->assertOk()
             ->call('requestChangesItem', 'article', (int) $changesRequested->id)
             ->call('rejectItem', 'article', (int) $rejected->id);
 
         $this->withSession($session)
-            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->actingAs($reviewer, (string) config('admin.guard', 'admin'))
             ->get('/ops/editorial-review')
             ->assertOk()
             ->assertSee('Changes requested')
             ->assertSee('Rejected');
+    }
+
+    public function test_editorial_workflow_assigns_owner_and_reviewer_then_submits_to_review(): void
+    {
+        $owner = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $reviewer = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+        ]);
+
+        $session = $this->opsSession((int) $owner->id);
+        $selectedOrgId = (int) $session['ops_org_id'];
+
+        $article = $this->seedArticle([
+            'org_id' => $selectedOrgId,
+            'title' => 'Workflow Assignment Article',
+            'excerpt' => 'Ready excerpt',
+            'content_md' => 'Ready body',
+            'status' => 'draft',
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => $selectedOrgId,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Workflow Assignment Article SEO Title',
+            'seo_description' => 'Workflow Assignment Article SEO Description',
+            'canonical_url' => 'https://example.test/articles/workflow-assignment-article',
+            'og_title' => 'Workflow Assignment Article OG Title',
+            'og_description' => 'Workflow Assignment Article OG Description',
+            'og_image_url' => 'https://example.test/images/workflow-assignment-article.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        $this->setOpsContext($selectedOrgId, $owner, '/ops/editorial-review');
+        Livewire::test(EditorialReviewPage::class)
+            ->assertOk()
+            ->set('ownerAssignments.article_'.$article->id, (string) $owner->id)
+            ->call('assignOwnerItem', 'article', (int) $article->id);
+
+        $this->setOpsContext($selectedOrgId, $reviewer, '/ops/editorial-review');
+        Livewire::test(EditorialReviewPage::class)
+            ->assertOk()
+            ->set('reviewerAssignments.article_'.$article->id, (string) $reviewer->id)
+            ->call('assignReviewerItem', 'article', (int) $article->id);
+
+        $this->setOpsContext($selectedOrgId, $owner, '/ops/editorial-review');
+        Livewire::test(EditorialReviewPage::class)
+            ->assertOk()
+            ->call('submitItem', 'article', (int) $article->id);
+
+        $workflow = EditorialReview::withoutGlobalScopes()
+            ->where('content_type', 'article')
+            ->where('content_id', (int) $article->id)
+            ->first();
+
+        $this->assertNotNull($workflow);
+        $this->assertSame((int) $owner->id, (int) $workflow->owner_admin_user_id);
+        $this->assertSame((int) $reviewer->id, (int) $workflow->reviewer_admin_user_id);
+        $this->assertSame(EditorialReview::STATE_IN_REVIEW, (string) $workflow->workflow_state);
+        $this->assertNotNull($workflow->submitted_at);
+
+        $this->withSession($this->opsSessionForOrg((int) $owner->id, $selectedOrgId))
+            ->actingAs($owner, (string) config('admin.guard', 'admin'))
+            ->get('/ops/editorial-review')
+            ->assertOk()
+            ->assertSee('Workflow Assignment Article')
+            ->assertSee('In review')
+            ->assertSee($owner->name)
+            ->assertSee($reviewer->name);
     }
 
     public function test_article_and_taxonomy_resources_are_scoped_to_selected_org_only(): void
@@ -745,15 +876,42 @@ final class ContentCmsProductLayerTest extends TestCase
 
     private function approveRecord(AdminUser $admin, int $orgId, string $type, object $record): void
     {
-        app()->instance('request', Request::create('/ops/editorial-review', 'POST'));
+        $this->routeRecordIntoReview($orgId, $admin, $admin, $type, $record);
+        $this->setOpsContext($orgId, $admin, '/ops/editorial-review');
+        EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, $type, $record);
+    }
+
+    private function routeRecordIntoReview(int $orgId, AdminUser $owner, AdminUser $reviewer, string $type, object $record): void
+    {
+        $this->setOpsContext($orgId, $owner, '/ops/editorial-review');
+        EditorialReviewAudit::assignOwner((int) $owner->id, $type, $record);
+
+        $this->setOpsContext($orgId, $reviewer, '/ops/editorial-review');
+        EditorialReviewAudit::assignReviewer((int) $reviewer->id, $type, $record);
+
+        $this->setOpsContext($orgId, $owner, '/ops/editorial-review');
+        EditorialReviewAudit::submit($type, $record);
+    }
+
+    private function setOpsContext(int $orgId, AdminUser $admin, string $path, string $method = 'POST'): void
+    {
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create($path, $method));
 
         $context = app(OrgContext::class);
         $context->set($orgId, (int) $admin->id, 'admin');
         app()->instance(OrgContext::class, $context);
+    }
 
-        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
-
-        EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, $type, $record);
+    /**
+     * @return array<string, mixed>
+     */
+    private function opsSessionForOrg(int $adminUserId, int $orgId): array
+    {
+        return [
+            'ops_org_id' => $orgId,
+            'ops_admin_totp_verified_user_id' => $adminUserId,
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
+++ b/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
@@ -24,7 +24,9 @@ use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTag;
 use App\Models\AuditLog;
 use App\Models\CareerGuide;
+use App\Models\CareerGuideSeoMeta;
 use App\Models\CareerJob;
+use App\Models\CareerJobSeoMeta;
 use App\Models\EditorialReview;
 use App\Models\Organization;
 use App\Models\Permission;
@@ -575,6 +577,125 @@ final class ContentCmsProductLayerTest extends TestCase
         $this->assertTrue($article->is_public);
     }
 
+    public function test_reassigning_reviewer_invalidates_existing_approval_until_resubmitted(): void
+    {
+        $owner = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $reviewer = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+        ]);
+        $replacementReviewer = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+        ]);
+        $publisher = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+
+        $session = $this->opsSession((int) $owner->id);
+        $selectedOrgId = (int) $session['ops_org_id'];
+
+        $article = $this->seedArticle([
+            'org_id' => $selectedOrgId,
+            'title' => 'Reviewer Reassignment Article',
+            'excerpt' => 'Ready excerpt',
+            'content_md' => 'Ready body',
+            'status' => 'draft',
+            'is_public' => false,
+            'published_at' => null,
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => $selectedOrgId,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Reviewer Reassignment Article SEO Title',
+            'seo_description' => 'Reviewer Reassignment Article SEO Description',
+            'canonical_url' => 'https://example.test/articles/reviewer-reassignment-article',
+            'og_title' => 'Reviewer Reassignment Article OG Title',
+            'og_description' => 'Reviewer Reassignment Article OG Description',
+            'og_image_url' => 'https://example.test/images/reviewer-reassignment-article.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        $this->routeRecordIntoReview($selectedOrgId, $owner, $reviewer, 'article', $article);
+        $this->setOpsContext($selectedOrgId, $reviewer, '/ops/editorial-review');
+        EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, 'article', $article);
+
+        $this->setOpsContext($selectedOrgId, $replacementReviewer, '/ops/editorial-review');
+        EditorialReviewAudit::assignReviewer((int) $replacementReviewer->id, 'article', $article);
+
+        $workflow = EditorialReview::withoutGlobalScopes()
+            ->where('content_type', 'article')
+            ->where('content_id', (int) $article->id)
+            ->first();
+
+        $this->assertNotNull($workflow);
+        $this->assertSame(EditorialReviewAudit::STATE_READY, (string) $workflow->workflow_state);
+        $this->assertNull($workflow->reviewed_at);
+        $this->assertNull($workflow->reviewed_by_admin_user_id);
+        $this->assertSame((int) $replacementReviewer->id, (int) $workflow->reviewer_admin_user_id);
+
+        $this->withSession($this->opsSessionForOrg((int) $publisher->id, $selectedOrgId))
+            ->actingAs($publisher, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-release')
+            ->assertOk()
+            ->assertSee('Ready')
+            ->assertSee('Reviewer Reassignment Article');
+
+        $this->setOpsContext($selectedOrgId, $publisher, '/ops/content-release');
+
+        $this->expectException(AuthorizationException::class);
+
+        ArticleResource::releaseRecord($article);
+    }
+
+    public function test_editorial_review_cannot_approve_record_before_submission(): void
+    {
+        $owner = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $reviewer = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+        ]);
+
+        $session = $this->opsSession((int) $owner->id);
+        $selectedOrgId = (int) $session['ops_org_id'];
+
+        $article = $this->seedArticle([
+            'org_id' => $selectedOrgId,
+            'title' => 'Premature Approval Article',
+            'excerpt' => 'Ready excerpt',
+            'content_md' => 'Ready body',
+            'status' => 'draft',
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => $selectedOrgId,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Premature Approval Article SEO Title',
+            'seo_description' => 'Premature Approval Article SEO Description',
+            'canonical_url' => 'https://example.test/articles/premature-approval-article',
+            'og_title' => 'Premature Approval Article OG Title',
+            'og_description' => 'Premature Approval Article OG Description',
+            'og_image_url' => 'https://example.test/images/premature-approval-article.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        $this->setOpsContext($selectedOrgId, $owner, '/ops/editorial-review');
+        EditorialReviewAudit::assignOwner((int) $owner->id, 'article', $article);
+
+        $this->setOpsContext($selectedOrgId, $reviewer, '/ops/editorial-review');
+        EditorialReviewAudit::assignReviewer((int) $reviewer->id, 'article', $article);
+
+        $this->expectException(AuthorizationException::class);
+
+        EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, 'article', $article);
+    }
+
     public function test_editorial_review_requires_real_seo_meta_before_marking_record_ready(): void
     {
         $admin = $this->createAdminWithPermissions([
@@ -834,10 +955,10 @@ final class ContentCmsProductLayerTest extends TestCase
         ]);
 
         foreach ($permissions as $permissionName) {
-            $permission = Permission::query()->firstOrCreate([
-                'name' => $permissionName,
-                'guard_name' => (string) config('admin.guard', 'admin'),
-            ]);
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['guard_name' => (string) config('admin.guard', 'admin')]
+            );
 
             $role->permissions()->syncWithoutDetaching([$permission->id]);
         }
@@ -876,13 +997,28 @@ final class ContentCmsProductLayerTest extends TestCase
 
     private function approveRecord(AdminUser $admin, int $orgId, string $type, object $record): void
     {
-        $this->routeRecordIntoReview($orgId, $admin, $admin, $type, $record);
+        $this->ensureSeoReady($orgId, $type, $record);
+
+        $owner = $admin;
+        if (
+            ! $admin->hasPermission(PermissionNames::ADMIN_CONTENT_WRITE)
+            && ! $admin->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+            && ! $admin->hasPermission(PermissionNames::ADMIN_OWNER)
+        ) {
+            $owner = $this->createAdminWithPermissions([
+                PermissionNames::ADMIN_CONTENT_WRITE,
+            ]);
+        }
+
+        $this->routeRecordIntoReview($orgId, $owner, $admin, $type, $record);
         $this->setOpsContext($orgId, $admin, '/ops/editorial-review');
         EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, $type, $record);
     }
 
     private function routeRecordIntoReview(int $orgId, AdminUser $owner, AdminUser $reviewer, string $type, object $record): void
     {
+        $this->ensureSeoReady($orgId, $type, $record);
+
         $this->setOpsContext($orgId, $owner, '/ops/editorial-review');
         EditorialReviewAudit::assignOwner((int) $owner->id, $type, $record);
 
@@ -891,6 +1027,80 @@ final class ContentCmsProductLayerTest extends TestCase
 
         $this->setOpsContext($orgId, $owner, '/ops/editorial-review');
         EditorialReviewAudit::submit($type, $record);
+    }
+
+    private function ensureSeoReady(int $orgId, string $type, object $record): void
+    {
+        $bodyField = match ($type) {
+            'article' => 'content_md',
+            'guide', 'job' => 'body_md',
+            default => 'content_md',
+        };
+
+        $bodyHtmlField = match ($type) {
+            'article' => 'content_html',
+            'guide', 'job' => 'body_html',
+            default => 'content_html',
+        };
+
+        if (
+            ! filled(data_get($record, 'excerpt'))
+            || ! filled(data_get($record, $bodyField))
+        ) {
+            $record->forceFill([
+                'excerpt' => filled(data_get($record, 'excerpt')) ? data_get($record, 'excerpt') : 'Ready excerpt',
+                $bodyField => filled(data_get($record, $bodyField)) ? data_get($record, $bodyField) : 'Ready body',
+                $bodyHtmlField => filled(data_get($record, $bodyHtmlField)) ? data_get($record, $bodyHtmlField) : '<p>Ready body</p>',
+            ])->save();
+        }
+
+        if ($type === 'article' && ! $record->seoMeta()->exists()) {
+            ArticleSeoMeta::query()->create([
+                'org_id' => $orgId,
+                'article_id' => (int) data_get($record, 'id'),
+                'locale' => (string) data_get($record, 'locale', 'en'),
+                'seo_title' => trim((string) data_get($record, 'title', 'Article')).' SEO Title',
+                'seo_description' => trim((string) data_get($record, 'excerpt', 'Article excerpt')).' SEO Description',
+                'canonical_url' => 'https://example.test/articles/'.trim((string) data_get($record, 'slug', 'article')),
+                'og_title' => trim((string) data_get($record, 'title', 'Article')).' OG Title',
+                'og_description' => trim((string) data_get($record, 'excerpt', 'Article excerpt')).' OG Description',
+                'og_image_url' => 'https://example.test/images/'.trim((string) data_get($record, 'slug', 'article')).'.png',
+                'robots' => 'index,follow',
+                'is_indexable' => true,
+            ]);
+        }
+
+        if ($type === 'guide' && ! $record->seoMeta()->exists()) {
+            CareerGuideSeoMeta::query()->create([
+                'career_guide_id' => (int) data_get($record, 'id'),
+                'seo_title' => trim((string) data_get($record, 'title', 'Guide')).' SEO Title',
+                'seo_description' => trim((string) data_get($record, 'excerpt', 'Guide excerpt')).' SEO Description',
+                'canonical_url' => 'https://example.test/guides/'.trim((string) data_get($record, 'slug', 'guide')),
+                'og_title' => trim((string) data_get($record, 'title', 'Guide')).' OG Title',
+                'og_description' => trim((string) data_get($record, 'excerpt', 'Guide excerpt')).' OG Description',
+                'og_image_url' => 'https://example.test/images/'.trim((string) data_get($record, 'slug', 'guide')).'.png',
+                'twitter_title' => trim((string) data_get($record, 'title', 'Guide')).' Twitter Title',
+                'twitter_description' => trim((string) data_get($record, 'excerpt', 'Guide excerpt')).' Twitter Description',
+                'twitter_image_url' => 'https://example.test/images/'.trim((string) data_get($record, 'slug', 'guide')).'-twitter.png',
+                'robots' => 'index,follow',
+            ]);
+        }
+
+        if ($type === 'job' && ! $record->seoMeta()->exists()) {
+            CareerJobSeoMeta::query()->create([
+                'job_id' => (int) data_get($record, 'id'),
+                'seo_title' => trim((string) data_get($record, 'title', 'Job')).' SEO Title',
+                'seo_description' => trim((string) data_get($record, 'excerpt', 'Job excerpt')).' SEO Description',
+                'canonical_url' => 'https://example.test/jobs/'.trim((string) data_get($record, 'slug', 'job')),
+                'og_title' => trim((string) data_get($record, 'title', 'Job')).' OG Title',
+                'og_description' => trim((string) data_get($record, 'excerpt', 'Job excerpt')).' OG Description',
+                'og_image_url' => 'https://example.test/images/'.trim((string) data_get($record, 'slug', 'job')).'.png',
+                'twitter_title' => trim((string) data_get($record, 'title', 'Job')).' Twitter Title',
+                'twitter_description' => trim((string) data_get($record, 'excerpt', 'Job excerpt')).' Twitter Description',
+                'twitter_image_url' => 'https://example.test/images/'.trim((string) data_get($record, 'slug', 'job')).'-twitter.png',
+                'robots' => 'index,follow',
+            ]);
+        }
     }
 
     private function setOpsContext(int $orgId, AdminUser $admin, string $path, string $method = 'POST'): void

--- a/backend/tests/Feature/Ops/PostReleaseObservabilityPageTest.php
+++ b/backend/tests/Feature/Ops/PostReleaseObservabilityPageTest.php
@@ -60,6 +60,9 @@ final class PostReleaseObservabilityPageTest extends TestCase
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_RELEASE,
         ]);
+        $owner = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
         $selectedOrg = $this->createOrganization('Release Observability Org');
 
         $article = Article::query()->create([
@@ -154,6 +157,13 @@ final class PostReleaseObservabilityPageTest extends TestCase
         $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
         app()->instance(OrgContext::class, $context);
 
+        $this->routeRecordIntoReview((int) $selectedOrg->id, $owner, $admin, 'article', $article);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/editorial-review', 'POST'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
         EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, 'article', $article);
 
         Livewire::test(ContentReleasePage::class)
@@ -208,6 +218,9 @@ final class PostReleaseObservabilityPageTest extends TestCase
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_RELEASE,
         ]);
+        $owner = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
         $selectedOrg = $this->createOrganization('Selected Observability Org');
         $otherOrg = $this->createOrganization('Other Observability Org');
 
@@ -222,6 +235,19 @@ final class PostReleaseObservabilityPageTest extends TestCase
             'is_public' => false,
             'is_indexable' => true,
         ]);
+        ArticleSeoMeta::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Resource Release Article SEO Title',
+            'seo_description' => 'Resource Release Article SEO Description',
+            'canonical_url' => 'https://example.test/articles/resource-release-article',
+            'og_title' => 'Resource Release Article OG Title',
+            'og_description' => 'Resource Release Article OG Description',
+            'og_image_url' => 'https://example.test/images/resource-release-article.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
 
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));
         app()->instance('request', Request::create('/ops/articles', 'POST'));
@@ -230,6 +256,13 @@ final class PostReleaseObservabilityPageTest extends TestCase
         $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
         app()->instance(OrgContext::class, $context);
 
+        $this->routeRecordIntoReview((int) $selectedOrg->id, $owner, $admin, 'article', $article);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/editorial-review', 'POST'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
         EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, 'article', $article);
         ArticleResource::releaseRecord($article, 'resource_table');
 
@@ -320,5 +353,32 @@ final class PostReleaseObservabilityPageTest extends TestCase
             'ops_org_id' => (int) $selectedOrg->id,
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
         ];
+    }
+
+    private function routeRecordIntoReview(int $orgId, AdminUser $owner, AdminUser $reviewer, string $type, object $record): void
+    {
+        $this->actingAs($owner, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/editorial-review', 'POST'));
+
+        $context = app(OrgContext::class);
+        $context->set($orgId, (int) $owner->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+        EditorialReviewAudit::assignOwner((int) $owner->id, $type, $record);
+
+        $this->actingAs($reviewer, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/editorial-review', 'POST'));
+
+        $context = app(OrgContext::class);
+        $context->set($orgId, (int) $reviewer->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+        EditorialReviewAudit::assignReviewer((int) $reviewer->id, $type, $record);
+
+        $this->actingAs($owner, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/editorial-review', 'POST'));
+
+        $context = app(OrgContext::class);
+        $context->set($orgId, (int) $owner->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+        EditorialReviewAudit::submit($type, $record);
     }
 }


### PR DESCRIPTION
## Summary
- add a persisted editorial review workflow table for owner/reviewer assignment and state transitions
- upgrade editorial review from a readiness checklist into a routed workflow with submit, approve, reject, and send-back actions
- gate CMS publishing on the persisted workflow state while keeping release audits and public content contracts intact

## Tests
- cd backend && php artisan migrate --pretend | rg 'editorial_reviews|create table|alter table'\n- cd backend && php artisan route:list | rg 'editorial-review|content-release|post-release-observability|content-search|content-metrics|seo-operations'\n- cd backend && php artisan test tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php\n- cd backend && php artisan test tests/Feature/Ops/ContentSearchPageTest.php tests/Feature/Ops/ContentMetricsPageTest.php tests/Feature/Ops/SeoOperationsPageTest.php\n- cd backend && php artisan test tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/V0_5/ArticlePublicApiTest.php