### PR TITLE
fix(seo): harden tests sitemap authority

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -13,8 +13,8 @@ use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\PersonalityProfileService;
 use App\Services\Cms\TopicProfileSeoService;
+use App\Services\Scale\ScaleRegistry;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 
 class SitemapGenerator
 {
@@ -27,10 +27,11 @@ class SitemapGenerator
         private readonly PersonalityProfileService $personalityProfileService,
         private readonly PersonalityProfileSeoService $personalityProfileSeoService,
         private readonly TopicProfileSeoService $topicProfileSeoService,
+        private readonly ScaleRegistry $scaleRegistry,
     ) {
         $configuredPrefix = trim((string) config('services.seo.tests_url_prefix', ''));
         if ($configuredPrefix === '') {
-            $configuredPrefix = rtrim((string) config('app.url', 'http://localhost'), '/').'/tests/';
+            $configuredPrefix = rtrim((string) config('app.frontend_url', config('app.url', 'http://localhost')), '/').'/tests/';
         }
 
         $this->urlPrefix = rtrim($configuredPrefix, '/').'/';
@@ -90,23 +91,26 @@ class SitemapGenerator
 
     private function getScaleUrls(string $locale): array
     {
-        $rows = DB::table('scales_registry')
-            ->select('primary_slug', 'slugs_json', 'view_policy_json', 'updated_at')
-            ->where('is_active', 1)
-            ->where('is_public', 1)
-            ->where('org_id', 0)
-            ->get();
+        $rows = $this->scaleRegistry->listActivePublic(0);
 
         $slugDates = [];
 
         foreach ($rows as $row) {
-            if (! $this->isIndexablePublic($row->view_policy_json ?? null)) {
+            if (! is_array($row)) {
                 continue;
             }
 
-            $updatedAt = $this->parseUpdatedAt($row->updated_at ?? null);
+            if (array_key_exists('is_indexable', $row) && ! (bool) ($row['is_indexable'] ?? true)) {
+                continue;
+            }
 
-            $slugs = $this->collectSlugs($row->primary_slug ?? null, $row->slugs_json ?? null);
+            if (! $this->isIndexablePublic($row['view_policy_json'] ?? null)) {
+                continue;
+            }
+
+            $updatedAt = $this->parseUpdatedAt($row['updated_at'] ?? null);
+
+            $slugs = $this->collectSlugs($row['primary_slug'] ?? null, $row['slugs_json'] ?? null);
             foreach ($slugs as $slug) {
                 $slug = trim((string) $slug);
                 if ($slug === '') {

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -108,7 +108,7 @@ return [
         'public_sitemap_authority' => env('SEO_PUBLIC_SITEMAP_AUTHORITY', 'frontend'),
         'tests_url_prefix' => env(
             'SEO_TESTS_URL_PREFIX',
-            rtrim((string) env('APP_URL', 'http://localhost'), '/').'/tests/'
+            rtrim((string) env('FRONTEND_URL', env('APP_URL', 'http://localhost')), '/').'/tests/'
         ),
         'articles_url_prefix' => env(
             'SEO_ARTICLES_PREFIX',

--- a/backend/scripts/pr24_verify_sitemap.sh
+++ b/backend/scripts/pr24_verify_sitemap.sh
@@ -9,9 +9,11 @@ export NO_COLOR=1
 
 SERVE_PORT="${SERVE_PORT:-1824}"
 API_BASE="http://127.0.0.1:${SERVE_PORT}"
+HEALTH_URL="${HEALTH_URL:-${API_BASE}/api/healthz}"
 URL_PREFIX="${SEO_TESTS_URL_PREFIX:-https://fermatmind.com/tests/}"
 URL_PREFIX="${URL_PREFIX%/}/"
 export SEO_TESTS_URL_PREFIX="${URL_PREFIX}"
+export SEO_PUBLIC_SITEMAP_AUTHORITY="${SEO_PUBLIC_SITEMAP_AUTHORITY:-backend}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -43,6 +45,7 @@ log "Clearing application cache"
 (
   cd "$BACKEND_DIR"
   php artisan cache:clear >/dev/null 2>&1 || true
+  php artisan config:clear >/dev/null 2>&1 || true
 )
 
 SERVER_PID=""
@@ -68,7 +71,7 @@ log "Waiting for health"
 health_code=""
 health_body="$ART_DIR/health_body.txt"
 for _i in $(seq 1 40); do
-  health_code="$(curl -s -o "$health_body" -w "%{http_code}" "$API_BASE/" || true)"
+  health_code="$(curl -s -o "$health_body" -w "%{http_code}" "$HEALTH_URL" || true)"
   if [[ "$health_code" == "200" ]]; then
     break
   fi
@@ -167,23 +170,39 @@ if [[ "$loc_count" != "100" ]]; then
   exit 1
 fi
 
-lastmod_count="$(grep -E '<lastmod>[0-9]{4}-[0-9]{2}-[0-9]{2}</lastmod>' "$body_200" | wc -l | tr -d ' ')"
-if [[ "$lastmod_count" != "100" ]]; then
-  log "Expected 100 lastmod entries, got $lastmod_count"
-  exit 1
-fi
+python3 - "$body_200" "$URL_PREFIX" <<'PY'
+import re
+import sys
+import xml.etree.ElementTree as ET
 
-changefreq_count="$(grep -E '<changefreq>weekly</changefreq>' "$body_200" | wc -l | tr -d ' ')"
-if [[ "$changefreq_count" != "100" ]]; then
-  log "Expected 100 changefreq entries, got $changefreq_count"
-  exit 1
-fi
+body_path, prefix = sys.argv[1], sys.argv[2]
+tree = ET.parse(body_path)
+root = tree.getroot()
+ns = {'sm': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
+urls = root.findall('sm:url', ns)
+matching = []
 
-priority_count="$(grep -E '<priority>0.7</priority>' "$body_200" | wc -l | tr -d ' ')"
-if [[ "$priority_count" != "100" ]]; then
-  log "Expected 100 priority entries, got $priority_count"
-  exit 1
-fi
+for node in urls:
+    loc = (node.findtext('sm:loc', default='', namespaces=ns) or '').strip()
+    if loc.startswith(prefix + 'pr24-'):
+        matching.append(node)
+
+if len(matching) != 100:
+    raise SystemExit(f'Expected 100 matching <url> nodes for prefix {prefix}, got {len(matching)}')
+
+for node in matching:
+    loc = (node.findtext('sm:loc', default='', namespaces=ns) or '').strip()
+    lastmod = (node.findtext('sm:lastmod', default='', namespaces=ns) or '').strip()
+    changefreq = (node.findtext('sm:changefreq', default='', namespaces=ns) or '').strip()
+    priority = (node.findtext('sm:priority', default='', namespaces=ns) or '').strip()
+
+    if not re.fullmatch(r'\d{4}-\d{2}-\d{2}', lastmod):
+        raise SystemExit(f'Invalid lastmod for {loc}: {lastmod!r}')
+    if changefreq != 'weekly':
+        raise SystemExit(f'Invalid changefreq for {loc}: {changefreq!r}')
+    if priority != '0.7':
+        raise SystemExit(f'Invalid priority for {loc}: {priority!r}')
+PY
 
 headers_304="$ART_DIR/headers_304.txt"
 body_304="$ART_DIR/body_304.txt"

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -523,6 +523,112 @@ class SitemapXmlTest extends TestCase
         $this->get('/sitemap.xml')->assertNotFound();
     }
 
+    public function test_sitemap_xml_defaults_tests_urls_to_frontend_host_when_prefix_is_not_explicitly_configured(): void
+    {
+        config([
+            'services.seo.public_sitemap_authority' => 'backend',
+            'services.seo.tests_url_prefix' => '',
+            'app.url' => 'https://api.fermatmind.com',
+            'app.frontend_url' => 'https://fermatmind.com',
+        ]);
+
+        DB::table('scales_registry')->insert([
+            'code' => 'PR24_HOST',
+            'org_id' => 0,
+            'primary_slug' => 'host-check',
+            'slugs_json' => json_encode(['host-check-alt']),
+            'driver_type' => 'MBTI',
+            'default_pack_id' => null,
+            'default_region' => null,
+            'default_locale' => null,
+            'default_dir_version' => null,
+            'capabilities_json' => null,
+            'view_policy_json' => null,
+            'commercial_json' => null,
+            'seo_schema_json' => null,
+            'is_public' => 1,
+            'is_active' => 1,
+            'created_at' => Carbon::create(2026, 1, 31, 9, 0, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 9, 0, 0),
+        ]);
+
+        $body = (string) $this->get('/sitemap.xml')->getContent();
+
+        $this->assertStringContainsString('<loc>https://fermatmind.com/tests/host-check</loc>', $body);
+        $this->assertStringContainsString('<loc>https://fermatmind.com/tests/host-check-alt</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://api.fermatmind.com/tests/host-check</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://api.fermatmind.com/tests/host-check-alt</loc>', $body);
+    }
+
+    public function test_sitemap_xml_reads_public_tests_from_v2_registry_when_legacy_registry_is_empty(): void
+    {
+        config([
+            'services.seo.public_sitemap_authority' => 'backend',
+            'services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/',
+        ]);
+
+        DB::table('scales_registry')->delete();
+        DB::table('scales_registry_v2')->delete();
+
+        DB::table('scales_registry_v2')->insert([
+            [
+                'org_id' => 0,
+                'code' => 'PR24_V2_PUBLIC',
+                'primary_slug' => 'v2-public',
+                'slugs_json' => json_encode(['v2-public-alt']),
+                'driver_type' => 'MBTI',
+                'assessment_driver' => null,
+                'default_pack_id' => null,
+                'default_region' => null,
+                'default_locale' => null,
+                'default_dir_version' => null,
+                'capabilities_json' => null,
+                'view_policy_json' => null,
+                'commercial_json' => null,
+                'seo_schema_json' => null,
+                'seo_i18n_json' => null,
+                'content_i18n_json' => null,
+                'report_summary_i18n_json' => null,
+                'is_public' => 1,
+                'is_active' => 1,
+                'is_indexable' => 1,
+                'created_at' => Carbon::create(2026, 1, 31, 9, 5, 0),
+                'updated_at' => Carbon::create(2026, 1, 31, 9, 5, 0),
+            ],
+            [
+                'org_id' => 0,
+                'code' => 'PR24_V2_NOINDEX',
+                'primary_slug' => 'v2-noindex',
+                'slugs_json' => json_encode(['v2-noindex-alt']),
+                'driver_type' => 'MBTI',
+                'assessment_driver' => null,
+                'default_pack_id' => null,
+                'default_region' => null,
+                'default_locale' => null,
+                'default_dir_version' => null,
+                'capabilities_json' => null,
+                'view_policy_json' => null,
+                'commercial_json' => null,
+                'seo_schema_json' => null,
+                'seo_i18n_json' => null,
+                'content_i18n_json' => null,
+                'report_summary_i18n_json' => null,
+                'is_public' => 1,
+                'is_active' => 1,
+                'is_indexable' => 0,
+                'created_at' => Carbon::create(2026, 1, 31, 9, 10, 0),
+                'updated_at' => Carbon::create(2026, 1, 31, 9, 10, 0),
+            ],
+        ]);
+
+        $body = (string) $this->get('/sitemap.xml')->getContent();
+
+        $this->assertStringContainsString('<loc>https://fermatmind.com/tests/v2-public</loc>', $body);
+        $this->assertStringContainsString('<loc>https://fermatmind.com/tests/v2-public-alt</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/tests/v2-noindex</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/tests/v2-noindex-alt</loc>', $body);
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */


### PR DESCRIPTION
## Summary
- fix tests sitemap host fallback to prefer FRONTEND_URL over APP_URL
- read public tests sitemap entries from ScaleRegistry so v2 registry remains covered
- harden pr24 sitemap verification script for backend authority, config cache, and tests-only XML assertions

## Tests
- php artisan route:list | rg 'sitemap.xml|SitemapController'
- php artisan migrate --force
- php artisan test tests/Feature/SEO/SitemapXmlTest.php
- bash backend/scripts/pr24_verify_sitemap.sh
- bash backend/scripts/ci_verify_mbti.sh
