### PR TITLE
feat(ops): add submission recovery and alert loop

### DIFF
--- a/backend/app/Console/Commands/Ops/AttemptSubmissionRecovery.php
+++ b/backend/app/Console/Commands/Ops/AttemptSubmissionRecovery.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Ops\AttemptSubmissionRecoveryService;
+use Illuminate\Console\Command;
+
+final class AttemptSubmissionRecovery extends Command
+{
+    protected $signature = 'ops:attempt-submission-recovery
+        {--attempt-id= : Inspect one attempt id exactly}
+        {--window-hours= : Recent lookback window in hours}
+        {--limit= : Max recent attempts to inspect}
+        {--pending-timeout-minutes= : Threshold for pending/running submissions}
+        {--repair=0 : Apply safe compensating actions}
+        {--alert= : Emit ops alert when findings exist}
+        {--strict= : Exit non-zero when findings exist}
+        {--json=1 : Output JSON payload}';
+
+    protected $description = 'Scan attempt submission inconsistencies and apply safe compensating actions.';
+
+    public function __construct(private readonly AttemptSubmissionRecoveryService $service)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $policy = $this->policy();
+        $attemptId = trim((string) ($this->option('attempt-id') ?? ''));
+        $windowHours = max(1, (int) ($this->option('window-hours') ?: ($policy['window_hours'] ?? 24)));
+        $limit = max(1, (int) ($this->option('limit') ?: ($policy['limit'] ?? 200)));
+        $pendingTimeoutMinutes = max(1, (int) ($this->option('pending-timeout-minutes') ?: ($policy['pending_timeout_minutes'] ?? 15)));
+        $repair = $this->isTruthy($this->option('repair'));
+        $strict = $this->option('strict') === null
+            ? (bool) ($policy['strict_default'] ?? false)
+            : $this->isTruthy($this->option('strict'));
+        $alert = $this->option('alert') === null
+            ? (bool) ($policy['alert_default'] ?? true)
+            : $this->isTruthy($this->option('alert'));
+
+        $payload = $this->service->recover(
+            $attemptId !== '' ? $attemptId : null,
+            $windowHours,
+            $limit,
+            $pendingTimeoutMinutes,
+            $repair
+        );
+        $payload['policy'] = [
+            'strict' => $strict,
+            'alert' => $alert,
+        ];
+
+        if ($alert) {
+            $this->service->emitAlert($payload);
+        }
+
+        if ($this->isTruthy($this->option('json'))) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->info('attempt_submission_recovery');
+            $this->line(sprintf(
+                'attempt=%s findings=%d repairs=%d repair_mode=%s',
+                (string) data_get($payload, 'scope.attempt_id', 'recent'),
+                (int) data_get($payload, 'summary.finding_total', 0),
+                (int) data_get($payload, 'summary.repair_total', 0),
+                $repair ? '1' : '0'
+            ));
+        }
+
+        if ($strict && (int) data_get($payload, 'summary.finding_total', 0) > 0) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function policy(): array
+    {
+        $policy = config('ops.attempt_submission_recovery');
+
+        return is_array($policy) ? $policy : [];
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/backend/app/Services/Ops/AttemptSubmissionRecoveryService.php
+++ b/backend/app/Services/Ops/AttemptSubmissionRecoveryService.php
@@ -1,0 +1,600 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use App\Jobs\ProcessAttemptSubmissionJob;
+use App\Models\Result;
+use App\Services\Storage\UnifiedAccessProjectionBackfillService;
+use App\Services\Storage\UnifiedAccessProjectionWriter;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+final class AttemptSubmissionRecoveryService
+{
+    public function __construct(
+        private readonly UnifiedAccessProjectionWriter $projectionWriter,
+        private readonly UnifiedAccessProjectionBackfillService $projectionBackfill,
+    ) {}
+
+    /**
+     * @return array{
+     *     ok:bool,
+     *     generated_at:string,
+     *     scope:array{attempt_id:?string,window_hours:int,limit:int,pending_timeout_minutes:int,repair:bool},
+     *     summary:array{finding_total:int,repair_total:int,by_issue_code:array<string,int>,by_repair_code:array<string,int>},
+     *     findings:list<array<string,mixed>>,
+     *     repairs:list<array<string,mixed>>,
+     *     pass:bool
+     * }
+     */
+    public function recover(?string $attemptId, int $windowHours, int $limit, int $pendingTimeoutMinutes, bool $repair): array
+    {
+        $attemptId = $this->normalizeNullableString($attemptId);
+        $windowHours = max(1, $windowHours);
+        $limit = max(1, $limit);
+        $pendingTimeoutMinutes = max(1, $pendingTimeoutMinutes);
+
+        $findings = [];
+        $repairs = [];
+
+        foreach ($this->candidateAttemptIds($attemptId, $windowHours, $limit) as $candidateAttemptId) {
+            $submission = $this->latestSubmissionRow($candidateAttemptId);
+            $resultExists = Result::query()->where('attempt_id', $candidateAttemptId)->exists();
+            $projection = Schema::hasTable('unified_access_projections')
+                ? DB::table('unified_access_projections')->where('attempt_id', $candidateAttemptId)->first()
+                : null;
+
+            if ($submission === null) {
+                if ($resultExists) {
+                    $findings[] = $this->finding($candidateAttemptId, 'submission_missing_with_result_present', 'critical', [
+                        'result_exists' => true,
+                        'projection_exists' => $projection !== null,
+                    ]);
+
+                    if ($repair && $projection === null) {
+                        $repairResult = $this->refreshProjectionFromArtifacts($candidateAttemptId);
+                        if ($repairResult !== null) {
+                            $repairs[] = $repairResult;
+                        }
+                    }
+                }
+
+                continue;
+            }
+
+            $submissionState = strtolower(trim((string) ($submission->state ?? 'pending')));
+            $updatedAt = $this->toCarbon($submission->updated_at ?? null);
+            $ageMinutes = $updatedAt?->diffInMinutes(now()) ?? 0;
+            $submissionPayload = $this->decodeArray($submission->response_payload_json ?? null);
+
+            if (in_array($submissionState, ['pending', 'running'], true) && $ageMinutes >= $pendingTimeoutMinutes && ! $resultExists) {
+                $findings[] = $this->finding($candidateAttemptId, 'submission_stuck_pending', 'critical', [
+                    'submission_id' => (string) ($submission->id ?? ''),
+                    'submission_state' => $submissionState,
+                    'age_minutes' => $ageMinutes,
+                    'result_exists' => false,
+                ]);
+
+                if ($repair) {
+                    $repairResult = $this->restartSubmission((string) ($submission->id ?? ''), 'submission_stuck_pending');
+                    if ($repairResult !== null) {
+                        $repairs[] = $repairResult;
+                    }
+                    $projectionRepair = $this->syncProjectionToPending($candidateAttemptId, $submission);
+                    if ($projectionRepair !== null) {
+                        $repairs[] = $projectionRepair;
+                    }
+                }
+            }
+
+            if ($submissionState === 'succeeded' && ! $resultExists) {
+                $findings[] = $this->finding($candidateAttemptId, 'submission_succeeded_result_missing', 'critical', [
+                    'submission_id' => (string) ($submission->id ?? ''),
+                    'submission_state' => $submissionState,
+                    'result_exists' => false,
+                ]);
+
+                if ($repair) {
+                    $repairResult = $this->restartSubmission((string) ($submission->id ?? ''), 'submission_succeeded_result_missing');
+                    if ($repairResult !== null) {
+                        $repairs[] = $repairResult;
+                    }
+                    $projectionRepair = $this->syncProjectionToPending($candidateAttemptId, $submission);
+                    if ($projectionRepair !== null) {
+                        $repairs[] = $projectionRepair;
+                    }
+                }
+            }
+
+            if (in_array($submissionState, ['pending', 'running'], true) && ! $this->projectionMatchesPending($projection)) {
+                $findings[] = $this->finding($candidateAttemptId, 'projection_stale_against_pending_submission', 'warning', [
+                    'submission_id' => (string) ($submission->id ?? ''),
+                    'submission_state' => $submissionState,
+                    'projection_exists' => $projection !== null,
+                    'projection_report_state' => $this->normalizeNullableString($projection->report_state ?? null),
+                    'projection_reason_code' => $this->normalizeNullableString($projection->reason_code ?? null),
+                ]);
+
+                if ($repair) {
+                    $projectionRepair = $this->syncProjectionToPending($candidateAttemptId, $submission);
+                    if ($projectionRepair !== null) {
+                        $repairs[] = $projectionRepair;
+                    }
+                }
+            }
+
+            if ($submissionState === 'failed' && ! $this->projectionMatchesFailed($projection)) {
+                $findings[] = $this->finding($candidateAttemptId, 'projection_stale_against_failed_submission', 'warning', [
+                    'submission_id' => (string) ($submission->id ?? ''),
+                    'submission_state' => $submissionState,
+                    'projection_exists' => $projection !== null,
+                    'projection_report_state' => $this->normalizeNullableString($projection->report_state ?? null),
+                    'projection_reason_code' => $this->normalizeNullableString($projection->reason_code ?? null),
+                ]);
+
+                if ($repair) {
+                    $projectionRepair = $this->syncProjectionToFailed($candidateAttemptId, $submission, $submissionPayload);
+                    if ($projectionRepair !== null) {
+                        $repairs[] = $projectionRepair;
+                    }
+                }
+            }
+
+            if ($resultExists && $projection === null) {
+                $findings[] = $this->finding($candidateAttemptId, 'projection_missing_after_result', 'warning', [
+                    'submission_id' => (string) ($submission->id ?? ''),
+                    'submission_state' => $submissionState,
+                    'result_exists' => true,
+                ]);
+
+                if ($repair) {
+                    $repairResult = $this->refreshProjectionFromArtifacts($candidateAttemptId);
+                    if ($repairResult !== null) {
+                        $repairs[] = $repairResult;
+                    }
+                }
+            }
+        }
+
+        $payload = [
+            'ok' => true,
+            'generated_at' => now()->toIso8601String(),
+            'scope' => [
+                'attempt_id' => $attemptId,
+                'window_hours' => $windowHours,
+                'limit' => $limit,
+                'pending_timeout_minutes' => $pendingTimeoutMinutes,
+                'repair' => $repair,
+            ],
+            'summary' => [
+                'finding_total' => count($findings),
+                'repair_total' => count($repairs),
+                'by_issue_code' => $this->countByKey($findings, 'issue_code'),
+                'by_repair_code' => $this->countByKey($repairs, 'repair_code'),
+            ],
+            'findings' => $findings,
+            'repairs' => $repairs,
+            'pass' => $findings === [],
+        ];
+
+        if ($findings !== []) {
+            Log::warning('ATTEMPT_SUBMISSION_RECOVERY_FINDINGS', [
+                'scope' => $payload['scope'],
+                'summary' => $payload['summary'],
+                'findings' => $findings,
+                'repairs' => $repairs,
+            ]);
+        }
+
+        return $payload;
+    }
+
+    public function emitAlert(array $payload): void
+    {
+        $findingTotal = (int) data_get($payload, 'summary.finding_total', 0);
+        $repairTotal = (int) data_get($payload, 'summary.repair_total', 0);
+        if ($findingTotal <= 0) {
+            return;
+        }
+
+        $scopeAttempt = $this->normalizeNullableString(data_get($payload, 'scope.attempt_id'));
+        $byIssueCode = is_array(data_get($payload, 'summary.by_issue_code')) ? data_get($payload, 'summary.by_issue_code') : [];
+        $issueSummary = [];
+        foreach ($byIssueCode as $issueCode => $count) {
+            $issueSummary[] = sprintf('%s=%d', (string) $issueCode, (int) $count);
+        }
+
+        $message = sprintf(
+            '[ops:attempt-submission-recovery] findings=%d repairs=%d scope=%s issues=%s',
+            $findingTotal,
+            $repairTotal,
+            $scopeAttempt ?? 'recent',
+            implode(',', $issueSummary)
+        );
+
+        OpsAlertService::send($message);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidateAttemptIds(?string $attemptId, int $windowHours, int $limit): array
+    {
+        if ($attemptId !== null) {
+            return [$attemptId];
+        }
+
+        $windowStart = now()->subHours($windowHours);
+        $attemptIds = [];
+
+        if (Schema::hasTable('attempt_submissions')) {
+            $rows = DB::table('attempt_submissions')
+                ->select('attempt_id')
+                ->where('updated_at', '>=', $windowStart)
+                ->orderByDesc('updated_at')
+                ->limit($limit)
+                ->pluck('attempt_id');
+
+            foreach ($rows as $value) {
+                $candidate = trim((string) $value);
+                if ($candidate !== '') {
+                    $attemptIds[$candidate] = true;
+                }
+            }
+        }
+
+        if (Schema::hasTable('results')) {
+            $rows = DB::table('results')
+                ->select('attempt_id')
+                ->where(function ($query) use ($windowStart): void {
+                    $query->where('computed_at', '>=', $windowStart)
+                        ->orWhere('created_at', '>=', $windowStart);
+                })
+                ->orderByDesc('computed_at')
+                ->limit($limit)
+                ->pluck('attempt_id');
+
+            foreach ($rows as $value) {
+                $candidate = trim((string) $value);
+                if ($candidate !== '') {
+                    $attemptIds[$candidate] = true;
+                }
+            }
+        }
+
+        if (Schema::hasTable('unified_access_projections')) {
+            $rows = DB::table('unified_access_projections')
+                ->select('attempt_id')
+                ->where(function ($query) use ($windowStart): void {
+                    $query->where('refreshed_at', '>=', $windowStart)
+                        ->orWhere('updated_at', '>=', $windowStart);
+                })
+                ->orderByDesc('refreshed_at')
+                ->limit($limit)
+                ->pluck('attempt_id');
+
+            foreach ($rows as $value) {
+                $candidate = trim((string) $value);
+                if ($candidate !== '') {
+                    $attemptIds[$candidate] = true;
+                }
+            }
+        }
+
+        $values = array_keys($attemptIds);
+        sort($values, SORT_STRING);
+
+        return array_slice($values, 0, $limit);
+    }
+
+    private function latestSubmissionRow(string $attemptId): ?object
+    {
+        if (! Schema::hasTable('attempt_submissions')) {
+            return null;
+        }
+
+        return DB::table('attempt_submissions')
+            ->where('attempt_id', $attemptId)
+            ->orderByDesc('updated_at')
+            ->orderByDesc('created_at')
+            ->first();
+    }
+
+    /**
+     * @param  array<string,mixed>  $details
+     * @return array<string,mixed>
+     */
+    private function finding(string $attemptId, string $issueCode, string $severity, array $details): array
+    {
+        return [
+            'attempt_id' => $attemptId,
+            'issue_code' => $issueCode,
+            'severity' => $severity,
+            'details' => $details,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function restartSubmission(string $submissionId, string $reasonCode): ?array
+    {
+        $submissionId = trim($submissionId);
+        if ($submissionId === '' || ! Schema::hasTable('attempt_submissions')) {
+            return null;
+        }
+
+        $row = DB::transaction(function () use ($submissionId): ?object {
+            $row = DB::table('attempt_submissions')
+                ->where('id', $submissionId)
+                ->lockForUpdate()
+                ->first();
+
+            if ($row === null) {
+                return null;
+            }
+
+            DB::table('attempt_submissions')
+                ->where('id', $submissionId)
+                ->update([
+                    'state' => 'pending',
+                    'error_code' => null,
+                    'error_message' => null,
+                    'response_payload_json' => null,
+                    'started_at' => null,
+                    'finished_at' => null,
+                    'updated_at' => now(),
+                ]);
+
+            return DB::table('attempt_submissions')->where('id', $submissionId)->first();
+        });
+
+        if ($row === null) {
+            return null;
+        }
+
+        ProcessAttemptSubmissionJob::dispatch($submissionId)->afterCommit();
+
+        return [
+            'attempt_id' => (string) ($row->attempt_id ?? ''),
+            'submission_id' => $submissionId,
+            'repair_code' => 'submission_requeued',
+            'reason_code' => $reasonCode,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function syncProjectionToPending(string $attemptId, object $submission): ?array
+    {
+        $projection = $this->projectionWriter->refreshAttemptProjection(
+            $attemptId,
+            [
+                'access_state' => 'locked',
+                'report_state' => 'pending',
+                'pdf_state' => 'missing',
+                'reason_code' => 'submission_pending',
+                'actions_json' => ['report' => true, 'pdf' => false],
+                'payload_json' => [
+                    'fallback' => true,
+                    'submission' => [
+                        'id' => (string) ($submission->id ?? ''),
+                        'state' => strtolower(trim((string) ($submission->state ?? 'pending'))),
+                    ],
+                ],
+            ],
+            [
+                'source_system' => 'attempt_submission_recovery',
+                'source_ref' => 'submission#'.(string) ($submission->id ?? ''),
+                'actor_type' => 'system',
+                'actor_id' => 'ops:attempt-submission-recovery',
+            ]
+        );
+
+        if ($projection === null) {
+            return null;
+        }
+
+        return [
+            'attempt_id' => $attemptId,
+            'submission_id' => (string) ($submission->id ?? ''),
+            'repair_code' => 'projection_refreshed',
+            'reason_code' => 'submission_pending',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $submissionPayload
+     * @return array<string,mixed>|null
+     */
+    private function syncProjectionToFailed(string $attemptId, object $submission, array $submissionPayload): ?array
+    {
+        $projection = $this->projectionWriter->refreshAttemptProjection(
+            $attemptId,
+            [
+                'access_state' => 'locked',
+                'report_state' => 'unavailable',
+                'pdf_state' => 'missing',
+                'reason_code' => 'submission_failed',
+                'actions_json' => ['report' => false, 'pdf' => false],
+                'payload_json' => [
+                    'fallback' => true,
+                    'submission' => [
+                        'id' => (string) ($submission->id ?? ''),
+                        'state' => strtolower(trim((string) ($submission->state ?? 'failed'))),
+                        'error_code' => $this->normalizeNullableString($submission->error_code ?? null),
+                    ],
+                    'result' => $submissionPayload !== [] ? $submissionPayload : null,
+                ],
+            ],
+            [
+                'source_system' => 'attempt_submission_recovery',
+                'source_ref' => 'submission#'.(string) ($submission->id ?? ''),
+                'actor_type' => 'system',
+                'actor_id' => 'ops:attempt-submission-recovery',
+            ]
+        );
+
+        if ($projection === null) {
+            return null;
+        }
+
+        return [
+            'attempt_id' => $attemptId,
+            'submission_id' => (string) ($submission->id ?? ''),
+            'repair_code' => 'projection_refreshed',
+            'reason_code' => 'submission_failed',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function refreshProjectionFromArtifacts(string $attemptId): ?array
+    {
+        if (Result::query()->where('attempt_id', $attemptId)->exists()) {
+            $projection = $this->projectionWriter->refreshAttemptProjection(
+                $attemptId,
+                [
+                    'access_state' => 'locked',
+                    'report_state' => 'ready',
+                    'pdf_state' => 'missing',
+                    'reason_code' => 'result_available',
+                    'actions_json' => ['report' => true, 'pdf' => false],
+                    'payload_json' => [
+                        'attempt_id' => $attemptId,
+                        'result_exists' => true,
+                        'fallback' => true,
+                    ],
+                ],
+                [
+                    'source_system' => 'attempt_submission_recovery',
+                    'source_ref' => 'result#'.$attemptId,
+                    'actor_type' => 'system',
+                    'actor_id' => 'ops:attempt-submission-recovery',
+                ]
+            );
+
+            if ($projection !== null) {
+                return [
+                    'attempt_id' => $attemptId,
+                    'submission_id' => null,
+                    'repair_code' => 'projection_backfilled',
+                    'reason_code' => 'result_available',
+                ];
+            }
+        }
+
+        $result = $this->projectionBackfill->executeBackfill(['attempt_id' => $attemptId]);
+
+        return [
+            'attempt_id' => $attemptId,
+            'submission_id' => null,
+            'repair_code' => 'projection_backfilled',
+            'reason_code' => 'projection_missing_after_result',
+            'details' => [
+                'attempt_receipts_inserted' => (int) ($result['attempt_receipts_inserted'] ?? 0),
+                'attempt_receipts_reused' => (int) ($result['attempt_receipts_reused'] ?? 0),
+            ],
+        ];
+    }
+
+    private function projectionMatchesPending(?object $projection): bool
+    {
+        if ($projection === null) {
+            return false;
+        }
+
+        return strtolower(trim((string) ($projection->access_state ?? ''))) === 'locked'
+            && strtolower(trim((string) ($projection->report_state ?? ''))) === 'pending'
+            && strtolower(trim((string) ($projection->reason_code ?? ''))) === 'submission_pending';
+    }
+
+    private function projectionMatchesFailed(?object $projection): bool
+    {
+        if ($projection === null) {
+            return false;
+        }
+
+        return strtolower(trim((string) ($projection->access_state ?? ''))) === 'locked'
+            && strtolower(trim((string) ($projection->report_state ?? ''))) === 'unavailable'
+            && strtolower(trim((string) ($projection->reason_code ?? ''))) === 'submission_failed';
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array<string,int>
+     */
+    private function countByKey(array $rows, string $key): array
+    {
+        $counts = [];
+        foreach ($rows as $row) {
+            $value = trim((string) ($row[$key] ?? ''));
+            if ($value === '') {
+                continue;
+            }
+
+            $counts[$value] = (int) ($counts[$value] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeArray(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function toCarbon(mixed $value): ?Carbon
+    {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance(\DateTimeImmutable::createFromInterface($value));
+        }
+
+        $text = trim((string) $value);
+        if ($text === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($text);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/Services/Ops/AttemptSubmissionRecoveryService.php
+++ b/backend/app/Services/Ops/AttemptSubmissionRecoveryService.php
@@ -42,13 +42,36 @@ final class AttemptSubmissionRecoveryService
         $repairs = [];
 
         foreach ($this->candidateAttemptIds($attemptId, $windowHours, $limit) as $candidateAttemptId) {
+            $attempt = Schema::hasTable('attempts')
+                ? DB::table('attempts')->where('id', $candidateAttemptId)->first()
+                : null;
             $submission = $this->latestSubmissionRow($candidateAttemptId);
             $resultExists = Result::query()->where('attempt_id', $candidateAttemptId)->exists();
             $projection = Schema::hasTable('unified_access_projections')
                 ? DB::table('unified_access_projections')->where('attempt_id', $candidateAttemptId)->first()
                 : null;
 
+            if ($attempt === null && $submission === null && ! $resultExists && $projection === null) {
+                $findings[] = $this->finding($candidateAttemptId, 'attempt_chain_absent', 'critical', [
+                    'attempt_exists' => false,
+                    'submission_exists' => false,
+                    'result_exists' => false,
+                    'projection_exists' => false,
+                ]);
+
+                continue;
+            }
+
             if ($submission === null) {
+                if ($attempt !== null && $this->toCarbon($attempt->submitted_at ?? null) instanceof Carbon) {
+                    $findings[] = $this->finding($candidateAttemptId, 'submission_missing_for_submitted_attempt', 'critical', [
+                        'attempt_exists' => true,
+                        'submitted_at' => $this->toCarbon($attempt->submitted_at ?? null)?->toIso8601String(),
+                        'result_exists' => $resultExists,
+                        'projection_exists' => $projection !== null,
+                    ]);
+                }
+
                 if ($resultExists) {
                     $findings[] = $this->finding($candidateAttemptId, 'submission_missing_with_result_present', 'critical', [
                         'result_exists' => true,
@@ -238,6 +261,26 @@ final class AttemptSubmissionRecoveryService
                 ->orderByDesc('updated_at')
                 ->limit($limit)
                 ->pluck('attempt_id');
+
+            foreach ($rows as $value) {
+                $candidate = trim((string) $value);
+                if ($candidate !== '') {
+                    $attemptIds[$candidate] = true;
+                }
+            }
+        }
+
+        if (Schema::hasTable('attempts')) {
+            $rows = DB::table('attempts')
+                ->select('id')
+                ->whereNotNull('submitted_at')
+                ->where(function ($query) use ($windowStart): void {
+                    $query->where('submitted_at', '>=', $windowStart)
+                        ->orWhere('updated_at', '>=', $windowStart);
+                })
+                ->orderByDesc('submitted_at')
+                ->limit($limit)
+                ->pluck('id');
 
             foreach ($rows as $value) {
                 $candidate = trim((string) $value);

--- a/backend/config/ops.php
+++ b/backend/config/ops.php
@@ -99,4 +99,12 @@ return [
             ],
         ],
     ],
+
+    'attempt_submission_recovery' => [
+        'window_hours' => (int) env('OPS_ATTEMPT_SUBMISSION_RECOVERY_WINDOW_HOURS', 24),
+        'limit' => (int) env('OPS_ATTEMPT_SUBMISSION_RECOVERY_LIMIT', 200),
+        'pending_timeout_minutes' => (int) env('OPS_ATTEMPT_SUBMISSION_RECOVERY_PENDING_TIMEOUT_MINUTES', 15),
+        'strict_default' => (bool) env('OPS_ATTEMPT_SUBMISSION_RECOVERY_STRICT_DEFAULT', false),
+        'alert_default' => (bool) env('OPS_ATTEMPT_SUBMISSION_RECOVERY_ALERT_DEFAULT', true),
+    ],
 ];

--- a/backend/tests/Feature/Ops/AttemptSubmissionRecoveryCommandTest.php
+++ b/backend/tests/Feature/Ops/AttemptSubmissionRecoveryCommandTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Models\UnifiedAccessProjection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptSubmissionRecoveryCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createAttempt(string $attemptId, string $anonId): void
+    {
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(10),
+            'submitted_at' => now()->subMinutes(9),
+            'pack_id' => 'MBTI.pack',
+            'dir_version' => 'MBTI.dir',
+            'content_package_version' => 'attempt-v1',
+            'scoring_spec_version' => 'attempt-score-v1',
+        ]);
+    }
+
+    private function createSubmission(string $attemptId, string $anonId, string $state, int $updatedMinutesAgo = 1, ?array $responsePayload = null): string
+    {
+        $submissionId = (string) Str::uuid();
+
+        \DB::table('attempt_submissions')->insert([
+            'id' => $submissionId,
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => null,
+            'actor_anon_id' => $anonId,
+            'dedupe_key' => hash('sha256', $attemptId.':'.$state),
+            'mode' => 'async',
+            'state' => $state,
+            'error_code' => $state === 'failed' ? 'SUBMISSION_JOB_TERMINAL_FAILURE' : null,
+            'error_message' => $state === 'failed' ? 'submission job terminal failure.' : null,
+            'request_payload_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'response_payload_json' => $responsePayload !== null ? json_encode($responsePayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : null,
+            'started_at' => now()->subMinutes($updatedMinutesAgo),
+            'finished_at' => in_array($state, ['succeeded', 'failed'], true) ? now()->subMinutes($updatedMinutesAgo) : null,
+            'created_at' => now()->subMinutes($updatedMinutesAgo + 1),
+            'updated_at' => now()->subMinutes($updatedMinutesAgo),
+        ]);
+
+        return $submissionId;
+    }
+
+    private function createResult(string $attemptId): void
+    {
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [],
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'result-v1',
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'pack_id' => 'MBTI.result-pack',
+            'dir_version' => 'MBTI.result-dir',
+            'scoring_spec_version' => 'result-score-v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now()->subMinutes(1),
+        ]);
+    }
+
+    public function test_command_reports_repairable_submission_chain_findings(): void
+    {
+        config()->set('storage_rollout.receipt_ledger_dual_write_enabled', true);
+        config()->set('storage_rollout.access_projection_dual_write_enabled', true);
+
+        $stuckAttemptId = (string) Str::uuid();
+        $missingResultAttemptId = (string) Str::uuid();
+        $failedProjectionAttemptId = (string) Str::uuid();
+        $projectionMissingAttemptId = (string) Str::uuid();
+
+        $this->createAttempt($stuckAttemptId, 'anon-stuck');
+        $this->createSubmission($stuckAttemptId, 'anon-stuck', 'pending', 25);
+
+        $this->createAttempt($missingResultAttemptId, 'anon-missing-result');
+        $this->createSubmission($missingResultAttemptId, 'anon-missing-result', 'succeeded', 3, [
+            'ok' => true,
+            'attempt_id' => $missingResultAttemptId,
+        ]);
+
+        $this->createAttempt($failedProjectionAttemptId, 'anon-failed');
+        $this->createSubmission($failedProjectionAttemptId, 'anon-failed', 'failed', 2, [
+            'ok' => false,
+            'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            'terminal_failure' => true,
+        ]);
+        UnifiedAccessProjection::query()->create([
+            'attempt_id' => $failedProjectionAttemptId,
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'ready',
+            'reason_code' => 'stale_ready',
+            'projection_version' => 1,
+            'actions_json' => ['report' => true, 'pdf' => true],
+            'payload_json' => ['attempt_id' => $failedProjectionAttemptId],
+            'produced_at' => now()->subMinutes(2),
+            'refreshed_at' => now()->subMinutes(2),
+        ]);
+
+        $this->createAttempt($projectionMissingAttemptId, 'anon-projection-missing');
+        $this->createSubmission($projectionMissingAttemptId, 'anon-projection-missing', 'succeeded', 1, [
+            'ok' => true,
+            'attempt_id' => $projectionMissingAttemptId,
+        ]);
+        $this->createResult($projectionMissingAttemptId);
+
+        $exitCode = Artisan::call('ops:attempt-submission-recovery', [
+            '--json' => 1,
+            '--strict' => 0,
+            '--window-hours' => 24,
+            '--pending-timeout-minutes' => 15,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame(5, (int) data_get($payload, 'summary.finding_total'));
+        $this->assertSame(0, (int) data_get($payload, 'summary.repair_total'));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.submission_stuck_pending'));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.projection_stale_against_pending_submission'));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.submission_succeeded_result_missing'));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.projection_stale_against_failed_submission'));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.projection_missing_after_result'));
+    }
+
+    public function test_repair_mode_requeues_safe_cases_refreshes_projection_and_emits_alert(): void
+    {
+        config()->set('storage_rollout.receipt_ledger_dual_write_enabled', true);
+        config()->set('storage_rollout.access_projection_dual_write_enabled', true);
+        config()->set('ops.alert.webhook', 'https://alerts.example.test/ops');
+        Http::fake(['https://alerts.example.test/*' => Http::response(['ok' => true], 200)]);
+        Queue::fake();
+
+        $stuckAttemptId = (string) Str::uuid();
+        $missingResultAttemptId = (string) Str::uuid();
+        $failedProjectionAttemptId = (string) Str::uuid();
+        $projectionMissingAttemptId = (string) Str::uuid();
+
+        $this->createAttempt($stuckAttemptId, 'anon-stuck');
+        $stuckSubmissionId = $this->createSubmission($stuckAttemptId, 'anon-stuck', 'running', 20);
+
+        $this->createAttempt($missingResultAttemptId, 'anon-missing-result');
+        $missingResultSubmissionId = $this->createSubmission($missingResultAttemptId, 'anon-missing-result', 'succeeded', 3, [
+            'ok' => true,
+            'attempt_id' => $missingResultAttemptId,
+        ]);
+
+        $this->createAttempt($failedProjectionAttemptId, 'anon-failed');
+        $failedSubmissionId = $this->createSubmission($failedProjectionAttemptId, 'anon-failed', 'failed', 2, [
+            'ok' => false,
+            'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+            'message' => 'submission job terminal failure.',
+            'terminal_failure' => true,
+        ]);
+
+        $this->createAttempt($projectionMissingAttemptId, 'anon-projection-missing');
+        $this->createSubmission($projectionMissingAttemptId, 'anon-projection-missing', 'succeeded', 1, [
+            'ok' => true,
+            'attempt_id' => $projectionMissingAttemptId,
+        ]);
+        $this->createResult($projectionMissingAttemptId);
+
+        $exitCode = Artisan::call('ops:attempt-submission-recovery', [
+            '--json' => 1,
+            '--strict' => 0,
+            '--repair' => 1,
+            '--window-hours' => 24,
+            '--pending-timeout-minutes' => 15,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame(5, (int) data_get($payload, 'summary.finding_total'));
+        $repairCounts = is_array(data_get($payload, 'summary.by_repair_code')) ? data_get($payload, 'summary.by_repair_code') : [];
+        $this->assertSame(array_sum(array_map('intval', $repairCounts)), (int) data_get($payload, 'summary.repair_total'));
+        $this->assertSame(2, (int) data_get($payload, 'summary.by_repair_code.submission_requeued'));
+        $this->assertGreaterThanOrEqual(3, (int) data_get($payload, 'summary.by_repair_code.projection_refreshed'));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_repair_code.projection_backfilled'));
+
+        Queue::assertPushed(\App\Jobs\ProcessAttemptSubmissionJob::class, 2);
+
+        $stuck = \DB::table('attempt_submissions')->where('id', $stuckSubmissionId)->first();
+        $this->assertSame('pending', (string) ($stuck->state ?? ''));
+        $this->assertNull($stuck->finished_at ?? null);
+
+        $missingResult = \DB::table('attempt_submissions')->where('id', $missingResultSubmissionId)->first();
+        $this->assertSame('pending', (string) ($missingResult->state ?? ''));
+
+        $failedProjection = UnifiedAccessProjection::query()->where('attempt_id', $failedProjectionAttemptId)->first();
+        $this->assertNotNull($failedProjection);
+        $this->assertSame('locked', (string) $failedProjection->access_state);
+        $this->assertSame('unavailable', (string) $failedProjection->report_state);
+        $this->assertSame('submission_failed', (string) $failedProjection->reason_code);
+
+        $backfilledProjection = UnifiedAccessProjection::query()->where('attempt_id', $projectionMissingAttemptId)->first();
+        $this->assertNotNull($backfilledProjection);
+
+        Http::assertSentCount(1);
+        Http::assertSent(function (\Illuminate\Http\Client\Request $request): bool {
+            return $request->url() === 'https://alerts.example.test/ops'
+                && str_contains((string) $request->body(), 'ops:attempt-submission-recovery');
+        });
+    }
+}

--- a/backend/tests/Feature/Ops/AttemptSubmissionRecoveryCommandTest.php
+++ b/backend/tests/Feature/Ops/AttemptSubmissionRecoveryCommandTest.php
@@ -108,6 +108,9 @@ final class AttemptSubmissionRecoveryCommandTest extends TestCase
             'attempt_id' => $missingResultAttemptId,
         ]);
 
+        $submittedWithoutSubmissionAttemptId = (string) Str::uuid();
+        $this->createAttempt($submittedWithoutSubmissionAttemptId, 'anon-missing-submission');
+
         $this->createAttempt($failedProjectionAttemptId, 'anon-failed');
         $this->createSubmission($failedProjectionAttemptId, 'anon-failed', 'failed', 2, [
             'ok' => false,
@@ -145,11 +148,12 @@ final class AttemptSubmissionRecoveryCommandTest extends TestCase
 
         $payload = json_decode(trim((string) Artisan::output()), true);
         $this->assertIsArray($payload);
-        $this->assertSame(5, (int) data_get($payload, 'summary.finding_total'));
+        $this->assertSame(6, (int) data_get($payload, 'summary.finding_total'));
         $this->assertSame(0, (int) data_get($payload, 'summary.repair_total'));
         $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.submission_stuck_pending'));
         $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.projection_stale_against_pending_submission'));
         $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.submission_succeeded_result_missing'));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.submission_missing_for_submitted_attempt'));
         $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.projection_stale_against_failed_submission'));
         $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.projection_missing_after_result'));
     }
@@ -233,5 +237,26 @@ final class AttemptSubmissionRecoveryCommandTest extends TestCase
             return $request->url() === 'https://alerts.example.test/ops'
                 && str_contains((string) $request->body(), 'ops:attempt-submission-recovery');
         });
+    }
+
+    public function test_strict_exact_attempt_diagnosis_fails_when_chain_is_absent(): void
+    {
+        $missingAttemptId = 'missing-attempt-demo';
+
+        $exitCode = Artisan::call('ops:attempt-submission-recovery', [
+            '--json' => 1,
+            '--strict' => 1,
+            '--alert' => 0,
+            '--attempt-id' => $missingAttemptId,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame($missingAttemptId, data_get($payload, 'scope.attempt_id'));
+        $this->assertSame(1, (int) data_get($payload, 'summary.finding_total'));
+        $this->assertSame(1, (int) data_get($payload, 'summary.by_issue_code.attempt_chain_absent'));
+        $this->assertFalse((bool) ($payload['pass'] ?? true));
     }
 }


### PR DESCRIPTION
## Summary
- add ops:attempt-submission-recovery for repairable submission-chain findings
- requeue stuck or result-missing submissions with safe compensation
- refresh or backfill projections and emit ops alerts for findings

## Tests
- php artisan test --filter=AttemptSubmissionRecoveryCommandTest
- php artisan test --filter='AttemptSubmissionFirstReadContractTest|AttemptSubmissionAsyncFlowTest|AttemptSubmissionJobTerminalFailureTest'
- php artisan route:list
- php artisan migrate
- bash backend/scripts/ci_verify_mbti.sh