### PR TITLE
fix(ops): recover from livewire page expiry

### DIFF
--- a/backend/app/Providers/Filament/AdminPanelProvider.php
+++ b/backend/app/Providers/Filament/AdminPanelProvider.php
@@ -102,6 +102,10 @@ class AdminPanelProvider extends PanelProvider
                 fn () => view('filament.ops.hooks.topbar-controls')
             )
             ->renderHook(
+                PanelsRenderHook::BODY_END,
+                fn () => view('filament.ops.hooks.livewire-page-expired-recovery')
+            )
+            ->renderHook(
                 PanelsRenderHook::SIDEBAR_FOOTER,
                 fn () => view('filament.ops.hooks.sidebar-footer')
             )

--- a/backend/resources/views/filament/ops/hooks/livewire-page-expired-recovery.blade.php
+++ b/backend/resources/views/filament/ops/hooks/livewire-page-expired-recovery.blade.php
@@ -1,0 +1,34 @@
+<script>
+    document.addEventListener('livewire:init', () => {
+        if (window.__opsLivewirePageExpiredRecoveryHookInstalled) {
+            return
+        }
+
+        window.__opsLivewirePageExpiredRecoveryHookInstalled = true
+
+        const autoRefreshStorageKeyPrefix = 'ops-livewire-page-expired-at:'
+        const autoRefreshCooldownMs = 30_000
+
+        window.Livewire?.hook('request', ({ fail }) => {
+            fail(({ status, preventDefault }) => {
+                const pathname = window.location.pathname || ''
+
+                if (status !== 419 || ! pathname.startsWith('/ops')) {
+                    return
+                }
+
+                const autoRefreshStorageKey = `${autoRefreshStorageKeyPrefix}${pathname}`
+                const lastAutoRefreshAt = Number(window.sessionStorage.getItem(autoRefreshStorageKey) || '0')
+                const now = Date.now()
+
+                if (Number.isFinite(lastAutoRefreshAt) && (now - lastAutoRefreshAt) < autoRefreshCooldownMs) {
+                    return
+                }
+
+                window.sessionStorage.setItem(autoRefreshStorageKey, String(now))
+                preventDefault()
+                window.location.reload()
+            })
+        })
+    })
+</script>

--- a/backend/resources/views/filament/ops/pages/auth/login.blade.php
+++ b/backend/resources/views/filament/ops/pages/auth/login.blade.php
@@ -62,36 +62,4 @@
     </form>
 
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::AUTH_LOGIN_FORM_AFTER, scopes: $this->getRenderHookScopes()) }}
-
-    <script>
-        document.addEventListener('livewire:init', () => {
-            if (window.__opsLoginAutoRefreshHookInstalled) {
-                return
-            }
-
-            window.__opsLoginAutoRefreshHookInstalled = true
-
-            const autoRefreshStorageKey = 'ops-login-livewire-page-expired-at'
-            const autoRefreshCooldownMs = 30_000
-
-            window.Livewire?.hook('request', ({ fail }) => {
-                fail(({ status, preventDefault }) => {
-                    if (status !== 419 || window.location.pathname !== '/ops/login') {
-                        return
-                    }
-
-                    const lastAutoRefreshAt = Number(window.sessionStorage.getItem(autoRefreshStorageKey) || '0')
-                    const now = Date.now()
-
-                    if (Number.isFinite(lastAutoRefreshAt) && (now - lastAutoRefreshAt) < autoRefreshCooldownMs) {
-                        return
-                    }
-
-                    window.sessionStorage.setItem(autoRefreshStorageKey, String(now))
-                    preventDefault()
-                    window.location.reload()
-                })
-            })
-        })
-    </script>
 </x-filament-panels::page.simple>

--- a/backend/tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
+++ b/backend/tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
@@ -51,7 +51,9 @@ final class OpsDashboardOrgContextInheritanceTest extends TestCase
             ->assertOk()
             ->assertSee($selectedOrg->name)
             ->assertDontSee(__('ops.topbar.no_org_selected'))
-            ->assertDontSee(__('ops.widgets.select_org_to_view_metrics'));
+            ->assertDontSee(__('ops.widgets.select_org_to_view_metrics'))
+            ->assertSee('window.__opsLivewirePageExpiredRecoveryHookInstalled', false)
+            ->assertSee("const autoRefreshStorageKeyPrefix = 'ops-livewire-page-expired-at:'", false);
     }
 
     public function test_ops_panel_registers_org_context_middleware_for_livewire_persistence(): void

--- a/backend/tests/Feature/Ops/OpsLoginPageTest.php
+++ b/backend/tests/Feature/Ops/OpsLoginPageTest.php
@@ -23,10 +23,10 @@ final class OpsLoginPageTest extends TestCase
             ->assertSee('autocomplete="current-password"', false)
             ->assertSee("\$wire.set('data.email', emailInput.value)", false)
             ->assertSee("\$wire.set('data.password', passwordInput.value)", false)
-            ->assertSee('window.__opsLoginAutoRefreshHookInstalled', false)
-            ->assertSee("const autoRefreshStorageKey = 'ops-login-livewire-page-expired-at'", false)
+            ->assertSee('window.__opsLivewirePageExpiredRecoveryHookInstalled', false)
+            ->assertSee("const autoRefreshStorageKeyPrefix = 'ops-livewire-page-expired-at:'", false)
             ->assertSee("window.Livewire?.hook('request'", false)
-            ->assertSee('if (status !== 419 || window.location.pathname !== \'/ops/login\')', false)
+            ->assertSee("if (status !== 419 || ! pathname.startsWith('/ops'))", false)
             ->assertSee('window.location.reload()', false);
     }
 }


### PR DESCRIPTION
## Summary
- add a shared Ops Livewire 419 recovery hook for all /ops pages
- remove the login-only inline recovery script and reuse the shared hook
- cover login and dashboard pages with focused regression assertions

## Tests
- cd backend && php artisan test tests/Feature/Ops/OpsLoginPageTest.php tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh