### PR TITLE
feat(ops): add attempt chain audit baseline

### DIFF
--- a/backend/app/Console/Commands/Ops/AttemptChainAudit.php
+++ b/backend/app/Console/Commands/Ops/AttemptChainAudit.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Ops\AttemptChainAuditService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+final class AttemptChainAudit extends Command
+{
+    protected $signature = 'ops:attempt-chain-audit
+        {--attempt-id= : Inspect one attempt id exactly}
+        {--window-hours= : Recent window to scan when --attempt-id is omitted}
+        {--limit= : Max recent rows per source table}
+        {--pending-timeout-minutes= : Threshold for pending/running submissions}
+        {--strict= : Exit non-zero when findings exist}
+        {--json=1 : Output JSON payload}';
+
+    protected $description = 'Audit bad attempt ids and missing attempt/submission/result/projection chains.';
+
+    public function __construct(
+        private readonly AttemptChainAuditService $auditService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $policy = is_array(config('ops.attempt_chain_audit')) ? config('ops.attempt_chain_audit') : [];
+
+        $attemptId = $this->normalizeString($this->option('attempt-id'));
+        $windowHours = $this->resolvePositiveInt($this->option('window-hours'), (int) ($policy['window_hours'] ?? 24), 24);
+        $limit = $this->resolvePositiveInt($this->option('limit'), (int) ($policy['limit'] ?? 200), 200);
+        $pendingTimeoutMinutes = $this->resolvePositiveInt(
+            $this->option('pending-timeout-minutes'),
+            (int) ($policy['pending_timeout_minutes'] ?? 15),
+            15
+        );
+        $strict = $this->resolveStrict($policy);
+
+        $payload = $this->auditService->audit($attemptId, $windowHours, $limit, $pendingTimeoutMinutes);
+        $findingsTotal = (int) data_get($payload, 'summary.finding_total', 0);
+
+        if ($findingsTotal > 0) {
+            Log::warning('ATTEMPT_CHAIN_AUDIT_FINDINGS', [
+                'selection' => $payload['selection'] ?? [],
+                'summary' => $payload['summary'] ?? [],
+                'inspected_count' => (int) ($payload['inspected_count'] ?? 0),
+            ]);
+        }
+
+        if ($this->isTruthy($this->option('json'))) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $selection = is_array($payload['selection'] ?? null) ? $payload['selection'] : [];
+            $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+
+            $this->info('attempt_chain_audit');
+            $this->line(sprintf(
+                'attempt_id=%s window_hours=%d limit=%d pending_timeout_minutes=%d strict=%s inspected=%d findings=%d',
+                (string) ($selection['attempt_id'] ?? 'recent'),
+                (int) ($selection['window_hours'] ?? 0),
+                (int) ($selection['limit'] ?? 0),
+                (int) ($selection['pending_timeout_minutes'] ?? 0),
+                $strict ? '1' : '0',
+                (int) ($payload['inspected_count'] ?? 0),
+                (int) ($summary['finding_total'] ?? 0),
+            ));
+
+            $byIssueCode = is_array($summary['by_issue_code'] ?? null) ? $summary['by_issue_code'] : [];
+            foreach ($byIssueCode as $issueCode => $count) {
+                $this->line(sprintf('issue=%s total=%d', (string) $issueCode, (int) $count));
+            }
+
+            $inspections = is_array($payload['inspections'] ?? null) ? $payload['inspections'] : [];
+            foreach ($inspections as $inspection) {
+                if (! is_array($inspection)) {
+                    continue;
+                }
+
+                $findings = is_array($inspection['findings'] ?? null) ? $inspection['findings'] : [];
+                if ($findings === []) {
+                    continue;
+                }
+
+                $codes = [];
+                foreach ($findings as $finding) {
+                    if (! is_array($finding)) {
+                        continue;
+                    }
+
+                    $issueCode = trim((string) ($finding['issue_code'] ?? ''));
+                    if ($issueCode !== '') {
+                        $codes[] = $issueCode;
+                    }
+                }
+
+                $this->warn(sprintf(
+                    '%s source=%s issues=%s',
+                    (string) ($inspection['attempt_id'] ?? ''),
+                    (string) ($inspection['source'] ?? 'attempt'),
+                    implode(',', $codes)
+                ));
+            }
+        }
+
+        if ($strict && $findingsTotal > 0) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string,mixed>  $policy
+     */
+    private function resolveStrict(array $policy): bool
+    {
+        $strictOption = $this->option('strict');
+        if ($strictOption === null || $strictOption === '') {
+            return (bool) ($policy['strict_default'] ?? false);
+        }
+
+        return $this->isTruthy($strictOption);
+    }
+
+    private function resolvePositiveInt(mixed $value, int $configured, int $fallback): int
+    {
+        if (is_numeric($value) && (int) $value > 0) {
+            return (int) $value;
+        }
+
+        if ($configured > 0) {
+            return $configured;
+        }
+
+        return $fallback;
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/Ops/AttemptChainAuditService.php
+++ b/backend/app/Services/Ops/AttemptChainAuditService.php
@@ -1,0 +1,554 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class AttemptChainAuditService
+{
+    /**
+     * @return array{
+     *     ok:bool,
+     *     timestamp:string,
+     *     selection:array{attempt_id:?string,window_hours:int,limit:int,pending_timeout_minutes:int},
+     *     inspected_count:int,
+     *     summary:array{finding_total:int,critical_total:int,warning_total:int,by_issue_code:array<string,int>},
+     *     inspections:list<array<string,mixed>>
+     * }
+     */
+    public function audit(?string $attemptId, int $windowHours, int $limit, int $pendingTimeoutMinutes): array
+    {
+        $attemptId = $this->normalizeString($attemptId);
+        $windowHours = max(1, $windowHours);
+        $limit = max(1, $limit);
+        $pendingTimeoutMinutes = max(1, $pendingTimeoutMinutes);
+
+        $inspections = $attemptId !== null
+            ? [$this->inspectAttemptId($attemptId, $pendingTimeoutMinutes)]
+            : $this->inspectRecentWindow($windowHours, $limit, $pendingTimeoutMinutes);
+
+        return [
+            'ok' => true,
+            'timestamp' => now()->toISOString(),
+            'selection' => [
+                'attempt_id' => $attemptId,
+                'window_hours' => $windowHours,
+                'limit' => $limit,
+                'pending_timeout_minutes' => $pendingTimeoutMinutes,
+            ],
+            'inspected_count' => count($inspections),
+            'summary' => $this->summarize($inspections),
+            'inspections' => $inspections,
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function inspectRecentWindow(int $windowHours, int $limit, int $pendingTimeoutMinutes): array
+    {
+        $windowStart = now()->subHours($windowHours);
+        $inspections = [];
+
+        if (Schema::hasTable('attempts')) {
+            $attemptIds = DB::table('attempts')
+                ->where(function ($query) use ($windowStart): void {
+                    $query->where('created_at', '>=', $windowStart)
+                        ->orWhere('updated_at', '>=', $windowStart)
+                        ->orWhere('submitted_at', '>=', $windowStart);
+                })
+                ->orderByRaw('COALESCE(submitted_at, updated_at, created_at) DESC')
+                ->limit($limit)
+                ->pluck('id')
+                ->filter(static fn ($value): bool => is_string($value) && trim($value) !== '')
+                ->map(static fn (string $value): string => trim($value))
+                ->values()
+                ->all();
+
+            foreach ($attemptIds as $attemptId) {
+                $inspections[] = $this->inspectAttemptId($attemptId, $pendingTimeoutMinutes);
+            }
+        }
+
+        return array_merge(
+            $inspections,
+            $this->inspectOrphanSubmissions($windowStart, $limit),
+            $this->inspectOrphanResults($windowStart, $limit),
+            $this->inspectOrphanProjections($windowStart, $limit),
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function inspectAttemptId(string $attemptId, int $pendingTimeoutMinutes): array
+    {
+        $attempt = $this->findAttempt($attemptId);
+        $submission = $this->findLatestSubmission($attemptId);
+        $result = $this->findResult($attemptId);
+        $projection = $this->findProjection($attemptId);
+
+        $findings = [];
+
+        if ($attempt === null && $submission === null && $result === null && $projection === null) {
+            $findings[] = $this->finding(
+                'attempt_chain_absent',
+                'critical',
+                'attempt/result/submission/projection are all missing for this attempt id.'
+            );
+        }
+
+        if ($attempt === null && $submission !== null) {
+            $findings[] = $this->finding(
+                'orphan_submission_without_attempt',
+                'critical',
+                'attempt_submission exists but the parent attempt row is missing.'
+            );
+        }
+
+        if ($attempt === null && $result !== null) {
+            $findings[] = $this->finding(
+                'orphan_result_without_attempt',
+                'critical',
+                'result exists but the parent attempt row is missing.'
+            );
+        }
+
+        if ($attempt === null && $projection !== null) {
+            $findings[] = $this->finding(
+                'orphan_projection_without_attempt',
+                'critical',
+                'unified_access_projection exists but the parent attempt row is missing.'
+            );
+        }
+
+        if ($attempt !== null && $submission !== null) {
+            $attemptOrgId = (int) ($attempt->org_id ?? 0);
+            $submissionOrgId = (int) ($submission->org_id ?? 0);
+            if ($submissionOrgId !== $attemptOrgId) {
+                $findings[] = $this->finding(
+                    'submission_org_mismatch',
+                    'critical',
+                    sprintf('attempt org_id=%d but latest submission org_id=%d.', $attemptOrgId, $submissionOrgId)
+                );
+            }
+        }
+
+        if ($attempt !== null && $result !== null) {
+            $attemptOrgId = (int) ($attempt->org_id ?? 0);
+            $resultOrgId = (int) ($result->org_id ?? 0);
+            if ($resultOrgId !== $attemptOrgId) {
+                $findings[] = $this->finding(
+                    'result_org_mismatch',
+                    'critical',
+                    sprintf('attempt org_id=%d but result org_id=%d.', $attemptOrgId, $resultOrgId)
+                );
+            }
+        }
+
+        $submittedAt = $this->parseTimestamp($attempt?->submitted_at ?? null);
+        $submissionState = strtolower((string) ($submission->state ?? ''));
+
+        if ($attempt !== null && $submittedAt instanceof Carbon && $submission === null && $result === null) {
+            $findings[] = $this->finding(
+                'submission_missing_for_submitted_attempt',
+                'critical',
+                'attempt was submitted but there is no submission record and no result row.'
+            );
+        }
+
+        if ($submission !== null && in_array($submissionState, ['pending', 'running'], true)) {
+            $updatedAt = $this->parseTimestamp($submission->updated_at ?? $submission->created_at ?? null);
+            if ($updatedAt instanceof Carbon) {
+                $ageMinutes = $updatedAt->diffInMinutes(now());
+                if ($ageMinutes >= $pendingTimeoutMinutes) {
+                    $findings[] = $this->finding(
+                        'submission_stuck_pending',
+                        'warning',
+                        sprintf('latest submission has been %s for %d minutes.', $submissionState, $ageMinutes)
+                    );
+                }
+            }
+        }
+
+        if ($submission !== null && $submissionState === 'succeeded' && $result === null) {
+            $findings[] = $this->finding(
+                'result_missing_after_submission_success',
+                'critical',
+                'latest submission succeeded but no result row exists.'
+            );
+        }
+
+        if ($result !== null && $projection === null) {
+            $findings[] = $this->finding(
+                'projection_missing_after_result',
+                'warning',
+                'result exists but unified_access_projection is missing.'
+            );
+        }
+
+        return [
+            'attempt_id' => $attemptId,
+            'source' => 'attempt',
+            'attempt' => $this->attemptPayload($attempt),
+            'submission' => $this->submissionPayload($submission),
+            'result' => $this->resultPayload($result),
+            'projection' => $this->projectionPayload($projection),
+            'findings' => $findings,
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function inspectOrphanSubmissions(Carbon $windowStart, int $limit): array
+    {
+        if (! Schema::hasTable('attempt_submissions') || ! Schema::hasTable('attempts')) {
+            return [];
+        }
+
+        $rows = DB::table('attempt_submissions')
+            ->leftJoin('attempts', 'attempts.id', '=', 'attempt_submissions.attempt_id')
+            ->whereNull('attempts.id')
+            ->where(function ($query) use ($windowStart): void {
+                $query->where('attempt_submissions.created_at', '>=', $windowStart)
+                    ->orWhere('attempt_submissions.updated_at', '>=', $windowStart);
+            })
+            ->select('attempt_submissions.*')
+            ->orderByDesc('attempt_submissions.updated_at')
+            ->limit($limit)
+            ->get();
+
+        $inspections = [];
+        foreach ($rows as $row) {
+            $inspections[] = [
+                'attempt_id' => trim((string) ($row->attempt_id ?? '')),
+                'source' => 'orphan_submission',
+                'attempt' => $this->attemptPayload(null),
+                'submission' => $this->submissionPayload($row),
+                'result' => $this->resultPayload($this->findResult((string) ($row->attempt_id ?? ''))),
+                'projection' => $this->projectionPayload($this->findProjection((string) ($row->attempt_id ?? ''))),
+                'findings' => [
+                    $this->finding(
+                        'orphan_submission_without_attempt',
+                        'critical',
+                        'attempt_submission exists in the recent window but the parent attempt row is missing.'
+                    ),
+                ],
+            ];
+        }
+
+        return $inspections;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function inspectOrphanResults(Carbon $windowStart, int $limit): array
+    {
+        if (! Schema::hasTable('results') || ! Schema::hasTable('attempts')) {
+            return [];
+        }
+
+        $rows = DB::table('results')
+            ->leftJoin('attempts', 'attempts.id', '=', 'results.attempt_id')
+            ->whereNull('attempts.id')
+            ->where(function ($query) use ($windowStart): void {
+                $query->where('results.created_at', '>=', $windowStart)
+                    ->orWhere('results.updated_at', '>=', $windowStart)
+                    ->orWhere('results.computed_at', '>=', $windowStart);
+            })
+            ->select('results.*')
+            ->orderByDesc('results.updated_at')
+            ->limit($limit)
+            ->get();
+
+        $inspections = [];
+        foreach ($rows as $row) {
+            $inspections[] = [
+                'attempt_id' => trim((string) ($row->attempt_id ?? '')),
+                'source' => 'orphan_result',
+                'attempt' => $this->attemptPayload(null),
+                'submission' => $this->submissionPayload($this->findLatestSubmission((string) ($row->attempt_id ?? ''))),
+                'result' => $this->resultPayload($row),
+                'projection' => $this->projectionPayload($this->findProjection((string) ($row->attempt_id ?? ''))),
+                'findings' => [
+                    $this->finding(
+                        'orphan_result_without_attempt',
+                        'critical',
+                        'result exists in the recent window but the parent attempt row is missing.'
+                    ),
+                ],
+            ];
+        }
+
+        return $inspections;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function inspectOrphanProjections(Carbon $windowStart, int $limit): array
+    {
+        if (! Schema::hasTable('unified_access_projections') || ! Schema::hasTable('attempts')) {
+            return [];
+        }
+
+        $rows = DB::table('unified_access_projections')
+            ->leftJoin('attempts', 'attempts.id', '=', 'unified_access_projections.attempt_id')
+            ->whereNull('attempts.id')
+            ->where(function ($query) use ($windowStart): void {
+                $query->where('unified_access_projections.created_at', '>=', $windowStart)
+                    ->orWhere('unified_access_projections.updated_at', '>=', $windowStart)
+                    ->orWhere('unified_access_projections.refreshed_at', '>=', $windowStart);
+            })
+            ->select('unified_access_projections.*')
+            ->orderByDesc('unified_access_projections.updated_at')
+            ->limit($limit)
+            ->get();
+
+        $inspections = [];
+        foreach ($rows as $row) {
+            $inspections[] = [
+                'attempt_id' => trim((string) ($row->attempt_id ?? '')),
+                'source' => 'orphan_projection',
+                'attempt' => $this->attemptPayload(null),
+                'submission' => $this->submissionPayload($this->findLatestSubmission((string) ($row->attempt_id ?? ''))),
+                'result' => $this->resultPayload($this->findResult((string) ($row->attempt_id ?? ''))),
+                'projection' => $this->projectionPayload($row),
+                'findings' => [
+                    $this->finding(
+                        'orphan_projection_without_attempt',
+                        'critical',
+                        'unified_access_projection exists in the recent window but the parent attempt row is missing.'
+                    ),
+                ],
+            ];
+        }
+
+        return $inspections;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $inspections
+     * @return array{finding_total:int,critical_total:int,warning_total:int,by_issue_code:array<string,int>}
+     */
+    private function summarize(array $inspections): array
+    {
+        $byIssueCode = [];
+        $criticalTotal = 0;
+        $warningTotal = 0;
+
+        foreach ($inspections as $inspection) {
+            $findings = is_array($inspection['findings'] ?? null) ? $inspection['findings'] : [];
+            foreach ($findings as $finding) {
+                if (! is_array($finding)) {
+                    continue;
+                }
+
+                $issueCode = trim((string) ($finding['issue_code'] ?? ''));
+                if ($issueCode !== '') {
+                    $byIssueCode[$issueCode] = ($byIssueCode[$issueCode] ?? 0) + 1;
+                }
+
+                $severity = strtolower(trim((string) ($finding['severity'] ?? 'warning')));
+                if ($severity === 'critical') {
+                    $criticalTotal++;
+                } else {
+                    $warningTotal++;
+                }
+            }
+        }
+
+        ksort($byIssueCode);
+
+        return [
+            'finding_total' => $criticalTotal + $warningTotal,
+            'critical_total' => $criticalTotal,
+            'warning_total' => $warningTotal,
+            'by_issue_code' => $byIssueCode,
+        ];
+    }
+
+    /**
+     * @return array{issue_code:string,severity:string,message:string}
+     */
+    private function finding(string $issueCode, string $severity, string $message): array
+    {
+        return [
+            'issue_code' => $issueCode,
+            'severity' => $severity,
+            'message' => $message,
+        ];
+    }
+
+    private function findAttempt(string $attemptId): ?object
+    {
+        if (! Schema::hasTable('attempts')) {
+            return null;
+        }
+
+        return DB::table('attempts')
+            ->where('id', trim($attemptId))
+            ->first();
+    }
+
+    private function findLatestSubmission(string $attemptId): ?object
+    {
+        if (! Schema::hasTable('attempt_submissions')) {
+            return null;
+        }
+
+        return DB::table('attempt_submissions')
+            ->where('attempt_id', trim($attemptId))
+            ->orderByDesc('updated_at')
+            ->orderByDesc('created_at')
+            ->first();
+    }
+
+    private function findResult(string $attemptId): ?object
+    {
+        if (! Schema::hasTable('results')) {
+            return null;
+        }
+
+        return DB::table('results')
+            ->where('attempt_id', trim($attemptId))
+            ->orderByDesc('computed_at')
+            ->orderByDesc('updated_at')
+            ->first();
+    }
+
+    private function findProjection(string $attemptId): ?object
+    {
+        if (! Schema::hasTable('unified_access_projections')) {
+            return null;
+        }
+
+        return DB::table('unified_access_projections')
+            ->where('attempt_id', trim($attemptId))
+            ->first();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function attemptPayload(?object $row): array
+    {
+        return [
+            'present' => $row !== null,
+            'org_id' => $this->nullableInt($row?->org_id ?? null),
+            'anon_id' => $this->normalizeString($row?->anon_id ?? null),
+            'user_id' => $this->normalizeString($row?->user_id ?? null),
+            'scale_code' => $this->normalizeString($row?->scale_code ?? null),
+            'submitted_at' => $this->formatTimestamp($row?->submitted_at ?? null),
+            'created_at' => $this->formatTimestamp($row?->created_at ?? null),
+            'updated_at' => $this->formatTimestamp($row?->updated_at ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function submissionPayload(?object $row): array
+    {
+        return [
+            'present' => $row !== null,
+            'id' => $this->normalizeString($row?->id ?? null),
+            'org_id' => $this->nullableInt($row?->org_id ?? null),
+            'state' => $this->normalizeString($row?->state ?? null),
+            'mode' => $this->normalizeString($row?->mode ?? null),
+            'actor_user_id' => $this->normalizeString($row?->actor_user_id ?? null),
+            'actor_anon_id' => $this->normalizeString($row?->actor_anon_id ?? null),
+            'error_code' => $this->normalizeString($row?->error_code ?? null),
+            'updated_at' => $this->formatTimestamp($row?->updated_at ?? null),
+            'created_at' => $this->formatTimestamp($row?->created_at ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function resultPayload(?object $row): array
+    {
+        return [
+            'present' => $row !== null,
+            'id' => $this->normalizeString($row?->id ?? null),
+            'org_id' => $this->nullableInt($row?->org_id ?? null),
+            'scale_code' => $this->normalizeString($row?->scale_code ?? null),
+            'type_code' => $this->normalizeString($row?->type_code ?? null),
+            'computed_at' => $this->formatTimestamp($row?->computed_at ?? null),
+            'created_at' => $this->formatTimestamp($row?->created_at ?? null),
+            'updated_at' => $this->formatTimestamp($row?->updated_at ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function projectionPayload(?object $row): array
+    {
+        return [
+            'present' => $row !== null,
+            'access_state' => $this->normalizeString($row?->access_state ?? null),
+            'report_state' => $this->normalizeString($row?->report_state ?? null),
+            'pdf_state' => $this->normalizeString($row?->pdf_state ?? null),
+            'reason_code' => $this->normalizeString($row?->reason_code ?? null),
+            'produced_at' => $this->formatTimestamp($row?->produced_at ?? null),
+            'refreshed_at' => $this->formatTimestamp($row?->refreshed_at ?? null),
+            'created_at' => $this->formatTimestamp($row?->created_at ?? null),
+            'updated_at' => $this->formatTimestamp($row?->updated_at ?? null),
+        ];
+    }
+
+    private function nullableInt(mixed $value): ?int
+    {
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function parseTimestamp(mixed $value): ?Carbon
+    {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance(\DateTimeImmutable::createFromInterface($value));
+        }
+
+        $normalized = $this->normalizeString($value);
+        if ($normalized === null) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($normalized);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function formatTimestamp(mixed $value): ?string
+    {
+        return $this->parseTimestamp($value)?->toISOString();
+    }
+}

--- a/backend/config/ops.php
+++ b/backend/config/ops.php
@@ -99,4 +99,11 @@ return [
             ],
         ],
     ],
+
+    'attempt_chain_audit' => [
+        'window_hours' => (int) env('OPS_ATTEMPT_CHAIN_AUDIT_WINDOW_HOURS', 24),
+        'limit' => (int) env('OPS_ATTEMPT_CHAIN_AUDIT_LIMIT', 200),
+        'pending_timeout_minutes' => (int) env('OPS_ATTEMPT_CHAIN_AUDIT_PENDING_TIMEOUT_MINUTES', 15),
+        'strict_default' => (bool) env('OPS_ATTEMPT_CHAIN_AUDIT_STRICT_DEFAULT', false),
+    ],
 ];

--- a/backend/tests/Feature/Ops/AttemptChainAuditCommandTest.php
+++ b/backend/tests/Feature/Ops/AttemptChainAuditCommandTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptChainAuditCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_reports_recent_chain_findings_and_orphans(): void
+    {
+        $now = now();
+
+        DB::table('attempts')->insert([
+            [
+                'id' => 'attempt-healthy',
+                'anon_id' => 'anon-healthy',
+                'user_id' => null,
+                'org_id' => 0,
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v1',
+                'question_count' => 12,
+                'answers_summary_json' => json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'client_platform' => 'web',
+                'client_version' => '1.0.0',
+                'channel' => 'organic',
+                'referrer' => null,
+                'started_at' => $now->copy()->subMinutes(40),
+                'submitted_at' => $now->copy()->subMinutes(39),
+                'created_at' => $now->copy()->subMinutes(40),
+                'updated_at' => $now->copy()->subMinutes(39),
+            ],
+            [
+                'id' => 'attempt-missing-submission',
+                'anon_id' => 'anon-ms',
+                'user_id' => null,
+                'org_id' => 0,
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v1',
+                'question_count' => 12,
+                'answers_summary_json' => json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'client_platform' => 'web',
+                'client_version' => '1.0.0',
+                'channel' => 'organic',
+                'referrer' => null,
+                'started_at' => $now->copy()->subMinutes(35),
+                'submitted_at' => $now->copy()->subMinutes(34),
+                'created_at' => $now->copy()->subMinutes(35),
+                'updated_at' => $now->copy()->subMinutes(34),
+            ],
+            [
+                'id' => 'attempt-succeeded-no-result',
+                'anon_id' => 'anon-snr',
+                'user_id' => null,
+                'org_id' => 0,
+                'scale_code' => 'BIG5_OCEAN',
+                'scale_version' => 'v1',
+                'question_count' => 10,
+                'answers_summary_json' => json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'client_platform' => 'web',
+                'client_version' => '1.0.0',
+                'channel' => 'organic',
+                'referrer' => null,
+                'started_at' => $now->copy()->subMinutes(30),
+                'submitted_at' => $now->copy()->subMinutes(29),
+                'created_at' => $now->copy()->subMinutes(30),
+                'updated_at' => $now->copy()->subMinutes(29),
+            ],
+            [
+                'id' => 'attempt-result-no-projection',
+                'anon_id' => 'anon-rnp',
+                'user_id' => null,
+                'org_id' => 0,
+                'scale_code' => 'EQ_60',
+                'scale_version' => 'v1',
+                'question_count' => 8,
+                'answers_summary_json' => json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'client_platform' => 'web',
+                'client_version' => '1.0.0',
+                'channel' => 'organic',
+                'referrer' => null,
+                'started_at' => $now->copy()->subMinutes(25),
+                'submitted_at' => $now->copy()->subMinutes(24),
+                'created_at' => $now->copy()->subMinutes(25),
+                'updated_at' => $now->copy()->subMinutes(24),
+            ],
+            [
+                'id' => 'attempt-pending-stuck',
+                'anon_id' => 'anon-pending',
+                'user_id' => null,
+                'org_id' => 0,
+                'scale_code' => 'IQ_RAVEN',
+                'scale_version' => 'v1',
+                'question_count' => 6,
+                'answers_summary_json' => json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'client_platform' => 'web',
+                'client_version' => '1.0.0',
+                'channel' => 'organic',
+                'referrer' => null,
+                'started_at' => $now->copy()->subMinutes(20),
+                'submitted_at' => $now->copy()->subMinutes(19),
+                'created_at' => $now->copy()->subMinutes(20),
+                'updated_at' => $now->copy()->subMinutes(19),
+            ],
+        ]);
+
+        DB::table('attempt_submissions')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'org_id' => 0,
+                'attempt_id' => 'attempt-healthy',
+                'actor_user_id' => null,
+                'actor_anon_id' => 'anon-healthy',
+                'dedupe_key' => hash('sha256', 'attempt-healthy'),
+                'mode' => 'async',
+                'state' => 'succeeded',
+                'error_code' => null,
+                'error_message' => null,
+                'request_payload_json' => null,
+                'response_payload_json' => null,
+                'started_at' => $now->copy()->subMinutes(39),
+                'finished_at' => $now->copy()->subMinutes(38),
+                'created_at' => $now->copy()->subMinutes(39),
+                'updated_at' => $now->copy()->subMinutes(38),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'org_id' => 0,
+                'attempt_id' => 'attempt-succeeded-no-result',
+                'actor_user_id' => null,
+                'actor_anon_id' => 'anon-snr',
+                'dedupe_key' => hash('sha256', 'attempt-succeeded-no-result'),
+                'mode' => 'async',
+                'state' => 'succeeded',
+                'error_code' => null,
+                'error_message' => null,
+                'request_payload_json' => null,
+                'response_payload_json' => null,
+                'started_at' => $now->copy()->subMinutes(29),
+                'finished_at' => $now->copy()->subMinutes(28),
+                'created_at' => $now->copy()->subMinutes(29),
+                'updated_at' => $now->copy()->subMinutes(28),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'org_id' => 0,
+                'attempt_id' => 'attempt-result-no-projection',
+                'actor_user_id' => null,
+                'actor_anon_id' => 'anon-rnp',
+                'dedupe_key' => hash('sha256', 'attempt-result-no-projection'),
+                'mode' => 'async',
+                'state' => 'succeeded',
+                'error_code' => null,
+                'error_message' => null,
+                'request_payload_json' => null,
+                'response_payload_json' => null,
+                'started_at' => $now->copy()->subMinutes(24),
+                'finished_at' => $now->copy()->subMinutes(23),
+                'created_at' => $now->copy()->subMinutes(24),
+                'updated_at' => $now->copy()->subMinutes(23),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'org_id' => 0,
+                'attempt_id' => 'attempt-pending-stuck',
+                'actor_user_id' => null,
+                'actor_anon_id' => 'anon-pending',
+                'dedupe_key' => hash('sha256', 'attempt-pending-stuck'),
+                'mode' => 'async',
+                'state' => 'pending',
+                'error_code' => null,
+                'error_message' => null,
+                'request_payload_json' => null,
+                'response_payload_json' => null,
+                'started_at' => null,
+                'finished_at' => null,
+                'created_at' => $now->copy()->subMinutes(18),
+                'updated_at' => $now->copy()->subMinutes(18),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'org_id' => 0,
+                'attempt_id' => 'attempt-orphan-submission',
+                'actor_user_id' => null,
+                'actor_anon_id' => 'anon-orphan',
+                'dedupe_key' => hash('sha256', 'attempt-orphan-submission'),
+                'mode' => 'async',
+                'state' => 'pending',
+                'error_code' => null,
+                'error_message' => null,
+                'request_payload_json' => null,
+                'response_payload_json' => null,
+                'started_at' => null,
+                'finished_at' => null,
+                'created_at' => $now->copy()->subMinutes(10),
+                'updated_at' => $now->copy()->subMinutes(10),
+            ],
+        ]);
+
+        DB::table('results')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'attempt_id' => 'attempt-healthy',
+                'org_id' => 0,
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v1',
+                'type_code' => 'INTJ-A',
+                'scores_json' => json_encode(['EI' => 10], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'profile_version' => 'mbti-v1',
+                'is_valid' => 1,
+                'computed_at' => $now->copy()->subMinutes(38),
+                'created_at' => $now->copy()->subMinutes(38),
+                'updated_at' => $now->copy()->subMinutes(38),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'attempt_id' => 'attempt-result-no-projection',
+                'org_id' => 0,
+                'scale_code' => 'EQ_60',
+                'scale_version' => 'v1',
+                'type_code' => 'EQ-READY',
+                'scores_json' => json_encode(['EQ' => 88], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'profile_version' => 'eq-v1',
+                'is_valid' => 1,
+                'computed_at' => $now->copy()->subMinutes(23),
+                'created_at' => $now->copy()->subMinutes(23),
+                'updated_at' => $now->copy()->subMinutes(23),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'attempt_id' => 'attempt-orphan-result',
+                'org_id' => 0,
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v1',
+                'type_code' => 'ENTP-A',
+                'scores_json' => json_encode(['EI' => 11], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'profile_version' => 'mbti-v1',
+                'is_valid' => 1,
+                'computed_at' => $now->copy()->subMinutes(9),
+                'created_at' => $now->copy()->subMinutes(9),
+                'updated_at' => $now->copy()->subMinutes(9),
+            ],
+        ]);
+
+        DB::table('unified_access_projections')->insert([
+            [
+                'attempt_id' => 'attempt-healthy',
+                'access_state' => 'available',
+                'report_state' => 'ready',
+                'pdf_state' => 'ready',
+                'reason_code' => null,
+                'projection_version' => 1,
+                'actions_json' => null,
+                'payload_json' => null,
+                'produced_at' => $now->copy()->subMinutes(38),
+                'refreshed_at' => $now->copy()->subMinutes(38),
+                'created_at' => $now->copy()->subMinutes(38),
+                'updated_at' => $now->copy()->subMinutes(38),
+            ],
+            [
+                'attempt_id' => 'attempt-orphan-projection',
+                'access_state' => 'available',
+                'report_state' => 'ready',
+                'pdf_state' => 'ready',
+                'reason_code' => null,
+                'projection_version' => 1,
+                'actions_json' => null,
+                'payload_json' => null,
+                'produced_at' => $now->copy()->subMinutes(8),
+                'refreshed_at' => $now->copy()->subMinutes(8),
+                'created_at' => $now->copy()->subMinutes(8),
+                'updated_at' => $now->copy()->subMinutes(8),
+            ],
+        ]);
+
+        $exitCode = Artisan::call('ops:attempt-chain-audit', [
+            '--json' => 1,
+            '--window-hours' => 24,
+            '--limit' => 20,
+            '--pending-timeout-minutes' => 15,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame(8, (int) ($payload['inspected_count'] ?? 0));
+        $this->assertSame(5, (int) data_get($payload, 'summary.critical_total', -1));
+        $this->assertSame(2, (int) data_get($payload, 'summary.warning_total', -1));
+        $this->assertSame(7, (int) data_get($payload, 'summary.finding_total', -1));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.submission_missing_for_submitted_attempt', -1));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.result_missing_after_submission_success', -1));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.projection_missing_after_result', -1));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.submission_stuck_pending', -1));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.orphan_submission_without_attempt', -1));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.orphan_result_without_attempt', -1));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.orphan_projection_without_attempt', -1));
+    }
+
+    public function test_command_exact_attempt_mode_reports_chain_absent_and_strict_fails(): void
+    {
+        $exitCode = Artisan::call('ops:attempt-chain-audit', [
+            '--json' => 1,
+            '--strict' => 1,
+            '--attempt-id' => 'missing-attempt-123',
+        ]);
+
+        $this->assertSame(1, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('missing-attempt-123', (string) data_get($payload, 'selection.attempt_id', ''));
+        $this->assertSame(1, (int) data_get($payload, 'summary.finding_total', 0));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.attempt_chain_absent', 0));
+
+        $inspection = data_get($payload, 'inspections.0');
+        $this->assertIsArray($inspection);
+        $this->assertFalse((bool) data_get($inspection, 'attempt.present', true));
+        $this->assertFalse((bool) data_get($inspection, 'submission.present', true));
+        $this->assertFalse((bool) data_get($inspection, 'result.present', true));
+        $this->assertFalse((bool) data_get($inspection, 'projection.present', true));
+    }
+}


### PR DESCRIPTION
## Summary
- add an ops attempt chain audit command for exact-id diagnosis and recent-window patrols
- classify missing attempt/submission/result/projection chains plus orphan rows and stuck pending submissions
- add feature coverage for strict mode and recent-window findings

## Tests
- php artisan test --filter=AttemptChainAuditCommandTest
- bash backend/scripts/ci_verify_mbti.sh