### PR TITLE
fix(ops): repair locale switcher livewire action

### DIFF
--- a/backend/resources/views/livewire/filament/ops/livewire/locale-switcher.blade.php
+++ b/backend/resources/views/livewire/filament/ops/livewire/locale-switcher.blade.php
@@ -1,6 +1,7 @@
 @php
     $localeLabel = $locales[$locale] ?? __('ops.locale.switcher_label');
     $localeCode = strtoupper(str_replace('_', '-', $locale));
+    $returnUrl = request()->fullUrl();
 @endphp
 
 <div class="ops-topbar-chip ops-topbar-chip--locale">
@@ -35,7 +36,11 @@
         <x-filament::dropdown.list>
             @foreach ($locales as $key => $label)
                 <x-filament::dropdown.list.item
-                    wire:click="setLocale('{{ $key }}', @js(request()->fullUrl()))"
+                    :wire:click="sprintf(
+                        'setLocale(%s, %s)',
+                        \Illuminate\Support\Js::from($key),
+                        \Illuminate\Support\Js::from($returnUrl),
+                    )"
                     :disabled="$locale === $key"
                 >
                     {{ $label }}

--- a/backend/tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
+++ b/backend/tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
@@ -52,6 +52,8 @@ final class OpsDashboardOrgContextInheritanceTest extends TestCase
             ->assertSee($selectedOrg->name)
             ->assertDontSee(__('ops.topbar.no_org_selected'))
             ->assertDontSee(__('ops.widgets.select_org_to_view_metrics'))
+            ->assertDontSee('@js(request()->fullUrl())', false)
+            ->assertSee('setLocale(', false)
             ->assertSee('window.__opsLivewirePageExpiredRecoveryHookInstalled', false)
             ->assertSee("const autoRefreshStorageKeyPrefix = 'ops-livewire-page-expired-at:'", false);
     }


### PR DESCRIPTION
## Summary
- repair the ops locale switcher wire:click expression so Blade resolves the return URL before Alpine parses it
- stop leaking raw `@js(request()->fullUrl())` into the browser
- keep dashboard assertions locked to the safe rendered output

## Tests
- cd backend && php artisan test tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php tests/Feature/Ops/LocaleSwitcherComponentTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh