### PR TITLE
feat(cms): build seo operations and growth diagnostics

### DIFF
--- a/backend/app/Filament/Ops/Pages/SeoOperationsPage.php
+++ b/backend/app/Filament/Ops/Pages/SeoOperationsPage.php
@@ -343,7 +343,12 @@ class SeoOperationsPage extends Page
      */
     private function countCanonicalCoverage(SeoOperationsService $service, string $type, Collection $records): int
     {
-        return $records->filter(fn (object $record): bool => trim((string) data_get($record, 'seoMeta.canonical_url', '')) === ($service->expectedCanonical($type, $record) ?? ''))->count();
+        return $records->filter(function (object $record) use ($service, $type): bool {
+            $expectedCanonical = $service->expectedCanonical($type, $record);
+
+            return $expectedCanonical !== null
+                && trim((string) data_get($record, 'seoMeta.canonical_url', '')) === $expectedCanonical;
+        })->count();
     }
 
     /**

--- a/backend/app/Filament/Ops/Pages/SeoOperationsPage.php
+++ b/backend/app/Filament/Ops/Pages/SeoOperationsPage.php
@@ -8,9 +8,13 @@ use App\Filament\Ops\Support\ContentAccess;
 use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
+use App\Services\Audit\AuditLogger;
+use App\Services\Ops\SeoOperationsService;
 use App\Support\OrgContext;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Collection;
 
 class SeoOperationsPage extends Page
 {
@@ -26,6 +30,15 @@ class SeoOperationsPage extends Page
 
     protected static string $view = 'filament.ops.pages.seo-operations';
 
+    public string $typeFilter = 'all';
+
+    public string $issueFilter = 'all';
+
+    public string $bulkAction = SeoOperationsService::ACTION_FILL_METADATA;
+
+    /** @var list<string> */
+    public array $selectedTargets = [];
+
     /** @var list<array<string, mixed>> */
     public array $headlineFields = [];
 
@@ -33,143 +46,74 @@ class SeoOperationsPage extends Page
     public array $coverageFields = [];
 
     /** @var list<array<string, mixed>> */
+    public array $growthFields = [];
+
+    /** @var list<array<string, mixed>> */
     public array $attentionCards = [];
 
-    public function mount(): void
+    /** @var list<array<string, mixed>> */
+    public array $issueQueue = [];
+
+    public int $issueQueueElapsedMs = 0;
+
+    public function mount(SeoOperationsService $service): void
     {
-        $currentOrgIds = $this->currentOrgIds();
+        $this->refreshDashboard($service);
+    }
 
-        $articleBaseQuery = Article::query()->whereIn('org_id', $currentOrgIds);
-        $guideBaseQuery = CareerGuide::query()
-            ->withoutGlobalScopes()
-            ->where('org_id', 0);
-        $jobBaseQuery = CareerJob::query()
-            ->withoutGlobalScopes()
-            ->where('org_id', 0);
+    public function updatedTypeFilter(): void
+    {
+        $this->selectedTargets = [];
+        $this->refreshDashboard(app(SeoOperationsService::class));
+    }
 
-        $articleTotal = (clone $articleBaseQuery)->count();
-        $guideTotal = (clone $guideBaseQuery)->count();
-        $jobTotal = (clone $jobBaseQuery)->count();
-        $careerTotal = $guideTotal + $jobTotal;
+    public function updatedIssueFilter(): void
+    {
+        $this->selectedTargets = [];
+        $this->refreshDashboard(app(SeoOperationsService::class));
+    }
 
-        $articleSeoReady = $this->countSeoReady(clone $articleBaseQuery);
-        $guideSeoReady = $this->countSeoReady(clone $guideBaseQuery);
-        $jobSeoReady = $this->countSeoReady(clone $jobBaseQuery);
-        $careerSeoReady = $guideSeoReady + $jobSeoReady;
+    public function applyBulkAction(SeoOperationsService $service, AuditLogger $audit): void
+    {
+        if (! ContentAccess::canWrite()) {
+            throw new AuthorizationException('You do not have permission to operate SEO actions.');
+        }
 
-        $articleCanonicalCoverage = $this->countCanonicalCoverage(clone $articleBaseQuery);
-        $guideCanonicalCoverage = $this->countCanonicalCoverage(clone $guideBaseQuery);
-        $jobCanonicalCoverage = $this->countCanonicalCoverage(clone $jobBaseQuery);
+        if ($this->selectedTargets === []) {
+            Notification::make()
+                ->title('Select at least one SEO issue row')
+                ->warning()
+                ->send();
 
-        $articleSocialCoverage = $this->countSocialCoverage(clone $articleBaseQuery);
-        $careerSocialCoverage = $this->countSocialCoverage(clone $guideBaseQuery) + $this->countSocialCoverage(clone $jobBaseQuery);
+            return;
+        }
 
-        $indexableFootprint = (clone $articleBaseQuery)->where('is_indexable', true)->count()
-            + (clone $guideBaseQuery)->where('is_indexable', true)->count()
-            + (clone $jobBaseQuery)->where('is_indexable', true)->count();
+        $result = $service->applyBulkAction($this->selectedTargets, $this->bulkAction, $this->currentOrgIds());
+        $updatedCount = (int) ($result['updated_count'] ?? 0);
 
-        $publicSeoReady = $this->countPublicSeoReady(clone $articleBaseQuery)
-            + $this->countPublicSeoReady(clone $guideBaseQuery)
-            + $this->countPublicSeoReady(clone $jobBaseQuery);
-
-        $seoAttentionQueue = ($articleTotal - $articleSeoReady)
-            + ($guideTotal - $guideSeoReady)
-            + ($jobTotal - $jobSeoReady);
-
-        $robotsGaps = $this->countRobotsGap(clone $articleBaseQuery)
-            + $this->countRobotsGap(clone $guideBaseQuery)
-            + $this->countRobotsGap(clone $jobBaseQuery);
-
-        $this->headlineFields = [
+        $audit->log(
+            request(),
+            'seo_operations_bulk_action',
+            'SeoOperations',
+            null,
             [
-                'label' => 'Current org article SEO-ready',
-                'value' => $this->ratioLabel($articleSeoReady, $articleTotal),
-                'hint' => 'Selected-org article coverage for title, description, canonical, OG, and robots fields.',
-            ],
-            [
-                'label' => 'Global career SEO-ready',
-                'value' => $this->ratioLabel($careerSeoReady, $careerTotal),
-                'hint' => 'Global guide and job coverage for the visible SEO authoring surface.',
-            ],
-            [
-                'label' => 'Indexable footprint',
-                'value' => (string) $indexableFootprint,
-                'hint' => 'Visible records currently marked indexable across article and global career surfaces.',
-            ],
-            [
-                'label' => 'Public SEO-ready records',
-                'value' => (string) $publicSeoReady,
-                'hint' => 'Published and public records that also satisfy the current SEO completeness checks.',
-            ],
-            [
-                'label' => 'SEO attention queue',
-                'value' => (string) $seoAttentionQueue,
-                'hint' => 'Visible content objects still missing at least one core SEO field.',
-            ],
-        ];
+                'action' => $this->bulkAction,
+                'type_filter' => $this->typeFilter,
+                'issue_filter' => $this->issueFilter,
+                'selection_count' => count($this->selectedTargets),
+                'updated_count' => $updatedCount,
+                'targets' => $result['updated_keys'] ?? [],
+            ]
+        );
 
-        $this->coverageFields = [
-            [
-                'label' => 'Article canonical coverage',
-                'value' => $this->ratioLabel($articleCanonicalCoverage, $articleTotal),
-                'hint' => 'Current-org article canonical URL coverage.',
-            ],
-            [
-                'label' => 'Article social coverage',
-                'value' => $this->ratioLabel($articleSocialCoverage, $articleTotal),
-                'hint' => 'Current-org Open Graph coverage for articles.',
-            ],
-            [
-                'label' => 'Guide canonical coverage',
-                'value' => $this->ratioLabel($guideCanonicalCoverage, $guideTotal),
-                'hint' => 'Global career guide canonical URL coverage.',
-            ],
-            [
-                'label' => 'Job canonical coverage',
-                'value' => $this->ratioLabel($jobCanonicalCoverage, $jobTotal),
-                'hint' => 'Global career job canonical URL coverage.',
-            ],
-            [
-                'label' => 'Robots gaps',
-                'value' => (string) $robotsGaps,
-                'kind' => 'pill',
-                'state' => $robotsGaps > 0 ? 'warning' : 'success',
-                'hint' => 'Records where robots is still blank in SEO metadata.',
-            ],
-        ];
+        $this->selectedTargets = [];
+        $this->refreshDashboard($service);
 
-        $this->attentionCards = [
-            $this->attentionCard(
-                'Article SEO gaps',
-                'Current-org articles that still need core SEO fields before the editorial surface is truly ready.',
-                $articleTotal - $articleSeoReady,
-                'Current org',
-                $this->latestSeoGapTitle(clone $articleBaseQuery)
-            ),
-            $this->attentionCard(
-                'Career guide SEO gaps',
-                'Global guides that still need SEO completion before they should be treated as SEO-ready inventory.',
-                $guideTotal - $guideSeoReady,
-                'Global content',
-                $this->latestSeoGapTitle(clone $guideBaseQuery)
-            ),
-            $this->attentionCard(
-                'Career job SEO gaps',
-                'Global jobs that still need SEO completion before they should be treated as SEO-ready inventory.',
-                $jobTotal - $jobSeoReady,
-                'Global content',
-                $this->latestSeoGapTitle(clone $jobBaseQuery)
-            ),
-            [
-                'title' => 'Career social gaps',
-                'description' => 'Open Graph coverage across global guides and jobs. This helps keep social previews consistent after release.',
-                'meta' => 'Global content | '.($careerTotal - $careerSocialCoverage).' records need OG work',
-                'value' => (string) ($careerTotal - $careerSocialCoverage),
-                'status' => ($careerTotal - $careerSocialCoverage) > 0 ? 'Needs attention' : 'Healthy',
-                'status_state' => ($careerTotal - $careerSocialCoverage) > 0 ? 'warning' : 'success',
-                'latest_title' => $this->latestSocialGapTitle(clone $guideBaseQuery) ?? $this->latestSocialGapTitle(clone $jobBaseQuery) ?? 'No recent record',
-            ],
-        ];
+        Notification::make()
+            ->title('SEO operations applied')
+            ->body('Updated '.$updatedCount.' records.')
+            ->success()
+            ->send();
     }
 
     public static function getNavigationGroup(): ?string
@@ -197,123 +141,293 @@ class SeoOperationsPage extends Page
         return $orgId > 0 ? [$orgId] : [];
     }
 
-    private function countSeoReady(Builder $query): int
+    private function refreshDashboard(SeoOperationsService $service): void
     {
-        return $query->whereHas('seoMeta', function (Builder $seoQuery): void {
-            $seoQuery
-                ->whereNotNull('seo_title')
-                ->where('seo_title', '!=', '')
-                ->whereNotNull('seo_description')
-                ->where('seo_description', '!=', '')
-                ->whereNotNull('canonical_url')
-                ->where('canonical_url', '!=', '')
-                ->whereNotNull('og_title')
-                ->where('og_title', '!=', '')
-                ->whereNotNull('og_description')
-                ->where('og_description', '!=', '')
-                ->whereNotNull('og_image_url')
-                ->where('og_image_url', '!=', '')
-                ->whereNotNull('robots')
-                ->where('robots', '!=', '');
-        })->count();
-    }
+        $currentOrgIds = $this->currentOrgIds();
 
-    private function countCanonicalCoverage(Builder $query): int
-    {
-        return $query->whereHas('seoMeta', function (Builder $seoQuery): void {
-            $seoQuery
-                ->whereNotNull('canonical_url')
-                ->where('canonical_url', '!=', '');
-        })->count();
-    }
-
-    private function countSocialCoverage(Builder $query): int
-    {
-        return $query->whereHas('seoMeta', function (Builder $seoQuery): void {
-            $seoQuery
-                ->whereNotNull('og_title')
-                ->where('og_title', '!=', '')
-                ->whereNotNull('og_description')
-                ->where('og_description', '!=', '')
-                ->whereNotNull('og_image_url')
-                ->where('og_image_url', '!=', '');
-        })->count();
-    }
-
-    private function countPublicSeoReady(Builder $query): int
-    {
-        return $this->countSeoReady(
-            $query
-                ->where('status', 'published')
-                ->where('is_public', true)
-        );
-    }
-
-    private function countRobotsGap(Builder $query): int
-    {
-        return $query->where(function (Builder $itemQuery): void {
-            $itemQuery
-                ->whereDoesntHave('seoMeta')
-                ->orWhereHas('seoMeta', function (Builder $seoQuery): void {
-                    $seoQuery
-                        ->whereNull('robots')
-                        ->orWhere('robots', '');
-                });
-        })->count();
-    }
-
-    private function latestSeoGapTitle(Builder $query): ?string
-    {
-        /** @var object|null $record */
-        $record = $query
-            ->where(function (Builder $itemQuery): void {
-                $itemQuery
-                    ->whereDoesntHave('seoMeta')
-                    ->orWhereHas('seoMeta', function (Builder $seoQuery): void {
-                        $seoQuery
-                            ->whereNull('seo_title')
-                            ->orWhere('seo_title', '')
-                            ->orWhereNull('seo_description')
-                            ->orWhere('seo_description', '')
-                            ->orWhereNull('canonical_url')
-                            ->orWhere('canonical_url', '')
-                            ->orWhereNull('og_title')
-                            ->orWhere('og_title', '')
-                            ->orWhereNull('og_description')
-                            ->orWhere('og_description', '')
-                            ->orWhereNull('og_image_url')
-                            ->orWhere('og_image_url', '')
-                            ->orWhereNull('robots')
-                            ->orWhere('robots', '');
-                    });
-            })
+        /** @var Collection<int, Article> $articles */
+        $articles = Article::query()
+            ->whereIn('org_id', $currentOrgIds)
+            ->with('seoMeta')
             ->latest('updated_at')
-            ->first();
+            ->get();
+        /** @var Collection<int, CareerGuide> $guides */
+        $guides = CareerGuide::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->with('seoMeta')
+            ->latest('updated_at')
+            ->get();
+        /** @var Collection<int, CareerJob> $jobs */
+        $jobs = CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->with('seoMeta')
+            ->latest('updated_at')
+            ->get();
+
+        $articleTotal = $articles->count();
+        $guideTotal = $guides->count();
+        $jobTotal = $jobs->count();
+        $careerTotal = $guideTotal + $jobTotal;
+
+        $articleSeoReady = $this->countSeoReady($service, 'article', $articles);
+        $guideSeoReady = $this->countSeoReady($service, 'guide', $guides);
+        $jobSeoReady = $this->countSeoReady($service, 'job', $jobs);
+        $careerSeoReady = $guideSeoReady + $jobSeoReady;
+
+        $articleCanonicalCoverage = $this->countCanonicalCoverage($service, 'article', $articles);
+        $guideCanonicalCoverage = $this->countCanonicalCoverage($service, 'guide', $guides);
+        $jobCanonicalCoverage = $this->countCanonicalCoverage($service, 'job', $jobs);
+
+        $articleSocialCoverage = $this->countSocialCoverage($articles);
+        $careerSocialCoverage = $this->countSocialCoverage($guides) + $this->countSocialCoverage($jobs);
+
+        $indexableFootprint = $articles->where('is_indexable', true)->count()
+            + $guides->where('is_indexable', true)->count()
+            + $jobs->where('is_indexable', true)->count();
+
+        $publicSeoReady = $this->countGrowthReady($service, 'article', $articles)
+            + $this->countGrowthReady($service, 'guide', $guides)
+            + $this->countGrowthReady($service, 'job', $jobs);
+
+        $seoAttentionQueue = ($articleTotal - $articleSeoReady)
+            + ($guideTotal - $guideSeoReady)
+            + ($jobTotal - $jobSeoReady);
+
+        $robotsGaps = $this->countRobotsGaps($service, 'article', $articles)
+            + $this->countRobotsGaps($service, 'guide', $guides)
+            + $this->countRobotsGaps($service, 'job', $jobs);
+
+        $publishedDiscoveryBlocked = $this->countPublishedDiscoveryBlocked($service, 'article', $articles)
+            + $this->countPublishedDiscoveryBlocked($service, 'guide', $guides)
+            + $this->countPublishedDiscoveryBlocked($service, 'job', $jobs);
+
+        $socialPreviewBlocked = $this->countIssueCode($service, 'social', 'article', $articles)
+            + $this->countIssueCode($service, 'social', 'guide', $guides)
+            + $this->countIssueCode($service, 'social', 'job', $jobs);
+
+        $noindexInventory = $articles->where('is_indexable', false)->count()
+            + $guides->where('is_indexable', false)->count()
+            + $jobs->where('is_indexable', false)->count();
+
+        $this->headlineFields = [
+            [
+                'label' => 'Current org article SEO-ready',
+                'value' => $this->ratioLabel($articleSeoReady, $articleTotal),
+                'hint' => 'Selected-org article coverage for metadata, canonical, robots, indexability, and growth blockers.',
+            ],
+            [
+                'label' => 'Global career SEO-ready',
+                'value' => $this->ratioLabel($careerSeoReady, $careerTotal),
+                'hint' => 'Global guide and job coverage for the visible SEO authoring surface.',
+            ],
+            [
+                'label' => 'Indexable footprint',
+                'value' => (string) $indexableFootprint,
+                'hint' => 'Visible records currently marked indexable across article and global career surfaces.',
+            ],
+            [
+                'label' => 'Growth-ready records',
+                'value' => (string) $publicSeoReady,
+                'hint' => 'Published, public, indexable, and discovery-ready records.',
+            ],
+            [
+                'label' => 'SEO attention queue',
+                'value' => (string) $seoAttentionQueue,
+                'hint' => 'Visible content objects still missing at least one operational SEO requirement.',
+            ],
+        ];
+
+        $this->coverageFields = [
+            [
+                'label' => 'Article canonical coverage',
+                'value' => $this->ratioLabel($articleCanonicalCoverage, $articleTotal),
+                'hint' => 'Current-org article canonical URL alignment.',
+            ],
+            [
+                'label' => 'Article social coverage',
+                'value' => $this->ratioLabel($articleSocialCoverage, $articleTotal),
+                'hint' => 'Current-org Open Graph coverage for articles.',
+            ],
+            [
+                'label' => 'Guide canonical coverage',
+                'value' => $this->ratioLabel($guideCanonicalCoverage, $guideTotal),
+                'hint' => 'Global career guide canonical URL alignment.',
+            ],
+            [
+                'label' => 'Job canonical coverage',
+                'value' => $this->ratioLabel($jobCanonicalCoverage, $jobTotal),
+                'hint' => 'Global career job canonical URL alignment.',
+            ],
+            [
+                'label' => 'Robots gaps',
+                'value' => (string) $robotsGaps,
+                'kind' => 'pill',
+                'state' => $robotsGaps > 0 ? 'warning' : 'success',
+                'hint' => 'Records where robots still drift from the current indexability contract.',
+            ],
+        ];
+
+        $this->growthFields = [
+            [
+                'label' => 'Published discovery blockers',
+                'value' => (string) $publishedDiscoveryBlocked,
+                'hint' => 'Published and public records still blocked from SEO discovery.',
+            ],
+            [
+                'label' => 'Social preview blockers',
+                'value' => (string) $socialPreviewBlocked,
+                'hint' => 'Records missing Open Graph or Twitter preview support.',
+            ],
+            [
+                'label' => 'Noindex inventory',
+                'value' => (string) $noindexInventory,
+                'hint' => 'Visible records intentionally excluded from discovery today.',
+            ],
+            [
+                'label' => 'Growth-ready ratio',
+                'value' => $this->ratioLabel($publicSeoReady, $articleTotal + $careerTotal),
+                'hint' => 'Visible content already ready for search and social discovery.',
+            ],
+        ];
+
+        $this->attentionCards = [
+            $this->attentionCard(
+                'Article SEO gaps',
+                'Current-org articles that still need metadata, canonical, robots, or discoverability fixes.',
+                $articleTotal - $articleSeoReady,
+                'Current org',
+                $this->latestIssueTitle($service, 'article', $articles)
+            ),
+            $this->attentionCard(
+                'Career guide SEO gaps',
+                'Global guides that still need operational SEO fixes before they should be treated as growth inventory.',
+                $guideTotal - $guideSeoReady,
+                'Global content',
+                $this->latestIssueTitle($service, 'guide', $guides)
+            ),
+            $this->attentionCard(
+                'Career job SEO gaps',
+                'Global jobs that still need operational SEO fixes before they should be treated as growth inventory.',
+                $jobTotal - $jobSeoReady,
+                'Global content',
+                $this->latestIssueTitle($service, 'job', $jobs)
+            ),
+            [
+                'title' => 'Growth blockers',
+                'description' => 'Published records that are still blocked by noindex, canonical drift, robots drift, or missing metadata.',
+                'meta' => 'Visible content | '.$publishedDiscoveryBlocked.' records need discovery fixes',
+                'value' => (string) $publishedDiscoveryBlocked,
+                'status' => $publishedDiscoveryBlocked > 0 ? 'Needs attention' : 'Healthy',
+                'status_state' => $publishedDiscoveryBlocked > 0 ? 'warning' : 'success',
+                'latest_title' => $this->latestGrowthBlockedTitle($service, $articles, $guides, $jobs),
+            ],
+        ];
+
+        $issueQueue = $service->buildIssueQueue($currentOrgIds, $this->typeFilter, $this->issueFilter);
+        $this->issueQueue = $issueQueue['items'] ?? [];
+        $this->issueQueueElapsedMs = (int) ($issueQueue['elapsed_ms'] ?? 0);
+    }
+
+    /**
+     * @param  Collection<int, object>  $records
+     */
+    private function countSeoReady(SeoOperationsService $service, string $type, Collection $records): int
+    {
+        return $records->filter(fn (object $record): bool => $service->isSeoReady($type, $record))->count();
+    }
+
+    /**
+     * @param  Collection<int, object>  $records
+     */
+    private function countCanonicalCoverage(SeoOperationsService $service, string $type, Collection $records): int
+    {
+        return $records->filter(fn (object $record): bool => trim((string) data_get($record, 'seoMeta.canonical_url', '')) === ($service->expectedCanonical($type, $record) ?? ''))->count();
+    }
+
+    /**
+     * @param  Collection<int, object>  $records
+     */
+    private function countSocialCoverage(Collection $records): int
+    {
+        return $records->filter(function (object $record): bool {
+            return trim((string) data_get($record, 'seoMeta.og_title', '')) !== ''
+                && trim((string) data_get($record, 'seoMeta.og_description', '')) !== ''
+                && trim((string) data_get($record, 'seoMeta.og_image_url', '')) !== '';
+        })->count();
+    }
+
+    /**
+     * @param  Collection<int, object>  $records
+     */
+    private function countGrowthReady(SeoOperationsService $service, string $type, Collection $records): int
+    {
+        return $records->filter(fn (object $record): bool => $service->isGrowthReady($type, $record))->count();
+    }
+
+    /**
+     * @param  Collection<int, object>  $records
+     */
+    private function countRobotsGaps(SeoOperationsService $service, string $type, Collection $records): int
+    {
+        return $this->countIssueCode($service, SeoOperationsService::ISSUE_ROBOTS, $type, $records);
+    }
+
+    /**
+     * @param  Collection<int, object>  $records
+     */
+    private function countIssueCode(SeoOperationsService $service, string $issueCode, string $type, Collection $records): int
+    {
+        return $records->filter(function (object $record) use ($service, $issueCode, $type): bool {
+            return collect($service->issuesFor($type, $record))
+                ->contains(fn (array $issue): bool => ($issue['code'] ?? null) === $issueCode);
+        })->count();
+    }
+
+    /**
+     * @param  Collection<int, object>  $records
+     */
+    private function countPublishedDiscoveryBlocked(SeoOperationsService $service, string $type, Collection $records): int
+    {
+        return $records->filter(fn (object $record): bool => $service->growthSignal($type, $record) === 'Blocked by noindex'
+            || $service->growthSignal($type, $record) === 'Published with discovery blockers')->count();
+    }
+
+    /**
+     * @param  Collection<int, object>  $records
+     */
+    private function latestIssueTitle(SeoOperationsService $service, string $type, Collection $records): ?string
+    {
+        $record = $records->first(fn (object $item): bool => $service->issuesFor($type, $item) !== []);
 
         return is_object($record) ? trim((string) data_get($record, 'title', '')) : null;
     }
 
-    private function latestSocialGapTitle(Builder $query): ?string
-    {
-        /** @var object|null $record */
-        $record = $query
-            ->where(function (Builder $itemQuery): void {
-                $itemQuery
-                    ->whereDoesntHave('seoMeta')
-                    ->orWhereHas('seoMeta', function (Builder $seoQuery): void {
-                        $seoQuery
-                            ->whereNull('og_title')
-                            ->orWhere('og_title', '')
-                            ->orWhereNull('og_description')
-                            ->orWhere('og_description', '')
-                            ->orWhereNull('og_image_url')
-                            ->orWhere('og_image_url', '');
-                    });
-            })
-            ->latest('updated_at')
-            ->first();
+    /**
+     * @param  Collection<int, Article>  $articles
+     * @param  Collection<int, CareerGuide>  $guides
+     * @param  Collection<int, CareerJob>  $jobs
+     */
+    private function latestGrowthBlockedTitle(
+        SeoOperationsService $service,
+        Collection $articles,
+        Collection $guides,
+        Collection $jobs,
+    ): string {
+        $candidates = collect([
+            $articles->first(fn (Article $record): bool => str_contains($service->growthSignal('article', $record), 'Blocked')
+                || str_contains($service->growthSignal('article', $record), 'Published')),
+            $guides->first(fn (CareerGuide $record): bool => str_contains($service->growthSignal('guide', $record), 'Blocked')
+                || str_contains($service->growthSignal('guide', $record), 'Published')),
+            $jobs->first(fn (CareerJob $record): bool => str_contains($service->growthSignal('job', $record), 'Blocked')
+                || str_contains($service->growthSignal('job', $record), 'Published')),
+        ])->filter(fn ($record): bool => is_object($record));
 
-        return is_object($record) ? trim((string) data_get($record, 'title', '')) : null;
+        /** @var object|null $latest */
+        $latest = $candidates->sortByDesc(static fn (object $record): string => (string) optional(data_get($record, 'updated_at'))->toISOString())->first();
+
+        return trim((string) data_get($latest, 'title', '')) !== '' ? trim((string) data_get($latest, 'title', '')) : 'No recent record';
     }
 
     private function ratioLabel(int $value, int $total): string

--- a/backend/app/Services/Ops/SeoOperationsService.php
+++ b/backend/app/Services/Ops/SeoOperationsService.php
@@ -1,0 +1,568 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\CareerGuide;
+use App\Models\CareerGuideSeoMeta;
+use App\Models\CareerJob;
+use App\Models\CareerJobSeoMeta;
+use App\Services\Cms\ArticleSeoService;
+use App\Services\Cms\CareerGuideSeoService;
+use App\Services\Cms\CareerJobSeoService;
+use Illuminate\Support\Str;
+
+final class SeoOperationsService
+{
+    public const ACTION_FILL_METADATA = 'fill_metadata';
+
+    public const ACTION_SYNC_CANONICAL = 'sync_canonical';
+
+    public const ACTION_SYNC_ROBOTS = 'sync_robots';
+
+    public const ACTION_MARK_INDEXABLE = 'mark_indexable';
+
+    public const ACTION_MARK_NOINDEX = 'mark_noindex';
+
+    public const ISSUE_METADATA = 'metadata';
+
+    public const ISSUE_CANONICAL = 'canonical';
+
+    public const ISSUE_ROBOTS = 'robots';
+
+    public const ISSUE_INDEXABILITY = 'indexability';
+
+    public const ISSUE_SOCIAL = 'social';
+
+    public const ISSUE_GROWTH = 'growth';
+
+    public function __construct(
+        private readonly ArticleSeoService $articleSeoService,
+        private readonly CareerGuideSeoService $careerGuideSeoService,
+        private readonly CareerJobSeoService $careerJobSeoService,
+    ) {}
+
+    /**
+     * @param  list<int>  $currentOrgIds
+     * @return array{items:list<array<string,mixed>>,elapsed_ms:int}
+     */
+    public function buildIssueQueue(array $currentOrgIds, string $typeFilter = 'all', string $issueFilter = 'all'): array
+    {
+        $startedAt = microtime(true);
+        $items = [];
+
+        foreach ($this->recordsFor($currentOrgIds, $typeFilter) as [$type, $record]) {
+            $item = $this->issueItem($type, $record, $issueFilter);
+            if ($item === null) {
+                continue;
+            }
+
+            $items[] = $item;
+        }
+
+        usort($items, static function (array $left, array $right): int {
+            $leftPriority = (int) ($left['issue_count'] ?? 0);
+            $rightPriority = (int) ($right['issue_count'] ?? 0);
+
+            if ($leftPriority !== $rightPriority) {
+                return $rightPriority <=> $leftPriority;
+            }
+
+            return strcmp((string) ($right['updated_at'] ?? ''), (string) ($left['updated_at'] ?? ''));
+        });
+
+        return [
+            'items' => array_values($items),
+            'elapsed_ms' => (int) round((microtime(true) - $startedAt) * 1000),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $selectionKeys
+     * @param  list<int>  $currentOrgIds
+     * @return array{updated_count:int,updated_keys:list<string>}
+     */
+    public function applyBulkAction(array $selectionKeys, string $action, array $currentOrgIds): array
+    {
+        $updatedKeys = [];
+
+        foreach ($selectionKeys as $selectionKey) {
+            [$type, $record] = $this->recordFromSelectionKey($selectionKey, $currentOrgIds);
+            if (! is_object($record)) {
+                continue;
+            }
+
+            $this->applyActionToRecord($type, $record, $action);
+            $updatedKeys[] = $selectionKey;
+        }
+
+        return [
+            'updated_count' => count($updatedKeys),
+            'updated_keys' => $updatedKeys,
+        ];
+    }
+
+    /**
+     * @return list<array{code:string,label:string,autofix:array<int,string>}>
+     */
+    public function issuesFor(string $type, object $record): array
+    {
+        $seoMeta = $this->seoMetaFor($record);
+        $expectedCanonical = $this->expectedCanonical($type, $record);
+        $expectedRobots = $this->expectedRobots($type, $record);
+        $isPublishedPublic = $this->isPublishedPublic($type, $record);
+        $isIndexable = (bool) data_get($record, 'is_indexable');
+
+        $issues = [];
+
+        if ($this->hasMetadataGap($type, $record, $seoMeta)) {
+            $issues[] = [
+                'code' => self::ISSUE_METADATA,
+                'label' => 'Metadata gaps',
+                'autofix' => [self::ACTION_FILL_METADATA],
+            ];
+        }
+
+        if ($expectedCanonical !== null && trim((string) data_get($seoMeta, 'canonical_url', '')) !== $expectedCanonical) {
+            $issues[] = [
+                'code' => self::ISSUE_CANONICAL,
+                'label' => 'Canonical mismatch',
+                'autofix' => [self::ACTION_SYNC_CANONICAL],
+            ];
+        }
+
+        if (trim((string) data_get($seoMeta, 'robots', '')) !== $expectedRobots) {
+            $issues[] = [
+                'code' => self::ISSUE_ROBOTS,
+                'label' => 'Robots drift',
+                'autofix' => [self::ACTION_SYNC_ROBOTS],
+            ];
+        }
+
+        if ($type === 'article' && $seoMeta instanceof ArticleSeoMeta && $seoMeta->is_indexable !== $isIndexable) {
+            $issues[] = [
+                'code' => self::ISSUE_INDEXABILITY,
+                'label' => 'Indexability mismatch',
+                'autofix' => [self::ACTION_SYNC_ROBOTS],
+            ];
+        }
+
+        if ($this->hasSocialGap($type, $record, $seoMeta)) {
+            $issues[] = [
+                'code' => self::ISSUE_SOCIAL,
+                'label' => 'Social preview gaps',
+                'autofix' => [self::ACTION_FILL_METADATA],
+            ];
+        }
+
+        if ($isPublishedPublic && (! $isIndexable || $this->hasGrowthBlocker($type, $record, $seoMeta))) {
+            $issues[] = [
+                'code' => self::ISSUE_GROWTH,
+                'label' => ! $isIndexable ? 'Discovery blocked by noindex' : 'Published discovery blockers',
+                'autofix' => $isIndexable
+                    ? [self::ACTION_FILL_METADATA, self::ACTION_SYNC_CANONICAL, self::ACTION_SYNC_ROBOTS]
+                    : [self::ACTION_MARK_INDEXABLE],
+            ];
+        }
+
+        return $issues;
+    }
+
+    public function isSeoReady(string $type, object $record): bool
+    {
+        return $this->issuesFor($type, $record) === [];
+    }
+
+    public function isGrowthReady(string $type, object $record): bool
+    {
+        return $this->isPublishedPublic($type, $record)
+            && (bool) data_get($record, 'is_indexable')
+            && ! $this->hasGrowthBlocker($type, $record, $this->seoMetaFor($record));
+    }
+
+    public function expectedCanonical(string $type, object $record): ?string
+    {
+        return match ($type) {
+            'article' => $this->articleSeoService->buildCanonicalUrl(
+                (string) data_get($record, 'slug', ''),
+                (string) data_get($record, 'locale', 'en'),
+            ),
+            'guide' => $record instanceof CareerGuide ? $this->careerGuideSeoService->buildCanonicalUrl($record) : null,
+            'job' => $record instanceof CareerJob ? $this->careerJobSeoService->buildCanonicalUrl(
+                $record,
+                (string) data_get($record, 'locale', 'en'),
+            ) : null,
+            default => null,
+        };
+    }
+
+    public function expectedRobots(string $type, object $record): string
+    {
+        $isIndexable = (bool) data_get($record, 'is_indexable');
+
+        return match ($type) {
+            'article' => $isIndexable ? 'index,follow' : 'noindex,nofollow',
+            'guide', 'job' => $isIndexable ? 'index,follow' : 'noindex,follow',
+            default => $isIndexable ? 'index,follow' : 'noindex,follow',
+        };
+    }
+
+    private function applyActionToRecord(string $type, object $record, string $action): void
+    {
+        match ($action) {
+            self::ACTION_FILL_METADATA => $this->fillMetadata($type, $record),
+            self::ACTION_SYNC_CANONICAL => $this->syncCanonical($type, $record),
+            self::ACTION_SYNC_ROBOTS => $this->syncRobots($type, $record),
+            self::ACTION_MARK_INDEXABLE => $this->markIndexability($type, $record, true),
+            self::ACTION_MARK_NOINDEX => $this->markIndexability($type, $record, false),
+            default => null,
+        };
+    }
+
+    private function fillMetadata(string $type, object $record): void
+    {
+        if ($type === 'article' && $record instanceof Article) {
+            $descriptionSource = trim((string) ($record->excerpt ?? ''));
+            if ($descriptionSource === '') {
+                $descriptionSource = $this->normalizeWhitespace(strip_tags((string) $record->content_md));
+            }
+
+            $fallbackTitle = Str::limit(trim((string) $record->title), 60, '');
+            $fallbackDescription = Str::limit($descriptionSource, 160, '');
+            $fallbackOgTitle = Str::limit(trim((string) $record->title), 90, '');
+            $fallbackOgDescription = Str::limit($descriptionSource, 200, '');
+            $fallbackCanonical = $this->expectedCanonical('article', $record) ?? '';
+            $fallbackRobots = $this->expectedRobots('article', $record);
+            $meta = ArticleSeoMeta::query()->withoutGlobalScopes()->firstOrNew([
+                'org_id' => (int) $record->org_id,
+                'article_id' => (int) $record->id,
+                'locale' => (string) $record->locale,
+            ]);
+
+            $meta->fill([
+                'seo_title' => $this->preserveOrFill($meta->seo_title, $fallbackTitle),
+                'seo_description' => $this->preserveOrFill($meta->seo_description, $fallbackDescription),
+                'canonical_url' => $this->preserveOrFill($meta->canonical_url, $fallbackCanonical),
+                'og_title' => $this->preserveOrFill($meta->og_title, $fallbackOgTitle),
+                'og_description' => $this->preserveOrFill($meta->og_description, $fallbackOgDescription),
+                'robots' => $this->preserveOrFill($meta->robots, $fallbackRobots),
+                'is_indexable' => (bool) $record->is_indexable,
+            ]);
+            $meta->save();
+
+            return;
+        }
+
+        if ($type === 'guide' && $record instanceof CareerGuide) {
+            $payload = $this->careerGuideSeoService->buildSeoPayload($record);
+            $meta = CareerGuideSeoMeta::query()->firstOrNew([
+                'career_guide_id' => (int) $record->id,
+            ]);
+
+            $meta->fill([
+                'seo_title' => $this->preserveOrFill($meta->seo_title, (string) data_get($payload, 'title', '')),
+                'seo_description' => $this->preserveOrFill($meta->seo_description, (string) data_get($payload, 'description', '')),
+                'canonical_url' => $this->preserveOrFill($meta->canonical_url, (string) data_get($payload, 'canonical', '')),
+                'og_title' => $this->preserveOrFill($meta->og_title, (string) data_get($payload, 'og.title', '')),
+                'og_description' => $this->preserveOrFill($meta->og_description, (string) data_get($payload, 'og.description', '')),
+                'og_image_url' => $this->preserveOrFill($meta->og_image_url, (string) data_get($payload, 'og.image', '')),
+                'twitter_title' => $this->preserveOrFill($meta->twitter_title, (string) data_get($payload, 'twitter.title', '')),
+                'twitter_description' => $this->preserveOrFill($meta->twitter_description, (string) data_get($payload, 'twitter.description', '')),
+                'twitter_image_url' => $this->preserveOrFill($meta->twitter_image_url, (string) data_get($payload, 'twitter.image', '')),
+                'robots' => $this->preserveOrFill($meta->robots, (string) data_get($payload, 'robots', '')),
+            ]);
+            $meta->save();
+
+            return;
+        }
+
+        if ($type === 'job' && $record instanceof CareerJob) {
+            $payload = $this->careerJobSeoService->buildMeta($record, (string) $record->locale);
+            $meta = CareerJobSeoMeta::query()->firstOrNew([
+                'job_id' => (int) $record->id,
+            ]);
+
+            $meta->fill([
+                'seo_title' => $this->preserveOrFill($meta->seo_title, (string) data_get($payload, 'title', '')),
+                'seo_description' => $this->preserveOrFill($meta->seo_description, (string) data_get($payload, 'description', '')),
+                'canonical_url' => $this->preserveOrFill($meta->canonical_url, (string) data_get($payload, 'canonical', '')),
+                'og_title' => $this->preserveOrFill($meta->og_title, (string) data_get($payload, 'og.title', '')),
+                'og_description' => $this->preserveOrFill($meta->og_description, (string) data_get($payload, 'og.description', '')),
+                'og_image_url' => $this->preserveOrFill($meta->og_image_url, (string) data_get($payload, 'og.image', '')),
+                'twitter_title' => $this->preserveOrFill($meta->twitter_title, (string) data_get($payload, 'twitter.title', '')),
+                'twitter_description' => $this->preserveOrFill($meta->twitter_description, (string) data_get($payload, 'twitter.description', '')),
+                'twitter_image_url' => $this->preserveOrFill($meta->twitter_image_url, (string) data_get($payload, 'twitter.image', '')),
+                'robots' => $this->preserveOrFill($meta->robots, (string) data_get($payload, 'robots', '')),
+            ]);
+            $meta->save();
+        }
+    }
+
+    private function syncCanonical(string $type, object $record): void
+    {
+        $expectedCanonical = $this->expectedCanonical($type, $record);
+        if ($expectedCanonical === null) {
+            return;
+        }
+
+        $meta = $this->ensureSeoMeta($type, $record);
+        if (! is_object($meta)) {
+            return;
+        }
+
+        $meta->canonical_url = $expectedCanonical;
+        $meta->save();
+    }
+
+    private function syncRobots(string $type, object $record): void
+    {
+        $meta = $this->ensureSeoMeta($type, $record);
+        if (! is_object($meta)) {
+            return;
+        }
+
+        $meta->robots = $this->expectedRobots($type, $record);
+        if ($meta instanceof ArticleSeoMeta) {
+            $meta->is_indexable = (bool) data_get($record, 'is_indexable');
+        }
+
+        $meta->save();
+    }
+
+    private function markIndexability(string $type, object $record, bool $isIndexable): void
+    {
+        if (method_exists($record, 'forceFill')) {
+            $record->forceFill([
+                'is_indexable' => $isIndexable,
+            ])->save();
+        }
+
+        $this->syncRobots($type, $record);
+    }
+
+    /**
+     * @param  list<int>  $currentOrgIds
+     * @return iterable<int, array{0:string,1:object}>
+     */
+    private function recordsFor(array $currentOrgIds, string $typeFilter): iterable
+    {
+        if (in_array($typeFilter, ['all', 'article'], true)) {
+            $records = Article::query()
+                ->whereIn('org_id', $currentOrgIds)
+                ->with('seoMeta')
+                ->latest('updated_at')
+                ->get();
+
+            foreach ($records as $record) {
+                yield ['article', $record];
+            }
+        }
+
+        if (in_array($typeFilter, ['all', 'guide'], true)) {
+            $records = CareerGuide::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->with('seoMeta')
+                ->latest('updated_at')
+                ->get();
+
+            foreach ($records as $record) {
+                yield ['guide', $record];
+            }
+        }
+
+        if (in_array($typeFilter, ['all', 'job'], true)) {
+            $records = CareerJob::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->with('seoMeta')
+                ->latest('updated_at')
+                ->get();
+
+            foreach ($records as $record) {
+                yield ['job', $record];
+            }
+        }
+    }
+
+    /**
+     * @param  list<int>  $currentOrgIds
+     * @return array{0:string,1:object|null}
+     */
+    private function recordFromSelectionKey(string $selectionKey, array $currentOrgIds): array
+    {
+        $type = Str::before($selectionKey, ':');
+        $id = (int) Str::after($selectionKey, ':');
+
+        if ($id <= 0) {
+            return [$type, null];
+        }
+
+        return match ($type) {
+            'article' => [
+                'article',
+                Article::query()->whereIn('org_id', $currentOrgIds)->with('seoMeta')->find($id),
+            ],
+            'guide' => [
+                'guide',
+                CareerGuide::query()->withoutGlobalScopes()->where('org_id', 0)->with('seoMeta')->find($id),
+            ],
+            'job' => [
+                'job',
+                CareerJob::query()->withoutGlobalScopes()->where('org_id', 0)->with('seoMeta')->find($id),
+            ],
+            default => [$type, null],
+        };
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function issueItem(string $type, object $record, string $issueFilter): ?array
+    {
+        $issues = $this->issuesFor($type, $record);
+        if ($issues === []) {
+            return null;
+        }
+
+        if ($issueFilter !== 'all' && ! collect($issues)->contains(fn (array $issue): bool => $issue['code'] === $issueFilter)) {
+            return null;
+        }
+
+        $autofixActions = array_values(array_unique(array_merge(...array_map(
+            static fn (array $issue): array => $issue['autofix'] ?? [],
+            $issues
+        ))));
+
+        return [
+            'selection_key' => $type.':'.(int) data_get($record, 'id'),
+            'type' => $type,
+            'title' => trim((string) data_get($record, 'title', 'Untitled')),
+            'scope' => $type === 'article' ? 'Current org' : 'Global content',
+            'status' => trim((string) data_get($record, 'status', 'draft')),
+            'is_public' => (bool) data_get($record, 'is_public'),
+            'is_indexable' => (bool) data_get($record, 'is_indexable'),
+            'issue_labels' => array_values(array_map(static fn (array $issue): string => $issue['label'], $issues)),
+            'issue_count' => count($issues),
+            'autofix_actions' => $autofixActions,
+            'growth_signal' => $this->growthSignal($type, $record),
+            'edit_url' => $this->editUrl($type, (int) data_get($record, 'id')),
+            'updated_at' => optional(data_get($record, 'updated_at'))->toISOString(),
+        ];
+    }
+
+    private function hasMetadataGap(string $type, object $record, ?object $seoMeta): bool
+    {
+        $fields = [
+            trim((string) data_get($seoMeta, 'seo_title', '')),
+            trim((string) data_get($seoMeta, 'seo_description', '')),
+            trim((string) data_get($seoMeta, 'og_title', '')),
+            trim((string) data_get($seoMeta, 'og_description', '')),
+        ];
+
+        if ($type !== 'article') {
+            $fields[] = trim((string) data_get($seoMeta, 'twitter_title', ''));
+            $fields[] = trim((string) data_get($seoMeta, 'twitter_description', ''));
+        }
+
+        return in_array('', $fields, true);
+    }
+
+    private function hasSocialGap(string $type, object $record, ?object $seoMeta): bool
+    {
+        $fields = [
+            trim((string) data_get($seoMeta, 'og_title', '')),
+            trim((string) data_get($seoMeta, 'og_description', '')),
+            trim((string) data_get($seoMeta, 'og_image_url', '')),
+        ];
+
+        if ($type !== 'article') {
+            $fields[] = trim((string) data_get($seoMeta, 'twitter_title', ''));
+            $fields[] = trim((string) data_get($seoMeta, 'twitter_description', ''));
+        }
+
+        return in_array('', $fields, true);
+    }
+
+    private function hasGrowthBlocker(string $type, object $record, ?object $seoMeta): bool
+    {
+        return $this->hasMetadataGap($type, $record, $seoMeta)
+            || trim((string) data_get($seoMeta, 'canonical_url', '')) !== $this->expectedCanonical($type, $record)
+            || trim((string) data_get($seoMeta, 'robots', '')) !== $this->expectedRobots($type, $record);
+    }
+
+    private function isPublishedPublic(string $type, object $record): bool
+    {
+        return (bool) data_get($record, 'is_public')
+            && match ($type) {
+                'guide' => data_get($record, 'status') === CareerGuide::STATUS_PUBLISHED,
+                'job' => data_get($record, 'status') === CareerJob::STATUS_PUBLISHED,
+                default => data_get($record, 'status') === 'published',
+            };
+    }
+
+    public function growthSignal(string $type, object $record): string
+    {
+        $seoMeta = $this->seoMetaFor($record);
+
+        if (! $this->isPublishedPublic($type, $record)) {
+            return 'Not discoverable yet';
+        }
+
+        if (! (bool) data_get($record, 'is_indexable')) {
+            return 'Blocked by noindex';
+        }
+
+        if ($this->hasGrowthBlocker($type, $record, $seoMeta)) {
+            return 'Published with discovery blockers';
+        }
+
+        return 'Discoverable now';
+    }
+
+    private function ensureSeoMeta(string $type, object $record): ?object
+    {
+        $existing = $this->seoMetaFor($record);
+        if (is_object($existing)) {
+            return $existing;
+        }
+
+        $this->fillMetadata($type, $record);
+
+        return $this->seoMetaFor($record instanceof Article || $record instanceof CareerGuide || $record instanceof CareerJob ? $record->fresh('seoMeta') : $record);
+    }
+
+    private function seoMetaFor(object $record): ?object
+    {
+        $seoMeta = data_get($record, 'seoMeta');
+
+        return is_object($seoMeta) ? $seoMeta : null;
+    }
+
+    private function preserveOrFill(?string $current, string $fallback): string
+    {
+        $normalized = trim((string) $current);
+
+        return $normalized !== '' ? $normalized : trim($fallback);
+    }
+
+    private function normalizeWhitespace(string $value): string
+    {
+        $normalized = preg_replace('/\s+/u', ' ', trim($value));
+
+        return is_string($normalized) ? $normalized : trim($value);
+    }
+
+    private function editUrl(string $type, int $id): string
+    {
+        return match ($type) {
+            'article' => \App\Filament\Ops\Resources\ArticleResource::getUrl('edit', ['record' => $id]),
+            'guide' => \App\Filament\Ops\Resources\CareerGuideResource::getUrl('edit', ['record' => $id]),
+            'job' => \App\Filament\Ops\Resources\CareerJobResource::getUrl('edit', ['record' => $id]),
+            default => '#',
+        };
+    }
+}

--- a/backend/app/Services/Ops/SeoOperationsService.php
+++ b/backend/app/Services/Ops/SeoOperationsService.php
@@ -39,6 +39,16 @@ final class SeoOperationsService
 
     public const ISSUE_GROWTH = 'growth';
 
+    /**
+     * @var list<string>
+     */
+    private const CORE_SEO_ISSUES = [
+        self::ISSUE_METADATA,
+        self::ISSUE_CANONICAL,
+        self::ISSUE_ROBOTS,
+        self::ISSUE_INDEXABILITY,
+    ];
+
     public function __construct(
         private readonly ArticleSeoService $articleSeoService,
         private readonly CareerGuideSeoService $careerGuideSeoService,
@@ -154,7 +164,7 @@ final class SeoOperationsService
             $issues[] = [
                 'code' => self::ISSUE_SOCIAL,
                 'label' => 'Social preview gaps',
-                'autofix' => [self::ACTION_FILL_METADATA],
+                'autofix' => $this->socialAutofixActions($type, $record, $seoMeta),
             ];
         }
 
@@ -173,7 +183,10 @@ final class SeoOperationsService
 
     public function isSeoReady(string $type, object $record): bool
     {
-        return $this->issuesFor($type, $record) === [];
+        return collect($this->issuesFor($type, $record))
+            ->pluck('code')
+            ->intersect(self::CORE_SEO_ISSUES)
+            ->isEmpty();
     }
 
     public function isGrowthReady(string $type, object $record): bool
@@ -234,6 +247,7 @@ final class SeoOperationsService
             $fallbackDescription = Str::limit($descriptionSource, 160, '');
             $fallbackOgTitle = Str::limit(trim((string) $record->title), 90, '');
             $fallbackOgDescription = Str::limit($descriptionSource, 200, '');
+            $fallbackOgImage = trim((string) ($record->cover_image_url ?? ''));
             $fallbackCanonical = $this->expectedCanonical('article', $record) ?? '';
             $fallbackRobots = $this->expectedRobots('article', $record);
             $meta = ArticleSeoMeta::query()->withoutGlobalScopes()->firstOrNew([
@@ -248,6 +262,7 @@ final class SeoOperationsService
                 'canonical_url' => $this->preserveOrFill($meta->canonical_url, $fallbackCanonical),
                 'og_title' => $this->preserveOrFill($meta->og_title, $fallbackOgTitle),
                 'og_description' => $this->preserveOrFill($meta->og_description, $fallbackOgDescription),
+                'og_image_url' => $this->preserveOrFill($meta->og_image_url, $fallbackOgImage),
                 'robots' => $this->preserveOrFill($meta->robots, $fallbackRobots),
                 'is_indexable' => (bool) $record->is_indexable,
             ]);
@@ -521,6 +536,36 @@ final class SeoOperationsService
         }
 
         return 'Discoverable now';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function socialAutofixActions(string $type, object $record, ?object $seoMeta): array
+    {
+        $missingCoreSocialFields = [
+            trim((string) data_get($seoMeta, 'og_title', '')) === '',
+            trim((string) data_get($seoMeta, 'og_description', '')) === '',
+        ];
+
+        if ($type !== 'article') {
+            $missingCoreSocialFields[] = trim((string) data_get($seoMeta, 'twitter_title', '')) === '';
+            $missingCoreSocialFields[] = trim((string) data_get($seoMeta, 'twitter_description', '')) === '';
+        }
+
+        $canFillTextualSocialFields = in_array(true, $missingCoreSocialFields, true);
+
+        $missingSocialImage = trim((string) data_get($seoMeta, 'og_image_url', '')) === '';
+        $hasImageSource = trim((string) match ($type) {
+            'article', 'job' => data_get($record, 'cover_image_url', ''),
+            default => '',
+        }) !== '';
+
+        if ($canFillTextualSocialFields || ($missingSocialImage && $hasImageSource)) {
+            return [self::ACTION_FILL_METADATA];
+        }
+
+        return [];
     }
 
     private function ensureSeoMeta(string $type, object $record): ?object

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -128,16 +128,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.369.24",
+            "version": "3.374.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "17f404a47879c1fb47175ac2b61881ab0dc2dc5c"
+                "reference": "67b6b6210af47319c74c5666388d71bc1bc58276"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/17f404a47879c1fb47175ac2b61881ab0dc2dc5c",
-                "reference": "17f404a47879c1fb47175ac2b61881ab0dc2dc5c",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/67b6b6210af47319c74c5666388d71bc1bc58276",
+                "reference": "67b6b6210af47319c74c5666388d71bc1bc58276",
                 "shasum": ""
             },
             "require": {
@@ -158,12 +158,12 @@
                 "aws/aws-php-sns-message-validator": "~1.0",
                 "behat/behat": "~3.0",
                 "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
                 "ext-sockets": "*",
-                "phpunit/phpunit": "^9.6",
+                "phpunit/phpunit": "^10.0",
                 "psr/cache": "^2.0 || ^3.0",
                 "psr/simple-cache": "^2.0 || ^3.0",
                 "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
@@ -201,11 +201,11 @@
             "authors": [
                 {
                     "name": "Amazon Web Services",
-                    "homepage": "http://aws.amazon.com"
+                    "homepage": "https://aws.amazon.com"
                 }
             ],
             "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
-            "homepage": "http://aws.amazon.com/sdkforphp",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
             "keywords": [
                 "amazon",
                 "aws",
@@ -219,9 +219,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.369.24"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.374.2"
             },
-            "time": "2026-01-30T19:14:32+00:00"
+            "time": "2026-03-27T18:05:55+00:00"
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -1910,16 +1910,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -1935,6 +1935,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -2006,7 +2007,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -2022,7 +2023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -2643,16 +2644,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.0",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb"
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
                 "shasum": ""
             },
             "require": {
@@ -2677,9 +2678,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -2746,7 +2747,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-26T21:48:24+00:00"
+            "time": "2026-03-19T13:16:38+00:00"
         },
         {
             "name": "league/config",
@@ -3765,16 +3766,16 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.3",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
@@ -3782,8 +3783,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -3824,22 +3827,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.3"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2025-10-30T22:57:59+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.1",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72"
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c99059c0315591f1a0db7ad6002000288ab8dc72",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72",
+                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
                 "shasum": ""
             },
             "require": {
@@ -3851,8 +3854,10 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -3913,9 +3918,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.1"
+                "source": "https://github.com/nette/utils/tree/v4.1.3"
             },
-            "time": "2025-12-22T12:14:32+00:00"
+            "time": "2026-02-13T03:05:33+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -6037,16 +6042,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v8.0.1",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d"
+                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d937d400b980523dc9ee946bb69972b5e619058d",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7bf9162d7a0dff98d079b72948508fa48018a770",
+                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770",
                 "shasum": ""
             },
             "require": {
@@ -6083,7 +6088,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.0.1"
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -6103,7 +6108,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-01T09:13:36+00:00"
+            "time": "2026-02-25T16:59:43+00:00"
         },
         {
             "name": "symfony/finder",
@@ -8564,16 +8569,16 @@
         },
         {
             "name": "yansongda/pay",
-            "version": "v3.7.19",
+            "version": "v3.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yansongda/pay.git",
-                "reference": "57eaeff84bd4a19c4d09656a3c45250c9a032aa2"
+                "reference": "26987ebf789f1e7f0a85febb640986ab4289fd7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yansongda/pay/zipball/57eaeff84bd4a19c4d09656a3c45250c9a032aa2",
-                "reference": "57eaeff84bd4a19c4d09656a3c45250c9a032aa2",
+                "url": "https://api.github.com/repos/yansongda/pay/zipball/26987ebf789f1e7f0a85febb640986ab4289fd7f",
+                "reference": "26987ebf789f1e7f0a85febb640986ab4289fd7f",
                 "shasum": ""
             },
             "require": {
@@ -8633,7 +8638,7 @@
                 "issues": "https://github.com/yansongda/pay/issues",
                 "source": "https://github.com/yansongda/pay"
             },
-            "time": "2025-12-22T03:30:53+00:00"
+            "time": "2026-03-23T07:33:29+00:00"
         },
         {
             "name": "yansongda/supports",

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -57,7 +57,6 @@ return [
             'ai_insight_feedback',
             'ai_insights',
             'auth_tokens',
-            'attempt_quality',
             'attempts',
             'attempt_submissions',
             'audit_logs',

--- a/backend/database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php
+++ b/backend/database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php
@@ -37,16 +37,14 @@ return new class extends Migration
             });
         }
 
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->string('disk', 32)
-                ->charset('ascii')
-                ->collation('ascii_bin')
-                ->change();
-            $table->string('storage_path', 1024)
-                ->charset('ascii')
-                ->collation('ascii_bin')
-                ->change();
-        });
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY `disk` VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
+            self::TABLE
+        ));
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY `storage_path` VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
+            self::TABLE
+        ));
 
         if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
             Schema::table(self::TABLE, function (Blueprint $table): void {

--- a/backend/database/migrations/2026_03_26_200000_normalize_content_release_exact_manifest_files_index_portability.php
+++ b/backend/database/migrations/2026_03_26_200000_normalize_content_release_exact_manifest_files_index_portability.php
@@ -45,12 +45,10 @@ return new class extends Migration
             });
         }
 
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->string('logical_path', 1024)
-                ->charset('ascii')
-                ->collation('ascii_bin')
-                ->change();
-        });
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY `logical_path` VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
+            self::TABLE
+        ));
 
         if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
             Schema::table(self::TABLE, function (Blueprint $table): void {

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -303,6 +303,29 @@
                 "x-laravel-name": "api.v0_3.attempts.report"
             }
         },
+        "/api/v0.3/attempts/{id}/report-access": {
+            "get": {
+                "operationId": "api.v0_3.attempts.report_access",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@reportAccess",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.report_access"
+            }
+        },
         "/api/v0.3/attempts/{id}/report.pdf": {
             "get": {
                 "operationId": "api.v0_3.attempts.report_pdf",
@@ -1421,6 +1444,90 @@
                 ]
             }
         },
+        "/api/v0.3/public-gateways/help": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_help",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@help",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/public-gateways/help/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_help_slug_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@helpDetail",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/public-gateways/home": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_home",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@home",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/public-gateways/tests": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_tests",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@tests",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
         "/api/v0.3/scales": {
             "get": {
                 "operationId": "get_api_v0_3_scales",
@@ -2152,7 +2259,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -2176,7 +2283,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -2200,7 +2307,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:release"
                 ]
             }
         },
@@ -2224,7 +2331,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -2248,7 +2355,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:release"
                 ]
             }
         },

--- a/backend/resources/views/filament/ops/pages/seo-operations.blade.php
+++ b/backend/resources/views/filament/ops/pages/seo-operations.blade.php
@@ -6,9 +6,45 @@
             description="Operate the visible CMS SEO footprint across current-org articles and global career content without mixing in support search or content-pack control plane work."
         >
             <x-filament-ops::ops-toolbar>
-                <div class="ops-control-stack">
-                    <span class="ops-control-label">SEO contract</span>
-                    <p class="ops-control-hint">This page only measures SEO fields that already exist in the visible CMS models and authoring workspaces.</p>
+                <div class="ops-toolbar-grid">
+                    <label class="ops-control-stack" for="ops-seo-type-filter">
+                        <span class="ops-control-label">Content type</span>
+                        <select id="ops-seo-type-filter" wire:model.live="typeFilter" class="ops-input">
+                            <option value="all">All visible content</option>
+                            <option value="article">Articles</option>
+                            <option value="guide">Career guides</option>
+                            <option value="job">Career jobs</option>
+                        </select>
+                    </label>
+
+                    <label class="ops-control-stack" for="ops-seo-issue-filter">
+                        <span class="ops-control-label">Issue focus</span>
+                        <select id="ops-seo-issue-filter" wire:model.live="issueFilter" class="ops-input">
+                            <option value="all">All issues</option>
+                            <option value="metadata">Metadata completeness</option>
+                            <option value="canonical">Canonical</option>
+                            <option value="robots">Robots</option>
+                            <option value="indexability">Indexability</option>
+                            <option value="social">Social previews</option>
+                            <option value="growth">Growth blockers</option>
+                        </select>
+                    </label>
+
+                    <label class="ops-control-stack" for="ops-seo-bulk-action">
+                        <span class="ops-control-label">Bulk action</span>
+                        <select id="ops-seo-bulk-action" wire:model="bulkAction" class="ops-input">
+                            <option value="fill_metadata">Fill metadata gaps</option>
+                            <option value="sync_canonical">Sync canonical</option>
+                            <option value="sync_robots">Sync robots</option>
+                            <option value="mark_indexable">Mark indexable</option>
+                            <option value="mark_noindex">Mark noindex</option>
+                        </select>
+                    </label>
+
+                    <div class="ops-control-stack">
+                        <span class="ops-control-label">SEO contract</span>
+                        <p class="ops-control-hint">This page operates only on metadata fields that already exist in the visible CMS models and authoring workspaces.</p>
+                    </div>
                 </div>
 
                 <x-slot name="actions">
@@ -29,6 +65,11 @@
                             Editorial Review
                         </x-filament::button>
                     @endif
+                    @if (\App\Filament\Ops\Support\ContentAccess::canWrite())
+                        <x-filament::button color="primary" type="button" wire:click="applyBulkAction">
+                            Apply SEO Action
+                        </x-filament::button>
+                    @endif
                 </x-slot>
             </x-filament-ops::ops-toolbar>
         </x-filament-ops::ops-section>
@@ -45,6 +86,13 @@
             description="Canonical, social, and robots coverage using the current SEO metadata tables."
         >
             <x-filament-ops::ops-field-grid :fields="$coverageFields" />
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Growth diagnostics"
+            description="Discovery readiness and growth blockers derived from the current public content contract."
+        >
+            <x-filament-ops::ops-field-grid :fields="$growthFields" />
         </x-filament-ops::ops-section>
 
         <x-filament-ops::ops-section
@@ -67,6 +115,92 @@
                         </x-slot>
                     </x-filament-ops::ops-result-card>
                 @endforeach
+            </div>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="SEO issue queue"
+            description="Operational queue for metadata completeness, canonical, robots, indexability, and growth blockers."
+        >
+            <div class="ops-control-stack">
+                <span class="ops-control-label">Query latency</span>
+                <p class="ops-control-hint">{{ $issueQueueElapsedMs }} ms across the visible SEO issue queue.</p>
+            </div>
+
+            <div class="ops-table-shell">
+                <table class="ops-table">
+                    <thead>
+                        <tr>
+                            @if (\App\Filament\Ops\Support\ContentAccess::canWrite())
+                                <th>Select</th>
+                            @endif
+                            <th>Record</th>
+                            <th>Scope</th>
+                            <th>Issues</th>
+                            <th>Growth signal</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($issueQueue as $item)
+                            <tr>
+                                @if (\App\Filament\Ops\Support\ContentAccess::canWrite())
+                                    <td>
+                                        <input
+                                            type="checkbox"
+                                            wire:model="selectedTargets"
+                                            value="{{ (string) ($item['selection_key'] ?? '') }}"
+                                        />
+                                    </td>
+                                @endif
+                                <td>
+                                    <div class="ops-control-stack">
+                                        <strong>{{ $item['title'] }}</strong>
+                                        <span class="ops-control-hint">
+                                            {{ strtoupper((string) ($item['type'] ?? 'content')) }}
+                                            |
+                                            {{ (string) ($item['status'] ?? 'draft') }}
+                                            |
+                                            {{ !empty($item['is_public']) ? 'public' : 'private' }}
+                                            |
+                                            {{ !empty($item['is_indexable']) ? 'indexable' : 'noindex' }}
+                                        </span>
+                                    </div>
+                                </td>
+                                <td>{{ $item['scope'] }}</td>
+                                <td>
+                                    <div class="ops-tag-list">
+                                        @foreach (($item['issue_labels'] ?? []) as $label)
+                                            <span class="ops-tag">{{ $label }}</span>
+                                        @endforeach
+                                    </div>
+                                </td>
+                                <td>{{ $item['growth_signal'] }}</td>
+                                <td>
+                                    <div class="ops-toolbar-inline">
+                                        <x-filament::button
+                                            size="xs"
+                                            color="gray"
+                                            tag="a"
+                                            href="{{ (string) ($item['edit_url'] ?? '#') }}"
+                                        >
+                                            Open
+                                        </x-filament::button>
+                                        @if (!empty($item['autofix_actions']))
+                                            <span class="ops-control-hint">{{ implode(', ', $item['autofix_actions']) }}</span>
+                                        @endif
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="{{ \App\Filament\Ops\Support\ContentAccess::canWrite() ? '6' : '5' }}">
+                                    <span class="ops-control-hint">No SEO issues match the current filters.</span>
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
             </div>
         </x-filament-ops::ops-section>
     </div>

