### PR TITLE
fix(ops): render dashboard widgets on initial request

### DIFF
--- a/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
+++ b/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\DB;
 
 class CommerceKpiWidget extends BaseWidget
 {
+    protected static bool $isLazy = false;
+
     private const NO_ORG_PLACEHOLDER = '—';
 
     protected function getHeading(): ?string

--- a/backend/app/Filament/Ops/Widgets/FunnelWidget.php
+++ b/backend/app/Filament/Ops/Widgets/FunnelWidget.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\DB;
 
 class FunnelWidget extends BaseWidget
 {
+    protected static bool $isLazy = false;
+
     protected function getHeading(): ?string
     {
         return '7-Day Funnel Snapshot';

--- a/backend/app/Filament/Ops/Widgets/HealthzStatusWidget.php
+++ b/backend/app/Filament/Ops/Widgets/HealthzStatusWidget.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\DB;
 
 class HealthzStatusWidget extends BaseWidget
 {
+    protected static bool $isLazy = false;
+
     protected function getHeading(): ?string
     {
         return 'Service Health Snapshot';

--- a/backend/app/Filament/Ops/Widgets/QueueFailureWidget.php
+++ b/backend/app/Filament/Ops/Widgets/QueueFailureWidget.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\DB;
 
 class QueueFailureWidget extends BaseWidget
 {
+    protected static bool $isLazy = false;
+
     protected function getHeading(): ?string
     {
         return 'Operational Stability';

--- a/backend/app/Filament/Ops/Widgets/WebhookFailureWidget.php
+++ b/backend/app/Filament/Ops/Widgets/WebhookFailureWidget.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\DB;
 
 class WebhookFailureWidget extends BaseWidget
 {
+    protected static bool $isLazy = false;
+
     protected function getHeading(): ?string
     {
         return 'Webhook Monitoring';

--- a/backend/tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
+++ b/backend/tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ops;
 
+use App\Filament\Ops\Widgets\CommerceKpiWidget;
+use App\Filament\Ops\Widgets\FunnelWidget;
+use App\Filament\Ops\Widgets\HealthzStatusWidget;
+use App\Filament\Ops\Widgets\QueueFailureWidget;
+use App\Filament\Ops\Widgets\WebhookFailureWidget;
 use App\Http\Middleware\EnsureAdminTotpVerified;
 use App\Http\Middleware\OpsAccessControl;
 use App\Http\Middleware\RequireOpsOrgSelected;
@@ -59,5 +64,14 @@ final class OpsDashboardOrgContextInheritanceTest extends TestCase
         $this->assertContains(EnsureAdminTotpVerified::class, $persistent);
         $this->assertContains(RequireOpsOrgSelected::class, $persistent);
         $this->assertContains(OpsAccessControl::class, $persistent);
+    }
+
+    public function test_ops_dashboard_widgets_render_on_initial_request_instead_of_lazy_livewire_updates(): void
+    {
+        $this->assertFalse(CommerceKpiWidget::isLazy());
+        $this->assertFalse(FunnelWidget::isLazy());
+        $this->assertFalse(WebhookFailureWidget::isLazy());
+        $this->assertFalse(QueueFailureWidget::isLazy());
+        $this->assertFalse(HealthzStatusWidget::isLazy());
     }
 }


### PR DESCRIPTION
## Summary
- render Ops dashboard widgets eagerly on the initial /ops request
- avoid relying on lazy Livewire widget hydration for org-scoped dashboard stats
- add a regression test that locks the widgets to non-lazy rendering

## Tests
- php artisan test tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php tests/Feature/Ops/LocaleSwitcherComponentTest.php tests/Feature/Ops/SelectOrgFlowTest.php tests/Feature/Ops/CurrentOrgSwitcherComponentTest.php
- php artisan route:list | rg 'ops$|ops/select-org|ops/content-overview|livewire/update'
- php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh