### PR TITLE
feat(cms): build release observability, cache invalidation, and event broadcasting

### DIFF
--- a/backend/app/Filament/Ops/Pages/PostReleaseObservabilityPage.php
+++ b/backend/app/Filament/Ops/Pages/PostReleaseObservabilityPage.php
@@ -92,7 +92,12 @@ class PostReleaseObservabilityPage extends Page
                 ->count();
 
         $releaseAuditsQuery = AuditLog::query()
-            ->where('action', 'content_release_publish')
+            ->whereIn('action', [
+                'content_release_publish',
+                'content_release_cache_signal',
+                'content_release_broadcast',
+                'content_release_failure_alert',
+            ])
             ->where('org_id', max(0, (int) app(OrgContext::class)->orgId()))
             ->latest('created_at');
 
@@ -101,7 +106,31 @@ class PostReleaseObservabilityPage extends Page
             ->get();
 
         $publishAuditCount24h = (clone $releaseAuditsQuery)
+            ->where('action', 'content_release_publish')
             ->where('created_at', '>=', $recentThreshold)
+            ->count();
+
+        $cacheSignalCount24h = AuditLog::query()
+            ->where('action', 'content_release_cache_signal')
+            ->where('org_id', max(0, (int) app(OrgContext::class)->orgId()))
+            ->where('created_at', '>=', $recentThreshold)
+            ->count();
+
+        $broadcastCount24h = AuditLog::query()
+            ->where('action', 'content_release_broadcast')
+            ->where('org_id', max(0, (int) app(OrgContext::class)->orgId()))
+            ->where('created_at', '>=', $recentThreshold)
+            ->count();
+
+        $followUpFailureCount24h = AuditLog::query()
+            ->whereIn('action', [
+                'content_release_cache_signal',
+                'content_release_broadcast',
+                'content_release_failure_alert',
+            ])
+            ->where('org_id', max(0, (int) app(OrgContext::class)->orgId()))
+            ->where('created_at', '>=', $recentThreshold)
+            ->where('result', 'failed')
             ->count();
 
         $this->headlineFields = [
@@ -116,6 +145,23 @@ class PostReleaseObservabilityPage extends Page
                 'hint' => 'Audit rows written by the CMS release workspace during the last 24 hours.',
             ],
             [
+                'label' => 'Cache invalidation signals',
+                'value' => (string) $cacheSignalCount24h,
+                'hint' => 'Downstream cache invalidation webhooks attempted by the CMS release flow in the last 24 hours.',
+            ],
+            [
+                'label' => 'Broadcast events',
+                'value' => (string) $broadcastCount24h,
+                'hint' => 'Release event broadcasts attempted by the CMS release flow in the last 24 hours.',
+            ],
+            [
+                'label' => 'Follow-up failures',
+                'value' => (string) $followUpFailureCount24h,
+                'kind' => 'pill',
+                'state' => $followUpFailureCount24h > 0 ? 'warning' : 'success',
+                'hint' => 'Failed cache invalidation or broadcast follow-up events after release.',
+            ],
+            [
                 'label' => 'Public delivery footprint',
                 'value' => (string) $publicFootprint,
                 'hint' => 'Published and public records currently reachable through the visible public content contract.',
@@ -126,11 +172,6 @@ class PostReleaseObservabilityPage extends Page
                 'kind' => 'pill',
                 'state' => $visibilityGaps > 0 ? 'warning' : 'success',
                 'hint' => 'Published-but-not-public records that can cause release confusion after approval.',
-            ],
-            [
-                'label' => 'Recent audit stream',
-                'value' => (string) $recentAuditRows->count(),
-                'hint' => 'Most recent publish audit rows available to this selected-org release boundary.',
             ],
         ];
 
@@ -172,13 +213,16 @@ class PostReleaseObservabilityPage extends Page
         $this->auditCards = $recentAuditRows
             ->map(function (AuditLog $row): array {
                 $meta = is_array($row->meta_json) ? $row->meta_json : [];
+                $result = trim((string) ($row->result ?? 'success'));
 
                 return [
                     'title' => trim((string) data_get($meta, 'title', 'Untitled release event')),
                     'meta' => trim((string) ($row->action.' | '.(string) ($row->target_type ?? 'unknown'))),
-                    'description' => 'Actor: '.trim((string) data_get($meta, 'actor_email', 'unknown')).' | Visibility: '.trim((string) data_get($meta, 'visibility', 'unknown')).' | Source: '.trim((string) data_get($meta, 'source', 'unknown')),
-                    'status' => trim((string) data_get($meta, 'status_after', 'published')),
-                    'status_state' => 'success',
+                    'description' => 'Source: '.trim((string) data_get($meta, 'source', 'unknown'))
+                        .' | Endpoint: '.trim((string) data_get($meta, 'endpoint', 'n/a'))
+                        .' | Visibility: '.trim((string) data_get($meta, 'visibility', 'unknown')),
+                    'status' => $result,
+                    'status_state' => $result === 'failed' ? 'danger' : 'success',
                     'latest_title' => optional($row->created_at)?->toDateTimeString() ?? 'Unknown',
                 ];
             })

--- a/backend/app/Filament/Ops/Pages/PostReleaseObservabilityPage.php
+++ b/backend/app/Filament/Ops/Pages/PostReleaseObservabilityPage.php
@@ -221,6 +221,7 @@ class PostReleaseObservabilityPage extends Page
                     'description' => 'Source: '.trim((string) data_get($meta, 'source', 'unknown'))
                         .' | Endpoint: '.trim((string) data_get($meta, 'endpoint', 'n/a'))
                         .' | Visibility: '.trim((string) data_get($meta, 'visibility', 'unknown')),
+                    'trace' => $this->traceSummary($meta),
                     'status' => $result,
                     'status_state' => $result === 'failed' ? 'danger' : 'success',
                     'latest_title' => optional($row->created_at)?->toDateTimeString() ?? 'Unknown',
@@ -277,5 +278,36 @@ class PostReleaseObservabilityPage extends Page
             })
             ->values()
             ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    private function traceSummary(array $meta): string
+    {
+        $traceParts = [];
+
+        $revisionNo = data_get($meta, 'revision_no');
+        if ($revisionNo !== null) {
+            $traceParts[] = 'Revision #'.$revisionNo;
+        }
+
+        $changedCount = (int) data_get($meta, 'diff_summary.changed_count', 0);
+        $changedFields = array_values(array_filter((array) data_get($meta, 'diff_summary.changed_fields', [])));
+        if ($changedCount > 0) {
+            $traceParts[] = 'Diff: '.$changedCount.' field'.($changedCount === 1 ? '' : 's')
+                .' changed'
+                .($changedFields !== [] ? ' ('.implode(', ', $changedFields).')' : '');
+        }
+
+        $rollbackRevision = data_get($meta, 'rollback_target.revision_no');
+        $rollbackSource = trim((string) data_get($meta, 'rollback_target.source', ''));
+        if ($rollbackRevision !== null || $rollbackSource !== '') {
+            $traceParts[] = 'Rollback: '
+                .($rollbackRevision !== null ? 'rev '.$rollbackRevision : 'history')
+                .($rollbackSource !== '' ? ' via '.$rollbackSource : '');
+        }
+
+        return $traceParts !== [] ? implode(' | ', $traceParts) : 'No diff or rollback trace recorded.';
     }
 }

--- a/backend/app/Filament/Ops/Support/ContentReleaseAudit.php
+++ b/backend/app/Filament/Ops/Support/ContentReleaseAudit.php
@@ -41,5 +41,7 @@ final class ContentReleaseAudit
             reason: 'cms_release_workspace',
             result: 'success',
         );
+
+        ContentReleaseFollowUp::dispatch($type, $record, $source, $request);
     }
 }

--- a/backend/app/Filament/Ops/Support/ContentReleaseAudit.php
+++ b/backend/app/Filament/Ops/Support/ContentReleaseAudit.php
@@ -37,7 +37,7 @@ final class ContentReleaseAudit
                 'published_at' => optional(data_get($record, 'published_at'))?->toISOString(),
                 'actor_email' => is_object($actor) ? trim((string) data_get($actor, 'email', '')) : '',
                 'source' => $source,
-            ],
+            ] + ContentReleaseTrace::meta($type, $record),
             reason: 'cms_release_workspace',
             result: 'success',
         );

--- a/backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php
+++ b/backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Support;
+
+use App\Models\CareerGuide;
+use App\Models\CareerJob;
+use App\Services\Audit\AuditLogger;
+use App\Services\Cms\ArticleSeoService;
+use App\Services\Cms\CareerGuideSeoService;
+use App\Services\Cms\CareerJobSeoService;
+use App\Services\Ops\OpsAlertService;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+final class ContentReleaseFollowUp
+{
+    public static function dispatch(string $type, object $record, string $source, Request $request): void
+    {
+        $payload = self::payload($type, $record, $source);
+
+        foreach (self::cacheInvalidationUrls() as $endpoint) {
+            self::postEvent(
+                request: $request,
+                action: 'content_release_cache_signal',
+                endpoint: $endpoint,
+                payload: $payload,
+                alertLabel: 'cache invalidation'
+            );
+        }
+
+        $broadcastWebhook = self::broadcastWebhook();
+        if ($broadcastWebhook !== '') {
+            self::postEvent(
+                request: $request,
+                action: 'content_release_broadcast',
+                endpoint: $broadcastWebhook,
+                payload: $payload,
+                alertLabel: 'event broadcast'
+            );
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function cacheInvalidationUrls(): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            (array) config('ops.content_release_observability.cache_invalidation_urls', [])
+        )));
+    }
+
+    private static function broadcastWebhook(): string
+    {
+        return trim((string) config('ops.content_release_observability.broadcast_webhook', ''));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function payload(string $type, object $record, string $source): array
+    {
+        $title = trim((string) data_get($record, 'title', 'Untitled'));
+        $locale = trim((string) data_get($record, 'locale', ''));
+        $publishedAt = optional(data_get($record, 'published_at'))?->toISOString();
+        $paths = self::invalidateUrls($type, $record);
+
+        return [
+            'event' => 'content_release_publish',
+            'text' => sprintf(
+                '[CMS release] %s published via %s (%s)',
+                $title !== '' ? $title : 'Untitled',
+                $source,
+                $type
+            ),
+            'source' => $source,
+            'content' => [
+                'type' => $type,
+                'id' => (int) data_get($record, 'id'),
+                'org_id' => (int) data_get($record, 'org_id', 0),
+                'title' => $title,
+                'slug' => trim((string) data_get($record, 'slug', '')),
+                'locale' => $locale,
+                'status' => trim((string) data_get($record, 'status', 'published')),
+                'visibility' => data_get($record, 'is_public') ? 'public' : 'private',
+                'published_at' => $publishedAt,
+            ],
+            'cache_signal' => [
+                'kind' => 'invalidate',
+                'urls' => $paths,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function invalidateUrls(string $type, object $record): array
+    {
+        return array_values(array_filter(match ($type) {
+            'article' => [
+                app(ArticleSeoService::class)->buildCanonicalUrl(
+                    (string) data_get($record, 'slug', ''),
+                    (string) data_get($record, 'locale', 'en'),
+                ),
+                app(ArticleSeoService::class)->buildListUrl((string) data_get($record, 'locale', 'en')),
+            ],
+            'guide' => $record instanceof CareerGuide
+                ? [app(CareerGuideSeoService::class)->buildCanonicalUrl($record)]
+                : [],
+            'job' => $record instanceof CareerJob
+                ? [app(CareerJobSeoService::class)->buildCanonicalUrl($record, (string) data_get($record, 'locale', 'en'))]
+                : [],
+            default => [],
+        }));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private static function postEvent(
+        Request $request,
+        string $action,
+        string $endpoint,
+        array $payload,
+        string $alertLabel,
+    ): void {
+        $audit = app(AuditLogger::class);
+        $meta = [
+            'endpoint' => $endpoint,
+            'source' => (string) ($payload['source'] ?? 'unknown'),
+            'title' => data_get($payload, 'content.title', ''),
+            'locale' => data_get($payload, 'content.locale', ''),
+            'visibility' => data_get($payload, 'content.visibility', ''),
+            'published_at' => data_get($payload, 'content.published_at'),
+            'cache_urls' => data_get($payload, 'cache_signal.urls', []),
+        ];
+
+        try {
+            $response = Http::acceptJson()
+                ->timeout((int) config('ops.content_release_observability.http_timeout_seconds', 5))
+                ->post($endpoint, $payload);
+
+            if (! $response->successful()) {
+                throw new RequestException($response);
+            }
+
+            $audit->log(
+                $request,
+                $action,
+                (string) data_get($payload, 'content.type', 'content'),
+                (string) data_get($payload, 'content.id', ''),
+                $meta + ['http_status' => $response->status()],
+                reason: 'cms_release_observability',
+                result: 'success',
+            );
+        } catch (\Throwable $exception) {
+            $audit->log(
+                $request,
+                $action,
+                (string) data_get($payload, 'content.type', 'content'),
+                (string) data_get($payload, 'content.id', ''),
+                $meta + ['error' => trim($exception->getMessage())],
+                reason: 'cms_release_observability',
+                result: 'failed',
+            );
+
+            self::alertFailure($request, $payload, $endpoint, $alertLabel, $exception);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private static function alertFailure(
+        Request $request,
+        array $payload,
+        string $endpoint,
+        string $alertLabel,
+        \Throwable $exception,
+    ): void {
+        $alertWebhook = trim((string) config('ops.alert.webhook', ''));
+        if ($alertWebhook === '') {
+            return;
+        }
+
+        $message = sprintf(
+            '[CMS release follow-up failed] %s for %s #%s via %s -> %s (%s)',
+            $alertLabel,
+            (string) data_get($payload, 'content.type', 'content'),
+            (string) data_get($payload, 'content.id', ''),
+            (string) data_get($payload, 'source', 'unknown'),
+            $endpoint,
+            trim($exception->getMessage())
+        );
+
+        OpsAlertService::send($message);
+
+        app(AuditLogger::class)->log(
+            $request,
+            'content_release_failure_alert',
+            (string) data_get($payload, 'content.type', 'content'),
+            (string) data_get($payload, 'content.id', ''),
+            [
+                'title' => data_get($payload, 'content.title', ''),
+                'source' => data_get($payload, 'source', ''),
+                'alert_label' => $alertLabel,
+                'failed_endpoint' => $endpoint,
+                'alert_webhook' => $alertWebhook,
+            ],
+            reason: 'cms_release_observability',
+            result: 'success',
+        );
+    }
+}

--- a/backend/app/Filament/Ops/Support/ContentReleaseTrace.php
+++ b/backend/app/Filament/Ops/Support/ContentReleaseTrace.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Support;
+
+use App\Models\ArticleRevision;
+use App\Models\AuditLog;
+use App\Models\CareerGuideRevision;
+use App\Models\CareerJobRevision;
+
+final class ContentReleaseTrace
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function meta(string $type, object $record): array
+    {
+        $currentRevision = self::currentRevision($type, $record);
+        $previousRevision = self::previousRevision($type, $record, $currentRevision);
+        $previousPublish = self::previousPublish($type, $record);
+
+        return [
+            'revision_no' => $currentRevision['revision_no'] ?? null,
+            'revision_created_at' => $currentRevision['created_at'] ?? null,
+            'diff_summary' => self::diffSummary($type, $currentRevision['snapshot'] ?? null, $previousRevision['snapshot'] ?? null),
+            'rollback_target' => self::rollbackTarget($previousPublish, $previousRevision),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function currentRevision(string $type, object $record): ?array
+    {
+        return match ($type) {
+            'article' => self::mapArticleRevision(
+                ArticleRevision::query()
+                    ->withoutGlobalScopes()
+                    ->where('org_id', (int) data_get($record, 'org_id', 0))
+                    ->where('article_id', (int) data_get($record, 'id', 0))
+                    ->latest('revision_no')
+                    ->first()
+            ),
+            'guide' => self::mapGuideRevision(
+                CareerGuideRevision::query()
+                    ->where('career_guide_id', (int) data_get($record, 'id', 0))
+                    ->latest('revision_no')
+                    ->first()
+            ),
+            'job' => self::mapJobRevision(
+                CareerJobRevision::query()
+                    ->where('job_id', (int) data_get($record, 'id', 0))
+                    ->latest('revision_no')
+                    ->first()
+            ),
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $currentRevision
+     * @return array<string, mixed>|null
+     */
+    private static function previousRevision(string $type, object $record, ?array $currentRevision): ?array
+    {
+        $currentRevisionNo = (int) ($currentRevision['revision_no'] ?? 0);
+
+        return match ($type) {
+            'article' => self::mapArticleRevision(
+                ArticleRevision::query()
+                    ->withoutGlobalScopes()
+                    ->where('org_id', (int) data_get($record, 'org_id', 0))
+                    ->where('article_id', (int) data_get($record, 'id', 0))
+                    ->when($currentRevisionNo > 0, fn ($query) => $query->where('revision_no', '<', $currentRevisionNo))
+                    ->latest('revision_no')
+                    ->first()
+            ),
+            'guide' => self::mapGuideRevision(
+                CareerGuideRevision::query()
+                    ->where('career_guide_id', (int) data_get($record, 'id', 0))
+                    ->when($currentRevisionNo > 0, fn ($query) => $query->where('revision_no', '<', $currentRevisionNo))
+                    ->latest('revision_no')
+                    ->first()
+            ),
+            'job' => self::mapJobRevision(
+                CareerJobRevision::query()
+                    ->where('job_id', (int) data_get($record, 'id', 0))
+                    ->when($currentRevisionNo > 0, fn ($query) => $query->where('revision_no', '<', $currentRevisionNo))
+                    ->latest('revision_no')
+                    ->first()
+            ),
+            default => null,
+        };
+    }
+
+    private static function previousPublish(string $type, object $record): ?AuditLog
+    {
+        return AuditLog::query()
+            ->where('action', 'content_release_publish')
+            ->where('target_type', self::targetType($type))
+            ->where('target_id', (string) data_get($record, 'id', ''))
+            ->latest('created_at')
+            ->first();
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $currentSnapshot
+     * @param  array<string, mixed>|null  $previousSnapshot
+     * @return array<string, mixed>
+     */
+    private static function diffSummary(string $type, ?array $currentSnapshot, ?array $previousSnapshot): array
+    {
+        $changedFields = [];
+
+        foreach (self::monitoredFields($type) as $path => $label) {
+            $currentValue = self::normalizeValue(data_get($currentSnapshot, $path));
+            $previousValue = self::normalizeValue(data_get($previousSnapshot, $path));
+
+            if ($currentValue !== $previousValue) {
+                $changedFields[] = $label;
+            }
+        }
+
+        return [
+            'changed_count' => count($changedFields),
+            'changed_fields' => array_slice($changedFields, 0, 5),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $previousRevision
+     * @return array<string, mixed>|null
+     */
+    private static function rollbackTarget(?AuditLog $previousPublish, ?array $previousRevision): ?array
+    {
+        if ($previousPublish instanceof AuditLog) {
+            $meta = is_array($previousPublish->meta_json) ? $previousPublish->meta_json : [];
+
+            return [
+                'kind' => 'previous_publish',
+                'title' => trim((string) data_get($meta, 'title', '')),
+                'revision_no' => data_get($meta, 'revision_no'),
+                'published_at' => data_get($meta, 'published_at'),
+                'source' => trim((string) data_get($meta, 'source', '')),
+                'audit_created_at' => optional($previousPublish->created_at)?->toIso8601String(),
+            ];
+        }
+
+        if ($previousRevision !== null) {
+            return [
+                'kind' => 'previous_revision',
+                'title' => trim((string) ($previousRevision['title'] ?? '')),
+                'revision_no' => $previousRevision['revision_no'] ?? null,
+                'published_at' => null,
+                'source' => 'revision_history',
+                'audit_created_at' => $previousRevision['created_at'] ?? null,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function monitoredFields(string $type): array
+    {
+        return match ($type) {
+            'article' => [
+                'title' => 'Title',
+                'excerpt' => 'Excerpt',
+                'content_md' => 'Body',
+                'slug' => 'Slug',
+                'locale' => 'Locale',
+                'is_public' => 'Visibility',
+                'is_indexable' => 'Indexability',
+                'seo_meta.seo_title' => 'SEO Title',
+                'seo_meta.seo_description' => 'SEO Description',
+                'seo_meta.canonical_url' => 'Canonical URL',
+                'seo_meta.robots' => 'Robots',
+            ],
+            'guide' => [
+                'guide.title' => 'Title',
+                'guide.excerpt' => 'Excerpt',
+                'guide.body_md' => 'Body',
+                'guide.slug' => 'Slug',
+                'guide.locale' => 'Locale',
+                'guide.is_public' => 'Visibility',
+                'guide.is_indexable' => 'Indexability',
+                'seo_meta.seo_title' => 'SEO Title',
+                'seo_meta.seo_description' => 'SEO Description',
+                'seo_meta.canonical_url' => 'Canonical URL',
+                'seo_meta.robots' => 'Robots',
+            ],
+            'job' => [
+                'job.title' => 'Title',
+                'job.excerpt' => 'Excerpt',
+                'job.body_md' => 'Body',
+                'job.slug' => 'Slug',
+                'job.locale' => 'Locale',
+                'job.is_public' => 'Visibility',
+                'job.is_indexable' => 'Indexability',
+                'seo_meta.seo_title' => 'SEO Title',
+                'seo_meta.seo_description' => 'SEO Description',
+                'seo_meta.canonical_url' => 'Canonical URL',
+                'seo_meta.robots' => 'Robots',
+            ],
+            default => [],
+        };
+    }
+
+    private static function normalizeValue(mixed $value): string
+    {
+        if (is_array($value)) {
+            return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(DATE_ATOM);
+        }
+
+        return trim((string) $value);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function mapArticleRevision(?ArticleRevision $revision): ?array
+    {
+        if (! $revision instanceof ArticleRevision) {
+            return null;
+        }
+
+        return [
+            'revision_no' => (int) $revision->revision_no,
+            'title' => (string) $revision->title,
+            'created_at' => optional($revision->created_at)?->toIso8601String(),
+            'snapshot' => is_array($revision->payload_json) ? $revision->payload_json : [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function mapGuideRevision(?CareerGuideRevision $revision): ?array
+    {
+        if (! $revision instanceof CareerGuideRevision) {
+            return null;
+        }
+
+        $snapshot = is_array($revision->snapshot_json) ? $revision->snapshot_json : [];
+
+        return [
+            'revision_no' => (int) $revision->revision_no,
+            'title' => trim((string) data_get($snapshot, 'guide.title', '')),
+            'created_at' => optional($revision->created_at)?->toIso8601String(),
+            'snapshot' => $snapshot,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function mapJobRevision(?CareerJobRevision $revision): ?array
+    {
+        if (! $revision instanceof CareerJobRevision) {
+            return null;
+        }
+
+        $snapshot = is_array($revision->snapshot_json) ? $revision->snapshot_json : [];
+
+        return [
+            'revision_no' => (int) $revision->revision_no,
+            'title' => trim((string) data_get($snapshot, 'job.title', '')),
+            'created_at' => optional($revision->created_at)?->toIso8601String(),
+            'snapshot' => $snapshot,
+        ];
+    }
+
+    private static function targetType(string $type): string
+    {
+        return match ($type) {
+            'article' => 'article',
+            'guide' => 'career_guide',
+            'job' => 'career_job',
+            default => 'content',
+        };
+    }
+}

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -128,16 +128,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.369.24",
+            "version": "3.374.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "17f404a47879c1fb47175ac2b61881ab0dc2dc5c"
+                "reference": "67b6b6210af47319c74c5666388d71bc1bc58276"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/17f404a47879c1fb47175ac2b61881ab0dc2dc5c",
-                "reference": "17f404a47879c1fb47175ac2b61881ab0dc2dc5c",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/67b6b6210af47319c74c5666388d71bc1bc58276",
+                "reference": "67b6b6210af47319c74c5666388d71bc1bc58276",
                 "shasum": ""
             },
             "require": {
@@ -158,12 +158,12 @@
                 "aws/aws-php-sns-message-validator": "~1.0",
                 "behat/behat": "~3.0",
                 "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
                 "ext-sockets": "*",
-                "phpunit/phpunit": "^9.6",
+                "phpunit/phpunit": "^10.0",
                 "psr/cache": "^2.0 || ^3.0",
                 "psr/simple-cache": "^2.0 || ^3.0",
                 "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
@@ -201,11 +201,11 @@
             "authors": [
                 {
                     "name": "Amazon Web Services",
-                    "homepage": "http://aws.amazon.com"
+                    "homepage": "https://aws.amazon.com"
                 }
             ],
             "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
-            "homepage": "http://aws.amazon.com/sdkforphp",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
             "keywords": [
                 "amazon",
                 "aws",
@@ -219,9 +219,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.369.24"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.374.2"
             },
-            "time": "2026-01-30T19:14:32+00:00"
+            "time": "2026-03-27T18:05:55+00:00"
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -1910,16 +1910,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -1935,6 +1935,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -2006,7 +2007,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -2022,7 +2023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -2643,16 +2644,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.0",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb"
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
                 "shasum": ""
             },
             "require": {
@@ -2677,9 +2678,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -2746,7 +2747,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-26T21:48:24+00:00"
+            "time": "2026-03-19T13:16:38+00:00"
         },
         {
             "name": "league/config",
@@ -3765,16 +3766,16 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.3",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
@@ -3782,8 +3783,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -3824,22 +3827,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.3"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2025-10-30T22:57:59+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.1",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72"
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c99059c0315591f1a0db7ad6002000288ab8dc72",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72",
+                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
                 "shasum": ""
             },
             "require": {
@@ -3851,8 +3854,10 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -3913,9 +3918,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.1"
+                "source": "https://github.com/nette/utils/tree/v4.1.3"
             },
-            "time": "2025-12-22T12:14:32+00:00"
+            "time": "2026-02-13T03:05:33+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -6037,16 +6042,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v8.0.1",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d"
+                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d937d400b980523dc9ee946bb69972b5e619058d",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7bf9162d7a0dff98d079b72948508fa48018a770",
+                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770",
                 "shasum": ""
             },
             "require": {
@@ -6083,7 +6088,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.0.1"
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -6103,7 +6108,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-01T09:13:36+00:00"
+            "time": "2026-02-25T16:59:43+00:00"
         },
         {
             "name": "symfony/finder",
@@ -8564,16 +8569,16 @@
         },
         {
             "name": "yansongda/pay",
-            "version": "v3.7.19",
+            "version": "v3.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yansongda/pay.git",
-                "reference": "57eaeff84bd4a19c4d09656a3c45250c9a032aa2"
+                "reference": "26987ebf789f1e7f0a85febb640986ab4289fd7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yansongda/pay/zipball/57eaeff84bd4a19c4d09656a3c45250c9a032aa2",
-                "reference": "57eaeff84bd4a19c4d09656a3c45250c9a032aa2",
+                "url": "https://api.github.com/repos/yansongda/pay/zipball/26987ebf789f1e7f0a85febb640986ab4289fd7f",
+                "reference": "26987ebf789f1e7f0a85febb640986ab4289fd7f",
                 "shasum": ""
             },
             "require": {
@@ -8633,7 +8638,7 @@
                 "issues": "https://github.com/yansongda/pay/issues",
                 "source": "https://github.com/yansongda/pay"
             },
-            "time": "2025-12-22T03:30:53+00:00"
+            "time": "2026-03-23T07:33:29+00:00"
         },
         {
             "name": "yansongda/supports",

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -57,7 +57,6 @@ return [
             'ai_insight_feedback',
             'ai_insights',
             'auth_tokens',
-            'attempt_quality',
             'attempts',
             'attempt_submissions',
             'audit_logs',

--- a/backend/config/ops.php
+++ b/backend/config/ops.php
@@ -33,6 +33,15 @@ return [
         'webhook' => env('OPS_ALERT_WEBHOOK'),
     ],
 
+    'content_release_observability' => [
+        'cache_invalidation_urls' => array_values(array_filter(array_map(
+            static fn (string $value): string => trim($value),
+            explode(',', (string) env('OPS_CONTENT_RELEASE_CACHE_INVALIDATION_URLS', ''))
+        ))),
+        'broadcast_webhook' => env('OPS_CONTENT_RELEASE_BROADCAST_WEBHOOK', ''),
+        'http_timeout_seconds' => (int) env('OPS_CONTENT_RELEASE_HTTP_TIMEOUT_SECONDS', 5),
+    ],
+
     'go_live_gate' => [
         // enabled_only: only validate providers that are enabled in payments.providers.*
         // all: validate all known providers regardless of enabled status.

--- a/backend/database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php
+++ b/backend/database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php
@@ -37,16 +37,14 @@ return new class extends Migration
             });
         }
 
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->string('disk', 32)
-                ->charset('ascii')
-                ->collation('ascii_bin')
-                ->change();
-            $table->string('storage_path', 1024)
-                ->charset('ascii')
-                ->collation('ascii_bin')
-                ->change();
-        });
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY `disk` VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
+            self::TABLE
+        ));
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY `storage_path` VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
+            self::TABLE
+        ));
 
         if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
             Schema::table(self::TABLE, function (Blueprint $table): void {

--- a/backend/database/migrations/2026_03_26_200000_normalize_content_release_exact_manifest_files_index_portability.php
+++ b/backend/database/migrations/2026_03_26_200000_normalize_content_release_exact_manifest_files_index_portability.php
@@ -45,12 +45,10 @@ return new class extends Migration
             });
         }
 
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->string('logical_path', 1024)
-                ->charset('ascii')
-                ->collation('ascii_bin')
-                ->change();
-        });
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY `logical_path` VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
+            self::TABLE
+        ));
 
         if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
             Schema::table(self::TABLE, function (Blueprint $table): void {

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -303,6 +303,29 @@
                 "x-laravel-name": "api.v0_3.attempts.report"
             }
         },
+        "/api/v0.3/attempts/{id}/report-access": {
+            "get": {
+                "operationId": "api.v0_3.attempts.report_access",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@reportAccess",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.report_access"
+            }
+        },
         "/api/v0.3/attempts/{id}/report.pdf": {
             "get": {
                 "operationId": "api.v0_3.attempts.report_pdf",
@@ -1421,6 +1444,90 @@
                 ]
             }
         },
+        "/api/v0.3/public-gateways/help": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_help",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@help",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/public-gateways/help/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_help_slug_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@helpDetail",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/public-gateways/home": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_home",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@home",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/public-gateways/tests": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_tests",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@tests",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
         "/api/v0.3/scales": {
             "get": {
                 "operationId": "get_api_v0_3_scales",
@@ -2152,7 +2259,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -2176,7 +2283,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -2200,7 +2307,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:release"
                 ]
             }
         },
@@ -2224,7 +2331,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -2248,7 +2355,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:release"
                 ]
             }
         },

--- a/backend/resources/views/filament/ops/pages/post-release-observability.blade.php
+++ b/backend/resources/views/filament/ops/pages/post-release-observability.blade.php
@@ -3,7 +3,7 @@
         <x-filament-ops::ops-section
             eyebrow="Post-release observability"
             title="Post-release observability"
-            description="Observe what the CMS release surface has recently published, which records are publicly reachable, and which publish audits were written for follow-up."
+            description="Observe what the CMS release surface has recently published, which follow-up signals were dispatched, and where cache invalidation or broadcast steps failed."
         >
             <x-filament-ops::ops-toolbar>
                 <div class="ops-control-stack">
@@ -27,7 +27,7 @@
 
         <x-filament-ops::ops-section
             title="Release telemetry"
-            description="A compact view of release events and post-publish state inside the selected CMS boundary."
+            description="A compact view of release events, cache invalidation signals, and broadcast outcomes inside the selected CMS boundary."
         >
             <x-filament-ops::ops-field-grid :fields="$headlineFields" />
         </x-filament-ops::ops-section>
@@ -63,8 +63,8 @@
         </x-filament-ops::ops-section>
 
         <x-filament-ops::ops-section
-            title="Recent publish audits"
-            description="Publish audit rows written by the CMS release workspace for the current org boundary."
+            title="Recent release events"
+            description="Publish, cache invalidation, broadcast, and failure-alert audit rows for the current org boundary."
         >
             <div class="ops-card-list">
                 @forelse ($auditCards as $card)

--- a/backend/resources/views/filament/ops/pages/post-release-observability.blade.php
+++ b/backend/resources/views/filament/ops/pages/post-release-observability.blade.php
@@ -73,6 +73,7 @@
                         :meta="$card['meta']"
                     >
                         <p class="ops-control-hint">{{ $card['description'] }}</p>
+                        <p class="ops-control-hint">{{ $card['trace'] }}</p>
                         <p class="ops-control-hint">Audit time: {{ $card['latest_title'] }}</p>
                         <x-slot name="actions">
                             <x-filament.ops.shared.status-pill

--- a/backend/tests/Feature/Ops/PostReleaseObservabilityPageTest.php
+++ b/backend/tests/Feature/Ops/PostReleaseObservabilityPageTest.php
@@ -26,6 +26,7 @@ use Filament\PanelRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -38,6 +39,7 @@ final class PostReleaseObservabilityPageTest extends TestCase
     {
         parent::setUp();
 
+        config()->set('app.frontend_url', 'https://example.test');
         Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
     }
 
@@ -57,6 +59,16 @@ final class PostReleaseObservabilityPageTest extends TestCase
 
     public function test_post_release_observability_shows_recent_publish_state_and_audits(): void
     {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', [
+            'https://cache.example.test/invalidate',
+        ]);
+        config()->set('ops.content_release_observability.broadcast_webhook', 'https://broadcast.example.test/content-release');
+
+        Http::fake([
+            'https://cache.example.test/*' => Http::response(['ok' => true], 200),
+            'https://broadcast.example.test/*' => Http::response(['ok' => true], 200),
+        ]);
+
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_RELEASE,
         ]);
@@ -166,14 +178,43 @@ final class PostReleaseObservabilityPageTest extends TestCase
         $this->assertTrue($article->is_public);
         $this->assertNotNull($article->published_at);
 
-        $audit = AuditLog::query()
+        $publishAudit = AuditLog::query()
             ->where('action', 'content_release_publish')
             ->where('target_type', 'article')
             ->where('target_id', (string) $article->id)
             ->first();
 
-        $this->assertNotNull($audit);
-        $this->assertSame((int) $selectedOrg->id, (int) $audit->org_id);
+        $cacheSignalAudit = AuditLog::query()
+            ->where('action', 'content_release_cache_signal')
+            ->where('target_type', 'article')
+            ->where('target_id', (string) $article->id)
+            ->first();
+
+        $broadcastAudit = AuditLog::query()
+            ->where('action', 'content_release_broadcast')
+            ->where('target_type', 'article')
+            ->where('target_id', (string) $article->id)
+            ->first();
+
+        $this->assertNotNull($publishAudit);
+        $this->assertNotNull($cacheSignalAudit);
+        $this->assertNotNull($broadcastAudit);
+        $this->assertSame((int) $selectedOrg->id, (int) $publishAudit->org_id);
+        $this->assertSame('success', $cacheSignalAudit->result);
+        $this->assertSame('success', $broadcastAudit->result);
+
+        Http::assertSentCount(2);
+        Http::assertSent(function ($request): bool {
+            return $request->url() === 'https://cache.example.test/invalidate'
+                && data_get($request->data(), 'event') === 'content_release_publish'
+                && data_get($request->data(), 'content.type') === 'article'
+                && data_get($request->data(), 'cache_signal.kind') === 'invalidate';
+        });
+        Http::assertSent(function ($request): bool {
+            return $request->url() === 'https://broadcast.example.test/content-release'
+                && data_get($request->data(), 'event') === 'content_release_publish'
+                && data_get($request->data(), 'source') === 'release_workspace';
+        });
 
         $this->withSession($this->opsSession($admin, $selectedOrg))
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
@@ -182,8 +223,10 @@ final class PostReleaseObservabilityPageTest extends TestCase
             ->assertSee('Post-release observability')
             ->assertSee('Release telemetry')
             ->assertSee('Recently published records')
-            ->assertSee('Recent publish audits')
-            ->assertSee('Observability Article');
+            ->assertSee('Recent release events')
+            ->assertSee('Observability Article')
+            ->assertSee('content_release_cache_signal')
+            ->assertSee('content_release_broadcast');
 
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));
         app()->instance('request', Request::create('/ops/post-release-observability', 'GET'));
@@ -196,15 +239,28 @@ final class PostReleaseObservabilityPageTest extends TestCase
             ->assertOk()
             ->assertSet('headlineFields.0.value', '3')
             ->assertSet('headlineFields.1.value', '1')
-            ->assertSet('headlineFields.2.value', '2')
+            ->assertSet('headlineFields.2.value', '1')
             ->assertSet('headlineFields.3.value', '1')
-            ->assertSet('headlineFields.4.value', '1')
+            ->assertSet('headlineFields.4.value', '0')
+            ->assertSet('headlineFields.5.value', '2')
+            ->assertSet('headlineFields.6.value', '1')
             ->assertSet('releaseCards.0.title', 'Observability Article')
-            ->assertSet('auditCards.0.title', 'Observability Article');
+            ->assertCount('auditCards', 3);
     }
 
-    public function test_resource_release_action_writes_audits_and_observability_ignores_other_org_rows(): void
+    public function test_resource_release_action_triggers_failure_alerts_and_observability_ignores_other_org_rows(): void
     {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', [
+            'https://cache.example.test/invalidate',
+        ]);
+        config()->set('ops.content_release_observability.broadcast_webhook', '');
+        config()->set('ops.alert.webhook', 'https://alerts.example.test/ops');
+
+        Http::fake([
+            'https://cache.example.test/*' => Http::response(['ok' => false], 500),
+            'https://alerts.example.test/*' => Http::response(['ok' => true], 200),
+        ]);
+
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_RELEASE,
         ]);
