### PR TITLE
feat(cms): build content growth attribution matrix

### DIFF
--- a/backend/app/Filament/Ops/Pages/ContentGrowthAttributionPage.php
+++ b/backend/app/Filament/Ops/Pages/ContentGrowthAttributionPage.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Pages;
+
+use App\Filament\Ops\Support\ContentAccess;
+use App\Services\Ops\ContentGrowthAttributionService;
+use App\Support\OrgContext;
+use Filament\Pages\Page;
+
+final class ContentGrowthAttributionPage extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-presentation-chart-line';
+
+    protected static ?string $navigationGroup = 'Content Overview';
+
+    protected static ?string $navigationLabel = 'Growth Attribution';
+
+    protected static ?int $navigationSort = 6;
+
+    protected static ?string $slug = 'content-growth-attribution';
+
+    protected static string $view = 'filament.ops.pages.content-growth-attribution';
+
+    /** @var list<array<string,mixed>> */
+    public array $headlineFields = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $diagnosticCards = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $matrixRows = [];
+
+    public function mount(ContentGrowthAttributionService $service): void
+    {
+        $dashboard = $service->build($this->currentOrgIds());
+
+        $this->headlineFields = $dashboard['headline_fields'];
+        $this->diagnosticCards = $dashboard['diagnostic_cards'];
+        $this->matrixRows = $dashboard['matrix_rows'];
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content_overview');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('ops.nav.content_growth_attribution');
+    }
+
+    public static function canAccess(): bool
+    {
+        return ContentAccess::canRead();
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function currentOrgIds(): array
+    {
+        $orgId = max(0, (int) app(OrgContext::class)->orgId());
+
+        return $orgId > 0 ? [$orgId] : [];
+    }
+}

--- a/backend/app/Http/Middleware/RequireOpsOrgSelected.php
+++ b/backend/app/Http/Middleware/RequireOpsOrgSelected.php
@@ -49,6 +49,7 @@ class RequireOpsOrgSelected
     private array $orgScopedPages = [
         'filament.ops.pages.content-overview',
         'filament.ops.pages.content-metrics',
+        'filament.ops.pages.content-growth-attribution',
         'filament.ops.pages.seo-operations',
         'filament.ops.pages.content-search',
         'filament.ops.pages.content-workspace',

--- a/backend/app/Services/Ops/ContentGrowthAttributionService.php
+++ b/backend/app/Services/Ops/ContentGrowthAttributionService.php
@@ -63,6 +63,24 @@ final class ContentGrowthAttributionService
                     ->filter(fn (Order $order): bool => $this->matchesSurface($surface, $this->orderCandidates($order)))
                     ->values();
 
+                $seedAliases = $this->shareAliases($matchingEvents, $matchingOrders);
+
+                if ($seedAliases !== []) {
+                    $matchingEvents = $events
+                        ->filter(function (Event $event) use ($surface, $seedAliases): bool {
+                            return $this->matchesSurface($surface, $this->eventCandidates($event))
+                                || $this->hasAnyAlias($this->eventShareAliases($event), $seedAliases);
+                        })
+                        ->values();
+
+                    $matchingOrders = $orders
+                        ->filter(function (Order $order) use ($surface, $seedAliases): bool {
+                            return $this->matchesSurface($surface, $this->orderCandidates($order))
+                                || $this->hasAnyAlias($this->orderShareAliases($order), $seedAliases);
+                        })
+                        ->values();
+                }
+
                 $shareTouchpoints = $this->shareTouchpoints($matchingEvents, $matchingOrders);
                 $paidOrders = $matchingOrders->count();
                 $shareAssistedOrders = $matchingOrders
@@ -235,7 +253,7 @@ final class ContentGrowthAttributionService
             'title' => trim((string) data_get($record, 'title', 'Untitled')),
             'public_path' => $publicPath,
             'public_url' => $publicUrl,
-            'canonical_ready' => $canonical !== '',
+            'canonical_ready' => $canonical !== '' && $this->urlsMatch($canonical, $publicUrl),
             'indexable' => (bool) data_get($record, 'is_indexable'),
             'published_at' => data_get($record, 'published_at'),
         ];
@@ -318,35 +336,7 @@ final class ContentGrowthAttributionService
      */
     private function shareTouchpoints(Collection $events, Collection $orders): int
     {
-        $touchpoints = [];
-
-        foreach ($events as $event) {
-            $shareId = trim((string) ($event->share_id ?? ''));
-            if ($shareId !== '') {
-                $touchpoints['share:'.$shareId] = true;
-            }
-
-            $meta = is_array($event->meta_json) ? $event->meta_json : [];
-            $shareClickId = trim((string) data_get($meta, 'share_click_id', ''));
-            if ($shareClickId !== '') {
-                $touchpoints['click:'.$shareClickId] = true;
-            }
-        }
-
-        foreach ($orders as $order) {
-            $attribution = $this->orders->extractAttributionFromOrder($order);
-            $shareId = trim((string) ($attribution['share_id'] ?? ''));
-            $shareClickId = trim((string) ($attribution['share_click_id'] ?? ''));
-
-            if ($shareId !== '') {
-                $touchpoints['share:'.$shareId] = true;
-            }
-            if ($shareClickId !== '') {
-                $touchpoints['click:'.$shareClickId] = true;
-            }
-        }
-
-        return count($touchpoints);
+        return count($this->shareAliases($events, $orders));
     }
 
     private function isShareAssistedOrder(Order $order): bool
@@ -410,6 +400,104 @@ final class ContentGrowthAttributionService
         $base = rtrim((string) config('app.frontend_url', config('app.url', 'https://example.test')), '/');
 
         return $base !== '' ? $base : 'https://example.test';
+    }
+
+    /**
+     * @param  Collection<int, Event>  $events
+     * @param  Collection<int, Order>  $orders
+     * @return list<string>
+     */
+    private function shareAliases(Collection $events, Collection $orders): array
+    {
+        $aliases = [];
+
+        foreach ($events as $event) {
+            foreach ($this->eventShareAliases($event) as $alias) {
+                $aliases[$alias] = true;
+            }
+        }
+
+        foreach ($orders as $order) {
+            foreach ($this->orderShareAliases($order) as $alias) {
+                $aliases[$alias] = true;
+            }
+        }
+
+        return array_keys($aliases);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function eventShareAliases(Event $event): array
+    {
+        $aliases = [];
+        $shareId = trim((string) ($event->share_id ?? ''));
+
+        if ($shareId !== '') {
+            $aliases[] = 'share:'.$shareId;
+        }
+
+        $meta = is_array($event->meta_json) ? $event->meta_json : [];
+        $shareClickId = trim((string) data_get($meta, 'share_click_id', ''));
+
+        if ($shareClickId !== '') {
+            $aliases[] = 'click:'.$shareClickId;
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function orderShareAliases(Order $order): array
+    {
+        $aliases = [];
+        $attribution = $this->orders->extractAttributionFromOrder($order);
+        $shareId = trim((string) ($attribution['share_id'] ?? ''));
+        $shareClickId = trim((string) ($attribution['share_click_id'] ?? ''));
+
+        if ($shareId !== '') {
+            $aliases[] = 'share:'.$shareId;
+        }
+
+        if ($shareClickId !== '') {
+            $aliases[] = 'click:'.$shareClickId;
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * @param  list<string>  $aliases
+     * @param  list<string>  $knownAliases
+     */
+    private function hasAnyAlias(array $aliases, array $knownAliases): bool
+    {
+        if ($aliases === [] || $knownAliases === []) {
+            return false;
+        }
+
+        $lookup = array_fill_keys($knownAliases, true);
+
+        foreach ($aliases as $alias) {
+            if (isset($lookup[$alias])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function urlsMatch(string $left, string $right): bool
+    {
+        return $this->normalizeUrl($left) === $this->normalizeUrl($right);
+    }
+
+    private function normalizeUrl(string $value): string
+    {
+        return rtrim(mb_strtolower(trim($value), 'UTF-8'), '/');
     }
 
     private function formatCurrencyCents(int $value): string

--- a/backend/app/Services/Ops/ContentGrowthAttributionService.php
+++ b/backend/app/Services/Ops/ContentGrowthAttributionService.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use App\Models\Article;
+use App\Models\CareerGuide;
+use App\Models\CareerJob;
+use App\Models\Event;
+use App\Models\Order;
+use App\Services\Commerce\OrderManager;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+final class ContentGrowthAttributionService
+{
+    public function __construct(
+        private readonly OrderManager $orders,
+    ) {}
+
+    /**
+     * @param  array<int, int>  $currentOrgIds
+     * @return array{
+     *   headline_fields:list<array<string,mixed>>,
+     *   diagnostic_cards:list<array<string,mixed>>,
+     *   matrix_rows:list<array<string,mixed>>
+     * }
+     */
+    public function build(array $currentOrgIds): array
+    {
+        $orgId = max(0, (int) ($currentOrgIds[0] ?? 0));
+        $lookbackThreshold = Carbon::now()->subDays(30);
+        $surfaces = $this->surfaceInventory($currentOrgIds);
+
+        $events = Event::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $orgId)
+            ->where('occurred_at', '>=', $lookbackThreshold)
+            ->get();
+
+        $orders = Order::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $orgId)
+            ->whereIn('status', [Order::STATUS_PAID, Order::STATUS_FULFILLED])
+            ->where(function ($query) use ($lookbackThreshold): void {
+                $query->where('paid_at', '>=', $lookbackThreshold)
+                    ->orWhere(function ($fallbackQuery) use ($lookbackThreshold): void {
+                        $fallbackQuery
+                            ->whereNull('paid_at')
+                            ->where('updated_at', '>=', $lookbackThreshold);
+                    });
+            })
+            ->get();
+
+        $matrixRows = $surfaces
+            ->map(function (array $surface) use ($events, $orders): array {
+                $matchingEvents = $events
+                    ->filter(fn (Event $event): bool => $this->matchesSurface($surface, $this->eventCandidates($event)))
+                    ->values();
+
+                $matchingOrders = $orders
+                    ->filter(fn (Order $order): bool => $this->matchesSurface($surface, $this->orderCandidates($order)))
+                    ->values();
+
+                $shareTouchpoints = $this->shareTouchpoints($matchingEvents, $matchingOrders);
+                $paidOrders = $matchingOrders->count();
+                $shareAssistedOrders = $matchingOrders
+                    ->filter(fn (Order $order): bool => $this->isShareAssistedOrder($order))
+                    ->count();
+                $revenueCents = (int) $matchingOrders->sum(function (Order $order): int {
+                    return (int) ($order->amount_cents ?? $order->amount_total ?? 0);
+                });
+                $signalCount = $matchingEvents->count();
+                $lastTouch = $this->latestTouchAt($matchingEvents, $matchingOrders);
+                $canonicalReady = $surface['canonical_ready'];
+                $indexable = $surface['indexable'];
+                $growthState = $paidOrders > 0 ? 'Converting' : ($signalCount > 0 ? 'Discovery' : 'Dormant');
+                $growthStateLabel = $indexable
+                    ? ($canonicalReady ? 'Indexable' : 'Canonical gap')
+                    : 'Noindex';
+
+                return [
+                    'title' => $surface['title'],
+                    'type' => $surface['type'],
+                    'scope' => $surface['scope'],
+                    'locale' => $surface['locale'],
+                    'slug' => $surface['slug'],
+                    'public_path' => $surface['public_path'],
+                    'public_url' => $surface['public_url'],
+                    'seo_label' => $growthStateLabel,
+                    'seo_state' => $indexable && $canonicalReady ? 'success' : ($paidOrders > 0 ? 'warning' : 'gray'),
+                    'signals' => $signalCount,
+                    'share_touchpoints' => $shareTouchpoints,
+                    'share_assisted_orders' => $shareAssistedOrders,
+                    'paid_orders' => $paidOrders,
+                    'revenue_cents' => $revenueCents,
+                    'revenue_label' => $this->formatCurrencyCents($revenueCents),
+                    'growth_state' => $growthState,
+                    'growth_state_label' => $growthState.' | '.$growthStateLabel,
+                    'last_touch_at' => $lastTouch,
+                    'last_touch_label' => $lastTouch?->toDateTimeString() ?? 'No recent touch',
+                    'published_at' => $surface['published_at'],
+                    'sort_weight' => ($paidOrders * 100000) + ($signalCount * 100) + $shareAssistedOrders,
+                    'converting_without_indexability' => $paidOrders > 0 && ! $indexable,
+                    'converting_without_canonical' => $paidOrders > 0 && ! $canonicalReady,
+                    'indexable_without_signals' => $indexable && $signalCount === 0 && $paidOrders === 0,
+                ];
+            })
+            ->sortByDesc(fn (array $row): int => $row['sort_weight'])
+            ->values();
+
+        $headlineFields = [
+            [
+                'label' => 'Indexable public surfaces',
+                'value' => (string) $matrixRows->where('seo_label', 'Indexable')->count(),
+                'hint' => 'Visible public content records that are both indexable and canonical-ready.',
+            ],
+            [
+                'label' => 'Attributed surfaces (30d)',
+                'value' => (string) $matrixRows
+                    ->filter(fn (array $row): bool => $row['signals'] > 0 || $row['paid_orders'] > 0)
+                    ->count(),
+                'hint' => 'Content surfaces with at least one entry signal or paid order in the last 30 days.',
+            ],
+            [
+                'label' => 'Tracked share touchpoints',
+                'value' => (string) $matrixRows->sum('share_touchpoints'),
+                'hint' => 'Distinct share_id or share_click_id touchpoints attributed back to visible content surfaces.',
+            ],
+            [
+                'label' => 'Paid conversions (30d)',
+                'value' => (string) $matrixRows->sum('paid_orders'),
+                'hint' => 'Paid or fulfilled orders carrying attribution that resolves back to visible content paths.',
+            ],
+            [
+                'label' => 'Attributed revenue (30d)',
+                'value' => $this->formatCurrencyCents((int) $matrixRows->sum('revenue_cents')),
+                'hint' => 'Revenue from paid orders attributed to visible content paths in the current org boundary.',
+            ],
+        ];
+
+        $diagnosticCards = [
+            $this->diagnosticCard(
+                'Converting but noindex',
+                'Published content with attributed paid conversions but still not marked indexable.',
+                $matrixRows->where('converting_without_indexability', true),
+                'SEO and growth mismatch'
+            ),
+            $this->diagnosticCard(
+                'Converting with canonical gaps',
+                'Content already producing paid orders while canonical coverage is still incomplete.',
+                $matrixRows->where('converting_without_canonical', true),
+                'SEO cleanup needed'
+            ),
+            $this->diagnosticCard(
+                'Share-assisted winners',
+                'Content surfaces with the strongest share-assisted order signal in the last 30 days.',
+                $matrixRows->filter(fn (array $row): bool => $row['share_assisted_orders'] > 0),
+                'Share propagation'
+            ),
+            $this->diagnosticCard(
+                'Indexable but dormant',
+                'Indexable public content that still has no attributed signals or paid conversions.',
+                $matrixRows->where('indexable_without_signals', true),
+                'Discovery gap'
+            ),
+        ];
+
+        return [
+            'headline_fields' => $headlineFields,
+            'diagnostic_cards' => $diagnosticCards,
+            'matrix_rows' => $matrixRows->take(12)->all(),
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $currentOrgIds
+     * @return Collection<int, array<string,mixed>>
+     */
+    private function surfaceInventory(array $currentOrgIds): Collection
+    {
+        $articles = Article::query()
+            ->whereIn('org_id', $currentOrgIds)
+            ->where('status', 'published')
+            ->where('is_public', true)
+            ->with('seoMeta')
+            ->get()
+            ->map(fn (Article $article): array => $this->surfaceRecord('article', $article, 'Current org'));
+
+        $guides = CareerGuide::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('status', CareerGuide::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->with('seoMeta')
+            ->get()
+            ->map(fn (CareerGuide $guide): array => $this->surfaceRecord('guide', $guide, 'Global content'));
+
+        $jobs = CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('status', CareerJob::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->with('seoMeta')
+            ->get()
+            ->map(fn (CareerJob $job): array => $this->surfaceRecord('job', $job, 'Global content'));
+
+        return collect()
+            ->concat($articles)
+            ->concat($guides)
+            ->concat($jobs)
+            ->values();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function surfaceRecord(string $type, object $record, string $scope): array
+    {
+        $publicPath = $this->publicPath($type, $record);
+        $publicUrl = $this->frontendBaseUrl().$publicPath;
+        $canonical = trim((string) data_get($record, 'seoMeta.canonical_url', ''));
+
+        return [
+            'type' => match ($type) {
+                'article' => 'Article',
+                'guide' => 'Career Guide',
+                'job' => 'Career Job',
+                default => 'Content',
+            },
+            'scope' => $scope,
+            'locale' => trim((string) data_get($record, 'locale', 'en')),
+            'slug' => trim((string) data_get($record, 'slug', '')),
+            'title' => trim((string) data_get($record, 'title', 'Untitled')),
+            'public_path' => $publicPath,
+            'public_url' => $publicUrl,
+            'canonical_ready' => $canonical !== '',
+            'indexable' => (bool) data_get($record, 'is_indexable'),
+            'published_at' => data_get($record, 'published_at'),
+        ];
+    }
+
+    private function publicPath(string $type, object $record): string
+    {
+        $slug = rawurlencode(trim((string) data_get($record, 'slug', '')));
+        $segment = $this->localeSegment(trim((string) data_get($record, 'locale', 'en')));
+
+        return match ($type) {
+            'article' => '/'.$segment.'/articles/'.$slug,
+            'guide' => '/'.$segment.'/career/guides/'.$slug,
+            'job' => '/'.$segment.'/career/jobs/'.$slug,
+            default => '/'.$segment,
+        };
+    }
+
+    /**
+     * @param  list<string>  $candidates
+     * @param  array<string,mixed>  $surface
+     */
+    private function matchesSurface(array $surface, array $candidates): bool
+    {
+        $path = mb_strtolower((string) $surface['public_path'], 'UTF-8');
+        $url = mb_strtolower((string) $surface['public_url'], 'UTF-8');
+        $slug = mb_strtolower((string) $surface['slug'], 'UTF-8');
+
+        foreach ($candidates as $candidate) {
+            $normalized = mb_strtolower(trim($candidate), 'UTF-8');
+            if ($normalized === '') {
+                continue;
+            }
+
+            if (str_contains($normalized, $path) || str_contains($normalized, $url)) {
+                return true;
+            }
+
+            if ($slug !== '' && str_contains($normalized, '/'.$slug)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function eventCandidates(Event $event): array
+    {
+        $meta = is_array($event->meta_json) ? $event->meta_json : [];
+
+        return array_values(array_filter([
+            trim((string) data_get($meta, 'landing_path', '')),
+            trim((string) data_get($meta, 'entry_page', '')),
+            trim((string) data_get($meta, 'referrer', '')),
+            trim((string) data_get($meta, 'ref', '')),
+            trim((string) data_get($meta, 'entrypoint', '')),
+        ]));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function orderCandidates(Order $order): array
+    {
+        $attribution = $this->orders->extractAttributionFromOrder($order);
+
+        return array_values(array_filter([
+            trim((string) ($attribution['landing_path'] ?? '')),
+            trim((string) ($attribution['referrer'] ?? '')),
+            trim((string) ($attribution['entrypoint'] ?? '')),
+        ]));
+    }
+
+    /**
+     * @param  Collection<int, Event>  $events
+     * @param  Collection<int, Order>  $orders
+     */
+    private function shareTouchpoints(Collection $events, Collection $orders): int
+    {
+        $touchpoints = [];
+
+        foreach ($events as $event) {
+            $shareId = trim((string) ($event->share_id ?? ''));
+            if ($shareId !== '') {
+                $touchpoints['share:'.$shareId] = true;
+            }
+
+            $meta = is_array($event->meta_json) ? $event->meta_json : [];
+            $shareClickId = trim((string) data_get($meta, 'share_click_id', ''));
+            if ($shareClickId !== '') {
+                $touchpoints['click:'.$shareClickId] = true;
+            }
+        }
+
+        foreach ($orders as $order) {
+            $attribution = $this->orders->extractAttributionFromOrder($order);
+            $shareId = trim((string) ($attribution['share_id'] ?? ''));
+            $shareClickId = trim((string) ($attribution['share_click_id'] ?? ''));
+
+            if ($shareId !== '') {
+                $touchpoints['share:'.$shareId] = true;
+            }
+            if ($shareClickId !== '') {
+                $touchpoints['click:'.$shareClickId] = true;
+            }
+        }
+
+        return count($touchpoints);
+    }
+
+    private function isShareAssistedOrder(Order $order): bool
+    {
+        $attribution = $this->orders->extractAttributionFromOrder($order);
+
+        return trim((string) ($attribution['share_id'] ?? '')) !== ''
+            || trim((string) ($attribution['share_click_id'] ?? '')) !== '';
+    }
+
+    /**
+     * @param  Collection<int, Event>  $events
+     * @param  Collection<int, Order>  $orders
+     */
+    private function latestTouchAt(Collection $events, Collection $orders): ?Carbon
+    {
+        $timestamps = collect()
+            ->concat($events->map(fn (Event $event): ?Carbon => $event->occurred_at instanceof Carbon ? $event->occurred_at : null))
+            ->concat($orders->map(function (Order $order): ?Carbon {
+                $paidAt = $order->paid_at instanceof Carbon ? $order->paid_at : null;
+
+                return $paidAt ?? ($order->updated_at instanceof Carbon ? $order->updated_at : null);
+            }))
+            ->filter(fn (?Carbon $value): bool => $value instanceof Carbon)
+            ->sortByDesc(fn (Carbon $value): int => $value->getTimestamp())
+            ->values();
+
+        $latest = $timestamps->first();
+
+        return $latest instanceof Carbon ? $latest : null;
+    }
+
+    /**
+     * @param  Collection<int, array<string,mixed>>  $rows
+     * @return array<string,mixed>
+     */
+    private function diagnosticCard(string $title, string $description, Collection $rows, string $meta): array
+    {
+        $latest = $rows
+            ->sortByDesc(fn (array $row): int => ($row['paid_orders'] * 1000) + $row['signals'])
+            ->first();
+
+        return [
+            'title' => $title,
+            'description' => $description,
+            'meta' => $meta.' | '.(string) $rows->count().' surfaces',
+            'value' => (string) $rows->count(),
+            'status' => $rows->isNotEmpty() ? 'Needs action' : 'Healthy',
+            'status_state' => $rows->isNotEmpty() ? 'warning' : 'success',
+            'latest_title' => is_array($latest) ? (string) ($latest['title'] ?? 'No recent record') : 'No recent record',
+        ];
+    }
+
+    private function localeSegment(string $locale): string
+    {
+        return str_starts_with(mb_strtolower(trim($locale), 'UTF-8'), 'zh') ? 'zh' : 'en';
+    }
+
+    private function frontendBaseUrl(): string
+    {
+        $base = rtrim((string) config('app.frontend_url', config('app.url', 'https://example.test')), '/');
+
+        return $base !== '' ? $base : 'https://example.test';
+    }
+
+    private function formatCurrencyCents(int $value): string
+    {
+        return '$'.number_format($value / 100, 2);
+    }
+}

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -128,16 +128,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.369.24",
+            "version": "3.374.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "17f404a47879c1fb47175ac2b61881ab0dc2dc5c"
+                "reference": "67b6b6210af47319c74c5666388d71bc1bc58276"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/17f404a47879c1fb47175ac2b61881ab0dc2dc5c",
-                "reference": "17f404a47879c1fb47175ac2b61881ab0dc2dc5c",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/67b6b6210af47319c74c5666388d71bc1bc58276",
+                "reference": "67b6b6210af47319c74c5666388d71bc1bc58276",
                 "shasum": ""
             },
             "require": {
@@ -158,12 +158,12 @@
                 "aws/aws-php-sns-message-validator": "~1.0",
                 "behat/behat": "~3.0",
                 "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
                 "ext-sockets": "*",
-                "phpunit/phpunit": "^9.6",
+                "phpunit/phpunit": "^10.0",
                 "psr/cache": "^2.0 || ^3.0",
                 "psr/simple-cache": "^2.0 || ^3.0",
                 "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
@@ -201,11 +201,11 @@
             "authors": [
                 {
                     "name": "Amazon Web Services",
-                    "homepage": "http://aws.amazon.com"
+                    "homepage": "https://aws.amazon.com"
                 }
             ],
             "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
-            "homepage": "http://aws.amazon.com/sdkforphp",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
             "keywords": [
                 "amazon",
                 "aws",
@@ -219,9 +219,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.369.24"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.374.2"
             },
-            "time": "2026-01-30T19:14:32+00:00"
+            "time": "2026-03-27T18:05:55+00:00"
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -1910,16 +1910,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -1935,6 +1935,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -2006,7 +2007,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -2022,7 +2023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -2643,16 +2644,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.0",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb"
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
                 "shasum": ""
             },
             "require": {
@@ -2677,9 +2678,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -2746,7 +2747,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-26T21:48:24+00:00"
+            "time": "2026-03-19T13:16:38+00:00"
         },
         {
             "name": "league/config",
@@ -3765,16 +3766,16 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.3",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
@@ -3782,8 +3783,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -3824,22 +3827,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.3"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2025-10-30T22:57:59+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.1",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72"
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c99059c0315591f1a0db7ad6002000288ab8dc72",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72",
+                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
                 "shasum": ""
             },
             "require": {
@@ -3851,8 +3854,10 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -3913,9 +3918,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.1"
+                "source": "https://github.com/nette/utils/tree/v4.1.3"
             },
-            "time": "2025-12-22T12:14:32+00:00"
+            "time": "2026-02-13T03:05:33+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -6037,16 +6042,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v8.0.1",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d"
+                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d937d400b980523dc9ee946bb69972b5e619058d",
-                "reference": "d937d400b980523dc9ee946bb69972b5e619058d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7bf9162d7a0dff98d079b72948508fa48018a770",
+                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770",
                 "shasum": ""
             },
             "require": {
@@ -6083,7 +6088,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.0.1"
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -6103,7 +6108,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-01T09:13:36+00:00"
+            "time": "2026-02-25T16:59:43+00:00"
         },
         {
             "name": "symfony/finder",
@@ -8564,16 +8569,16 @@
         },
         {
             "name": "yansongda/pay",
-            "version": "v3.7.19",
+            "version": "v3.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yansongda/pay.git",
-                "reference": "57eaeff84bd4a19c4d09656a3c45250c9a032aa2"
+                "reference": "26987ebf789f1e7f0a85febb640986ab4289fd7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yansongda/pay/zipball/57eaeff84bd4a19c4d09656a3c45250c9a032aa2",
-                "reference": "57eaeff84bd4a19c4d09656a3c45250c9a032aa2",
+                "url": "https://api.github.com/repos/yansongda/pay/zipball/26987ebf789f1e7f0a85febb640986ab4289fd7f",
+                "reference": "26987ebf789f1e7f0a85febb640986ab4289fd7f",
                 "shasum": ""
             },
             "require": {
@@ -8633,7 +8638,7 @@
                 "issues": "https://github.com/yansongda/pay/issues",
                 "source": "https://github.com/yansongda/pay"
             },
-            "time": "2025-12-22T03:30:53+00:00"
+            "time": "2026-03-23T07:33:29+00:00"
         },
         {
             "name": "yansongda/supports",

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -57,7 +57,6 @@ return [
             'ai_insight_feedback',
             'ai_insights',
             'auth_tokens',
-            'attempt_quality',
             'attempts',
             'attempt_submissions',
             'audit_logs',

--- a/backend/database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php
+++ b/backend/database/migrations/2026_03_26_190000_normalize_storage_blob_locations_index_portability.php
@@ -37,16 +37,14 @@ return new class extends Migration
             });
         }
 
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->string('disk', 32)
-                ->charset('ascii')
-                ->collation('ascii_bin')
-                ->change();
-            $table->string('storage_path', 1024)
-                ->charset('ascii')
-                ->collation('ascii_bin')
-                ->change();
-        });
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY `disk` VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
+            self::TABLE
+        ));
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY `storage_path` VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
+            self::TABLE
+        ));
 
         if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
             Schema::table(self::TABLE, function (Blueprint $table): void {

--- a/backend/database/migrations/2026_03_26_200000_normalize_content_release_exact_manifest_files_index_portability.php
+++ b/backend/database/migrations/2026_03_26_200000_normalize_content_release_exact_manifest_files_index_portability.php
@@ -45,12 +45,10 @@ return new class extends Migration
             });
         }
 
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->string('logical_path', 1024)
-                ->charset('ascii')
-                ->collation('ascii_bin')
-                ->change();
-        });
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY `logical_path` VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
+            self::TABLE
+        ));
 
         if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_INDEX)) {
             Schema::table(self::TABLE, function (Blueprint $table): void {

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -303,6 +303,29 @@
                 "x-laravel-name": "api.v0_3.attempts.report"
             }
         },
+        "/api/v0.3/attempts/{id}/report-access": {
+            "get": {
+                "operationId": "api.v0_3.attempts.report_access",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@reportAccess",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.report_access"
+            }
+        },
         "/api/v0.3/attempts/{id}/report.pdf": {
             "get": {
                 "operationId": "api.v0_3.attempts.report_pdf",
@@ -1421,6 +1444,90 @@
                 ]
             }
         },
+        "/api/v0.3/public-gateways/help": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_help",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@help",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/public-gateways/help/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_help_slug_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@helpDetail",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/public-gateways/home": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_home",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@home",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/public-gateways/tests": {
+            "get": {
+                "operationId": "get_api_v0_3_public_gateways_tests",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\PublicGatewaySurfaceController@tests",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
         "/api/v0.3/scales": {
             "get": {
                 "operationId": "get_api_v0_3_scales",
@@ -2152,7 +2259,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -2176,7 +2283,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -2200,7 +2307,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:release"
                 ]
             }
         },
@@ -2224,7 +2331,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -2248,7 +2355,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:release"
                 ]
             }
         },

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -46,6 +46,7 @@ return [
         'orders' => 'Orders',
         'content_overview' => 'Content Overview',
         'content_metrics' => 'Content Metrics',
+        'content_growth_attribution' => 'Growth Attribution',
         'seo_operations' => 'SEO Operations',
         'content_search' => 'Content Search',
         'content_workspace' => 'Content Workspace',

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -46,6 +46,7 @@ return [
         'orders' => '订单',
         'content_overview' => '内容总览',
         'content_metrics' => '内容指标',
+        'content_growth_attribution' => '增长归因',
         'seo_operations' => 'SEO运营',
         'content_search' => '内容搜索',
         'content_workspace' => '内容工作台',

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -26,6 +26,7 @@
     <php>
         <ini name="memory_limit" value="512M"/>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="APP_CONFIG_CACHE" value="bootstrap/cache/config-testing.php"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
@@ -40,6 +41,7 @@
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
         <env name="PAYMENTS_ALLOW_STUB" value="true"/>
+        <env name="FAP_ADMIN_PANEL_ENABLED" value="true"/>
         <env name="FAP_FEATURE_SUBMIT_ASYNC_V2" value="false"/>
         <env name="FAP_FEATURE_REPORT_SNAPSHOT_STRICT_V2" value="false"/>
     </php>

--- a/backend/resources/views/filament/ops/hooks/topbar-context.blade.php
+++ b/backend/resources/views/filament/ops/hooks/topbar-context.blade.php
@@ -9,6 +9,7 @@
         str_contains($routeName, 'post-release-observability'),
         str_contains($routeName, 'content-release') => __('ops.group.content_release'),
         str_contains($routeName, 'content-metrics'),
+        str_contains($routeName, 'content-growth-attribution'),
         str_contains($routeName, 'seo-operations'),
         str_contains($routeName, 'content-search'),
         str_contains($routeName, 'content-overview'),

--- a/backend/resources/views/filament/ops/pages/content-growth-attribution.blade.php
+++ b/backend/resources/views/filament/ops/pages/content-growth-attribution.blade.php
@@ -1,0 +1,121 @@
+<x-filament-panels::page>
+    <div class="ops-shell-page">
+        <x-filament-ops::ops-section
+            eyebrow="Growth attribution"
+            title="Content growth attribution"
+            description="Tie public content SEO posture to share propagation, attributed entry signals, and paid conversion outcomes inside the selected org boundary."
+        >
+            <x-filament-ops::ops-toolbar>
+                <div class="ops-control-stack">
+                    <span class="ops-control-label">Attribution contract</span>
+                    <p class="ops-control-hint">This surface matches visible CMS content against attributed landing paths, share touchpoints, and paid orders. It does not rewrite checkout or payment data models.</p>
+                </div>
+
+                <x-slot name="actions">
+                    <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\ContentOverviewPage::getUrl() }}">
+                        Overview
+                    </x-filament::button>
+                    <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\ContentMetricsPage::getUrl() }}">
+                        Content Metrics
+                    </x-filament::button>
+                    <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\SeoOperationsPage::getUrl() }}">
+                        SEO Operations
+                    </x-filament::button>
+                    <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\ContentSearchPage::getUrl() }}">
+                        Content Search
+                    </x-filament::button>
+                </x-slot>
+            </x-filament-ops::ops-toolbar>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Growth dashboard"
+            description="Headline attribution signals across public CMS content in the last 30 days."
+        >
+            <x-filament-ops::ops-field-grid :fields="$headlineFields" />
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Growth diagnostics"
+            description="Use these queues to spot SEO-to-growth mismatches and the content surfaces already proving conversion value."
+        >
+            <div class="ops-card-list">
+                @foreach ($diagnosticCards as $card)
+                    <x-filament-ops::ops-result-card
+                        :title="$card['title']"
+                        :meta="$card['meta']"
+                    >
+                        <p class="ops-control-hint">{{ $card['description'] }}</p>
+                        <p class="ops-control-hint">Latest surface: {{ $card['latest_title'] }}</p>
+                        <x-slot name="actions">
+                            <x-filament.ops.shared.status-pill
+                                :state="$card['status_state']"
+                                :label="$card['status'].' | '.$card['value']"
+                            />
+                        </x-slot>
+                    </x-filament-ops::ops-result-card>
+                @endforeach
+            </div>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Attribution matrix"
+            description="Public content surfaces ranked by paid conversions, discovery signals, and share-assisted outcomes."
+        >
+            <x-filament-ops::ops-table
+                :has-rows="$matrixRows !== []"
+                empty-eyebrow="Growth attribution"
+                empty-icon="heroicon-o-presentation-chart-line"
+                empty-title="No attributed content signals yet"
+                empty-description="Once public content starts receiving attributed traffic or orders, the matrix will appear here."
+            >
+                <x-slot name="head">
+                    <tr>
+                        <th>Surface</th>
+                        <th>SEO</th>
+                        <th>Signals</th>
+                        <th>Share</th>
+                        <th>Paid</th>
+                        <th>Revenue</th>
+                        <th>Latest touch</th>
+                    </tr>
+                </x-slot>
+
+                @foreach ($matrixRows as $row)
+                    <tr>
+                        <td>
+                            <div class="ops-control-stack">
+                                <span class="ops-control-label">{{ $row['title'] }}</span>
+                                <span class="ops-control-hint">{{ $row['type'] }} | {{ $row['scope'] }} | {{ $row['locale'] }}</span>
+                                <span class="ops-control-hint">{{ $row['public_path'] }}</span>
+                            </div>
+                        </td>
+                        <td>
+                            <x-filament.ops.shared.status-pill
+                                :state="$row['seo_state']"
+                                :label="$row['growth_state_label']"
+                            />
+                        </td>
+                        <td>{{ $row['signals'] }}</td>
+                        <td>
+                            <div class="ops-control-stack">
+                                <span>{{ $row['share_touchpoints'] }} touchpoints</span>
+                                <span class="ops-control-hint">{{ $row['share_assisted_orders'] }} assisted orders</span>
+                            </div>
+                        </td>
+                        <td>{{ $row['paid_orders'] }}</td>
+                        <td>{{ $row['revenue_label'] }}</td>
+                        <td>
+                            <div class="ops-control-stack">
+                                <span>{{ $row['last_touch_label'] }}</span>
+                                <x-filament::button size="xs" color="gray" tag="a" href="{{ $row['public_url'] }}" target="_blank">
+                                    View Public
+                                </x-filament::button>
+                            </div>
+                        </td>
+                    </tr>
+                @endforeach
+            </x-filament-ops::ops-table>
+        </x-filament-ops::ops-section>
+    </div>
+</x-filament-panels::page>

--- a/backend/resources/views/filament/ops/pages/content-overview.blade.php
+++ b/backend/resources/views/filament/ops/pages/content-overview.blade.php
@@ -18,6 +18,9 @@
                     <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\ContentMetricsPage::getUrl() }}">
                         Content Metrics
                     </x-filament::button>
+                    <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\ContentGrowthAttributionPage::getUrl() }}">
+                        Growth Attribution
+                    </x-filament::button>
                     <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\SeoOperationsPage::getUrl() }}">
                         SEO Operations
                     </x-filament::button>

--- a/backend/resources/views/filament/ops/pages/seo-operations.blade.php
+++ b/backend/resources/views/filament/ops/pages/seo-operations.blade.php
@@ -18,6 +18,9 @@
                     <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\ContentMetricsPage::getUrl() }}">
                         Content Metrics
                     </x-filament::button>
+                    <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\ContentGrowthAttributionPage::getUrl() }}">
+                        Growth Attribution
+                    </x-filament::button>
                     <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Pages\ContentSearchPage::getUrl() }}">
                         Content Search
                     </x-filament::button>

--- a/backend/tests/Feature/Ops/ContentGrowthAttributionPageTest.php
+++ b/backend/tests/Feature/Ops/ContentGrowthAttributionPageTest.php
@@ -37,6 +37,7 @@ final class ContentGrowthAttributionPageTest extends TestCase
         parent::setUp();
 
         $this->withoutVite();
