### PR TITLE
fix(attempts): unify public artifact read contract

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -77,14 +77,8 @@ class AttemptReadController extends Controller
      */
     public function submission(Request $request, string $attemptId): JsonResponse
     {
-        $this->ownedAttemptQuery($request, $attemptId)->firstOrFail();
-
-        $payload = $this->attemptSubmissionService->latestForAttempt(
-            $this->currentOrgContext(),
-            $attemptId,
-            $this->resolveUserId($request),
-            $this->resolveAnonId($request)
-        );
+        $attempt = $this->resolveAttemptForSubmissionRead($request, $attemptId);
+        $payload = $this->latestSubmissionPayload($request, $attemptId, $attempt);
 
         $status = (int) ($payload['http_status'] ?? 200);
         unset($payload['http_status']);
@@ -341,7 +335,7 @@ class AttemptReadController extends Controller
             $userId !== null ? (string) $userId : null,
             $anonId,
             $this->currentOrgContext()->role(),
-            false,
+            $this->shouldUsePublicArtifactFallback($request, $attempt),
             $forceRefresh,
         );
 
@@ -567,10 +561,20 @@ class AttemptReadController extends Controller
                 return $attempt;
             }
 
+            $attempt = $this->resolvePublicAttemptFromArtifacts($request, $this->currentOrgContext()->orgId(), $attemptId, $scaleCode);
+            if ($attempt instanceof Attempt) {
+                return $attempt;
+            }
+
             throw new ApiProblemException(404, 'ATTEMPT_NOT_FOUND', 'attempt not found.');
         }
 
         $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
+        if ($attempt instanceof Attempt) {
+            return $attempt;
+        }
+
+        $attempt = $this->resolvePublicAttemptFromArtifacts($request, $this->currentOrgContext()->orgId(), $attemptId);
         if ($attempt instanceof Attempt) {
             return $attempt;
         }
@@ -594,6 +598,11 @@ class AttemptReadController extends Controller
         }
 
         $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
+        if ($attempt instanceof Attempt) {
+            return $attempt;
+        }
+
+        $attempt = $this->resolvePublicAttemptFromArtifacts($request, $orgId, $attemptId);
         if ($attempt instanceof Attempt) {
             return $attempt;
         }
@@ -1451,23 +1460,129 @@ class AttemptReadController extends Controller
 
     private function latestReadableSubmission(Request $request, string $attemptId): ?array
     {
-        $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
-        if (! $attempt instanceof Attempt) {
-            $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
-        }
+        $attempt = $this->resolveReadableAttemptForSubmissionPayload($request, $attemptId);
 
         if (! $attempt instanceof Attempt) {
             return null;
         }
 
+        $payload = $this->latestSubmissionPayload($request, $attemptId, $attempt);
+
+        return ($payload['ok'] ?? false) === true ? $payload : null;
+    }
+
+    private function resolveAttemptForSubmissionRead(Request $request, string $attemptId): Attempt
+    {
+        $attempt = $this->resolveReadableAttemptForSubmissionPayload($request, $attemptId);
+        if ($attempt instanceof Attempt) {
+            return $attempt;
+        }
+
+        throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+    }
+
+    private function resolveReadableAttemptForSubmissionPayload(Request $request, string $attemptId): ?Attempt
+    {
+        $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
+        if ($attempt instanceof Attempt) {
+            return $attempt;
+        }
+
+        $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
+        if ($attempt instanceof Attempt) {
+            return $attempt;
+        }
+
+        return $this->resolvePublicAttemptFromArtifacts($request, $this->currentOrgContext()->orgId(), $attemptId);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function latestSubmissionPayload(Request $request, string $attemptId, Attempt $attempt): array
+    {
         $payload = $this->attemptSubmissionService->latestForAttempt(
             $this->currentOrgContext(),
             $attemptId,
             $this->resolveUserId($request),
             $this->resolveAnonId($request)
         );
+        if (($payload['ok'] ?? false) === true) {
+            return $payload;
+        }
 
-        return ($payload['ok'] ?? false) === true ? $payload : null;
+        if (! $this->shouldUsePublicArtifactFallback($request, $attempt)) {
+            return $payload;
+        }
+
+        $fallbackUserId = isset($attempt->user_id) && $attempt->user_id !== null ? (string) $attempt->user_id : null;
+        $fallbackAnonId = isset($attempt->anon_id) && $attempt->anon_id !== null ? (string) $attempt->anon_id : null;
+        if ($fallbackUserId === null && $fallbackAnonId === null) {
+            return $payload;
+        }
+
+        $fallbackPayload = $this->attemptSubmissionService->latestForAttempt(
+            $this->currentOrgContext(),
+            $attemptId,
+            $fallbackUserId,
+            $fallbackAnonId
+        );
+
+        return ($fallbackPayload['ok'] ?? false) === true ? $fallbackPayload : $payload;
+    }
+
+    private function resolvePublicAttemptFromArtifacts(
+        Request $request,
+        int $orgId,
+        string $attemptId,
+        ?string $scaleCode = null
+    ): ?Attempt {
+        if ($this->hasResolvedReadActor($request)) {
+            return null;
+        }
+
+        $attempt = $this->reportSubjects->findAttemptForSystem($orgId, $attemptId);
+        if (! $attempt instanceof Attempt) {
+            return null;
+        }
+
+        $normalizedScaleCode = strtoupper(trim($scaleCode !== null ? $scaleCode : (string) ($attempt->scale_code ?? '')));
+        if (! $this->isPublicReportScale($normalizedScaleCode)) {
+            return null;
+        }
+
+        if (! $this->hasPublicReadableArtifact($orgId, $attemptId)) {
+            return null;
+        }
+
+        return $attempt;
+    }
+
+    private function shouldUsePublicArtifactFallback(Request $request, Attempt $attempt): bool
+    {
+        if ($this->hasResolvedReadActor($request)) {
+            return false;
+        }
+
+        if (! $this->isPublicReportScale(strtoupper(trim((string) ($attempt->scale_code ?? ''))))) {
+            return false;
+        }
+
+        return $this->hasPublicReadableArtifact((int) ($attempt->org_id ?? 0), (string) ($attempt->id ?? ''));
+    }
+
+    private function hasResolvedReadActor(Request $request): bool
+    {
+        return $this->resolveUserId($request) !== null || $this->resolveAnonId($request) !== null;
+    }
+
+    private function hasPublicReadableArtifact(int $orgId, string $attemptId): bool
+    {
+        if (Result::query()->where('org_id', $orgId)->where('attempt_id', $attemptId)->exists()) {
+            return true;
+        }
+
+        return UnifiedAccessProjection::query()->where('attempt_id', $attemptId)->exists();
     }
 
     private function pendingSubmissionResponse(string $attemptId, array $submissionPayload, bool $includeReport): JsonResponse

--- a/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
@@ -203,6 +203,24 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
         $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
     }
 
