### PR TITLE
fix(deploy): enforce queue worker single owner

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -36,7 +36,15 @@ Truth Source: `backend/composer.json` / `backend/package.json` / `backend/config
 - PHP-FPM（Laravel 应用）
 - MySQL（主库）
 - Redis（cache + queue lock）
-- Supervisor（驻留 queue workers）
+- Supervisor（唯一驻留 queue workers owner）
+
+### 3.1 Queue owner 单一化（正式基线）
+- 正式基线只保留 **Supervisor** 作为 queue worker manager。
+- 不允许 production/staging 同时存在：
+  - `supervisor` worker
+  - `systemd` 的 `fap-queue.service`
+- 若历史环境仍保留 `fap-queue.service`，deploy hook 会先执行 `php artisan queue:restart`，再重启 Supervisor programs，并停止/禁用遗留 `systemd` queue service。
+- 任何看到 `systemd + supervisor` 双跑的环境，都视为漂移环境，必须先收口再继续上线。
 
 ## 4. 配置清单（上线必填）
 以 `backend/.env.example` 为模板，生产必须由密钥系统注入。
@@ -127,6 +135,22 @@ php artisan event:cache
 # 6) 数据库迁移
 php artisan migrate --force
 
+# 6.1) queue worker reload（唯一 owner = supervisor）
+php artisan queue:restart
+sudo supervisorctl reread
+sudo supervisorctl update
+sudo supervisorctl restart fap-queue-default-high:*
+sudo supervisorctl restart fap-queue-reports:*
+# 可选队列
+sudo supervisorctl restart fap-queue-ops:* || true
+sudo supervisorctl restart fap-queue-commerce:* || true
+sudo supervisorctl restart fap-queue-content:* || true
+sudo supervisorctl restart fap-queue-insights:* || true
+
+# 若历史环境存在遗留 systemd queue service，必须停用，避免双跑
+sudo systemctl stop fap-queue.service || true
+sudo systemctl disable fap-queue.service || true
+
 # 7) Ops 资产验收
 test -s public/css/app/ops-theme.css
 test -s public/css/filament/filament/app.css
@@ -161,6 +185,35 @@ curl -sSI https://staging.fermatmind.com/ops/login | rg '^HTTP/[0-9.]+ 200 '
 
 # 7.3) 基线校验
 php artisan fap:schema:verify
+
+# 7.4) queue smoke（deploy 后必须通过）
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+$queue = (string) config("ops.deploy_queue_smoke.queue", "default");
+$maxDepth = max(0, (int) config("ops.deploy_queue_smoke.max_depth", 5));
+$waitSeconds = max(1, (int) config("ops.deploy_queue_smoke.stability_wait_seconds", 15));
+$maxGrowth = max(0, (int) config("ops.deploy_queue_smoke.max_growth", 1));
+$pendingWindowMinutes = max(1, (int) config("ops.deploy_queue_smoke.pending_window_minutes", 30));
+$maxRecentPending = max(0, (int) config("ops.deploy_queue_smoke.max_recent_pending", 3));
+$queueConnectionName = (string) config("queue.default", "redis");
+$queueConnection = (array) config("queue.connections.".$queueConnectionName, []);
+$redisConnection = (string) ($queueConnection["connection"] ?? "default");
+$redis = Illuminate\Support\Facades\Redis::connection($redisConnection);
+$before = (int) $redis->llen("queues:".$queue);
+sleep($waitSeconds);
+$after = (int) $redis->llen("queues:".$queue);
+$recentPending = (int) Illuminate\Support\Facades\DB::table("attempt_submissions")
+  ->whereIn("state", ["pending", "running"])
+  ->where("updated_at", ">=", now()->subMinutes($pendingWindowMinutes))
+  ->count();
+dump(compact("queue","before","after","maxDepth","waitSeconds","maxGrowth","recentPending","maxRecentPending"));
+if ($after > $maxDepth || ($after - $before) > $maxGrowth || $recentPending > $maxRecentPending) {
+    exit(1);
+}
+'
 ```
 
 ### 5.1 Ops Theme Build in Deploy Pipeline
@@ -255,6 +308,7 @@ stopwaitsecs=360
 
 ### 6.4 生效命令
 ```bash
+php artisan queue:restart
 sudo supervisorctl reread
 sudo supervisorctl update
 sudo supervisorctl restart fap-queue-default-high:*
@@ -266,6 +320,19 @@ sudo supervisorctl restart fap-queue-content:*
 sudo supervisorctl restart fap-queue-insights:*
 ```
 
+### 6.5 遗留 systemd queue service 处理
+如果历史环境里存在 `fap-queue.service`，必须停用：
+
+```bash
+sudo systemctl stop fap-queue.service || true
+sudo systemctl disable fap-queue.service || true
+sudo systemctl is-active fap-queue.service
+```
+
+通过标准：
+- `systemctl is-active fap-queue.service` 返回非 `active`
+- 只保留 `supervisorctl status fap-queue-*` 里的 worker 作为正式 owner
+
 ## 7. 发布后验收
 ```bash
 cd /opt/fap-api/backend
@@ -276,6 +343,7 @@ curl -i http://127.0.0.1:8000/api/healthz
 curl -i http://127.0.0.1:8000/api/v0.4/boot
 curl -i -X POST http://127.0.0.1:8000/api/v0.3/auth/guest -H 'Content-Type: application/json' -d '{"anon_id":"deploy_contract_probe"}'
 curl -i -X POST http://127.0.0.1:8000/api/v0.3/attempts/start -H 'Content-Type: application/json' -d '{"scale_code":"MBTI"}'
+php artisan ops:attempt-submission-recovery --json=1 --alert=0 --strict=0 --window-hours=1 --limit=50
 
 cd /opt/fap-api
 bash backend/scripts/ci_verify_mbti.sh
@@ -295,3 +363,23 @@ bash backend/scripts/ci_verify_mbti.sh
    - 完成代码切换/配置恢复
    - 再按 `reports -> default/high -> 其他队列` 顺序启动
 5. 验收通过后恢复流量。
+
+## 9. Attempt Submission 补偿 Runbook
+当线上出现 “submit 返回 202，但结果页长期 pending / 404” 时，先不要直接重试前台页面，按下面顺序处置：
+
+```bash
+cd /opt/fap-api/backend
+
+# 1) 精确诊断一条 attempt
+php artisan ops:attempt-submission-recovery --json=1 --alert=0 --strict=0 --attempt-id=<attempt_id>
+
+# 2) recent 窗口巡检
+php artisan ops:attempt-submission-recovery --json=1 --alert=0 --strict=0 --window-hours=1 --limit=100
+
+# 3) 安全补偿（会重排队 stuck / result-missing submission，并修正 stale projection）
+php artisan ops:attempt-submission-recovery --json=1 --alert=0 --strict=0 --repair=1 --window-hours=1 --limit=100
+```
+
+适用边界：
+- `--repair=1` 只用于当前 release 已确认健康、queue worker 已按本 runbook 收口到 Supervisor 单 owner 后。
+- 如果 queue smoke 仍失败，先处理 worker owner/consumer 问题，再做补偿。

--- a/backend/config/ops.php
+++ b/backend/config/ops.php
@@ -114,4 +114,13 @@ return [
         'strict_default' => (bool) env('OPS_ATTEMPT_SUBMISSION_RECOVERY_STRICT_DEFAULT', false),
         'alert_default' => (bool) env('OPS_ATTEMPT_SUBMISSION_RECOVERY_ALERT_DEFAULT', true),
     ],
+
+    'deploy_queue_smoke' => [
+        'queue' => env('OPS_DEPLOY_QUEUE_SMOKE_QUEUE', 'default'),
+        'max_depth' => (int) env('OPS_DEPLOY_QUEUE_SMOKE_MAX_DEPTH', 5),
+        'stability_wait_seconds' => (int) env('OPS_DEPLOY_QUEUE_SMOKE_WAIT_SECONDS', 15),
+        'max_growth' => (int) env('OPS_DEPLOY_QUEUE_SMOKE_MAX_GROWTH', 1),
+        'pending_window_minutes' => (int) env('OPS_DEPLOY_QUEUE_SMOKE_PENDING_WINDOW_MINUTES', 30),
+        'max_recent_pending' => (int) env('OPS_DEPLOY_QUEUE_SMOKE_MAX_RECENT_PENDING', 3),
+    ],
 ];

--- a/backend/docs/ops/queue-runbook.md
+++ b/backend/docs/ops/queue-runbook.md
@@ -22,7 +22,16 @@ Truth Source: `config/queue.php`, `app/Jobs/*`, `Phase C snapshot chain`
 | 通用任务 | default connection | high/default | 平台保底 worker |
 
 ## 2. Worker 驻留规范
-生产建议使用 Supervisor 分组驻留，不使用 horizon。
+生产正式基线：使用 Supervisor 分组驻留，不使用 horizon，也不允许与 `systemd` queue service 双跑。
+
+### 2.0 单一 owner 规则
+- 当前唯一允许的 queue worker owner 是 **Supervisor**。
+- `fap-queue.service` 这类历史 `systemd` worker 只能作为迁移遗留，不允许与 `supervisorctl status fap-queue-*` 同时 active。
+- deploy 后必须执行：
+  1. `php artisan queue:restart`
+  2. `supervisorctl reread/update`
+  3. `supervisorctl restart fap-queue-*`
+  4. `systemctl stop/disable fap-queue.service`（若存在）
 
 ### 2.1 推荐 Supervisor 样例
 ```ini
@@ -63,6 +72,7 @@ command=/usr/bin/php artisan queue:work redis --queue=insights --sleep=1 --tries
 
 ### 2.2 发布后生效
 ```bash
+php artisan queue:restart
 sudo supervisorctl reread
 sudo supervisorctl update
 sudo supervisorctl restart fap-queue-default-high:*
@@ -72,6 +82,17 @@ sudo supervisorctl restart fap-queue-commerce:*
 sudo supervisorctl restart fap-queue-content:*
 sudo supervisorctl restart fap-queue-insights:*
 ```
+
+若历史环境仍保留 `systemd` queue service：
+```bash
+sudo systemctl stop fap-queue.service || true
+sudo systemctl disable fap-queue.service || true
+sudo systemctl is-active fap-queue.service
+```
+
+通过标准：
+- `systemctl is-active fap-queue.service` 非 `active`
+- `supervisorctl status fap-queue-*` 中的程序均为 `RUNNING`
 
 ## 3. 报告生成卡住（重点）
 现象：用户提交后报告长期 loading，或 `report_snapshots.status` 长时间 `pending`。
@@ -86,6 +107,49 @@ sudo supervisorctl restart fap-queue-insights:*
 5. 检查应用日志关键字：
    - `REPORT_SNAPSHOT_GENERATE_FAILED`
 6. 若 payment 链触发，额外检查 `payment_events.handle_status` 是否 `reprocess_failed/failed`。
+
+### 3.1 attempt submission stuck / result 404（当前线上重点）
+当现象是：
+- submit 返回 `202`
+- `/submission` 长时间 `pending`
+- `/result` / `/report-access` 仍然 404
+
+按下面顺序执行：
+
+```bash
+cd /opt/fap-api/backend
+
+# 1) 确认 deploy 后 queue smoke
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+$queue = (string) config("ops.deploy_queue_smoke.queue", "default");
+$redis = Illuminate\Support\Facades\Redis::connection((string) ((array) config("queue.connections.".config("queue.default", "redis")))["connection"] ?? "default");
+$before = (int) $redis->llen("queues:".$queue);
+sleep((int) config("ops.deploy_queue_smoke.stability_wait_seconds", 15));
+$after = (int) $redis->llen("queues:".$queue);
+$recentPending = (int) Illuminate\Support\Facades\DB::table("attempt_submissions")
+  ->whereIn("state", ["pending", "running"])
+  ->where("updated_at", ">=", now()->subMinutes((int) config("ops.deploy_queue_smoke.pending_window_minutes", 30)))
+  ->count();
+dump(compact("queue","before","after","recentPending"));
+'
+
+# 2) 精确诊断
+php artisan ops:attempt-submission-recovery --json=1 --alert=0 --strict=0 --attempt-id=<attempt_id>
+
+# 3) recent 巡检
+php artisan ops:attempt-submission-recovery --json=1 --alert=0 --strict=0 --window-hours=1 --limit=100
+
+# 4) 当前 release/queue 已健康时，执行安全补偿
+php artisan ops:attempt-submission-recovery --json=1 --alert=0 --strict=0 --repair=1 --window-hours=1 --limit=100
+```
+
+不要跳过顺序：
+- 如果 queue smoke 失败，先修 worker owner / consumer，不要直接 `--repair=1`
+- 只有 queue smoke 通过后，补偿命令才有意义
 
 ## 4. 失败任务重试标准操作
 ```bash
@@ -177,6 +241,7 @@ cd /opt/fap-api/backend
 php artisan queue:failed
 php artisan queue:work --once --queue=reports
 php artisan queue:work --once --queue=ops
+php artisan ops:attempt-submission-recovery --json=1 --alert=0 --strict=0 --window-hours=1 --limit=100
 php artisan tinker
 # 在 tinker 中可查询 jobs/failed_jobs/report_snapshots/admin_approvals
 ```

--- a/deploy.php
+++ b/deploy.php
@@ -62,6 +62,20 @@ set('healthcheck_scheme', 'https');
 set('healthcheck_use_resolve', true);
 set('nginx_site', '/etc/nginx/sites-enabled/fap-api');
 set('php_fpm_service', 'php8.4-fpm');
+set('queue_manager', 'supervisor');
+set('queue_supervisorctl', '/usr/bin/supervisorctl');
+set('queue_supervisor_required_programs', [
+    'fap-queue-default-high',
+    'fap-queue-reports',
+]);
+set('queue_supervisor_optional_programs', [
+    'fap-queue-ops',
+    'fap-queue-commerce',
+    'fap-queue-content',
+    'fap-queue-insights',
+]);
+set('legacy_queue_systemd_service', 'fap-queue.service');
+set('legacy_queue_systemd_disable', true);
 
 /**
  * ======================================================
@@ -263,6 +277,62 @@ task('reload:nginx', function () {
     run('sudo -n /usr/bin/systemctl reload nginx');
 });
 
+task('queue:reload-workers', function () {
+    $manager = strtolower(trim((string) get('queue_manager', 'supervisor')));
+
+    if ($manager === 'supervisor') {
+        $supervisorctl = trim((string) get('queue_supervisorctl', '/usr/bin/supervisorctl'));
+        $requiredPrograms = array_values(array_filter((array) get('queue_supervisor_required_programs', []), static fn (mixed $value): bool => trim((string) $value) !== ''));
+        $optionalPrograms = array_values(array_filter((array) get('queue_supervisor_optional_programs', []), static fn (mixed $value): bool => trim((string) $value) !== ''));
+        $legacySystemdService = trim((string) get('legacy_queue_systemd_service', ''));
+        $disableLegacySystemd = (bool) get('legacy_queue_systemd_disable', true);
+
+        within('{{current_path}}/backend', function () {
+            run('{{bin/php}} artisan queue:restart --ansi');
+        });
+
+        run("sudo -n {$supervisorctl} reread");
+        run("sudo -n {$supervisorctl} update");
+
+        foreach ($requiredPrograms as $program) {
+            run("sudo -n {$supervisorctl} restart {$program}:* >/dev/null 2>&1 || sudo -n {$supervisorctl} restart {$program}");
+        }
+
+        foreach ($optionalPrograms as $program) {
+            run("sudo -n {$supervisorctl} restart {$program}:* >/dev/null 2>&1 || sudo -n {$supervisorctl} restart {$program} >/dev/null 2>&1 || true");
+        }
+
+        if ($legacySystemdService !== '') {
+            $quotedService = escapeshellarg($legacySystemdService);
+            run("if sudo -n /usr/bin/systemctl list-unit-files {$quotedService} >/dev/null 2>&1; then sudo -n /usr/bin/systemctl stop {$quotedService} >/dev/null 2>&1 || true; fi");
+
+            if ($disableLegacySystemd) {
+                run("if sudo -n /usr/bin/systemctl list-unit-files {$quotedService} >/dev/null 2>&1; then sudo -n /usr/bin/systemctl disable {$quotedService} >/dev/null 2>&1 || true; fi");
+            }
+
+            run("if sudo -n /usr/bin/systemctl list-unit-files {$quotedService} >/dev/null 2>&1 && sudo -n /usr/bin/systemctl is-active --quiet {$quotedService}; then echo 'legacy queue systemd service still active: {$legacySystemdService}' >&2; exit 1; fi");
+        }
+
+        return;
+    }
+
+    if ($manager === 'systemd') {
+        $systemdService = trim((string) get('legacy_queue_systemd_service', ''));
+        if ($systemdService === '') {
+            throw new \RuntimeException('queue manager systemd requires legacy_queue_systemd_service');
+        }
+
+        within('{{current_path}}/backend', function () {
+            run('{{bin/php}} artisan queue:restart --ansi');
+        });
+        run('sudo -n /usr/bin/systemctl restart ' . $systemdService);
+
+        return;
+    }
+
+    throw new \RuntimeException('unsupported queue_manager [' . $manager . ']');
+});
+
 /**
  * ======================================================
  * 固化权限修复（关键）
@@ -404,6 +474,73 @@ task('healthcheck:ops-entry-contract', function () {
     );
 });
 
+task('healthcheck:queue-smoke', function () {
+    within('{{current_path}}/backend', function () {
+        run(<<<'BASH'
+{{bin/php}} -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+
+$queue = (string) config("ops.deploy_queue_smoke.queue", "default");
+$maxDepth = max(0, (int) config("ops.deploy_queue_smoke.max_depth", 5));
+$waitSeconds = max(1, (int) config("ops.deploy_queue_smoke.stability_wait_seconds", 15));
+$maxGrowth = max(0, (int) config("ops.deploy_queue_smoke.max_growth", 1));
+$pendingWindowMinutes = max(1, (int) config("ops.deploy_queue_smoke.pending_window_minutes", 30));
+$maxRecentPending = max(0, (int) config("ops.deploy_queue_smoke.max_recent_pending", 3));
+
+$queueConnectionName = (string) config("queue.default", "redis");
+$queueConnection = (array) config("queue.connections." . $queueConnectionName, []);
+if (($queueConnection["driver"] ?? "") !== "redis") {
+    fwrite(STDERR, "deploy queue smoke requires redis queue driver\n");
+    exit(1);
+}
+
+$redisConnection = (string) ($queueConnection["connection"] ?? "default");
+$redis = Illuminate\Support\Facades\Redis::connection($redisConnection);
+$queueKey = "queues:" . $queue;
+$before = (int) $redis->llen($queueKey);
+sleep($waitSeconds);
+$after = (int) $redis->llen($queueKey);
+$recentPending = (int) Illuminate\Support\Facades\DB::table("attempt_submissions")
+    ->whereIn("state", ["pending", "running"])
+    ->where("updated_at", ">=", now()->subMinutes($pendingWindowMinutes))
+    ->count();
+
+$payload = [
+    "queue" => $queue,
+    "before" => $before,
+    "after" => $after,
+    "max_depth" => $maxDepth,
+    "wait_seconds" => $waitSeconds,
+    "max_growth" => $maxGrowth,
+    "recent_pending_window_minutes" => $pendingWindowMinutes,
+    "recent_pending" => $recentPending,
+    "max_recent_pending" => $maxRecentPending,
+];
+
+if ($after > $maxDepth) {
+    fwrite(STDERR, "deploy queue smoke failed: queue depth exceeds threshold: " . json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n");
+    exit(1);
+}
+
+if (($after - $before) > $maxGrowth) {
+    fwrite(STDERR, "deploy queue smoke failed: queue depth still growing: " . json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n");
+    exit(1);
+}
+
+if ($recentPending > $maxRecentPending) {
+    fwrite(STDERR, "deploy queue smoke failed: recent pending submissions exceed threshold: " . json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n");
+    exit(1);
+}
+
+echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+'
+BASH);
+    });
+});
+
 /**
  * ======================================================
  * Seed shared content_packages
@@ -441,9 +578,11 @@ after('artisan:migrate', 'ensure:release-runtime-perms');
 
 after('deploy:symlink', 'reload:php-fpm');
 after('deploy:symlink', 'reload:nginx');
+after('deploy:symlink', 'queue:reload-workers');
 after('deploy:symlink', 'healthcheck:public');
 after('deploy:symlink', 'healthcheck:auth-guest-contract');
 after('deploy:symlink', 'healthcheck:ops-entry-contract');
+after('deploy:symlink', 'healthcheck:queue-smoke');
 
 after('rollback', 'bootstrap-cache:rebuild-current');
 after('bootstrap-cache:rebuild-current', 'rollback:healthcheck');


### PR DESCRIPTION
## Summary
- add deploy-time queue worker reload using Supervisor as the single queue owner
- stop and disable the legacy `fap-queue.service` during deploy to prevent systemd + supervisor dual-running
- add deploy queue smoke and document `ops:attempt-submission-recovery --repair=1` in the deploy/runbook flow

## Verification
- `php -l deploy.php`
- `cd backend && php -l config/ops.php`
- `cd backend && php artisan route:list | rg 'api/v0.3/attempts/(start|submit)|api/v0.3/attempts/.*/(submission|result|report|report-access)'`
- `cd backend && php artisan migrate --force`
- `cd backend && php artisan ops:attempt-submission-recovery --json=1 --alert=0 --strict=0 --attempt-id=missing-attempt-demo`
- `bash backend/scripts/ci_verify_mbti.sh`

## Context
This PR closes the deploy/ops gap discovered during production incident triage where queue jobs were accepted but worker ownership had drifted across Supervisor and systemd, and deploys were not restarting workers or smoke-checking queue health.
