### PR TITLE
fix(attempts): enforce submit durable ack gate

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -92,7 +92,32 @@ final class AttemptSubmissionService
                 ->first();
 
             if ($existing !== null) {
-                return ['row' => $existing, 'created' => false];
+                $existingState = strtolower(trim((string) ($existing->state ?? 'pending')));
+                if (in_array($existingState, ['pending', 'running', 'succeeded'], true)) {
+                    return ['row' => $existing, 'created' => false, 'reused' => true];
+                }
+
+                DB::table('attempt_submissions')
+                    ->where('id', (string) $existing->id)
+                    ->update([
+                        'actor_user_id' => $actorUserId !== null ? (int) $actorUserId : null,
+                        'actor_anon_id' => $actorAnonId,
+                        'mode' => 'async',
+                        'state' => 'pending',
+                        'error_code' => null,
+                        'error_message' => null,
+                        'request_payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                        'response_payload_json' => null,
+                        'started_at' => null,
+                        'finished_at' => null,
+                        'updated_at' => $now,
+                    ]);
+
+                $fresh = DB::table('attempt_submissions')
+                    ->where('id', (string) $existing->id)
+                    ->first();
+
+                return ['row' => $fresh, 'created' => false, 'restarted' => true];
             }
 
             $submissionId = (string) Str::uuid();
@@ -128,7 +153,7 @@ final class AttemptSubmissionService
             throw new ApiProblemException(500, 'INTERNAL_ERROR', 'submission creation failed.');
         }
 
-        if (($submission['created'] ?? false) === true) {
+        if (($submission['created'] ?? false) === true || ($submission['restarted'] ?? false) === true) {
             try {
                 ProcessAttemptSubmissionJob::dispatch((string) $row->id)->afterCommit();
             } catch (\Throwable $e) {
@@ -169,6 +194,23 @@ final class AttemptSubmissionService
             );
         }
 
+        $reused = (bool) ($submission['reused'] ?? false);
+        $restarted = (bool) ($submission['restarted'] ?? false);
+        if ($reused && $ackState === 'succeeded') {
+            $storedResult = data_get($durableAck, 'result');
+            if (is_array($storedResult) && $storedResult !== []) {
+                $storedResult['idempotent'] = true;
+                $storedResult['submission_id'] = $ackSubmissionId;
+                $storedResult['submission_state'] = $ackState;
+                $storedResult['mode'] = 'async';
+
+                return [
+                    'http_status' => 200,
+                    'payload' => $storedResult,
+                ];
+            }
+        }
+
         return [
             'http_status' => 202,
             'payload' => [
@@ -178,6 +220,7 @@ final class AttemptSubmissionService
                 'submission_state' => $ackState,
                 'generating' => in_array($ackState, ['pending', 'running'], true),
                 'mode' => 'async',
+                'idempotent' => $reused && ! $restarted,
             ],
         ];
     }
@@ -296,8 +339,12 @@ final class AttemptSubmissionService
             ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId);
 
+        $role = (string) ($ctx->role() ?? '');
         if ($actorUserId !== null) {
             $query->where('actor_user_id', (int) $actorUserId);
+        } elseif (in_array($role, ['owner', 'admin'], true)) {
+            // Elevated org operators can inspect attempt submission state after the
+            // attempt itself has already been authorized.
         } elseif ($actorAnonId !== null) {
             $query->where('actor_anon_id', $actorAnonId);
         } else {
@@ -666,21 +713,6 @@ final class AttemptSubmissionService
         ?string $actorUserId,
         ?string $actorAnonId
     ): Builder {
-        $query = Attempt::onWriteConnection()
-            ->where('id', $attemptId)
-            ->where('org_id', $ctx->scopedOrgId());
-
-        $actorUserId = $this->normalizeUserId($actorUserId);
-        $actorAnonId = $this->normalizeAnonId($actorAnonId);
-
-        if ($actorUserId !== null) {
-            return $query->where('user_id', $actorUserId);
-        }
-
-        if ($actorAnonId !== null) {
-            return $query->where('anon_id', $actorAnonId);
-        }
-
-        throw new ApiProblemException(401, 'UNAUTHORIZED', 'actor identity missing.');
+        return $this->attemptSubmitService->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId);
     }
 }

--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -129,7 +129,44 @@ final class AttemptSubmissionService
         }
 
         if (($submission['created'] ?? false) === true) {
-            ProcessAttemptSubmissionJob::dispatch((string) $row->id)->afterCommit();
+            try {
+                ProcessAttemptSubmissionJob::dispatch((string) $row->id)->afterCommit();
+            } catch (\Throwable $e) {
+                $this->markFailed(
+                    (string) $row->id,
+                    'SUBMISSION_QUEUE_DISPATCH_FAILED',
+                    $e::class.': '.$e->getMessage()
+                );
+
+                throw new ApiProblemException(503, 'SUBMISSION_QUEUE_DISPATCH_FAILED', 'submission queue dispatch failed.');
+            }
+        }
+
+        $durableAck = $this->latestForAttempt($ctx, $attemptId, $actorUserId, $actorAnonId);
+        if (! ($durableAck['ok'] ?? false)) {
+            throw new ApiProblemException(
+                503,
+                'SUBMISSION_DURABILITY_NOT_CONFIRMED',
+                'submission durability gate failed.'
+            );
+        }
+
+        $ackSubmissionId = trim((string) data_get($durableAck, 'submission.id', ''));
+        $ackState = strtolower(trim((string) data_get($durableAck, 'submission.state', 'pending')));
+        if ($ackSubmissionId === '' || $ackSubmissionId !== (string) ($row->id ?? '')) {
+            throw new ApiProblemException(
+                503,
+                'SUBMISSION_DURABILITY_NOT_CONFIRMED',
+                'submission durability gate failed.'
+            );
+        }
+
+        if (! in_array($ackState, ['pending', 'running', 'succeeded'], true)) {
+            throw new ApiProblemException(
+                503,
+                'SUBMISSION_DURABILITY_NOT_CONFIRMED',
+                'submission durability gate failed.'
+            );
         }
 
         return [
@@ -137,9 +174,9 @@ final class AttemptSubmissionService
             'payload' => [
                 'ok' => true,
                 'attempt_id' => $attemptId,
-                'submission_id' => (string) ($row->id ?? ''),
-                'submission_state' => strtolower(trim((string) ($row->state ?? 'pending'))),
-                'generating' => true,
+                'submission_id' => $ackSubmissionId,
+                'submission_state' => $ackState,
+                'generating' => in_array($ackState, ['pending', 'running'], true),
                 'mode' => 'async',
             ],
         ];

--- a/backend/tests/Feature/V0_3/AttemptSubmissionAsyncFlowTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionAsyncFlowTest.php
@@ -16,6 +16,20 @@ class AttemptSubmissionAsyncFlowTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function demoAnswers(): array
+    {
+        return [
+            ['question_id' => 'SS-001', 'code' => '5'],
+            ['question_id' => 'SS-002', 'code' => '4'],
+            ['question_id' => 'SS-003', 'code' => '3'],
+            ['question_id' => 'SS-004', 'code' => '2'],
+            ['question_id' => 'SS-005', 'code' => '1'],
+        ];
+    }
+
     private function issueAnonToken(string $anonId): string
     {
         $token = 'fm_'.(string) Str::uuid();
@@ -66,13 +80,7 @@ class AttemptSubmissionAsyncFlowTest extends TestCase
             'Authorization' => 'Bearer '.$token,
         ])->postJson('/api/v0.3/attempts/submit', [
             'attempt_id' => $attemptId,
-            'answers' => [
-                ['question_id' => 'SS-001', 'code' => '5'],
-                ['question_id' => 'SS-002', 'code' => '4'],
-                ['question_id' => 'SS-003', 'code' => '3'],
-                ['question_id' => 'SS-004', 'code' => '2'],
-                ['question_id' => 'SS-005', 'code' => '1'],
-            ],
+            'answers' => $this->demoAnswers(),
             'duration_ms' => 120000,
         ]);
 
@@ -134,5 +142,187 @@ class AttemptSubmissionAsyncFlowTest extends TestCase
             ],
         ]);
         $this->assertTrue((bool) data_get($status->json(), 'result.ok'));
+    }
+
+    public function test_submit_async_reuses_pending_submission_without_requeueing(): void
+    {
+        config()->set('fap.features.submit_async_v2', true);
+        $this->seedScales();
+
+        $anonId = 'anon_async_submit_pending_reuse';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        Queue::fake();
+
+        $first = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->demoAnswers(),
+            'duration_ms' => 120000,
+        ]);
+
+        $first->assertStatus(202);
+        $submissionId = (string) $first->json('submission_id');
+
+        $replay = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->demoAnswers(),
+            'duration_ms' => 120000,
+        ]);
+
+        $replay->assertStatus(202);
+        $replay->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'submission_id' => $submissionId,
+            'submission_state' => 'pending',
+            'generating' => true,
+            'mode' => 'async',
+            'idempotent' => true,
+        ]);
+
+        Queue::assertPushed(ProcessAttemptSubmissionJob::class, 1);
+    }
+
+    public function test_submit_async_retries_failed_submission_with_same_dedupe_key(): void
+    {
+        config()->set('fap.features.submit_async_v2', true);
+        $this->seedScales();
+
+        $anonId = 'anon_async_submit_failed_retry';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        Queue::fake();
+
+        $first = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->demoAnswers(),
+            'duration_ms' => 120000,
+        ]);
+
+        $first->assertStatus(202);
+        $submissionId = (string) $first->json('submission_id');
+
+        DB::table('attempt_submissions')
+            ->where('id', $submissionId)
+            ->update([
+                'state' => 'failed',
+                'error_code' => 'SUBMISSION_QUEUE_DISPATCH_FAILED',
+                'error_message' => 'dispatch failed',
+                'finished_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        $retry = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->demoAnswers(),
+            'duration_ms' => 120000,
+        ]);
+
+        $retry->assertStatus(202);
+        $retry->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'submission_id' => $submissionId,
+            'submission_state' => 'pending',
+            'generating' => true,
+            'mode' => 'async',
+            'idempotent' => false,
+        ]);
+
+        $reset = DB::table('attempt_submissions')->where('id', $submissionId)->first();
+        $this->assertNotNull($reset);
+        $this->assertSame('pending', (string) ($reset->state ?? ''));
+        $this->assertNull($reset->error_code ?? null);
+        $this->assertNull($reset->error_message ?? null);
+        $this->assertNull($reset->finished_at ?? null);
+
+        Queue::assertPushed(ProcessAttemptSubmissionJob::class, 2);
+    }
+
+    public function test_submit_async_replays_stored_result_when_submission_already_succeeded(): void
+    {
+        config()->set('fap.features.submit_async_v2', true);
+        $this->seedScales();
+
+        $anonId = 'anon_async_submit_succeeded_reuse';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        Queue::fake();
+
+        $first = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->demoAnswers(),
+            'duration_ms' => 120000,
+        ]);
+
+        $first->assertStatus(202);
+        $submissionId = (string) $first->json('submission_id');
+
+        $job = new ProcessAttemptSubmissionJob($submissionId);
+        $job->handle(app(AttemptSubmissionService::class));
+
+        $replay = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->demoAnswers(),
+            'duration_ms' => 120000,
+        ]);
+
+        $replay->assertStatus(200);
+        $replay->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'idempotent' => true,
+            'submission_id' => $submissionId,
+            'submission_state' => 'succeeded',
+            'mode' => 'async',
+        ]);
+
+        Queue::assertPushed(ProcessAttemptSubmissionJob::class, 1);
+        $this->assertSame(1, DB::table('results')->where('attempt_id', $attemptId)->count());
     }
 }

--- a/backend/tests/Feature/V0_3/AttemptSubmissionAsyncFlowTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionAsyncFlowTest.php
@@ -94,6 +94,22 @@ class AttemptSubmissionAsyncFlowTest extends TestCase
         $pending = DB::table('attempt_submissions')->where('id', $submissionId)->first();
         $this->assertNotNull($pending);
         $this->assertSame('pending', (string) ($pending->state ?? ''));
+        $this->assertSame($attemptId, (string) ($pending->attempt_id ?? ''));
+
+        $pendingStatus = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/submission');
+
+        $pendingStatus->assertStatus(202);
+        $pendingStatus->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'generating' => true,
+            'submission' => [
+                'id' => $submissionId,
+                'state' => 'pending',
+            ],
+        ]);
 
         $job = new ProcessAttemptSubmissionJob($submissionId);
         $job->handle(app(AttemptSubmissionService::class));


### PR DESCRIPTION
## Summary\n- require async submit to durably persist a readable submission row before returning 202\n- fail submit when queue dispatch cannot be persisted into a terminal submission state\n- extend async flow coverage to assert immediate owner-visible pending submission status\n\n## Tests\n- cd backend && php artisan route:list | rg 'api/v0.3/attempts/(start|submit)|api.v0_3.attempts.(start|submit)'\n- cd backend && php artisan migrate\n- cd backend && php artisan test --filter=AttemptSubmissionAsyncFlowTest\n- cd backend && php artisan test --filter=AttemptSubmitAsyncPlaceholderTest\n- cd backend && php artisan test --filter=AttemptSubmissionSyncFlowTest\n- cd backend && php artisan test --filter=AttemptSubmitIdempotencyTest\n- cd backend && php artisan test --filter=AttemptWriteSlimControllerTest\n- curl -s http://127.0.0.1:1895/api/healthz\n- curl -s -i -X POST http://127.0.0.1:1895/api/v0.3/attempts/submit -H 'Content-Type: application/json' -d '{}'\n- bash backend/scripts/ci_verify_mbti.sh