+    public function test_public_mbti_report_reads_public_result_without_actor_when_attempt_and_result_exist(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'MBTI', 'anon_mbti_artifact_owner');
+        $this->createResult($attemptId, 'MBTI');
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('scale_code', 'MBTI');
+        $response->assertJsonPath('meta.scale_code', 'MBTI');
+        $this->assertStringNotContainsString('ATTEMPT_NOT_FOUND', (string) $response->getContent());
+    }
+
     public function test_sds20_report_still_requires_existing_ownership_chain(): void
     {
         $this->seedScales();

--- a/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
@@ -214,6 +214,37 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
         $response->assertJsonPath('submission.id', $submissionId);
     }
 
+    public function test_submission_reads_succeeded_public_submission_without_actor_when_result_exists(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_submission_public_artifact_fallback';
+        $submissionId = $this->createSubmission($attemptId, $anonId, 'succeeded', [
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'type_code' => 'INTJ-A',
+        ]);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createResult($attemptId);
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/submission");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'generating' => false,
+            'submission' => [
+                'id' => $submissionId,
+                'state' => 'succeeded',
+            ],
+            'result' => [
+                'ok' => true,
+                'attempt_id' => $attemptId,
+                'type_code' => 'INTJ-A',
+            ],
+        ]);
+    }
+
     public function test_report_returns_terminal_failure_contract_when_submission_failed_and_result_is_missing(): void
     {
         $attemptId = (string) Str::uuid();
@@ -338,6 +369,49 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
         ]);
         $response->assertJsonPath('payload.submission.id', $submissionId);
         $response->assertJsonPath('actions.wait_href', "/result/{$attemptId}");
+    }
+
+    public function test_report_access_reads_public_projection_without_actor_when_projection_exists(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_public_artifact_fallback';
+        $this->createAttempt($attemptId, $anonId);
+        $this->createResult($attemptId);
+        $this->createProjection($attemptId);
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'ready',
+            'reason_code' => 'report_ready',
+        ]);
+        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+    }
+
+    public function test_report_access_reads_public_projection_without_actor_when_only_projection_exists(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_public_projection_only';
+        $this->createAttempt($attemptId, $anonId);
+        $this->createProjection($attemptId, accessState: 'locked', reportState: 'ready');
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'access_state' => 'locked',
+            'report_state' => 'ready',
+            'pdf_state' => 'ready',
+            'reason_code' => 'report_ready',
+        ]);
+        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
     }
 
     public function test_report_access_returns_submission_failed_fallback_when_projection_and_result_are_missing(): void


### PR DESCRIPTION
## Summary
- unify public-scale read contracts so `/submission`, `/report-access`, and `/report` can fall back to completed public artifacts
- keep existing mismatched-owner and sensitive-scale 404 contracts intact
- add regression coverage for actorless public result/projection reads

## Tests
- php artisan test --filter='AttemptSubmissionFirstReadContractTest|AttemptPublicReportReadHotfixTest|AttemptPublicResultReadHotfixTest|AttemptReportAccessReadTest'
- ./vendor/bin/pint --dirty
- bash backend/scripts/ci_verify_mbti.sh