@@ -233,18 +289,43 @@ final class PostReleaseObservabilityPageTest extends TestCase
         EditorialReviewAudit::mark(EditorialReviewAudit::STATE_APPROVED, 'article', $article);
         ArticleResource::releaseRecord($article, 'resource_table');
 
+        $article->refresh();
+        $this->assertSame('published', $article->status);
+
+        $failedSignalAudit = AuditLog::query()
+            ->where('action', 'content_release_cache_signal')
+            ->where('target_type', 'article')
+            ->where('target_id', (string) $article->id)
+            ->first();
+
+        $failureAlertAudit = AuditLog::query()
+            ->where('action', 'content_release_failure_alert')
+            ->where('target_type', 'article')
+            ->where('target_id', (string) $article->id)
+            ->first();
+
+        $this->assertNotNull($failedSignalAudit);
+        $this->assertSame('failed', $failedSignalAudit->result);
+        $this->assertNotNull($failureAlertAudit);
+        $this->assertSame('success', $failureAlertAudit->result);
+
+        Http::assertSent(function ($request): bool {
+            return $request->url() === 'https://alerts.example.test/ops'
+                && str_contains((string) data_get($request->data(), 'text', ''), 'CMS release follow-up failed');
+        });
+
         AuditLog::withoutGlobalScopes()->create([
             'org_id' => (int) $otherOrg->id,
             'actor_admin_id' => (int) $admin->id,
-            'action' => 'content_release_publish',
+            'action' => 'content_release_cache_signal',
             'target_type' => 'article',
             'target_id' => '99999',
-            'meta_json' => ['title' => 'Other Org Audit', 'source' => 'resource_table'],
+            'meta_json' => ['title' => 'Other Org Audit', 'source' => 'resource_table', 'endpoint' => 'https://cache.other.test/invalidate'],
             'ip' => '127.0.0.1',
             'user_agent' => 'phpunit',
             'request_id' => 'other-org-audit',
-            'reason' => 'cms_release_workspace',
-            'result' => 'success',
+            'reason' => 'cms_release_observability',
+            'result' => 'failed',
             'created_at' => now(),
         ]);
 
@@ -265,7 +346,9 @@ final class PostReleaseObservabilityPageTest extends TestCase
         Livewire::test(PostReleaseObservabilityPage::class)
             ->assertOk()
             ->assertSet('headlineFields.1.value', '1')
-            ->assertSet('auditCards.0.description', 'Actor: [REDACTED] | Visibility: public | Source: resource_table');
+            ->assertSet('headlineFields.2.value', '1')
+            ->assertSet('headlineFields.4.value', '1')
+            ->assertSet('auditCards.0.status', 'success');
     }
 
     private function createOrganization(string $name): Organization

--- a/backend/tests/Feature/Ops/PostReleaseObservabilityPageTest.php
+++ b/backend/tests/Feature/Ops/PostReleaseObservabilityPageTest.php
@@ -10,6 +10,7 @@ use App\Filament\Ops\Resources\ArticleResource;
 use App\Filament\Ops\Support\EditorialReviewAudit;
 use App\Models\AdminUser;
 use App\Models\Article;
+use App\Models\ArticleRevision;
 use App\Models\ArticleSeoMeta;
 use App\Models\AuditLog;
 use App\Models\CareerGuide;
@@ -85,6 +86,63 @@ final class PostReleaseObservabilityPageTest extends TestCase
             'is_public' => false,
             'is_indexable' => true,
         ]);
