### PR TITLE
[codex] Auto-refresh stale Ops login snapshots

### DIFF
--- a/backend/resources/views/filament/ops/pages/auth/login.blade.php
+++ b/backend/resources/views/filament/ops/pages/auth/login.blade.php
@@ -62,4 +62,36 @@
     </form>
 
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::AUTH_LOGIN_FORM_AFTER, scopes: $this->getRenderHookScopes()) }}
+
+    <script>
+        document.addEventListener('livewire:init', () => {
+            if (window.__opsLoginAutoRefreshHookInstalled) {
+                return
+            }
+
+            window.__opsLoginAutoRefreshHookInstalled = true
+
+            const autoRefreshStorageKey = 'ops-login-livewire-page-expired-at'
+            const autoRefreshCooldownMs = 30_000
+
+            window.Livewire?.hook('request', ({ fail }) => {
+                fail(({ status, preventDefault }) => {
+                    if (status !== 419 || window.location.pathname !== '/ops/login') {
+                        return
+                    }
+
+                    const lastAutoRefreshAt = Number(window.sessionStorage.getItem(autoRefreshStorageKey) || '0')
+                    const now = Date.now()
+
+                    if (Number.isFinite(lastAutoRefreshAt) && (now - lastAutoRefreshAt) < autoRefreshCooldownMs) {
+                        return
+                    }
+
+                    window.sessionStorage.setItem(autoRefreshStorageKey, String(now))
+                    preventDefault()
+                    window.location.reload()
+                })
+            })
+        })
+    </script>
 </x-filament-panels::page.simple>

--- a/backend/tests/Feature/Ops/OpsLoginPageTest.php
+++ b/backend/tests/Feature/Ops/OpsLoginPageTest.php
@@ -22,6 +22,11 @@ final class OpsLoginPageTest extends TestCase
             ->assertSee('autocomplete="username"', false)
             ->assertSee('autocomplete="current-password"', false)
             ->assertSee("\$wire.set('data.email', emailInput.value)", false)
-            ->assertSee("\$wire.set('data.password', passwordInput.value)", false);
+            ->assertSee("\$wire.set('data.password', passwordInput.value)", false)
+            ->assertSee('window.__opsLoginAutoRefreshHookInstalled', false)
+            ->assertSee("const autoRefreshStorageKey = 'ops-login-livewire-page-expired-at'", false)
+            ->assertSee("window.Livewire?.hook('request'", false)
+            ->assertSee('if (status !== 419 || window.location.pathname !== \'/ops/login\')', false)
+            ->assertSee('window.location.reload()', false);
     }
 }


### PR DESCRIPTION
## Summary

This change applies a minimal UI-side fix for the Fermat Ops login page when the browser submits a stale Livewire snapshot. Instead of surfacing Livewire's default `This page has expired. Would you like to refresh the page?` confirm dialog, the login page now performs one silent refresh and reloads a fresh CSRF/session snapshot.

## User impact

Before this change, users who returned to an old `/ops/login` tab or restored a stale browser session could hit a 419 Livewire request failure and see a generic expiration dialog. The dialog is abrupt, looks like a backend failure, and makes the login flow feel broken.

After this change, the first stale-snapshot failure on `/ops/login` is handled automatically by reloading the page. Users land on a fresh login page with valid cookies and CSRF state instead of being forced through the confirm prompt.

## Root cause

The login page uses a Livewire form submission. When the page snapshot, session, or CSRF token becomes stale, Livewire receives a `419` response and falls back to its built-in `handlePageExpiry()` confirm dialog. The backend login path itself is still healthy on a fresh page; the failure is caused by stale client state.

## Fix

The login Blade now registers a small `livewire:init` request hook that:

- only targets `/ops/login`
- intercepts request failures with status `419`
- suppresses the default Livewire page-expired dialog once
- reloads the page automatically to fetch a fresh session and snapshot
- uses `sessionStorage` with a 30 second cooldown to avoid reload loops

A feature test was updated to assert that the login page continues to expose the browser-friendly form behavior and now includes the auto-refresh hook.

## Validation

The following checks were run locally:

- `cd backend && php artisan route:list | rg 'ops/login|filament.ops.auth.login'`
- `cd backend && php artisan migrate --force`
- `cd backend && ./vendor/bin/pint resources/views/filament/ops/pages/auth/login.blade.php tests/Feature/Ops/OpsLoginPageTest.php`
- `cd backend && php artisan test --filter=OpsLoginPageTest`
- `cd backend && php artisan test --filter=OpsLoginLimiterResetTest`
- `cd backend && php artisan serve --host=127.0.0.1 --port=1891`
- `curl -s http://127.0.0.1:1891/ops/login | rg -n "ops-login-livewire-page-expired-at|window\\.Livewire\\?\\.hook\\('request'|window\\.location\\.reload\\(\\)"`
- `curl -I -s http://127.0.0.1:1891/ops/login`
- `bash backend/scripts/ci_verify_mbti.sh`

`ci_verify_mbti.sh` remained green for the application chain and stopped only on the repository's existing dependency security gate (`high_or_critical=2`).
