### PR TITLE
fix(ops): include public paid orders in dashboard kpis

### DIFF
--- a/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
+++ b/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
@@ -23,6 +23,7 @@ class CommerceKpiWidget extends BaseWidget
     protected function getStats(): array
     {
         $orgId = max(0, (int) app(OrgContext::class)->orgId());
+        $currentOrgIds = $this->currentOrgIds($orgId);
         $start = now()->startOfDay();
         $end = (clone $start)->addDay();
 
@@ -38,39 +39,39 @@ class CommerceKpiWidget extends BaseWidget
         }
 
         $paidOrders = (int) DB::table('orders')
-            ->where('org_id', $orgId)
+            ->whereIn('org_id', $currentOrgIds)
             ->where('payment_state', 'paid')
             ->where('paid_at', '>=', $start)
             ->where('paid_at', '<', $end)
             ->count();
 
         $pendingUnresolved = (int) DB::table('orders')
-            ->where('org_id', $orgId)
+            ->whereIn('org_id', $currentOrgIds)
             ->whereIn('payment_state', ['created', 'pending'])
             ->count();
 
         $paidNoGrant = (int) DB::table('orders')
-            ->where('org_id', $orgId)
+            ->whereIn('org_id', $currentOrgIds)
             ->where('payment_state', 'paid')
             ->where('grant_state', '!=', 'granted')
             ->count();
 
         $compensatedRecently = (int) DB::table('orders')
-            ->where('org_id', $orgId)
+            ->whereIn('org_id', $currentOrgIds)
             ->whereNotNull('last_reconciled_at')
             ->where('last_reconciled_at', '>=', $start)
             ->where('last_reconciled_at', '<', $end)
             ->count();
 
         $refundCount = (int) DB::table('orders')
-            ->where('org_id', $orgId)
+            ->whereIn('org_id', $currentOrgIds)
             ->where('payment_state', 'refunded')
             ->where('refunded_at', '>=', $start)
             ->where('refunded_at', '<', $end)
             ->count();
 
         $webhookFailures = (int) DB::table('payment_events')
-            ->where('org_id', $orgId)
+            ->whereIn('org_id', $currentOrgIds)
             ->where('created_at', '>=', $start)
             ->where('created_at', '<', $end)
             ->where(function ($query): void {
@@ -100,5 +101,13 @@ class CommerceKpiWidget extends BaseWidget
         return Stat::make($label, self::NO_ORG_PLACEHOLDER)
             ->description($description)
             ->color('gray');
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function currentOrgIds(int $orgId): array
+    {
+        return $orgId > 0 ? [0, $orgId] : [0];
     }
 }

--- a/backend/tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php
+++ b/backend/tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php
@@ -73,12 +73,51 @@ final class CommerceKpiExceptionSummaryTest extends TestCase
         }
 
         $this->assertContains('Pending unresolved', $labels);
-        $this->assertContains('Paid no grant', $labels);
-        $this->assertContains('Compensated recently', $labels);
+        $this->assertContains('Paid without grant', $labels);
+        $this->assertContains('Compensated today', $labels);
         $this->assertSame('2', $valuesByLabel[__('ops.widgets.paid_orders_today')] ?? null);
         $this->assertSame('2', $valuesByLabel['Pending unresolved'] ?? null);
-        $this->assertSame('1', $valuesByLabel['Paid no grant'] ?? null);
-        $this->assertSame('1', $valuesByLabel['Compensated recently'] ?? null);
+        $this->assertSame('1', $valuesByLabel['Paid without grant'] ?? null);
+        $this->assertSame('1', $valuesByLabel['Compensated today'] ?? null);
+    }
+
+    public function test_commerce_kpi_widget_includes_public_realm_orders_in_selected_org_summary(): void
+    {
+        $orgId = 75;
+
+        $this->seedCommerceOpsChain($orgId, 'ord_tenant_paid_today_ops', [
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'paid',
+            'paid_at' => now()->subMinutes(12),
+        ]);
+
+        $this->seedCommerceOpsChain(0, 'ord_public_paid_today_ops', [
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'paid',
+            'paid_at' => now()->subMinutes(9),
+            'payment_event_status' => 'failed',
+            'payment_event_handle_status' => 'failed',
+            'signature_ok' => 0,
+        ]);
+
+        $context = app(OrgContext::class);
+        $context->set($orgId, null, null, null, OrgContext::KIND_TENANT);
+        app()->instance(OrgContext::class, $context);
+
+        $widget = app(CommerceKpiWidget::class);
+        $method = new ReflectionMethod($widget, 'getStats');
+        $method->setAccessible(true);
+        $stats = $method->invoke($widget);
+
+        $valuesByLabel = [];
+        foreach ($stats as $stat) {
+            $valuesByLabel[(string) $stat->getLabel()] = (string) $stat->getValue();
+        }
+
+        $this->assertSame('2', $valuesByLabel[__('ops.widgets.paid_orders_today')] ?? null);
+        $this->assertSame('1', $valuesByLabel[__('ops.widgets.webhook_failures')] ?? null);
     }
 
     public function test_commerce_kpi_widget_uses_placeholder_when_no_org_is_selected(): void
@@ -101,6 +140,6 @@ final class CommerceKpiExceptionSummaryTest extends TestCase
             $this->assertNotSame('0', (string) $stat->getValue());
         }
 
-        $this->assertSame(__('ops.widgets.no_org_selected'), (string) $stats[1]->getDescription());
+        $this->assertSame(__('ops.widgets.select_org_to_view_metrics'), (string) $stats[1]->getDescription());
     }
 }


### PR DESCRIPTION
## Summary
- include public realm orders and payment events in ops dashboard commerce KPIs when a tenant org is selected
- add regression coverage for public paid orders showing up in today paid orders and webhook failures
- sync stale widget test labels/descriptions with the current UI copy

## Tests
- php -d opcache.enable_cli=0 artisan test tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php
- php -d opcache.enable_cli=0 artisan test tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
- php -d opcache.enable_cli=0 artisan test tests/Feature/Commerce/CheckoutWebhookOpsTenantVisibilityAcceptanceTest.php
- bash backend/scripts/ci_verify_mbti.sh