### PR TITLE
fix(attempts): persist terminal job failure state

### DIFF
--- a/backend/app/Jobs/ProcessAttemptSubmissionJob.php
+++ b/backend/app/Jobs/ProcessAttemptSubmissionJob.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Throwable;
 
 class ProcessAttemptSubmissionJob implements ShouldQueue
 {
@@ -35,5 +36,17 @@ class ProcessAttemptSubmissionJob implements ShouldQueue
     public function handle(AttemptSubmissionService $service): void
     {
         $service->process($this->submissionId);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        app(AttemptSubmissionService::class)->recordTerminalJobFailure(
+            $this->submissionId,
+            $exception,
+            (int) $this->attempts(),
+            (int) $this->tries,
+            is_string($this->connection) ? $this->connection : null,
+            is_string($this->queue) ? $this->queue : null,
+        );
     }
 }

--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -11,8 +11,11 @@ use App\Models\Attempt;
 use App\Support\OrgContext;
 use App\Support\SchemaBaseline;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Queue\MaxAttemptsExceededException;
+use Illuminate\Queue\TimeoutExceededException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Throwable;
 
 final class AttemptSubmissionService
 {
@@ -243,7 +246,7 @@ final class AttemptSubmissionService
             }
 
             $state = strtolower(trim((string) ($row->state ?? 'pending')));
-            if (in_array($state, ['running', 'succeeded'], true)) {
+            if (in_array($state, ['running', 'succeeded', 'failed'], true)) {
                 return ['state' => $state];
             }
 
@@ -390,6 +393,76 @@ final class AttemptSubmissionService
             'generating' => in_array($state, ['pending', 'running'], true),
             'http_status' => in_array($state, ['pending', 'running'], true) ? 202 : 200,
         ];
+    }
+
+    public function recordTerminalJobFailure(
+        string $submissionId,
+        Throwable $exception,
+        int $attempts = 0,
+        int $maxTries = 0,
+        ?string $connection = null,
+        ?string $queue = null
+    ): void {
+        $submissionId = trim($submissionId);
+        if ($submissionId === '' || ! SchemaBaseline::hasTable('attempt_submissions')) {
+            return;
+        }
+
+        $errorCode = 'SUBMISSION_JOB_RETRY_EXHAUSTED';
+        $message = 'submission job retry exhausted.';
+        if ($exception instanceof TimeoutExceededException) {
+            $errorCode = 'SUBMISSION_JOB_TIMEOUT';
+            $message = 'submission job timed out.';
+        } elseif (! $exception instanceof MaxAttemptsExceededException) {
+            $errorCode = 'SUBMISSION_JOB_TERMINAL_FAILURE';
+            $message = 'submission job terminal failure.';
+        }
+
+        $exceptionMessage = trim($exception->getMessage());
+        if ($exceptionMessage !== '') {
+            $message .= ' '.$exceptionMessage;
+        }
+
+        $payload = [
+            'ok' => false,
+            'error_code' => $errorCode,
+            'message' => $this->truncate($message, 255),
+            'terminal_failure' => true,
+            'job' => [
+                'attempts' => max(0, $attempts),
+                'max_tries' => max(0, $maxTries),
+                'connection' => $this->nullableString($connection),
+                'queue' => $this->nullableString($queue),
+                'exception' => $this->truncate($exception::class.': '.$exceptionMessage, 255),
+            ],
+        ];
+
+        DB::transaction(function () use ($submissionId, $errorCode, $payload): void {
+            $row = DB::table('attempt_submissions')
+                ->where('id', $submissionId)
+                ->lockForUpdate()
+                ->first();
+
+            if ($row === null) {
+                return;
+            }
+
+            $state = strtolower(trim((string) ($row->state ?? 'pending')));
+            if (in_array($state, ['succeeded', 'failed'], true)) {
+                return;
+            }
+
+            DB::table('attempt_submissions')
+                ->where('id', $submissionId)
+                ->update([
+                    'state' => 'failed',
+                    'error_code' => $errorCode,
+                    'error_message' => $this->truncate((string) ($payload['message'] ?? ''), 255),
+                    'response_payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'finished_at' => now(),
+                    'updated_at' => now(),
+                ]);
+        });
     }
 
     private function markSucceeded(string $submissionId, array $payload): void

--- a/backend/tests/Feature/V0_3/AttemptSubmissionJobTerminalFailureTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionJobTerminalFailureTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature\V0_3;
 
 use App\Jobs\ProcessAttemptSubmissionJob;
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Queue\TimeoutExceededException;
 use Illuminate\Support\Facades\DB;
@@ -12,6 +14,32 @@ use Tests\TestCase;
 class AttemptSubmissionJobTerminalFailureTest extends TestCase
 {
     use RefreshDatabase;
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('auth_tokens')->insert([
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'meta_json' => null,
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr17SimpleScoreDemoSeeder)->run();
+    }
 
     public function test_job_failed_marks_running_submission_as_terminal_failed(): void
     {
@@ -108,5 +136,67 @@ class AttemptSubmissionJobTerminalFailureTest extends TestCase
         $this->assertSame('failed', (string) ($failed->state ?? ''));
         $this->assertSame('SUBMISSION_JOB_FAILED', (string) ($failed->error_code ?? ''));
         $this->assertSame('existing terminal failure', (string) ($failed->error_message ?? ''));
+    }
+
+    public function test_submission_endpoint_returns_terminal_failure_payload_after_job_failed_callback(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_terminal_failure_read';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $submissionId = (string) Str::uuid();
+        DB::table('attempt_submissions')->insert([
+            'id' => $submissionId,
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => null,
+            'actor_anon_id' => $anonId,
+            'dedupe_key' => hash('sha256', 'attempt-terminal-read-'.$attemptId),
+            'mode' => 'async',
+            'state' => 'running',
+            'error_code' => null,
+            'error_message' => null,
+            'request_payload_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'response_payload_json' => null,
+            'started_at' => now()->subMinute(),
+            'finished_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        (new ProcessAttemptSubmissionJob($submissionId))->failed(new \RuntimeException('fatal worker failure'));
+
+        $status = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/submission');
+
+        $status->assertStatus(200);
+        $status->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'generating' => false,
+            'submission' => [
+                'id' => $submissionId,
+                'state' => 'failed',
+                'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            ],
+            'result' => [
+                'ok' => false,
+                'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+                'terminal_failure' => true,
+            ],
+        ]);
     }
 }

--- a/backend/tests/Feature/V0_3/AttemptSubmissionJobTerminalFailureTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionJobTerminalFailureTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Jobs\ProcessAttemptSubmissionJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Queue\TimeoutExceededException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class AttemptSubmissionJobTerminalFailureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_job_failed_marks_running_submission_as_terminal_failed(): void
+    {
+        $submissionId = (string) Str::uuid();
+        DB::table('attempt_submissions')->insert([
+            'id' => $submissionId,
+            'org_id' => 0,
+            'attempt_id' => 'attempt-terminal-running',
+            'actor_user_id' => null,
+            'actor_anon_id' => 'anon_terminal_running',
+            'dedupe_key' => hash('sha256', 'attempt-terminal-running'),
+            'mode' => 'async',
+            'state' => 'running',
+            'error_code' => null,
+            'error_message' => null,
+            'request_payload_json' => json_encode(['attempt_id' => 'attempt-terminal-running'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'response_payload_json' => null,
+            'started_at' => now()->subMinute(),
+            'finished_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        $job = new ProcessAttemptSubmissionJob($submissionId);
+        $job->failed(new TimeoutExceededException('worker timed out.'));
+
+        $row = DB::table('attempt_submissions')->where('id', $submissionId)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('failed', (string) ($row->state ?? ''));
+        $this->assertSame('SUBMISSION_JOB_TIMEOUT', (string) ($row->error_code ?? ''));
+        $this->assertNotNull($row->finished_at ?? null);
+
+        $payload = json_decode((string) ($row->response_payload_json ?? '{}'), true);
+        $this->assertTrue((bool) ($payload['terminal_failure'] ?? false));
+        $this->assertSame('SUBMISSION_JOB_TIMEOUT', (string) ($payload['error_code'] ?? ''));
+        $this->assertNotSame('', (string) data_get($payload, 'job.queue', ''));
+    }
+
+    public function test_job_failed_does_not_overwrite_existing_succeeded_or_failed_submission(): void
+    {
+        $succeededId = (string) Str::uuid();
+        $failedId = (string) Str::uuid();
+
+        DB::table('attempt_submissions')->insert([
+            [
+                'id' => $succeededId,
+                'org_id' => 0,
+                'attempt_id' => 'attempt-terminal-succeeded',
+                'actor_user_id' => null,
+                'actor_anon_id' => 'anon_terminal_succeeded',
+                'dedupe_key' => hash('sha256', 'attempt-terminal-succeeded'),
+                'mode' => 'async',
+                'state' => 'succeeded',
+                'error_code' => null,
+                'error_message' => null,
+                'request_payload_json' => json_encode(['attempt_id' => 'attempt-terminal-succeeded'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'response_payload_json' => json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'started_at' => now()->subMinutes(2),
+                'finished_at' => now()->subMinute(),
+                'created_at' => now()->subMinutes(2),
+                'updated_at' => now()->subMinute(),
+            ],
+            [
+                'id' => $failedId,
+                'org_id' => 0,
+                'attempt_id' => 'attempt-terminal-failed',
+                'actor_user_id' => null,
+                'actor_anon_id' => 'anon_terminal_failed',
+                'dedupe_key' => hash('sha256', 'attempt-terminal-failed'),
+                'mode' => 'async',
+                'state' => 'failed',
+                'error_code' => 'SUBMISSION_JOB_FAILED',
+                'error_message' => 'existing terminal failure',
+                'request_payload_json' => json_encode(['attempt_id' => 'attempt-terminal-failed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'response_payload_json' => json_encode(['ok' => false, 'error_code' => 'SUBMISSION_JOB_FAILED'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'started_at' => now()->subMinutes(3),
+                'finished_at' => now()->subMinutes(2),
+                'created_at' => now()->subMinutes(3),
+                'updated_at' => now()->subMinutes(2),
+            ],
+        ]);
+
+        (new ProcessAttemptSubmissionJob($succeededId))->failed(new \RuntimeException('should not overwrite success'));
+        (new ProcessAttemptSubmissionJob($failedId))->failed(new \RuntimeException('should not overwrite failure'));
+
+        $succeeded = DB::table('attempt_submissions')->where('id', $succeededId)->first();
+        $failed = DB::table('attempt_submissions')->where('id', $failedId)->first();
+
+        $this->assertNotNull($succeeded);
+        $this->assertSame('succeeded', (string) ($succeeded->state ?? ''));
+        $this->assertSame('{"ok":true}', (string) ($succeeded->response_payload_json ?? ''));
+
+        $this->assertNotNull($failed);
+        $this->assertSame('failed', (string) ($failed->state ?? ''));
+        $this->assertSame('SUBMISSION_JOB_FAILED', (string) ($failed->error_code ?? ''));
+        $this->assertSame('existing terminal failure', (string) ($failed->error_message ?? ''));
+    }
+}


### PR DESCRIPTION
## Summary\n- mark attempt submissions failed when the queue job reaches terminal failure or timeout\n- stop processing already-failed submissions unless Loop 2 explicitly resets them to pending\n- add terminal failure regression coverage for running and already-terminal submissions\n\n## Tests\n- cd backend && php artisan route:list | rg 'api/v0.3/attempts/(start|submit)|api.v0_3.attempts.(start|submit)'\n- cd backend && php artisan migrate\n- cd backend && php artisan test --filter=AttemptSubmissionJobTerminalFailureTest\n- cd backend && php artisan test --filter=ProcessAttemptSubmissionJobTest\n- cd backend && php artisan test --filter=AttemptSubmissionAsyncFlowTest\n- cd backend && php artisan test --filter=AttemptSubmissionSyncFlowTest\n- cd backend && ./vendor/bin/pint --dirty\n- curl -s http://127.0.0.1:1897/api/healthz\n- curl -s -i -X POST http://127.0.0.1:1897/api/v0.3/attempts/submit -H 'Content-Type: application/json' -d '{}'\n- bash backend/scripts/ci_verify_mbti.sh