### PR TITLE
fix(attempts): enforce submission-first read contract

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -100,6 +100,22 @@ class AttemptReadController extends Controller
         $orgId = $this->currentOrgContext()->orgId();
         $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $id)->first();
         if (! $result instanceof Result) {
+            $submissionPayload = $this->latestReadableSubmission($request, $id);
+            if (($submissionPayload['ok'] ?? false) === true) {
+                $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
+                if (in_array($submissionState, ['pending', 'running'], true)) {
+                    return $this->pendingSubmissionResponse($id, $submissionPayload, includeReport: false);
+                }
+
+                if ($submissionState === 'failed') {
+                    return $this->failedSubmissionResponse($id, $submissionPayload, includeReport: false);
+                }
+
+                if ($submissionState === 'succeeded') {
+                    return $this->missingResultAfterSubmissionResponse($id, $submissionPayload, includeReport: false);
+                }
+            }
+
             throw new ApiProblemException(404, 'RESULT_NOT_FOUND', 'result not found.');
         }
 
@@ -291,23 +307,20 @@ class AttemptReadController extends Controller
         $anonId = $this->resolveAnonId($request);
         $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $id)->first();
         if (! $result instanceof Result) {
-            $submissionPayload = $this->attemptSubmissionService->latestForAttempt(
-                $this->currentOrgContext(),
-                $id,
-                $userId !== null ? (string) $userId : null,
-                $anonId
-            );
+            $submissionPayload = $this->latestReadableSubmission($request, $id);
+            if (($submissionPayload['ok'] ?? false) === true) {
+                $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
+                if (in_array($submissionState, ['pending', 'running'], true)) {
+                    return $this->pendingSubmissionResponse($id, $submissionPayload, includeReport: true);
+                }
 
-            if (($submissionPayload['ok'] ?? false) === true && ($submissionPayload['generating'] ?? false) === true) {
-                return response()->json([
-                    'ok' => true,
-                    'attempt_id' => $id,
-                    'generating' => true,
-                    'submission_state' => (string) data_get($submissionPayload, 'submission.state', 'pending'),
-                    'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
-                    'result' => null,
-                    'report' => [],
-                ], 202);
+                if ($submissionState === 'failed') {
+                    return $this->failedSubmissionResponse($id, $submissionPayload, includeReport: true);
+                }
+
+                if ($submissionState === 'succeeded') {
+                    return $this->missingResultAfterSubmissionResponse($id, $submissionPayload, includeReport: true);
+                }
             }
 
             throw new ApiProblemException(404, 'RESULT_NOT_FOUND', 'result not found.');
@@ -487,11 +500,12 @@ class AttemptReadController extends Controller
     {
         $orgId = $this->currentOrgContext()->orgId();
         $attempt = $this->resolveAttemptForAccessRead($request, $orgId, $id);
+        $submissionPayload = $this->latestReadableSubmission($request, (string) $attempt->id);
         $projection = UnifiedAccessProjection::query()
             ->where('attempt_id', (string) $attempt->id)
             ->first();
 
-        $fallbackStates = $this->fallbackProjectionStates($orgId, (string) $attempt->id);
+        $fallbackStates = $this->fallbackProjectionStates($orgId, (string) $attempt->id, $submissionPayload);
         $accessState = trim((string) ($projection?->access_state ?? $fallbackStates['access_state']));
         $reportState = trim((string) ($projection?->report_state ?? $fallbackStates['report_state']));
         $pdfState = trim((string) ($projection?->pdf_state ?? $fallbackStates['pdf_state']));
@@ -568,12 +582,58 @@ class AttemptReadController extends Controller
     /**
      * @return array{access_state:string,report_state:string,pdf_state:string,reason_code:string,payload_json:array<string,mixed>}
      */
-    private function fallbackProjectionStates(int $orgId, string $attemptId): array
+    private function fallbackProjectionStates(int $orgId, string $attemptId, ?array $submissionPayload = null): array
     {
         $resultExists = Result::query()
             ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId)
             ->exists();
+
+        if (! $resultExists && ($submissionPayload['ok'] ?? false) === true) {
+            $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
+            if (in_array($submissionState, ['pending', 'running'], true)) {
+                return [
+                    'access_state' => 'locked',
+                    'report_state' => 'pending',
+                    'pdf_state' => 'missing',
+                    'reason_code' => 'submission_pending',
+                    'payload_json' => [
+                        'fallback' => true,
+                        'result_exists' => false,
+                        'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+                    ],
+                ];
+            }
+
+            if ($submissionState === 'failed') {
+                return [
+                    'access_state' => 'locked',
+                    'report_state' => 'unavailable',
+                    'pdf_state' => 'missing',
+                    'reason_code' => 'submission_failed',
+                    'payload_json' => [
+                        'fallback' => true,
+                        'result_exists' => false,
+                        'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+                        'result' => is_array($submissionPayload['result'] ?? null) ? $submissionPayload['result'] : null,
+                    ],
+                ];
+            }
+
+            if ($submissionState === 'succeeded') {
+                return [
+                    'access_state' => 'locked',
+                    'report_state' => 'restoring',
+                    'pdf_state' => 'missing',
+                    'reason_code' => 'submission_succeeded_result_missing',
+                    'payload_json' => [
+                        'fallback' => true,
+                        'result_exists' => false,
+                        'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+                    ],
+                ];
+            }
+        }
 
         return [
             'access_state' => $resultExists ? 'locked' : 'pending',
@@ -1309,6 +1369,87 @@ class AttemptReadController extends Controller
     private function currentOrgContext(): OrgContext
     {
         return app(OrgContext::class);
+    }
+
+    private function latestReadableSubmission(Request $request, string $attemptId): ?array
+    {
+        $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
+        if (! $attempt instanceof Attempt) {
+            $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
+        }
+
+        if (! $attempt instanceof Attempt) {
+            return null;
+        }
+
+        $payload = $this->attemptSubmissionService->latestForAttempt(
+            $this->currentOrgContext(),
+            $attemptId,
+            $this->resolveUserId($request),
+            $this->resolveAnonId($request)
+        );
+
+        return ($payload['ok'] ?? false) === true ? $payload : null;
+    }
+
+    private function pendingSubmissionResponse(string $attemptId, array $submissionPayload, bool $includeReport): JsonResponse
+    {
+        $payload = [
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'generating' => true,
+            'submission_state' => (string) data_get($submissionPayload, 'submission.state', 'pending'),
+            'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+            'result' => null,
+        ];
+        if ($includeReport) {
+            $payload['report'] = [];
+        }
+
+        return response()->json($payload, 202);
+    }
+
+    private function failedSubmissionResponse(string $attemptId, array $submissionPayload, bool $includeReport): JsonResponse
+    {
+        $message = trim((string) data_get($submissionPayload, 'submission.error_message', ''));
+        if ($message === '') {
+            $message = trim((string) data_get($submissionPayload, 'result.message', 'submission failed.'));
+        }
+
+        $payload = [
+            'ok' => false,
+            'attempt_id' => $attemptId,
+            'error_code' => 'SUBMISSION_FAILED',
+            'message' => $message !== '' ? $message : 'submission failed.',
+            'generating' => false,
+            'submission_state' => (string) data_get($submissionPayload, 'submission.state', 'failed'),
+            'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+            'result' => is_array($submissionPayload['result'] ?? null) ? $submissionPayload['result'] : null,
+        ];
+        if ($includeReport) {
+            $payload['report'] = [];
+        }
+
+        return response()->json($payload);
+    }
+
+    private function missingResultAfterSubmissionResponse(string $attemptId, array $submissionPayload, bool $includeReport): JsonResponse
+    {
+        $payload = [
+            'ok' => false,
+            'attempt_id' => $attemptId,
+            'error_code' => 'SUBMISSION_SUCCEEDED_RESULT_MISSING',
+            'message' => 'submission succeeded but result is not readable yet.',
+            'generating' => false,
+            'submission_state' => (string) data_get($submissionPayload, 'submission.state', 'succeeded'),
+            'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+            'result' => null,
+        ];
+        if ($includeReport) {
+            $payload['report'] = [];
+        }
+
+        return response()->json($payload);
     }
 
     private function resolveAttemptId(Result $result, ?Attempt $attempt, string $fallbackAttemptId): string

--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -98,19 +98,22 @@ class AttemptReadController extends Controller
     public function result(Request $request, string $id): JsonResponse
     {
         $orgId = $this->currentOrgContext()->orgId();
+        $submissionPayload = $this->latestReadableSubmission($request, $id);
+        if (($submissionPayload['ok'] ?? false) === true) {
+            $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
+            if (in_array($submissionState, ['pending', 'running'], true)) {
+                return $this->pendingSubmissionResponse($id, $submissionPayload, includeReport: false);
+            }
+
+            if ($submissionState === 'failed') {
+                return $this->failedSubmissionResponse($id, $submissionPayload, includeReport: false);
+            }
+        }
+
         $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $id)->first();
         if (! $result instanceof Result) {
-            $submissionPayload = $this->latestReadableSubmission($request, $id);
             if (($submissionPayload['ok'] ?? false) === true) {
                 $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
-                if (in_array($submissionState, ['pending', 'running'], true)) {
-                    return $this->pendingSubmissionResponse($id, $submissionPayload, includeReport: false);
-                }
-
-                if ($submissionState === 'failed') {
-                    return $this->failedSubmissionResponse($id, $submissionPayload, includeReport: false);
-                }
-
                 if ($submissionState === 'succeeded') {
                     return $this->missingResultAfterSubmissionResponse($id, $submissionPayload, includeReport: false);
                 }
@@ -305,19 +308,22 @@ class AttemptReadController extends Controller
         $orgId = $this->currentOrgContext()->orgId();
         $userId = $this->resolveUserId($request);
         $anonId = $this->resolveAnonId($request);
+        $submissionPayload = $this->latestReadableSubmission($request, $id);
+        if (($submissionPayload['ok'] ?? false) === true) {
+            $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
+            if (in_array($submissionState, ['pending', 'running'], true)) {
+                return $this->pendingSubmissionResponse($id, $submissionPayload, includeReport: true);
+            }
+
+            if ($submissionState === 'failed') {
+                return $this->failedSubmissionResponse($id, $submissionPayload, includeReport: true);
+            }
+        }
+
         $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $id)->first();
         if (! $result instanceof Result) {
-            $submissionPayload = $this->latestReadableSubmission($request, $id);
             if (($submissionPayload['ok'] ?? false) === true) {
                 $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
-                if (in_array($submissionState, ['pending', 'running'], true)) {
-                    return $this->pendingSubmissionResponse($id, $submissionPayload, includeReport: true);
-                }
-
-                if ($submissionState === 'failed') {
-                    return $this->failedSubmissionResponse($id, $submissionPayload, includeReport: true);
-                }
-
                 if ($submissionState === 'succeeded') {
                     return $this->missingResultAfterSubmissionResponse($id, $submissionPayload, includeReport: true);
                 }
@@ -501,19 +507,35 @@ class AttemptReadController extends Controller
         $orgId = $this->currentOrgContext()->orgId();
         $attempt = $this->resolveAttemptForAccessRead($request, $orgId, $id);
         $submissionPayload = $this->latestReadableSubmission($request, (string) $attempt->id);
+        $resultExists = Result::query()
+            ->where('org_id', $orgId)
+            ->where('attempt_id', (string) $attempt->id)
+            ->exists();
         $projection = UnifiedAccessProjection::query()
             ->where('attempt_id', (string) $attempt->id)
             ->first();
+        $submissionProjectionStates = $this->submissionProjectionStates($resultExists, $submissionPayload);
 
-        $fallbackStates = $this->fallbackProjectionStates($orgId, (string) $attempt->id, $submissionPayload);
-        $accessState = trim((string) ($projection?->access_state ?? $fallbackStates['access_state']));
-        $reportState = trim((string) ($projection?->report_state ?? $fallbackStates['report_state']));
-        $pdfState = trim((string) ($projection?->pdf_state ?? $fallbackStates['pdf_state']));
-        $reasonCode = trim((string) ($projection?->reason_code ?? $fallbackStates['reason_code']));
-        $projectionVersion = (int) ($projection?->projection_version ?? 1);
-        $payloadJson = is_array($projection?->payload_json) ? $projection->payload_json : $fallbackStates['payload_json'];
-        $producedAt = optional($projection?->produced_at)->toIso8601String();
-        $refreshedAt = optional($projection?->refreshed_at)->toIso8601String();
+        if ($submissionProjectionStates !== null) {
+            $accessState = trim((string) ($submissionProjectionStates['access_state'] ?? 'locked'));
+            $reportState = trim((string) ($submissionProjectionStates['report_state'] ?? 'pending'));
+            $pdfState = trim((string) ($submissionProjectionStates['pdf_state'] ?? 'missing'));
+            $reasonCode = trim((string) ($submissionProjectionStates['reason_code'] ?? ''));
+            $projectionVersion = 1;
+            $payloadJson = is_array($submissionProjectionStates['payload_json'] ?? null) ? $submissionProjectionStates['payload_json'] : [];
+            $producedAt = optional($projection?->produced_at)->toIso8601String();
+            $refreshedAt = optional($projection?->refreshed_at)->toIso8601String();
+        } else {
+            $fallbackStates = $this->fallbackProjectionStates($orgId, (string) $attempt->id, $submissionPayload);
+            $accessState = trim((string) ($projection?->access_state ?? $fallbackStates['access_state']));
+            $reportState = trim((string) ($projection?->report_state ?? $fallbackStates['report_state']));
+            $pdfState = trim((string) ($projection?->pdf_state ?? $fallbackStates['pdf_state']));
+            $reasonCode = trim((string) ($projection?->reason_code ?? $fallbackStates['reason_code']));
+            $projectionVersion = (int) ($projection?->projection_version ?? 1);
+            $payloadJson = is_array($projection?->payload_json) ? $projection->payload_json : $fallbackStates['payload_json'];
+            $producedAt = optional($projection?->produced_at)->toIso8601String();
+            $refreshedAt = optional($projection?->refreshed_at)->toIso8601String();
+        }
 
         return response()->json([
             'ok' => true,
@@ -645,6 +667,62 @@ class AttemptReadController extends Controller
                 'result_exists' => $resultExists,
             ],
         ];
+    }
+
+    /**
+     * @return array{access_state:string,report_state:string,pdf_state:string,reason_code:string,payload_json:array<string,mixed>}|null
+     */
+    private function submissionProjectionStates(bool $resultExists, ?array $submissionPayload): ?array
+    {
+        if (($submissionPayload['ok'] ?? false) !== true) {
+            return null;
+        }
+
+        $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
+        if (in_array($submissionState, ['pending', 'running'], true)) {
+            return [
+                'access_state' => 'locked',
+                'report_state' => 'pending',
+                'pdf_state' => 'missing',
+                'reason_code' => 'submission_pending',
+                'payload_json' => [
+                    'fallback' => true,
+                    'result_exists' => $resultExists,
+                    'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+                ],
+            ];
+        }
+
+        if ($submissionState === 'failed') {
+            return [
+                'access_state' => 'locked',
+                'report_state' => 'unavailable',
+                'pdf_state' => 'missing',
+                'reason_code' => 'submission_failed',
+                'payload_json' => [
+                    'fallback' => true,
+                    'result_exists' => $resultExists,
+                    'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+                    'result' => is_array($submissionPayload['result'] ?? null) ? $submissionPayload['result'] : null,
+                ],
+            ];
+        }
+
+        if (! $resultExists && $submissionState === 'succeeded') {
+            return [
+                'access_state' => 'locked',
+                'report_state' => 'restoring',
+                'pdf_state' => 'missing',
+                'reason_code' => 'submission_succeeded_result_missing',
+                'payload_json' => [
+                    'fallback' => true,
+                    'result_exists' => false,
+                    'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+                ],
+            ];
+        }
+
+        return null;
     }
 
     /**

--- a/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
+use App\Models\Result;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -85,6 +86,47 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
         return $submissionId;
     }
 
+    private function createResult(string $attemptId, string $scaleCode = 'MBTI'): void
+    {
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [],
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'result-v1',
+            'result_json' => ['type_code' => 'INTJ-A', 'source' => 'stale_result'],
+            'pack_id' => "{$scaleCode}.result-pack",
+            'dir_version' => "{$scaleCode}.result-dir",
+            'scoring_spec_version' => 'result-score-v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now()->subSeconds(20),
+        ]);
+    }
+
+    private function createProjection(string $attemptId, string $accessState = 'ready', string $reportState = 'ready'): void
+    {
+        DB::table('unified_access_projections')->insert([
+            'attempt_id' => $attemptId,
+            'access_state' => $accessState,
+            'report_state' => $reportState,
+            'pdf_state' => 'ready',
+            'reason_code' => 'report_ready',
+            'projection_version' => 1,
+            'actions_json' => json_encode(['report' => true, 'pdf' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_json' => json_encode(['attempt_id' => $attemptId, 'has_active_grant' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'produced_at' => now()->subSeconds(15),
+            'refreshed_at' => now()->subSeconds(10),
+            'created_at' => now()->subSeconds(15),
+            'updated_at' => now()->subSeconds(10),
+        ]);
+    }
+
     public function test_result_returns_generating_placeholder_when_submission_is_pending_and_result_is_missing(): void
     {
         $attemptId = (string) Str::uuid();
@@ -147,6 +189,31 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
         ]);
     }
 
+    public function test_result_prefers_pending_submission_over_existing_stale_result(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_result_stale_pending';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'pending');
+        $this->createResult($attemptId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(202);
+        $response->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'generating' => true,
+            'submission_state' => 'pending',
+            'result' => null,
+        ]);
+        $response->assertJsonPath('submission.id', $submissionId);
+    }
+
     public function test_report_returns_terminal_failure_contract_when_submission_failed_and_result_is_missing(): void
     {
         $attemptId = (string) Str::uuid();
@@ -186,6 +253,39 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
         ]);
     }
 
+    public function test_report_prefers_failed_submission_over_existing_stale_result(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_report_stale_failed';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'failed', [
+            'ok' => false,
+            'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            'message' => 'submission job terminal failure.',
+            'terminal_failure' => true,
+        ]);
+        $this->createResult($attemptId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => false,
+            'attempt_id' => $attemptId,
+            'error_code' => 'SUBMISSION_FAILED',
+            'submission_state' => 'failed',
+            'submission' => [
+                'id' => $submissionId,
+                'state' => 'failed',
+            ],
+            'report' => [],
+        ]);
+    }
+
     public function test_report_access_returns_submission_pending_fallback_when_projection_and_result_are_missing(): void
     {
         $attemptId = (string) Str::uuid();
@@ -209,6 +309,33 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
             'reason_code' => 'submission_pending',
         ]);
         $response->assertJsonPath('payload.fallback', true);
+        $response->assertJsonPath('payload.submission.id', $submissionId);
+        $response->assertJsonPath('actions.wait_href', "/result/{$attemptId}");
+    }
+
+    public function test_report_access_prefers_pending_submission_over_existing_ready_projection(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_access_stale_pending';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'pending');
+        $this->createResult($attemptId);
+        $this->createProjection($attemptId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'access_state' => 'locked',
+            'report_state' => 'pending',
+            'reason_code' => 'submission_pending',
+        ]);
         $response->assertJsonPath('payload.submission.id', $submissionId);
         $response->assertJsonPath('actions.wait_href', "/result/{$attemptId}");
     }
@@ -241,6 +368,39 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
             'reason_code' => 'submission_failed',
         ]);
         $response->assertJsonPath('payload.fallback', true);
+        $response->assertJsonPath('payload.submission.id', $submissionId);
+        $response->assertJsonPath('payload.result.error_code', 'SUBMISSION_JOB_TERMINAL_FAILURE');
+        $response->assertJsonPath('actions.wait_href', null);
+    }
+
+    public function test_report_access_prefers_failed_submission_over_existing_ready_projection(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_access_stale_failed';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'failed', [
+            'ok' => false,
+            'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            'message' => 'submission job terminal failure.',
+            'terminal_failure' => true,
+        ]);
+        $this->createResult($attemptId);
+        $this->createProjection($attemptId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'access_state' => 'locked',
+            'report_state' => 'unavailable',
+            'reason_code' => 'submission_failed',
+        ]);
         $response->assertJsonPath('payload.submission.id', $submissionId);
         $response->assertJsonPath('payload.result.error_code', 'SUBMISSION_JOB_TERMINAL_FAILURE');
         $response->assertJsonPath('actions.wait_href', null);

--- a/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptSubmissionFirstReadContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('auth_tokens')->insert([
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'meta_json' => null,
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createAttempt(string $attemptId, string $anonId, string $scaleCode = 'MBTI'): void
+    {
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(2),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => "{$scaleCode}.pack",
+            'dir_version' => "{$scaleCode}.dir",
+            'content_package_version' => 'attempt-v1',
+            'scoring_spec_version' => 'attempt-score-v1',
+        ]);
+    }
+
+    private function createSubmission(string $attemptId, string $anonId, string $state, ?array $responsePayload = null): string
+    {
+        $submissionId = (string) Str::uuid();
+
+        DB::table('attempt_submissions')->insert([
+            'id' => $submissionId,
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => null,
+            'actor_anon_id' => $anonId,
+            'dedupe_key' => hash('sha256', "{$attemptId}:{$state}"),
+            'mode' => 'async',
+            'state' => $state,
+            'error_code' => $state === 'failed' ? 'SUBMISSION_JOB_TERMINAL_FAILURE' : null,
+            'error_message' => $state === 'failed' ? 'submission job terminal failure.' : null,
+            'request_payload_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'response_payload_json' => $responsePayload !== null
+                ? json_encode($responsePayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+                : null,
+            'started_at' => now()->subMinute(),
+            'finished_at' => in_array($state, ['succeeded', 'failed'], true) ? now()->subSeconds(10) : null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subSeconds(5),
+        ]);
+
+        return $submissionId;
+    }
+
+    public function test_result_returns_generating_placeholder_when_submission_is_pending_and_result_is_missing(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_result_pending';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'pending');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(202);
+        $response->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'generating' => true,
+            'submission_state' => 'pending',
+            'result' => null,
+        ]);
+        $response->assertJsonPath('submission.id', $submissionId);
+    }
+
+    public function test_result_returns_terminal_failure_contract_when_submission_failed_and_result_is_missing(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_result_failed';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'failed', [
+            'ok' => false,
+            'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            'message' => 'submission job terminal failure.',
+            'terminal_failure' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => false,
+            'attempt_id' => $attemptId,
+            'error_code' => 'SUBMISSION_FAILED',
+            'generating' => false,
+            'submission_state' => 'failed',
+            'submission' => [
+                'id' => $submissionId,
+                'state' => 'failed',
+                'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            ],
+            'result' => [
+                'ok' => false,
+                'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+                'terminal_failure' => true,
+            ],
+        ]);
+    }
+
+    public function test_report_returns_terminal_failure_contract_when_submission_failed_and_result_is_missing(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_report_failed';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'failed', [
+            'ok' => false,
+            'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            'message' => 'submission job terminal failure.',
+            'terminal_failure' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => false,
+            'attempt_id' => $attemptId,
+            'error_code' => 'SUBMISSION_FAILED',
+            'generating' => false,
+            'submission_state' => 'failed',
+            'submission' => [
+                'id' => $submissionId,
+                'state' => 'failed',
+                'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            ],
+            'result' => [
+                'ok' => false,
+                'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+                'terminal_failure' => true,
+            ],
+            'report' => [],
+        ]);
+    }
+
+    public function test_report_access_returns_submission_pending_fallback_when_projection_and_result_are_missing(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_access_pending';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'pending');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'access_state' => 'locked',
+            'report_state' => 'pending',
+            'pdf_state' => 'missing',
+            'reason_code' => 'submission_pending',
+        ]);
+        $response->assertJsonPath('payload.fallback', true);
+        $response->assertJsonPath('payload.submission.id', $submissionId);
+        $response->assertJsonPath('actions.wait_href', "/result/{$attemptId}");
+    }
+
+    public function test_report_access_returns_submission_failed_fallback_when_projection_and_result_are_missing(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_first_access_failed';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'failed', [
+            'ok' => false,
+            'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            'message' => 'submission job terminal failure.',
+            'terminal_failure' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'access_state' => 'locked',
+            'report_state' => 'unavailable',
+            'pdf_state' => 'missing',
+            'reason_code' => 'submission_failed',
+        ]);
+        $response->assertJsonPath('payload.fallback', true);
+        $response->assertJsonPath('payload.submission.id', $submissionId);
+        $response->assertJsonPath('payload.result.error_code', 'SUBMISSION_JOB_TERMINAL_FAILURE');
+        $response->assertJsonPath('actions.wait_href', null);
+    }
+}


### PR DESCRIPTION
## Summary
- make /result and /report consult durable submission state before falling back to result-not-found
- project pending and terminal failed submission states through /report-access fallback responses
- add feature coverage for pending and failed submission-first read contracts

## Tests
- cd backend && ./vendor/bin/pint --dirty
- cd backend && php artisan test --filter=AttemptSubmissionFirstReadContractTest
- cd backend && php artisan test --filter='AttemptPublicResultReadHotfixTest|AttemptPublicReportReadHotfixTest|AttemptReportAccessReadTest|AttemptSubmitAsyncPlaceholderTest'
- cd backend && php artisan route:list | rg 'api/v0.3/attempts/(start|submit)|api/v0.3/attempts/\{attempt_id\}/submission|api/v0.3/attempts/\{id\}/(result|report|report-access)'
- cd backend && php artisan migrate
- cd backend && php artisan serve --host=127.0.0.1 --port=1899
- curl -s http://127.0.0.1:1899/api/healthz
- curl -s -i -X POST http://127.0.0.1:1899/api/v0.3/attempts/submit -H 'Content-Type: application/json' -d '{}'
- bash backend/scripts/ci_verify_mbti.sh