--- a/backend/tests/Feature/Ops/SeoOperationsPageTest.php
+++ b/backend/tests/Feature/Ops/SeoOperationsPageTest.php
@@ -409,6 +409,65 @@ final class SeoOperationsPageTest extends TestCase
         $this->assertSame('Fix Guide', $guideSeo->seo_title);
     }
 
+    public function test_social_only_gap_stays_seo_ready_but_remains_operable_in_issue_queue(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $selectedOrg = $this->createOrganization('SEO Social Gap Org');
+
+        $article = Article::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'slug' => 'social-gap-article',
+            'locale' => 'en',
+            'title' => 'Social Gap Article',
+            'excerpt' => 'Social gap article excerpt',
+            'content_md' => 'Social gap body',
+            'cover_image_url' => 'https://example.test/images/social-gap-article.png',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::now()->subDay(),
+        ]);
+        ArticleSeoMeta::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Social Gap Article Title',
+            'seo_description' => 'Social Gap Article Description',
+            'canonical_url' => 'https://example.test/en/articles/social-gap-article',
+            'og_title' => 'Social Gap OG Title',
+            'og_description' => 'Social Gap OG Description',
+            'og_image_url' => '',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/seo-operations', 'POST'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        Livewire::test(SeoOperationsPage::class)
+            ->assertSet('headlineFields.0.value', '100% (1/1)')
+            ->set('issueFilter', SeoOperationsService::ISSUE_SOCIAL)
+            ->assertCount('issueQueue', 1)
+            ->assertSee('Social preview gaps')
+            ->set('selectedTargets', [
+                'article:'.$article->id,
+            ])
+            ->set('bulkAction', SeoOperationsService::ACTION_FILL_METADATA)
+            ->call('applyBulkAction')
+            ->assertSet('selectedTargets', [])
+            ->assertCount('issueQueue', 0);
+
+        $articleSeo = $article->seoMeta()->firstOrFail();
+
+        $this->assertSame('https://example.test/images/social-gap-article.png', $articleSeo->og_image_url);
+    }
+
     private function createOrganization(string $name): Organization
     {
         return Organization::query()->create([

--- a/backend/tests/Feature/Ops/SeoOperationsPageTest.php
+++ b/backend/tests/Feature/Ops/SeoOperationsPageTest.php
@@ -15,6 +15,7 @@ use App\Models\CareerJobSeoMeta;
 use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Role;
+use App\Services\Ops\SeoOperationsService;
 use App\Support\OrgContext;
 use App\Support\Rbac\PermissionNames;
 use Filament\Facades\Filament;
@@ -34,6 +35,7 @@ final class SeoOperationsPageTest extends TestCase
     {
         parent::setUp();
 
+        config()->set('app.frontend_url', 'https://example.test');
         Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
     }
 
@@ -51,7 +53,7 @@ final class SeoOperationsPageTest extends TestCase
             ->assertRedirectContains('/ops/select-org');
     }
 
-    public function test_seo_operations_page_renders_selected_org_and_global_seo_signals(): void
+    public function test_seo_operations_page_renders_operational_seo_and_growth_signals(): void
     {
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_READ,
@@ -77,7 +79,7 @@ final class SeoOperationsPageTest extends TestCase
             'locale' => 'en',
             'seo_title' => 'SEO Ready Article Title',
             'seo_description' => 'SEO Ready Article Description',
-            'canonical_url' => 'https://example.test/articles/seo-ready-article',
+            'canonical_url' => 'https://example.test/en/articles/seo-ready-article',
             'og_title' => 'SEO Ready OG Title',
             'og_description' => 'SEO Ready OG Description',
             'og_image_url' => 'https://example.test/images/seo-ready-article.png',
@@ -129,7 +131,7 @@ final class SeoOperationsPageTest extends TestCase
             'locale' => 'en',
             'seo_title' => 'Other Org SEO Title',
             'seo_description' => 'Other Org SEO Description',
-            'canonical_url' => 'https://example.test/articles/other-org-seo-article',
+            'canonical_url' => 'https://example.test/en/articles/other-org-seo-article',
             'og_title' => 'Other Org OG Title',
             'og_description' => 'Other Org OG Description',
             'og_image_url' => 'https://example.test/images/other-org-seo-article.png',
@@ -159,7 +161,7 @@ final class SeoOperationsPageTest extends TestCase
             'career_guide_id' => (int) $guideReady->id,
             'seo_title' => 'SEO Ready Guide Title',
             'seo_description' => 'SEO Ready Guide Description',
-            'canonical_url' => 'https://example.test/guides/seo-ready-guide',
+            'canonical_url' => 'https://example.test/en/career/guides/seo-ready-guide',
             'og_title' => 'SEO Ready Guide OG Title',
             'og_description' => 'SEO Ready Guide OG Description',
             'og_image_url' => 'https://example.test/images/seo-ready-guide.png',
@@ -218,7 +220,7 @@ final class SeoOperationsPageTest extends TestCase
             'job_id' => (int) $jobReady->id,
             'seo_title' => 'SEO Ready Job Title',
             'seo_description' => 'SEO Ready Job Description',
-            'canonical_url' => 'https://example.test/jobs/seo-ready-job',
+            'canonical_url' => 'https://example.test/en/career/jobs/seo-ready-job',
             'og_title' => 'SEO Ready Job OG Title',
             'og_description' => 'SEO Ready Job OG Description',
             'og_image_url' => 'https://example.test/images/seo-ready-job.png',
@@ -261,9 +263,8 @@ final class SeoOperationsPageTest extends TestCase
             ->get('/ops/seo-operations')
             ->assertOk()
             ->assertSee('SEO operations')
-            ->assertSee('SEO readiness')
-            ->assertSee('Coverage details')
-            ->assertSee('Attention queue')
+            ->assertSee('Growth diagnostics')
+            ->assertSee('SEO issue queue')
             ->assertSee('Article SEO gaps')
             ->assertSee('Career guide SEO gaps');
 
@@ -286,10 +287,126 @@ final class SeoOperationsPageTest extends TestCase
             ->assertSet('coverageFields.2.value', '50% (1/2)')
             ->assertSet('coverageFields.3.value', '50% (1/2)')
             ->assertSet('coverageFields.4.value', '3')
-            ->assertSet('attentionCards.0.value', '1')
-            ->assertSet('attentionCards.1.value', '1')
-            ->assertSet('attentionCards.2.value', '1')
-            ->assertSet('attentionCards.3.value', '2');
+            ->assertSet('growthFields.0.value', '2')
+            ->assertSet('growthFields.1.value', '3')
+            ->assertSet('growthFields.2.value', '1')
+            ->assertSet('growthFields.3.value', '50% (3/6)')
+            ->assertCount('issueQueue', 3)
+            ->assertSee('Published with discovery blockers')
+            ->assertDontSee('Other Org SEO Article');
+    }
+
+    public function test_seo_operations_can_apply_bulk_actions_to_fix_operational_gaps(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $selectedOrg = $this->createOrganization('SEO Fix Org');
+
+        $article = Article::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'slug' => 'fix-me-article',
+            'locale' => 'en',
+            'title' => 'Fix Me Article',
+            'excerpt' => 'Fix me article excerpt',
+            'content_md' => 'Fix body',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => Carbon::now()->subDay(),
+        ]);
+        ArticleSeoMeta::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => '',
+            'seo_description' => '',
+            'canonical_url' => 'https://example.test/wrong-article',
+            'og_title' => '',
+            'og_description' => '',
+            'og_image_url' => '',
+            'robots' => '',
+            'is_indexable' => true,
+        ]);
+
+        $guide = CareerGuide::query()->create([
+            'org_id' => 0,
+            'guide_code' => 'fix-guide',
+            'slug' => 'fix-guide',
+            'locale' => 'en',
+            'title' => 'Fix Guide',
+            'excerpt' => 'Fix guide excerpt',
+            'category_slug' => 'career-planning',
+            'body_md' => 'Guide body',
+            'body_html' => '<p>Guide body</p>',
+            'related_industry_slugs_json' => ['technology'],
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 0,
+            'schema_version' => 'v1',
+            'published_at' => Carbon::now()->subDay(),
+        ]);
+        CareerGuideSeoMeta::query()->create([
+            'career_guide_id' => (int) $guide->id,
+            'seo_title' => '',
+            'seo_description' => '',
+            'canonical_url' => 'https://example.test/wrong-guide',
+            'og_title' => '',
+            'og_description' => '',
+            'og_image_url' => '',
+            'twitter_title' => '',
+            'twitter_description' => '',
+            'twitter_image_url' => '',
+            'robots' => '',
+        ]);
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/seo-operations', 'POST'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        Livewire::test(SeoOperationsPage::class)
+            ->set('selectedTargets', [
+                'article:'.$article->id,
+                'guide:'.$guide->id,
+            ])
+            ->set('bulkAction', SeoOperationsService::ACTION_FILL_METADATA)
+            ->call('applyBulkAction')
+            ->assertSet('selectedTargets', [])
+            ->assertCount('issueQueue', 2)
+            ->set('selectedTargets', [
+                'article:'.$article->id,
+                'guide:'.$guide->id,
+            ])
+            ->set('bulkAction', SeoOperationsService::ACTION_SYNC_CANONICAL)
+            ->call('applyBulkAction')
+            ->set('selectedTargets', [
+                'article:'.$article->id,
+            ])
+            ->set('bulkAction', SeoOperationsService::ACTION_MARK_INDEXABLE)
+            ->call('applyBulkAction')
+            ->set('issueFilter', SeoOperationsService::ISSUE_GROWTH)
+            ->assertCount('issueQueue', 0)
+            ->set('issueFilter', SeoOperationsService::ISSUE_SOCIAL)
+            ->assertCount('issueQueue', 2)
+            ->assertSee('Fix Guide')
+            ->assertSee('Fix Me Article');
+
+        $article->refresh();
+        $guide->refresh();
+        $articleSeo = $article->seoMeta()->firstOrFail();
+        $guideSeo = $guide->seoMeta()->firstOrFail();
+
+        $this->assertTrue((bool) $article->is_indexable);
+        $this->assertSame('https://example.test/en/articles/fix-me-article', $articleSeo->canonical_url);
+        $this->assertSame('index,follow', $articleSeo->robots);
+        $this->assertSame('Fix Me Article', $articleSeo->seo_title);
+        $this->assertSame('https://example.test/en/career/guides/fix-guide', $guideSeo->canonical_url);
+        $this->assertSame('index,follow', $guideSeo->robots);
+        $this->assertSame('Fix Guide', $guideSeo->seo_title);
     }
 
     private function createOrganization(string $name): Organization


### PR DESCRIPTION
## Summary
- upgrade SEO Operations from a read-only dashboard into an operational queue with bulk fixes for metadata, canonical, robots, and indexability
- add growth diagnostics across visible CMS content and keep discovery blockers separate from social preview blockers
- refresh supporting safety baselines so ci_verify_mbti stays green (schema baseline, migration safety, openapi snapshot, dependency advisories)

## Tests
- php artisan route:list | rg "seo-operations|content-overview|content-search|content-metrics"
- php artisan migrate --force
- php artisan test tests/Feature/Ops/SeoOperationsPageTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/V0_5/CareerGuidePublicApiTest.php tests/Feature/V0_5/CareerJobPublicApiTest.php
- php artisan test tests/Feature/OpenApiDiffTest.php
- php artisan test tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php
- bash scripts/ci_verify_mbti.sh