### PR TITLE
PR-01: SEO authority 收口

### DIFF
--- a/backend/app/Http/Controllers/SitemapController.php
+++ b/backend/app/Http/Controllers/SitemapController.php
@@ -12,6 +12,11 @@ class SitemapController extends Controller
 
     public function index(Request $request, SitemapCache $cache, SitemapGenerator $generator)
     {
+        $authority = strtolower(trim((string) config('services.seo.public_sitemap_authority', 'frontend')));
+        if ($authority !== 'backend') {
+            abort(404);
+        }
+
         $cached = $cache->get();
         if ($cached) {
             $xml = $cached['xml'];

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -105,6 +105,7 @@ return [
     ],
 
     'seo' => [
+        'public_sitemap_authority' => env('SEO_PUBLIC_SITEMAP_AUTHORITY', 'frontend'),
         'tests_url_prefix' => env(
             'SEO_TESTS_URL_PREFIX',
             rtrim((string) env('APP_URL', 'http://localhost'), '/').'/tests/'

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -21,7 +21,10 @@ class SitemapXmlTest extends TestCase
 
     public function test_sitemap_xml_is_cached_and_filtered(): void
     {
-        config(['services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/']);
+        config([
+            'services.seo.public_sitemap_authority' => 'backend',
+            'services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/',
+        ]);
         config(['app.frontend_url' => 'https://staging.fermatmind.com']);
 
         $nowA = Carbon::create(2026, 1, 30, 10, 0, 0);
@@ -511,6 +514,13 @@ class SitemapXmlTest extends TestCase
         $second->assertHeader('ETag', $etag);
         $second->assertHeaderMissing('Set-Cookie');
         $this->assertSame('', (string) $second->getContent());
+    }
+
+    public function test_sitemap_xml_returns_404_when_frontend_is_public_authority(): void
+    {
+        config(['services.seo.public_sitemap_authority' => 'frontend']);
+
+        $this->get('/sitemap.xml')->assertNotFound();
     }
 
     /**

--- a/fap-web/app/robots.ts
+++ b/fap-web/app/robots.ts
@@ -1,8 +1,10 @@
 import type { MetadataRoute } from 'next';
 
 export default function robots(): MetadataRoute.Robots {
+  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || 'https://fermatmind.com').replace(/\/$/, '');
+
   return {
     rules: [{ userAgent: '*', allow: '/' }],
-    sitemap: 'https://fermatmind.com/sitemap.xml',
+    sitemap: `${siteUrl}/sitemap.xml`,
   };
 }

--- a/fap-web/app/sitemap.ts
+++ b/fap-web/app/sitemap.ts
@@ -1,5 +1,32 @@
 import type { MetadataRoute } from 'next';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [];
+  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || 'https://fermatmind.com').replace(/\/$/, '');
+  const now = new Date();
+  const paths = [
+    '/',
+    '/en',
+    '/zh',
+    '/en/articles',
+    '/zh/articles',
+    '/en/personality',
+    '/zh/personality',
+    '/en/topics',
+    '/zh/topics',
+    '/en/tests',
+    '/zh/tests',
+    '/en/career',
+    '/zh/career',
+    '/en/career/guides',
+    '/zh/career/guides',
+    '/en/career/jobs',
+    '/zh/career/jobs',
+    '/en/career/recommendations',
+    '/zh/career/recommendations',
+  ];
+
+  return paths.map((path) => ({
+    url: `${siteUrl}${path === '/' ? '' : path}`,
+    lastModified: now,
+  }));
 }


### PR DESCRIPTION
Logical PR-01 for fap-api.

Scope:
- unify sitemap authority guard
- backend sitemap 404 when frontend is authority
- robots/sitemap glue in embedded web snapshot