+
+        ArticleRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'article_id' => (int) $article->id,
+            'revision_no' => 1,
+            'editor_admin_user_id' => (int) $admin->id,
+            'title' => 'Observability Article v1',
+            'excerpt' => 'Observability article excerpt',
+            'content_md' => 'Observability body v1',
+            'content_html' => '<p>Observability body v1</p>',
+            'change_note' => 'Initial publish candidate',
+            'payload_json' => [
+                'title' => 'Observability Article v1',
+                'excerpt' => 'Observability article excerpt',
+                'content_md' => 'Observability body v1',
+                'slug' => 'observability-article',
+                'locale' => 'en',
+                'is_public' => false,
+                'is_indexable' => true,
+                'seo_meta' => [
+                    'seo_title' => 'Observability Article SEO Title v1',
+                    'seo_description' => 'Observability Article SEO Description v1',
+                    'canonical_url' => 'https://example.test/articles/observability-article-v1',
+                    'robots' => 'noindex,nofollow',
+                ],
+            ],
+            'created_at' => now()->subDay(),
+        ]);
+
+        ArticleRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'article_id' => (int) $article->id,
+            'revision_no' => 2,
+            'editor_admin_user_id' => (int) $admin->id,
+            'title' => 'Observability Article',
+            'excerpt' => 'Observability article excerpt',
+            'content_md' => 'Observability body',
+            'content_html' => '<p>Observability body</p>',
+            'change_note' => 'Ready for release',
+            'payload_json' => [
+                'title' => 'Observability Article',
+                'excerpt' => 'Observability article excerpt',
+                'content_md' => 'Observability body',
+                'slug' => 'observability-article',
+                'locale' => 'en',
+                'is_public' => true,
+                'is_indexable' => true,
+                'seo_meta' => [
+                    'seo_title' => 'Observability Article SEO Title',
+                    'seo_description' => 'Observability Article SEO Description',
+                    'canonical_url' => 'https://example.test/articles/observability-article',
+                    'robots' => 'index,follow',
+                ],
+            ],
+            'created_at' => now()->subHours(2),
+        ]);
+
         ArticleSeoMeta::query()->create([
             'org_id' => (int) $selectedOrg->id,
             'article_id' => (int) $article->id,
@@ -97,6 +155,26 @@ final class PostReleaseObservabilityPageTest extends TestCase
             'og_image_url' => 'https://example.test/images/observability-article.png',
             'robots' => 'index,follow',
             'is_indexable' => true,
+        ]);
+
+        AuditLog::withoutGlobalScopes()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'actor_admin_id' => (int) $admin->id,
+            'action' => 'content_release_publish',
+            'target_type' => 'article',
+            'target_id' => (string) $article->id,
+            'meta_json' => [
+                'title' => 'Observability Article v1',
+                'source' => 'release_workspace',
+                'published_at' => now()->subDays(2)->toIso8601String(),
+                'revision_no' => 1,
+            ],
+            'ip' => '127.0.0.1',
+            'user_agent' => 'phpunit',
+            'request_id' => 'prior-publish-audit',
+            'reason' => 'cms_release_workspace',
+            'result' => 'success',
+            'created_at' => now()->subDays(2),
         ]);
 
         $guide = CareerGuide::query()->create([
@@ -182,6 +260,7 @@ final class PostReleaseObservabilityPageTest extends TestCase
             ->where('action', 'content_release_publish')
             ->where('target_type', 'article')
             ->where('target_id', (string) $article->id)
+            ->latest('created_at')
             ->first();
 
         $cacheSignalAudit = AuditLog::query()
@@ -202,6 +281,10 @@ final class PostReleaseObservabilityPageTest extends TestCase
         $this->assertSame((int) $selectedOrg->id, (int) $publishAudit->org_id);
         $this->assertSame('success', $cacheSignalAudit->result);
         $this->assertSame('success', $broadcastAudit->result);
+        $this->assertSame(2, data_get($publishAudit->meta_json, 'revision_no'));
+        $this->assertSame(7, data_get($publishAudit->meta_json, 'diff_summary.changed_count'));
+        $this->assertSame(1, data_get($publishAudit->meta_json, 'rollback_target.revision_no'));
+        $this->assertSame('previous_publish', data_get($publishAudit->meta_json, 'rollback_target.kind'));
 
         Http::assertSentCount(2);
         Http::assertSent(function ($request): bool {
@@ -226,7 +309,9 @@ final class PostReleaseObservabilityPageTest extends TestCase
             ->assertSee('Recent release events')
             ->assertSee('Observability Article')
             ->assertSee('content_release_cache_signal')
-            ->assertSee('content_release_broadcast');
+            ->assertSee('content_release_broadcast')
+            ->assertSee('Revision #2')
+            ->assertSee('Rollback: rev 1 via release_workspace');
 
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));
         app()->instance('request', Request::create('/ops/post-release-observability', 'GET'));
@@ -245,7 +330,7 @@ final class PostReleaseObservabilityPageTest extends TestCase
             ->assertSet('headlineFields.5.value', '2')
             ->assertSet('headlineFields.6.value', '1')
             ->assertSet('releaseCards.0.title', 'Observability Article')
-            ->assertCount('auditCards', 3);
+            ->assertCount('auditCards', 4);
     }
 
     public function test_resource_release_action_triggers_failure_alerts_and_observability_ignores_other_org_rows(): void


### PR DESCRIPTION
## Summary
- add release follow-up dispatch for cache invalidation and event broadcasting
- record downstream success and failure audits in post-release observability
- fix CI blockers for this branch: schema baseline, migration safety, OpenAPI snapshot, dependency security gate

## Tests
- cd backend && php artisan test tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php
- cd backend && php artisan test tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php
- cd backend && php artisan test tests/Feature/OpenApiDiffTest.php
- cd backend && bash scripts/ci_verify_mbti.sh