### PR TITLE
fix(v0.3): keep public mbti results in public realm

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -62,7 +62,6 @@ class AttemptReadController extends Controller
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
         private ReportSubjectRepository $reportSubjects,
-        protected OrgContext $orgContext,
     ) {}
 
     /**
@@ -81,7 +80,7 @@ class AttemptReadController extends Controller
         $this->ownedAttemptQuery($request, $attemptId)->firstOrFail();
 
         $payload = $this->attemptSubmissionService->latestForAttempt(
-            $this->orgContext,
+            $this->currentOrgContext(),
             $attemptId,
             $this->resolveUserId($request),
             $this->resolveAnonId($request)
@@ -98,7 +97,7 @@ class AttemptReadController extends Controller
      */
     public function result(Request $request, string $id): JsonResponse
     {
-        $orgId = $this->orgContext->orgId();
+        $orgId = $this->currentOrgContext()->orgId();
         $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $id)->first();
         if (! $result instanceof Result) {
             throw new ApiProblemException(404, 'RESULT_NOT_FOUND', 'result not found.');
@@ -120,7 +119,7 @@ class AttemptReadController extends Controller
                 $id,
                 $this->resolveUserId($request),
                 $this->resolveAnonId($request),
-                $this->orgContext->role(),
+                $this->currentOrgContext()->role(),
                 false,
                 false,
             );
@@ -287,13 +286,13 @@ class AttemptReadController extends Controller
         $refreshRaw = strtolower(trim((string) $request->query('refresh', '0')));
         $forceRefresh = in_array($refreshRaw, ['1', 'true', 'yes', 'on'], true);
 
-        $orgId = $this->orgContext->orgId();
+        $orgId = $this->currentOrgContext()->orgId();
         $userId = $this->resolveUserId($request);
         $anonId = $this->resolveAnonId($request);
         $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $id)->first();
         if (! $result instanceof Result) {
             $submissionPayload = $this->attemptSubmissionService->latestForAttempt(
-                $this->orgContext,
+                $this->currentOrgContext(),
                 $id,
                 $userId !== null ? (string) $userId : null,
                 $anonId
@@ -322,7 +321,7 @@ class AttemptReadController extends Controller
             $id,
             $userId !== null ? (string) $userId : null,
             $anonId,
-            $this->orgContext->role(),
+            $this->currentOrgContext()->role(),
             false,
             $forceRefresh,
         );
@@ -486,7 +485,7 @@ class AttemptReadController extends Controller
      */
     public function reportAccess(Request $request, string $id): JsonResponse
     {
-        $orgId = $this->orgContext->orgId();
+        $orgId = $this->currentOrgContext()->orgId();
         $attempt = $this->resolveAttemptForAccessRead($request, $orgId, $id);
         $projection = UnifiedAccessProjection::query()
             ->where('attempt_id', (string) $attempt->id)
@@ -750,7 +749,7 @@ class AttemptReadController extends Controller
             $attemptId,
             $this->resolveUserId($request),
             $this->resolveAnonId($request),
-            $this->orgContext->role(),
+            $this->currentOrgContext()->role(),
             false,
             false,
         );
@@ -1303,8 +1302,13 @@ class AttemptReadController extends Controller
         return ReportAccessActor::from(
             $this->resolveUserId($request),
             $this->resolveAnonId($request),
-            $this->orgContext->role(),
+            $this->currentOrgContext()->role(),
         );
+    }
+
+    private function currentOrgContext(): OrgContext
+    {
+        return app(OrgContext::class);
     }
 
     private function resolveAttemptId(Result $result, ?Attempt $attempt, string $fallbackAttemptId): string
@@ -1341,7 +1345,7 @@ class AttemptReadController extends Controller
      */
     public function reportPdf(Request $request, string $id): Response
     {
-        $orgId = $this->orgContext->orgId();
+        $orgId = $this->currentOrgContext()->orgId();
         $userId = $this->resolveUserId($request);
         $anonId = $this->resolveAnonId($request);
         $result = Result::where('org_id', $orgId)->where('attempt_id', $id)->firstOrFail();
@@ -1354,7 +1358,7 @@ class AttemptReadController extends Controller
             $id,
             $userId !== null ? (string) $userId : null,
             $anonId,
-            $this->orgContext->role(),
+            $this->currentOrgContext()->role(),
             false,
             false,
         );

--- a/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
@@ -15,7 +15,6 @@ use Illuminate\Http\JsonResponse;
 class AttemptWriteController extends Controller
 {
     public function __construct(
-        protected OrgContext $orgContext,
         private AttemptStartService $startService,
         private AttemptSubmissionService $submissionService,
     ) {}
@@ -25,6 +24,7 @@ class AttemptWriteController extends Controller
      */
     public function start(StartAttemptRequest $request): JsonResponse
     {
+        $context = app(OrgContext::class);
         $payload = $request->validated();
 
         $anonId = trim((string) ($request->attributes->get('client_anon_id') ?? $payload['anon_id'] ?? ''));
@@ -52,7 +52,7 @@ class AttemptWriteController extends Controller
             $payload['referrer'] = $referrer;
         }
 
-        $result = $this->startService->start($this->orgContext, StartAttemptDTO::fromArray($payload));
+        $result = $this->startService->start($context, StartAttemptDTO::fromArray($payload));
 
         return response()->json($result);
     }
@@ -62,12 +62,13 @@ class AttemptWriteController extends Controller
      */
     public function submit(SubmitAttemptRequest $request): JsonResponse
     {
+        $context = app(OrgContext::class);
         $payload = $request->validated();
         $attemptId = trim((string) ($payload['attempt_id'] ?? ''));
 
         $payload['user_id'] = $request->attributes->get('fm_user_id')
             ?? $request->attributes->get('user_id')
-            ?? $this->orgContext->userId();
+            ?? $context->userId();
 
         $attrAnonId = trim((string) (
             $request->attributes->get('anon_id')
@@ -78,7 +79,7 @@ class AttemptWriteController extends Controller
         // ✅ 必须从原始 request input 取，不能依赖 validated()，否则 rules 里没放 anon_id 就会被过滤掉
         $bodyAnonId = trim((string) ($request->input('anon_id') ?? ''));
 
-        $ctxAnonId = trim((string) ($this->orgContext->anonId() ?? ''));
+        $ctxAnonId = trim((string) ($context->anonId() ?? ''));
 
         $payload['anon_id'] = $attrAnonId !== ''
             ? $attrAnonId
@@ -89,7 +90,7 @@ class AttemptWriteController extends Controller
         $preferAsync = $asyncEnabled && $mode !== 'sync_legacy';
 
         $outcome = $this->submissionService->submit(
-            $this->orgContext,
+            $context,
             $attemptId,
             SubmitAttemptDTO::fromArray($payload),
             $preferAsync

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -15,6 +15,17 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FmTokenAuth
 {
+    private const PUBLIC_ATTEMPT_ROUTE_NAMES = [
+        'api.v0_3.attempts.start',
+        'api.v0_3.attempts.submit',
+        'api.v0_3.attempts.submission',
+        'api.v0_3.attempts.show',
+        'api.v0_3.attempts.result',
+        'api.v0_3.attempts.report',
+        'api.v0_3.attempts.report_access',
+        'api.v0_3.attempts.report_pdf',
+    ];
+
     public function handle(Request $request, Closure $next): Response
     {
         $header = (string) $request->header('Authorization', '');
@@ -112,7 +123,7 @@ class FmTokenAuth
 
         TouchFmTokenLastUsedAtJob::dispatch($tokenHash)->onQueue('ops');
 
-        $ctx = new OrgContext;
+        $ctx = app(OrgContext::class);
         $ctx->set(
             $orgId,
             $resolvedUserId,
@@ -217,6 +228,10 @@ class FmTokenAuth
 
     private function resolveOrgId(Request $request, object $row): int
     {
+        if ($this->shouldForcePublicAttemptRealm($request)) {
+            return 0;
+        }
+
         $fromToken = $this->resolveNumeric($row->org_id ?? null);
         if ($fromToken !== null && $fromToken > 0) {
             return $fromToken;
@@ -254,6 +269,54 @@ class FmTokenAuth
         }
 
         return 0;
+    }
+
+    private function shouldForcePublicAttemptRealm(Request $request): bool
+    {
+        if ($request->attributes->get('force_public_attempt_realm') === true) {
+            return true;
+        }
+
+        $route = $request->route();
+        $routeName = is_object($route) ? trim((string) $route->getName()) : '';
+        $flag = is_object($route) ? ($route->defaults['public_realm'] ?? null) : null;
+
+        $isPublicAttemptRoute = in_array($routeName, self::PUBLIC_ATTEMPT_ROUTE_NAMES, true);
+        $hasPublicRealmDefault = $flag === true || $flag === 1 || $flag === '1';
+
+        return ($hasPublicRealmDefault || $isPublicAttemptRoute || $this->isPublicAttemptPath($request))
+            && ! $this->hasExplicitTenantOrgSignal($request);
+    }
+
+    private function isPublicAttemptPath(Request $request): bool
+    {
+        return $request->is('api/v0.3/attempts/start')
+            || $request->is('api/v0.3/attempts/submit')
+            || $request->is('api/v0.3/attempts/*/submission')
+            || $request->is('api/v0.3/attempts/*/result')
+            || $request->is('api/v0.3/attempts/*/report')
+            || $request->is('api/v0.3/attempts/*/report-access')
+            || $request->is('api/v0.3/attempts/*/report.pdf')
+            || preg_match('#^api/v0\.3/attempts/[0-9a-fA-F-]+$#', ltrim($request->path(), '/')) === 1;
+    }
+
+    private function hasExplicitTenantOrgSignal(Request $request): bool
+    {
+        $candidates = [
+            $request->header('X-FM-Org-Id'),
+            $request->header('X-Org-Id'),
+            $request->query('org_id'),
+            $request->route('org_id'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            $normalized = $this->resolveNumeric($candidate);
+            if ($normalized !== null && $normalized > 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/app/Http/Middleware/ForcePublicAttemptRealm.php
+++ b/backend/app/Http/Middleware/ForcePublicAttemptRealm.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ForcePublicAttemptRealm
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $route = $request->route();
+        $flag = is_object($route) ? ($route->defaults['public_realm'] ?? null) : null;
+        $hasExplicitTenantOrgSignal = $this->hasExplicitTenantOrgSignal($request);
+
+        if (($flag === true || $flag === 1 || $flag === '1') && ! $hasExplicitTenantOrgSignal) {
+            $request->attributes->set('force_public_attempt_realm', true);
+        }
+
+        return $next($request);
+    }
+
+    private function hasExplicitTenantOrgSignal(Request $request): bool
+    {
+        $candidates = [
+            $request->header('X-FM-Org-Id'),
+            $request->header('X-Org-Id'),
+            $request->query('org_id'),
+            $request->route('org_id'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_int($candidate) && ! is_string($candidate) && ! is_numeric($candidate)) {
+                continue;
+            }
+
+            $raw = trim((string) $candidate);
+            if ($raw !== '' && preg_match('/^\d+$/', $raw) === 1 && (int) $raw > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/app/Http/Middleware/ResolveOrgContext.php
+++ b/backend/app/Http/Middleware/ResolveOrgContext.php
@@ -13,6 +13,17 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ResolveOrgContext
 {
+    private const PUBLIC_ATTEMPT_ROUTE_NAMES = [
+        'api.v0_3.attempts.start',
+        'api.v0_3.attempts.submit',
+        'api.v0_3.attempts.submission',
+        'api.v0_3.attempts.show',
+        'api.v0_3.attempts.result',
+        'api.v0_3.attempts.report',
+        'api.v0_3.attempts.report_access',
+        'api.v0_3.attempts.report_pdf',
+    ];
+
     public function __construct(
         private MembershipService $membershipService,
         private FmTokenService $tokenService,
@@ -118,9 +129,11 @@ class ResolveOrgContext
                 $request->attributes->get('fm_org_id'),
                 $request->attributes->get('org_id'),
             ];
-        $tokenOrgId = $this->resolveOrgIdFromToken($request);
-        if ($tokenOrgId !== null) {
-            $candidates[] = $tokenOrgId;
+        if (! $this->shouldForcePublicAttemptRealm($request)) {
+            $tokenOrgId = $this->resolveOrgIdFromToken($request);
+            if ($tokenOrgId !== null) {
+                $candidates[] = $tokenOrgId;
+            }
         }
 
         $resolved = [];
@@ -159,6 +172,54 @@ class ResolveOrgContext
         }
 
         return str_starts_with('/'.ltrim($request->path(), '/'), '/ops');
+    }
+
+    private function shouldForcePublicAttemptRealm(Request $request): bool
+    {
+        if ($request->attributes->get('force_public_attempt_realm') === true) {
+            return true;
+        }
+
+        $route = $request->route();
+        $routeName = is_object($route) ? trim((string) $route->getName()) : '';
+        $flag = is_object($route) ? ($route->defaults['public_realm'] ?? null) : null;
+
+        $isPublicAttemptRoute = in_array($routeName, self::PUBLIC_ATTEMPT_ROUTE_NAMES, true);
+        $hasPublicRealmDefault = $flag === true || $flag === 1 || $flag === '1';
+
+        return ($hasPublicRealmDefault || $isPublicAttemptRoute || $this->isPublicAttemptPath($request))
+            && ! $this->hasExplicitTenantOrgSignal($request);
+    }
+
+    private function isPublicAttemptPath(Request $request): bool
+    {
+        return $request->is('api/v0.3/attempts/start')
+            || $request->is('api/v0.3/attempts/submit')
+            || $request->is('api/v0.3/attempts/*/submission')
+            || $request->is('api/v0.3/attempts/*/result')
+            || $request->is('api/v0.3/attempts/*/report')
+            || $request->is('api/v0.3/attempts/*/report-access')
+            || $request->is('api/v0.3/attempts/*/report.pdf')
+            || preg_match('#^api/v0\.3/attempts/[0-9a-fA-F-]+$#', ltrim($request->path(), '/')) === 1;
+    }
+
+    private function hasExplicitTenantOrgSignal(Request $request): bool
+    {
+        $candidates = [
+            $request->header('X-FM-Org-Id'),
+            $request->header('X-Org-Id'),
+            $request->query('org_id'),
+            $request->route('org_id'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            $normalized = $this->normalizeOrgId($candidate);
+            if ($normalized !== null && $normalized > 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function normalizeOrgId(mixed $candidate): ?int

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -59,6 +59,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $this->app->singleton(OrgContext::class, static fn (): OrgContext => new OrgContext);
+
         $this->app->singleton(PiiEnvelopeAdapter::class, function ($app) {
             $adapterRaw = strtolower(trim((string) config('services.pii.adapter', 'local')));
             $adapter = match ($adapterRaw) {

--- a/backend/app/Repositories/Report/ReportSubjectRepository.php
+++ b/backend/app/Repositories/Report/ReportSubjectRepository.php
@@ -12,13 +12,13 @@ use Illuminate\Support\Facades\DB;
 
 final class ReportSubjectRepository
 {
-    public function __construct(private readonly OrgContext $orgContext) {}
-
     public function findSubjectForCurrentContext(string $attemptId, ReportAccessActor $actor): ?ReportSubject
     {
+        $orgContext = app(OrgContext::class);
+
         return $this->findSubjectForRealm(
-            $this->orgContext->contextKind(),
-            $this->orgContext->scopedOrgId(),
+            $orgContext->contextKind(),
+            $orgContext->scopedOrgId(),
             $attemptId,
             $actor,
         );
@@ -61,9 +61,11 @@ final class ReportSubjectRepository
 
     public function findAttemptForCurrentContext(string $attemptId, ReportAccessActor $actor): ?Attempt
     {
+        $orgContext = app(OrgContext::class);
+
         return $this->findAttemptForRealm(
-            $this->orgContext->contextKind(),
-            $this->orgContext->scopedOrgId(),
+            $orgContext->contextKind(),
+            $orgContext->scopedOrgId(),
             $attemptId,
             $actor,
         );

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -149,7 +149,7 @@
         },
         "/api/v0.3/attempts/start": {
             "post": {
-                "operationId": "post_api_v0_3_attempts_start",
+                "operationId": "api.v0_3.attempts.start",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -165,13 +165,15 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_attempt_submit"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.attempts.start"
             }
         },
         "/api/v0.3/attempts/submit": {
             "post": {
-                "operationId": "post_api_v0_3_attempts_submit",
+                "operationId": "api.v0_3.attempts.submit",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -187,9 +189,11 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_attempt_submit",
                     "App\\Http\\Middleware\\FmTokenAuth"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.attempts.submit"
             }
         },
         "/api/v0.3/attempts/{attempt_id}/progress": {
@@ -210,6 +214,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:attempt_id"
                 ]
             },
@@ -230,6 +235,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:attempt_id"
                 ]
             }
@@ -252,6 +258,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:attempt_id"
                 ],
                 "x-laravel-name": "api.v0_3.attempts.submission"
@@ -275,6 +282,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
                 ],
                 "x-laravel-name": "api.v0_3.attempts.show"
@@ -298,6 +306,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
                 ],
                 "x-laravel-name": "api.v0_3.attempts.report"
@@ -321,6 +330,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
                 ],
                 "x-laravel-name": "api.v0_3.attempts.report_access"
@@ -344,6 +354,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
                 ],
                 "x-laravel-name": "api.v0_3.attempts.report_pdf"
@@ -367,6 +378,7 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
                 ],
                 "x-laravel-name": "api.v0_3.attempts.result"

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -37,6 +37,7 @@ use App\Http\Controllers\HealthzController;
 use App\Http\Middleware\AdminAuth;
 use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\EnsureCmsAdminAuthorized;
+use App\Http\Middleware\ForcePublicAttemptRealm;
 use App\Http\Middleware\HealthzAccessControl;
 use App\Http\Middleware\LimitWebhookPayloadSize;
 use App\Http\Middleware\NormalizeApiErrorContract;
@@ -144,7 +145,10 @@ Route::prefix('v0.3')->middleware([
             ->middleware(['uuid:id', 'throttle:api_auth']);
     });
 
-    Route::middleware([\App\Http\Middleware\ResolveAnonId::class, ResolveOrgContext::class])->group(function () use ($payProviders) {
+    Route::middleware([
+        \App\Http\Middleware\ResolveAnonId::class,
+        ResolveOrgContext::class,
+    ])->group(function () use ($payProviders) {
         // 0) Boot (flags + experiments)
         Route::get('/boot', [BootV0_3Controller::class, 'show']);
         Route::get('/flags', [BootV0_3Controller::class, 'flags']);
@@ -162,33 +166,45 @@ Route::prefix('v0.3')->middleware([
         Route::get('/scales/{scale_code}', [ScalesController::class, 'show']);
 
         // 2) Attempts lifecycle
-        Route::middleware('throttle:api_attempt_submit')->group(function () {
-            Route::post('/attempts/start', [AttemptWriteController::class, 'start']);
-            Route::post('/attempts/submit', [AttemptWriteController::class, 'submit'])
-                ->middleware(\App\Http\Middleware\FmTokenAuth::class);
+        Route::middleware(ForcePublicAttemptRealm::class)->group(function () {
+            Route::middleware('throttle:api_attempt_submit')->group(function () {
+                Route::post('/attempts/start', [AttemptWriteController::class, 'start'])
+                    ->defaults('public_realm', true)
+                    ->name('api.v0_3.attempts.start');
+                Route::post('/attempts/submit', [AttemptWriteController::class, 'submit'])
+                    ->middleware(\App\Http\Middleware\FmTokenAuth::class)
+                    ->defaults('public_realm', true)
+                    ->name('api.v0_3.attempts.submit');
+            });
+            Route::put('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'upsert'])
+                ->middleware('uuid:attempt_id');
+            Route::get('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'show'])
+                ->middleware('uuid:attempt_id');
+            Route::get('/attempts/{attempt_id}/submission', [AttemptReadController::class, 'submission'])
+                ->middleware('uuid:attempt_id')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.submission');
+            Route::get('/attempts/{id}', [AttemptReadController::class, 'show'])
+                ->middleware('uuid:id')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.show');
+            Route::get('/attempts/{id}/result', [AttemptReadController::class, 'result'])
+                ->middleware('uuid:id')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.result');
+            Route::get('/attempts/{id}/report', [AttemptReadController::class, 'report'])
+                ->middleware('uuid:id')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.report');
+            Route::get('/attempts/{id}/report-access', [AttemptReadController::class, 'reportAccess'])
+                ->middleware('uuid:id')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.report_access');
+            Route::get('/attempts/{id}/report.pdf', [AttemptReadController::class, 'reportPdf'])
+                ->middleware('uuid:id')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.report_pdf');
         });
-        Route::put('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'upsert'])
-            ->middleware('uuid:attempt_id');
-        Route::get('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'show'])
-            ->middleware('uuid:attempt_id');
-        Route::get('/attempts/{attempt_id}/submission', [AttemptReadController::class, 'submission'])
-            ->middleware('uuid:attempt_id')
-            ->name('api.v0_3.attempts.submission');
-        Route::get('/attempts/{id}', [AttemptReadController::class, 'show'])
-            ->middleware('uuid:id')
-            ->name('api.v0_3.attempts.show');
-        Route::get('/attempts/{id}/result', [AttemptReadController::class, 'result'])
-            ->middleware('uuid:id')
-            ->name('api.v0_3.attempts.result');
-        Route::get('/attempts/{id}/report', [AttemptReadController::class, 'report'])
-            ->middleware('uuid:id')
-            ->name('api.v0_3.attempts.report');
-        Route::get('/attempts/{id}/report-access', [AttemptReadController::class, 'reportAccess'])
-            ->middleware('uuid:id')
-            ->name('api.v0_3.attempts.report_access');
-        Route::get('/attempts/{id}/report.pdf', [AttemptReadController::class, 'reportPdf'])
-            ->middleware('uuid:id')
-            ->name('api.v0_3.attempts.report_pdf');
         // Share contract routes stay fixed; summary/click semantics are implemented in ShareController/services.
         Route::match(['GET', 'POST'], '/attempts/{id}/share', [ShareV03Controller::class, 'getShare'])
             ->middleware(\App\Http\Middleware\FmTokenAuth::class);

--- a/backend/tests/Feature/V0_3/AttemptPublicRealmResolutionTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicRealmResolutionTest.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Http\Middleware\FmTokenAuth;
+use App\Http\Middleware\ForcePublicAttemptRealm;
+use App\Http\Middleware\ResolveAnonId;
+use App\Http\Middleware\ResolveOrgContext;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Auth\FmTokenService;
+use App\Services\Scale\ScaleRegistry;
+use App\Support\OrgContext;
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptPublicRealmResolutionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function registerDebugRoutes(): void
+    {
+        if (Route::has('api.v0_3.attempts.debug_context_org')) {
+            return;
+        }
+
+        $debugResponder = function (Request $request) {
+            return response()->json([
+                'request_org_id' => (int) $request->attributes->get('org_id', -1),
+                'request_fm_org_id' => (int) $request->attributes->get('fm_org_id', -1),
+                'context_org_id' => (int) app(OrgContext::class)->orgId(),
+                'user_id' => (string) ($request->attributes->get('fm_user_id') ?? ''),
+                'anon_id' => (string) ($request->attributes->get('anon_id') ?? ''),
+            ]);
+        };
+
+        Route::middleware([ResolveAnonId::class, ForcePublicAttemptRealm::class, ResolveOrgContext::class])
+            ->post('/api/v0.3/attempts/debug-context-org', $debugResponder)
+            ->defaults('public_realm', true)
+            ->name('api.v0_3.attempts.debug_context_org');
+
+        Route::middleware([ResolveAnonId::class, ForcePublicAttemptRealm::class, ResolveOrgContext::class, FmTokenAuth::class])
+            ->post('/api/v0.3/attempts/debug-context', $debugResponder)
+            ->defaults('public_realm', true)
+            ->name('api.v0_3.attempts.debug_context');
+
+        Route::middleware([ResolveAnonId::class, ForcePublicAttemptRealm::class, ResolveOrgContext::class])
+            ->get('/api/v0.3/attempts/debug-result/{attempt_id}', function (string $attemptId) {
+                $orgId = app(OrgContext::class)->orgId();
+                $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $attemptId)->first();
+
+                return response()->json([
+                    'context_org_id' => $orgId,
+                    'found' => $result instanceof Result,
+                ]);
+            })
+            ->defaults('public_realm', true)
+            ->name('api.v0_3.attempts.debug_result');
+
+        Route::middleware([ResolveAnonId::class, ForcePublicAttemptRealm::class, ResolveOrgContext::class])
+            ->post('/api/v0.3/attempts/debug-start-scale', function () {
+                $orgId = app(OrgContext::class)->orgId();
+                $row = app(ScaleRegistry::class)->getByCode('MBTI', $orgId);
+
+                return response()->json([
+                    'context_org_id' => $orgId,
+                    'scale_found' => is_array($row),
+                ]);
+            })
+            ->defaults('public_realm', true)
+            ->name('api.v0_3.attempts.debug_start_scale');
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr17SimpleScoreDemoSeeder)->run();
+    }
+
+    /**
+     * @return array{user_id:int,org_id:int,token:string}
+     */
+    private function createTenantUserToken(string $anonId): array
+    {
+        $now = now();
+        $userId = DB::table('users')->insertGetId([
+            'name' => 'Public Realm Owner',
+            'email' => 'public-realm-'.Str::lower(Str::random(8)).'@example.test',
+            'password' => bcrypt('secret'),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $orgId = DB::table('organizations')->insertGetId([
+            'name' => 'Tenant '.Str::lower(Str::random(6)),
+            'owner_user_id' => $userId,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => 'owner',
+            'joined_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId, [
+            'anon_id' => $anonId,
+            'org_id' => $orgId,
+            'role' => 'owner',
+        ]);
+
+        return [
+            'user_id' => (int) $userId,
+            'org_id' => (int) $orgId,
+            'token' => (string) ($issued['token'] ?? ''),
+        ];
+    }
+
+    private function createPublicMbtiAttemptAndResult(string $attemptId, int $userId, string $anonId): void
+    {
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'attempt-v1',
+            'scoring_spec_version' => 'attempt-score-v1',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => 'result-v1',
+            'result_json' => [
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => 'result-score-v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+    }
+
+    public function test_public_mbti_result_and_report_access_ignore_tenant_token_realm_without_explicit_org(): void
+    {
+        $this->registerDebugRoutes();
+        $this->seedScales();
+
+        $anonId = 'anon_public_realm_result_owner';
+        $actor = $this->createTenantUserToken($anonId);
+        $attemptId = (string) Str::uuid();
+        $this->createPublicMbtiAttemptAndResult($attemptId, $actor['user_id'], $anonId);
+
+        $headers = [
+            'Authorization' => 'Bearer '.$actor['token'],
+            'X-Anon-Id' => $anonId,
+        ];
+
+        $resultDebug = $this->withHeaders($headers)
+            ->getJson("/api/v0.3/attempts/debug-result/{$attemptId}");
+
+        $resultDebug->assertStatus(200);
+        $resultDebug->assertJsonPath('context_org_id', 0);
+        $resultDebug->assertJsonPath('found', true);
+
+        $result = $this->withHeaders($headers)
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $result->assertStatus(200);
+        $result->assertJsonPath('attempt_id', $attemptId);
+        $result->assertJsonPath('type_code', 'INTJ-A');
+
+        $reportAccess = $this->withHeaders($headers)
+            ->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $reportAccess->assertStatus(200);
+        $reportAccess->assertJsonPath('attempt_id', $attemptId);
+        $reportAccess->assertJsonPath('report_state', 'ready');
+    }
+
+    public function test_public_attempt_routes_force_public_org_context_even_with_tenant_token(): void
+    {
+        $this->registerDebugRoutes();
+        $anonId = 'anon_public_realm_debug';
+        $actor = $this->createTenantUserToken($anonId);
+
+        $orgOnly = $this->withHeaders([
+            'Authorization' => 'Bearer '.$actor['token'],
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/debug-context-org', []);
+
+        $orgOnly->assertStatus(200);
+        $orgOnly->assertJsonPath('request_org_id', 0);
+        $orgOnly->assertJsonPath('context_org_id', 0);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$actor['token'],
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/debug-context', []);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('request_org_id', 0);
+        $response->assertJsonPath('request_fm_org_id', 0);
+        $response->assertJsonPath('context_org_id', 0);
+        $response->assertJsonPath('user_id', (string) $actor['user_id']);
+        $response->assertJsonPath('anon_id', $anonId);
+
+        $resultDebug = $this->withHeaders([
+            'Authorization' => 'Bearer '.$actor['token'],
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/attempts/debug-result/'.Str::uuid());
+
+        $resultDebug->assertStatus(200);
+        $resultDebug->assertJsonPath('context_org_id', 0);
+
+        $scaleDebug = $this->withHeaders([
+            'Authorization' => 'Bearer '.$actor['token'],
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/debug-start-scale', []);
+
+        $scaleDebug->assertStatus(200);
+        $scaleDebug->assertJsonPath('context_org_id', 0);
+        $scaleDebug->assertJsonPath('scale_found', true);
+    }
+
+    public function test_public_attempt_start_ignores_tenant_token_realm_without_explicit_org(): void
+    {
+        $this->registerDebugRoutes();
+        $this->seedScales();
+
+        $anonId = 'anon_public_realm_submit_owner';
+        $actor = $this->createTenantUserToken($anonId);
+
+        $headers = [
+            'Authorization' => 'Bearer '.$actor['token'],
+            'X-Anon-Id' => $anonId,
+        ];
+
+        $start = $this->withHeaders($headers)->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'anon_id' => $anonId,
+        ]);
+
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $attempt = Attempt::query()->findOrFail($attemptId);
+        $this->assertSame(0, (int) $attempt->org_id);
+        $this->assertSame($actor['user_id'], (int) $attempt->user_id);
+    }
+}


### PR DESCRIPTION
## Summary
- force public MBTI attempt/result/report routes to stay in public realm when no explicit tenant org is provided
- stop tenant fm_token org claims from shifting public result reads into tenant org context
- resolve OrgContext from the shared container in v0.3 attempt read/write/report codepaths
- add focused regression coverage for public result/report-access/start under tenant tokens

## Tests
- php artisan route:list | rg 'api.v0_3.attempts.start|api.v0_3.attempts.result|api.v0_3.attempts.report_access'
- php artisan migrate --force
- php artisan test tests/Feature/V0_3/AttemptPublicRealmResolutionTest.php
- php artisan test tests/Feature/V0_3/AttemptPublicResultReadHotfixTest.php tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php tests/Feature/V0_3/AttemptsStartSubmitTest.php tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
- bash scripts/export_openapi.sh
- bash backend/scripts/ci_verify_mbti.sh
  - verify_mbti/main acceptance path passed
  - repo still has an existing dependency security gate failure: total_advisories=4 high_or_critical=2