+        config()->set('app.frontend_url', 'https://frontend.example.test');
         Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
     }
 
@@ -269,6 +270,113 @@ final class ContentGrowthAttributionPageTest extends TestCase
             ->assertSet('matrixRows.0.share_assisted_orders', 1)
             ->assertSet('matrixRows.1.title', 'Growth Guide')
             ->assertSet('matrixRows.1.paid_orders', 1);
+    }
+
+    public function test_content_growth_attribution_tracks_share_only_conversion_lineage_and_strict_canonical_health(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Growth Lineage Org');
+
+        $article = Article::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'slug' => 'lineage-article',
+            'locale' => 'en',
+            'title' => 'Lineage Article',
+            'excerpt' => 'Lineage article excerpt',
+            'content_md' => 'Body',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::now()->subDays(2),
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Lineage Article SEO',
+            'seo_description' => 'Lineage article description',
+            'canonical_url' => 'https://frontend.example.test/en/articles/not-the-real-slug',
+            'og_title' => 'Lineage Article OG',
+            'og_description' => 'Lineage Article OG Description',
+            'og_image_url' => 'https://frontend.example.test/images/lineage-article.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        Event::query()->create([
+            'id' => (string) Str::uuid(),
+            'event_code' => 'share_generate',
+            'event_name' => 'share_generate',
+            'org_id' => (int) $selectedOrg->id,
+            'meta_json' => [
+                'landing_path' => '/en/articles/lineage-article',
+                'share_click_id' => 'lineage_click_1',
+            ],
+            'share_id' => 'lineage_share_1',
+            'occurred_at' => Carbon::now()->subDays(2),
+        ]);
+
+        Event::query()->create([
+            'id' => (string) Str::uuid(),
+            'event_code' => 'share_click',
+            'event_name' => 'share_click',
+            'org_id' => (int) $selectedOrg->id,
+            'meta_json' => [
+                'entry_page' => 'share_page',
+                'share_click_id' => 'lineage_click_1',
+            ],
+            'share_id' => 'lineage_share_1',
+            'occurred_at' => Carbon::now()->subDay(),
+        ]);
+
+        Order::query()->create([
+            'id' => (string) Str::uuid(),
+            'order_no' => 'ord_lineage_article',
+            'provider' => 'stripe',
+            'status' => 'paid',
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'amount_total' => 4999,
+            'amount_cents' => 4999,
+            'currency' => 'USD',
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'anon_id' => 'anon_lineage_article',
+            'org_id' => (int) $selectedOrg->id,
+            'meta_json' => [
+                'attribution' => [
+                    'share_id' => 'lineage_share_1',
+                    'share_click_id' => 'lineage_click_1',
+                    'entrypoint' => 'share_page',
+                ],
+            ],
+            'paid_at' => Carbon::now()->subHours(8),
+        ]);
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/content-growth-attribution', 'GET'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        Livewire::test(ContentGrowthAttributionPage::class)
+            ->assertOk()
+            ->assertSet('headlineFields.0.value', '0')
+            ->assertSet('headlineFields.1.value', '1')
+            ->assertSet('headlineFields.2.value', '2')
+            ->assertSet('headlineFields.3.value', '1')
+            ->assertSet('headlineFields.4.value', '$49.99')
+            ->assertSet('diagnosticCards.1.value', '1')
+            ->assertSet('matrixRows.0.title', 'Lineage Article')
+            ->assertSet('matrixRows.0.paid_orders', 1)
+            ->assertSet('matrixRows.0.share_assisted_orders', 1)
+            ->assertSet('matrixRows.0.share_touchpoints', 2)
+            ->assertSet('matrixRows.0.seo_label', 'Canonical gap');
     }
 
     private function createOrganization(string $name): Organization

--- a/backend/tests/Feature/Ops/ContentGrowthAttributionPageTest.php
+++ b/backend/tests/Feature/Ops/ContentGrowthAttributionPageTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Pages\ContentGrowthAttributionPage;
+use App\Models\AdminUser;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\CareerGuide;
+use App\Models\CareerGuideSeoMeta;
+use App\Models\CareerJob;
+use App\Models\CareerJobSeoMeta;
+use App\Models\Event;
+use App\Models\Order;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class ContentGrowthAttributionPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_content_growth_attribution_page_requires_org_selection(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+        ]);
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-growth-attribution')
+            ->assertRedirectContains('/ops/select-org');
+    }
+
+    public function test_content_growth_attribution_page_renders_growth_matrix_for_selected_org_and_global_content(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Growth Org');
+        $otherOrg = $this->createOrganization('Other Growth Org');
+
+        $article = Article::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'slug' => 'growth-article',
+            'locale' => 'en',
+            'title' => 'Growth Article',
+            'excerpt' => 'Growth article excerpt',
+            'content_md' => 'Body',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::now()->subDays(4),
+        ]);
+        ArticleSeoMeta::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Growth Article SEO',
+            'seo_description' => 'Growth article description',
+            'canonical_url' => 'https://frontend.example.test/en/articles/growth-article',
+            'og_title' => 'Growth Article OG',
+            'og_description' => 'Growth Article OG Description',
+            'og_image_url' => 'https://frontend.example.test/images/growth-article.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        Article::query()->create([
+            'org_id' => (int) $otherOrg->id,
+            'slug' => 'other-org-article',
+            'locale' => 'en',
+            'title' => 'Other Org Article',
+            'excerpt' => 'Other org article excerpt',
+            'content_md' => 'Body',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::now()->subDays(3),
+        ]);
+
+        $guide = CareerGuide::query()->create([
+            'org_id' => 0,
+            'guide_code' => 'growth-guide',
+            'slug' => 'growth-guide',
+            'locale' => 'en',
+            'title' => 'Growth Guide',
+            'excerpt' => 'Growth guide excerpt',
+            'category_slug' => 'career-planning',
+            'body_md' => 'Guide body',
+            'body_html' => '<p>Guide body</p>',
+            'related_industry_slugs_json' => ['technology'],
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'sort_order' => 0,
+            'schema_version' => 'v1',
+            'published_at' => Carbon::now()->subDays(2),
+        ]);
+        CareerGuideSeoMeta::query()->create([
+            'career_guide_id' => (int) $guide->id,
+            'seo_title' => 'Growth Guide SEO',
+            'seo_description' => 'Growth guide description',
+            'canonical_url' => '',
+            'og_title' => 'Growth Guide OG',
+            'og_description' => 'Growth Guide OG Description',
+            'og_image_url' => 'https://frontend.example.test/images/growth-guide.png',
+            'twitter_title' => 'Growth Guide Twitter',
+            'twitter_description' => 'Growth Guide Twitter Description',
+            'twitter_image_url' => 'https://frontend.example.test/images/growth-guide-twitter.png',
+            'robots' => 'noindex,follow',
+        ]);
+
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'growth-job',
+            'slug' => 'growth-job',
+            'locale' => 'en',
+            'title' => 'Growth Job',
+            'excerpt' => 'Growth job excerpt',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+            'published_at' => Carbon::now()->subDay(),
+        ]);
+        CareerJobSeoMeta::query()->create([
+            'job_id' => (int) $job->id,
+            'seo_title' => 'Growth Job SEO',
+            'seo_description' => 'Growth job description',
+            'canonical_url' => 'https://frontend.example.test/en/career/jobs/growth-job',
+            'og_title' => 'Growth Job OG',
+            'og_description' => 'Growth Job OG Description',
+            'og_image_url' => 'https://frontend.example.test/images/growth-job.png',
+            'twitter_title' => 'Growth Job Twitter',
+            'twitter_description' => 'Growth Job Twitter Description',
+            'twitter_image_url' => 'https://frontend.example.test/images/growth-job-twitter.png',
+            'robots' => 'index,follow',
+        ]);
+
+        Event::query()->create([
+            'id' => (string) Str::uuid(),
+            'event_code' => 'content_entry',
+            'event_name' => 'content_entry',
+            'org_id' => (int) $selectedOrg->id,
+            'meta_json' => [
+                'landing_path' => '/en/articles/growth-article',
+                'share_click_id' => 'click_growth_article',
+            ],
+            'share_id' => 'share_growth_article',
+            'occurred_at' => Carbon::now()->subDays(3),
+        ]);
+
+        Event::query()->create([
+            'id' => (string) Str::uuid(),
+            'event_code' => 'content_entry',
+            'event_name' => 'content_entry',
+            'org_id' => (int) $selectedOrg->id,
+            'meta_json' => [
+                'landing_path' => '/en/career/jobs/growth-job',
+            ],
+            'occurred_at' => Carbon::now()->subDay(),
+        ]);
+
+        Order::query()->create([
+            'id' => (string) Str::uuid(),
+            'order_no' => 'ord_growth_article',
+            'provider' => 'stripe',
+            'status' => 'paid',
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'amount_total' => 1299,
+            'amount_cents' => 1299,
+            'currency' => 'USD',
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'anon_id' => 'anon_growth_article',
+            'org_id' => (int) $selectedOrg->id,
+            'meta_json' => [
+                'attribution' => [
+                    'landing_path' => '/en/articles/growth-article',
+                    'share_id' => 'share_growth_article',
+                    'share_click_id' => 'click_growth_article',
+                    'entrypoint' => 'article_detail',
+                ],
+            ],
+            'paid_at' => Carbon::now()->subDays(2),
+        ]);
+
+        Order::query()->create([
+            'id' => (string) Str::uuid(),
+            'order_no' => 'ord_growth_guide',
+            'provider' => 'stripe',
+            'status' => 'fulfilled',
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'amount_total' => 2599,
+            'amount_cents' => 2599,
+            'currency' => 'USD',
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'anon_id' => 'anon_growth_guide',
+            'org_id' => (int) $selectedOrg->id,
+            'meta_json' => [
+                'attribution' => [
+                    'landing_path' => '/en/career/guides/growth-guide',
+                    'entrypoint' => 'career_guide_detail',
+                ],
+            ],
+            'paid_at' => Carbon::now()->subDay(),
+        ]);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-growth-attribution')
+            ->assertOk()
+            ->assertSee('Content growth attribution')
+            ->assertSee('Growth dashboard')
+            ->assertSee('Growth diagnostics')
+            ->assertSee('Attribution matrix')
+            ->assertSee('Growth Article')
+            ->assertSee('Growth Guide')
+            ->assertSee('Growth Job')
+            ->assertDontSee('Other Org Article');
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/content-growth-attribution', 'GET'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        Livewire::test(ContentGrowthAttributionPage::class)
+            ->assertOk()
+            ->assertSet('headlineFields.0.value', '2')
+            ->assertSet('headlineFields.1.value', '3')
+            ->assertSet('headlineFields.2.value', '2')
+            ->assertSet('headlineFields.3.value', '2')
+            ->assertSet('headlineFields.4.value', '$38.98')
+            ->assertSet('diagnosticCards.0.value', '1')
+            ->assertSet('diagnosticCards.1.value', '1')
+            ->assertSet('matrixRows.0.title', 'Growth Article')
+            ->assertSet('matrixRows.0.paid_orders', 1)
+            ->assertSet('matrixRows.0.share_assisted_orders', 1)
+            ->assertSet('matrixRows.1.title', 'Growth Guide')
+            ->assertSet('matrixRows.1.paid_orders', 1);
+    }
+
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+}

--- a/backend/tests/Feature/Storage/ContentReleaseExactManifestFilesIndexPortabilityTest.php
+++ b/backend/tests/Feature/Storage/ContentReleaseExactManifestFilesIndexPortabilityTest.php
@@ -32,7 +32,7 @@ final class ContentReleaseExactManifestFilesIndexPortabilityTest extends TestCas
         $this->assertStringContainsString("charset('ascii')", $createMigration);
         $this->assertStringContainsString("collation('ascii_bin')", $createMigration);
         $this->assertStringContainsString(
-            "->string('logical_path', 1024)\n                ->charset('ascii')\n                ->collation('ascii_bin')\n                ->change();",
+            'ALTER TABLE `%s` MODIFY `logical_path` VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
             $normalizeMigration
         );
         $this->assertStringContainsString(

--- a/backend/tests/Feature/Storage/StorageBlobLocationsIndexPortabilityTest.php
+++ b/backend/tests/Feature/Storage/StorageBlobLocationsIndexPortabilityTest.php
@@ -33,11 +33,11 @@ final class StorageBlobLocationsIndexPortabilityTest extends TestCase
         $this->assertStringContainsString("charset('ascii')", $createMigration);
         $this->assertStringContainsString("collation('ascii_bin')", $createMigration);
         $this->assertStringContainsString(
-            "->string('disk', 32)\n                ->charset('ascii')\n                ->collation('ascii_bin')\n                ->change();",
+            'ALTER TABLE `%s` MODIFY `disk` VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
             $normalizeMigration
         );
         $this->assertStringContainsString(
-            "->string('storage_path', 1024)\n                ->charset('ascii')\n                ->collation('ascii_bin')\n                ->change();",
+            'ALTER TABLE `%s` MODIFY `storage_path` VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_bin NOT NULL',
             $normalizeMigration
         );
         $this->assertStringNotContainsString('storage_path(191)', $createMigration.$normalizeMigration);


### PR DESCRIPTION
## Summary
- add a growth attribution dashboard for visible CMS content surfaces
- connect public content to SEO readiness, share touchpoints, paid orders, and attributed revenue
- refresh CI baselines required for this loop: migration safety, OpenAPI snapshot, schema baseline, and dependency advisories

## Tests
- php artisan test tests/Feature/Ops/ContentGrowthAttributionPageTest.php tests/Feature/Ops/SeoOperationsPageTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php
- php artisan test tests/Feature/OpenApiDiffTest.php tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php tests/Feature/Storage/StorageBlobLocationsIndexPortabilityTest.php tests/Feature/Storage/ContentReleaseExactManifestFilesIndexPortabilityTest.php
- bash scripts/ci_verify_mbti.sh