### PR TITLE
feat: MBTI desktop clone asset slot owner + published slot ref contract

### DIFF
--- a/backend/app/Filament/Ops/Resources/PersonalityVariantCloneContentResource.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityVariantCloneContentResource.php
@@ -9,6 +9,7 @@ use App\Filament\Ops\Support\StatusBadge;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariant;
 use App\Models\PersonalityProfileVariantCloneContent;
+use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
 use App\Support\Rbac\PermissionNames;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -91,14 +92,60 @@ class PersonalityVariantCloneContentResource extends Resource
                 ->formatStateUsing(fn (mixed $state): string => self::encodeJson($state))
                 ->dehydrateStateUsing(fn (mixed $state): array => self::decodeJsonText($state, 'content_json') ?? [])
                 ->helperText('Authoritative desktop clone content JSON for this fullCode variant.'),
-            Forms\Components\Textarea::make('asset_slots_json')
+            Forms\Components\Repeater::make('asset_slots_json')
                 ->required()
-                ->rules(['required', 'json'])
-                ->rows(14)
-                ->default('[]')
-                ->formatStateUsing(fn (mixed $state): string => self::encodeJson($state))
-                ->dehydrateStateUsing(fn (mixed $state): array => self::decodeJsonText($state, 'asset_slots_json') ?? [])
-                ->helperText('Asset slot owner structure (slotId/label/aspectRatio/status/assetRef/alt/meta).'),
+                ->default(self::defaultAssetSlots())
+                ->formatStateUsing(fn (mixed $state): array => PersonalityDesktopCloneAssetSlotSupport::normalizeAssetSlots(
+                    is_array($state) ? $state : [],
+                ))
+                ->dehydrateStateUsing(fn (mixed $state): array => PersonalityDesktopCloneAssetSlotSupport::normalizeAssetSlots(
+                    is_array($state) ? $state : [],
+                ))
+                ->itemLabel(static fn (array $state): string => (string) ($state['slot_id'] ?? 'asset-slot'))
+                ->schema([
+                    Forms\Components\Select::make('slot_id')
+                        ->required()
+                        ->native(false)
+                        ->options(PersonalityDesktopCloneAssetSlotSupport::slotIdOptions())
+                        ->helperText('slot_id is fixed by desktop clone template schema.'),
+                    Forms\Components\TextInput::make('label')
+                        ->required()
+                        ->maxLength(120),
+                    Forms\Components\TextInput::make('aspect_ratio')
+                        ->required()
+                        ->maxLength(16)
+                        ->helperText('Use ratio format like 236:160 / 636:148.'),
+                    Forms\Components\Select::make('status')
+                        ->required()
+                        ->native(false)
+                        ->options(self::assetStatusOptions()),
+                    Forms\Components\TextInput::make('asset_ref.provider')
+                        ->label('asset_ref.provider')
+                        ->maxLength(32),
+                    Forms\Components\TextInput::make('asset_ref.path')
+                        ->label('asset_ref.path')
+                        ->maxLength(2048),
+                    Forms\Components\TextInput::make('asset_ref.url')
+                        ->label('asset_ref.url')
+                        ->maxLength(2048),
+                    Forms\Components\TextInput::make('asset_ref.version')
+                        ->label('asset_ref.version')
+                        ->maxLength(120),
+                    Forms\Components\TextInput::make('asset_ref.checksum')
+                        ->label('asset_ref.checksum')
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('alt')
+                        ->label('alt')
+                        ->maxLength(255),
+                    Forms\Components\KeyValue::make('meta')
+                        ->label('meta')
+                        ->keyLabel('key')
+                        ->valueLabel('value'),
+                ])
+                ->columns(2)
+                ->reorderable(false)
+                ->collapsible()
+                ->helperText('Authoritative asset slot owner fields: slot_id/label/aspect_ratio/status/asset_ref/alt/meta.'),
             Forms\Components\Textarea::make('meta_json')
                 ->rules(['nullable', 'json'])
                 ->rows(8)
@@ -189,6 +236,17 @@ class PersonalityVariantCloneContentResource extends Resource
     }
 
     /**
+     * @return array<string, string>
+     */
+    private static function assetStatusOptions(): array
+    {
+        return array_combine(
+            PersonalityDesktopCloneAssetSlotSupport::allowedStatuses(),
+            PersonalityDesktopCloneAssetSlotSupport::allowedStatuses(),
+        ) ?: [];
+    }
+
+    /**
      * @return array<int, string>
      */
     private static function variantOptions(): array
@@ -212,6 +270,78 @@ class PersonalityVariantCloneContentResource extends Resource
                 ];
             })
             ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function defaultAssetSlots(): array
+    {
+        return [
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_HERO_ILLUSTRATION,
+                'label' => 'Hero illustration',
+                'aspect_ratio' => '236:160',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_TRAITS_ILLUSTRATION,
+                'label' => 'Traits illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_TRAITS_SUMMARY_ILLUSTRATION,
+                'label' => 'Traits summary illustration',
+                'aspect_ratio' => '240:118',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_CAREER_ILLUSTRATION,
+                'label' => 'Career illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_GROWTH_ILLUSTRATION,
+                'label' => 'Growth illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_RELATIONSHIPS_ILLUSTRATION,
+                'label' => 'Relationships illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_FINAL_OFFER_ILLUSTRATION,
+                'label' => 'Final offer illustration',
+                'aspect_ratio' => '252:220',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+        ];
     }
 
     private static function encodeJson(mixed $value): string

--- a/backend/app/Models/PersonalityProfileVariantCloneContent.php
+++ b/backend/app/Models/PersonalityProfileVariantCloneContent.php
@@ -53,7 +53,7 @@ class PersonalityProfileVariantCloneContent extends Model
             $content->asset_slots_json = is_array($content->asset_slots_json) ? $content->asset_slots_json : [];
             $content->meta_json = is_array($content->meta_json) ? $content->meta_json : null;
 
-            app(PersonalityVariantCloneContentValidator::class)->assertValid(
+            $content->asset_slots_json = app(PersonalityVariantCloneContentValidator::class)->assertValid(
                 $content->content_json,
                 $content->asset_slots_json,
                 $content->status,

--- a/backend/app/PersonalityCms/DesktopClone/Baseline/PersonalityDesktopCloneBaselineImporter.php
+++ b/backend/app/PersonalityCms/DesktopClone/Baseline/PersonalityDesktopCloneBaselineImporter.php
@@ -43,11 +43,12 @@ final class PersonalityDesktopCloneBaselineImporter
         ];
 
         foreach ($rows as $row) {
-            $this->validator->assertValid(
+            $normalizedAssetSlots = $this->validator->assertValid(
                 (array) ($row['content_json'] ?? []),
                 (array) ($row['asset_slots_json'] ?? []),
                 $status,
             );
+            $row['asset_slots_json'] = $normalizedAssetSlots;
 
             $variant = $this->resolveVariant($row);
             $templateKey = (string) ($row['template_key'] ?? PersonalityProfileVariantCloneContent::TEMPLATE_KEY_MBTI_DESKTOP_CLONE_V1);

--- a/backend/app/PersonalityCms/DesktopClone/Baseline/PersonalityDesktopCloneBaselineNormalizer.php
+++ b/backend/app/PersonalityCms/DesktopClone/Baseline/PersonalityDesktopCloneBaselineNormalizer.php
@@ -6,6 +6,7 @@ namespace App\PersonalityCms\DesktopClone\Baseline;
 
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariantCloneContent;
+use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
 use RuntimeException;
 
 final class PersonalityDesktopCloneBaselineNormalizer
@@ -157,7 +158,7 @@ final class PersonalityDesktopCloneBaselineNormalizer
             'full_code' => $fullCode,
             'base_code' => (string) $matches['base'],
             'content_json' => $contentJson,
-            'asset_slots_json' => array_values($assetSlotsJson),
+            'asset_slots_json' => PersonalityDesktopCloneAssetSlotSupport::normalizeAssetSlots(array_values($assetSlotsJson)),
             'meta_json' => $metaJson,
         ];
     }

--- a/backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php
+++ b/backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PersonalityCms\DesktopClone;
+
+final class PersonalityDesktopCloneAssetSlotSupport
+{
+    public const SLOT_ID_HERO_ILLUSTRATION = 'hero-illustration';
+
+    public const SLOT_ID_TRAITS_ILLUSTRATION = 'traits-illustration';
+
+    public const SLOT_ID_TRAITS_SUMMARY_ILLUSTRATION = 'traits-summary-illustration';
+
+    public const SLOT_ID_CAREER_ILLUSTRATION = 'career-illustration';
+
+    public const SLOT_ID_GROWTH_ILLUSTRATION = 'growth-illustration';
+
+    public const SLOT_ID_RELATIONSHIPS_ILLUSTRATION = 'relationships-illustration';
+
+    public const SLOT_ID_FINAL_OFFER_ILLUSTRATION = 'final-offer-illustration';
+
+    public const STATUS_PLACEHOLDER = 'placeholder';
+
+    public const STATUS_READY = 'ready';
+
+    public const STATUS_DISABLED = 'disabled';
+
+    public const ASSET_PROVIDER_OSS = 'oss';
+
+    public const ASSET_PROVIDER_CDN = 'cdn';
+
+    public const ASSET_PROVIDER_INTERNAL = 'internal';
+
+    public const ASSET_PROVIDER_PLACEHOLDER = 'placeholder';
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedSlotIds(): array
+    {
+        return [
+            self::SLOT_ID_HERO_ILLUSTRATION,
+            self::SLOT_ID_TRAITS_ILLUSTRATION,
+            self::SLOT_ID_TRAITS_SUMMARY_ILLUSTRATION,
+            self::SLOT_ID_CAREER_ILLUSTRATION,
+            self::SLOT_ID_GROWTH_ILLUSTRATION,
+            self::SLOT_ID_RELATIONSHIPS_ILLUSTRATION,
+            self::SLOT_ID_FINAL_OFFER_ILLUSTRATION,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedStatuses(): array
+    {
+        return [
+            self::STATUS_PLACEHOLDER,
+            self::STATUS_READY,
+            self::STATUS_DISABLED,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedAssetProviders(): array
+    {
+        return [
+            self::ASSET_PROVIDER_OSS,
+            self::ASSET_PROVIDER_CDN,
+            self::ASSET_PROVIDER_INTERNAL,
+            self::ASSET_PROVIDER_PLACEHOLDER,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function slotIdOptions(): array
+    {
+        return array_combine(self::allowedSlotIds(), self::allowedSlotIds()) ?: [];
+    }
+
+    /**
+     * @param  array<int, mixed>  $assetSlots
+     * @return array<int, array<string, mixed>>
+     */
+    public static function normalizeAssetSlots(array $assetSlots): array
+    {
+        $normalized = [];
+
+        foreach ($assetSlots as $slot) {
+            if (! is_array($slot)) {
+                continue;
+            }
+
+            $normalized[] = self::normalizeAssetSlot($slot);
+        }
+
+        return self::sortAssetSlotsBySchemaOrder($normalized);
+    }
+
+    /**
+     * @param  array<string, mixed>  $slot
+     * @return array<string, mixed>
+     */
+    public static function normalizeAssetSlot(array $slot): array
+    {
+        $slotId = self::normalizeSlotId($slot['slot_id'] ?? $slot['slotId'] ?? null);
+        $label = self::normalizeNullableText($slot['label'] ?? null) ?? '';
+        $aspectRatio = self::normalizeNullableText($slot['aspect_ratio'] ?? $slot['aspectRatio'] ?? null) ?? '';
+        $status = strtolower(trim((string) ($slot['status'] ?? '')));
+        $assetRef = self::normalizeAssetRef($slot['asset_ref'] ?? $slot['assetRef'] ?? null);
+        $alt = self::normalizeNullableText($slot['alt'] ?? null);
+        $meta = is_array($slot['meta'] ?? null) ? $slot['meta'] : null;
+
+        return [
+            'slot_id' => $slotId,
+            'label' => $label,
+            'aspect_ratio' => $aspectRatio,
+            'status' => $status,
+            'asset_ref' => $assetRef,
+            'alt' => $alt,
+            'meta' => $meta,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $assetRef
+     * @return array<string, string|null>|null
+     */
+    public static function normalizeAssetRef(mixed $assetRef): ?array
+    {
+        if (! is_array($assetRef)) {
+            return null;
+        }
+
+        $provider = self::normalizeNullableText($assetRef['provider'] ?? null);
+        $path = self::normalizeNullableText($assetRef['path'] ?? null);
+        $url = self::normalizeNullableText($assetRef['url'] ?? null);
+        $version = self::normalizeNullableText($assetRef['version'] ?? null);
+        $checksum = self::normalizeNullableText($assetRef['checksum'] ?? null);
+
+        if ($provider === null && $path === null && $url === null && $version === null && $checksum === null) {
+            return null;
+        }
+
+        return [
+            'provider' => $provider,
+            'path' => $path,
+            'url' => $url,
+            'version' => $version,
+            'checksum' => $checksum,
+        ];
+    }
+
+    public static function normalizeSlotId(mixed $slotId): string
+    {
+        $candidate = strtolower(trim((string) $slotId));
+
+        return match ($candidate) {
+            'hero.cover' => self::SLOT_ID_HERO_ILLUSTRATION,
+            'chapter.career.banner' => self::SLOT_ID_CAREER_ILLUSTRATION,
+            'traits-summary-asset' => self::SLOT_ID_TRAITS_SUMMARY_ILLUSTRATION,
+            'final-offer-asset' => self::SLOT_ID_FINAL_OFFER_ILLUSTRATION,
+            default => $candidate,
+        };
+    }
+
+    public static function isAllowedSlotId(string $slotId): bool
+    {
+        return in_array($slotId, self::allowedSlotIds(), true);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $assetSlots
+     * @return array<int, array<string, mixed>>
+     */
+    public static function sortAssetSlotsBySchemaOrder(array $assetSlots): array
+    {
+        $indexMap = [];
+        foreach (self::allowedSlotIds() as $index => $slotId) {
+            $indexMap[$slotId] = $index;
+        }
+
+        usort($assetSlots, static function (array $left, array $right) use ($indexMap): int {
+            $leftSlotId = strtolower(trim((string) ($left['slot_id'] ?? '')));
+            $rightSlotId = strtolower(trim((string) ($right['slot_id'] ?? '')));
+
+            $leftIndex = $indexMap[$leftSlotId] ?? PHP_INT_MAX;
+            $rightIndex = $indexMap[$rightSlotId] ?? PHP_INT_MAX;
+
+            if ($leftIndex === $rightIndex) {
+                return $leftSlotId <=> $rightSlotId;
+            }
+
+            return $leftIndex <=> $rightIndex;
+        });
+
+        return array_values($assetSlots);
+    }
+
+    private static function normalizeNullableText(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/PersonalityCms/DesktopClone/PersonalityVariantCloneContentValidator.php
+++ b/backend/app/PersonalityCms/DesktopClone/PersonalityVariantCloneContentValidator.php
@@ -6,6 +6,7 @@ namespace App\PersonalityCms\DesktopClone;
 
 use App\Models\PersonalityProfileVariantCloneContent;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 final class PersonalityVariantCloneContentValidator
@@ -13,10 +14,12 @@ final class PersonalityVariantCloneContentValidator
     /**
      * @param  array<string, mixed>  $contentJson
      * @param  array<int, array<string, mixed>>  $assetSlotsJson
+     * @return array<int, array<string, mixed>>
      */
-    public function assertValid(array $contentJson, array $assetSlotsJson, string $status): void
+    public function assertValid(array $contentJson, array $assetSlotsJson, string $status): array
     {
         $normalizedStatus = strtolower(trim($status));
+        $normalizedAssetSlots = PersonalityDesktopCloneAssetSlotSupport::normalizeAssetSlots($assetSlotsJson);
 
         if (! in_array($normalizedStatus, [
             PersonalityProfileVariantCloneContent::STATUS_DRAFT,
@@ -29,7 +32,7 @@ final class PersonalityVariantCloneContentValidator
 
         $validator = Validator::make([
             'content' => $contentJson,
-            'asset_slots' => $assetSlotsJson,
+            'asset_slots' => $normalizedAssetSlots,
         ], [
             'content' => ['required', 'array'],
             'content.hero' => ['required', 'array'],
@@ -137,19 +140,76 @@ final class PersonalityVariantCloneContentValidator
             'content.finalOffer.guarantee' => ['required', 'string'],
 
             'asset_slots' => ['required', 'array', 'min:1'],
-            'asset_slots.*.slotId' => ['required', 'string'],
+            'asset_slots.*.slot_id' => ['required', 'string', Rule::in(PersonalityDesktopCloneAssetSlotSupport::allowedSlotIds()), 'distinct:strict'],
             'asset_slots.*.label' => ['required', 'string'],
-            'asset_slots.*.aspectRatio' => ['required', 'string'],
-            'asset_slots.*.status' => ['required', 'in:placeholder,ready'],
-            'asset_slots.*.assetRef' => ['present', 'nullable', 'array'],
+            'asset_slots.*.aspect_ratio' => ['required', 'string', 'regex:/^[1-9]\d{0,3}:[1-9]\d{0,3}$/'],
+            'asset_slots.*.status' => ['required', Rule::in(PersonalityDesktopCloneAssetSlotSupport::allowedStatuses())],
+            'asset_slots.*.asset_ref' => ['present', 'nullable', 'array'],
+            'asset_slots.*.asset_ref.provider' => ['nullable', 'string', Rule::in(PersonalityDesktopCloneAssetSlotSupport::allowedAssetProviders())],
+            'asset_slots.*.asset_ref.path' => ['nullable', 'string'],
+            'asset_slots.*.asset_ref.url' => ['nullable', 'string'],
+            'asset_slots.*.asset_ref.version' => ['nullable', 'string'],
+            'asset_slots.*.asset_ref.checksum' => ['nullable', 'string'],
             'asset_slots.*.alt' => ['present', 'nullable', 'string'],
             'asset_slots.*.meta' => ['present', 'nullable', 'array'],
         ]);
 
-        if (! $validator->fails()) {
-            return;
+        $validator->after(function ($validator) use ($normalizedAssetSlots): void {
+            $slotIds = [];
+
+            foreach ($normalizedAssetSlots as $index => $slot) {
+                $slotId = strtolower(trim((string) ($slot['slot_id'] ?? '')));
+                $slotIds[] = $slotId;
+
+                $status = strtolower(trim((string) ($slot['status'] ?? '')));
+                $assetRef = is_array($slot['asset_ref'] ?? null) ? $slot['asset_ref'] : null;
+
+                if ($status === PersonalityDesktopCloneAssetSlotSupport::STATUS_READY) {
+                    if ($assetRef === null) {
+                        $validator->errors()->add(
+                            sprintf('asset_slots.%d.asset_ref', $index),
+                            'Ready asset slot must contain asset_ref.',
+                        );
+
+                        continue;
+                    }
+
+                    $provider = trim((string) ($assetRef['provider'] ?? ''));
+                    $path = trim((string) ($assetRef['path'] ?? ''));
+                    $url = trim((string) ($assetRef['url'] ?? ''));
+
+                    if ($provider === '') {
+                        $validator->errors()->add(
+                            sprintf('asset_slots.%d.asset_ref.provider', $index),
+                            'Ready asset slot requires asset_ref.provider.',
+                        );
+                    }
+
+                    if ($path === '' && $url === '') {
+                        $validator->errors()->add(
+                            sprintf('asset_slots.%d.asset_ref', $index),
+                            'Ready asset slot requires asset_ref.path or asset_ref.url.',
+                        );
+                    }
+                }
+            }
+
+            sort($slotIds);
+            $required = PersonalityDesktopCloneAssetSlotSupport::allowedSlotIds();
+            sort($required);
+
+            if ($slotIds !== $required) {
+                $validator->errors()->add(
+                    'asset_slots',
+                    'Asset slots must contain the exact allowed slot_id set for mbti_desktop_clone_v1.',
+                );
+            }
+        });
+
+        if ($validator->fails()) {
+            throw ValidationException::withMessages($validator->errors()->toArray());
         }
 
-        throw ValidationException::withMessages($validator->errors()->toArray());
+        return PersonalityDesktopCloneAssetSlotSupport::sortAssetSlotsBySchemaOrder($normalizedAssetSlots);
     }
 }

--- a/backend/app/Services/Cms/PersonalityDesktopCloneContentService.php
+++ b/backend/app/Services/Cms/PersonalityDesktopCloneContentService.php
@@ -6,6 +6,7 @@ namespace App\Services\Cms;
 
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariantCloneContent;
+use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
 use App\Repositories\PersonalityVariantCloneContentRepository;
 
 final class PersonalityDesktopCloneContentService
@@ -57,7 +58,9 @@ final class PersonalityDesktopCloneContentService
             'base_code' => $baseCode,
             'locale' => (string) $profile->locale,
             'content' => is_array($record->content_json) ? $record->content_json : [],
-            'asset_slots' => is_array($record->asset_slots_json) ? $record->asset_slots_json : [],
+            'asset_slots' => PersonalityDesktopCloneAssetSlotSupport::normalizeAssetSlots(
+                is_array($record->asset_slots_json) ? $record->asset_slots_json : [],
+            ),
             '_meta' => [
                 'authority_source' => 'personality_profile_variant_clone_contents',
                 'route_mode' => 'full_code_exact',

--- a/backend/database/migrations/2026_04_01_100000_normalize_personality_clone_asset_slots_schema.php
+++ b/backend/database/migrations/2026_04_01_100000_normalize_personality_clone_asset_slots_schema.php
@@ -2,13 +2,25 @@
 
 declare(strict_types=1);
 
-use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_SLOT_IDS = [
+        'hero-illustration',
+        'traits-illustration',
+        'traits-summary-illustration',
+        'career-illustration',
+        'growth-illustration',
+        'relationships-illustration',
+        'final-offer-illustration',
+    ];
+
     public function up(): void
     {
         if (! Schema::hasTable('personality_profile_variant_clone_contents')) {
@@ -25,7 +37,7 @@ return new class extends Migration
                         $raw = [];
                     }
 
-                    $normalized = PersonalityDesktopCloneAssetSlotSupport::normalizeAssetSlots($raw);
+                    $normalized = $this->normalizeAssetSlots($raw);
 
                     if ($normalized === $raw) {
                         continue;
@@ -45,5 +57,126 @@ return new class extends Migration
     {
         // forward-only migration: rollback disabled to prevent data loss in production.
         // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    /**
+     * @param  array<int, mixed>  $assetSlots
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeAssetSlots(array $assetSlots): array
+    {
+        $normalized = [];
+
+        foreach ($assetSlots as $slot) {
+            if (! is_array($slot)) {
+                continue;
+            }
+
+            $normalized[] = $this->normalizeAssetSlot($slot);
+        }
+
+        return $this->sortAssetSlotsBySchemaOrder($normalized);
+    }
+
+    /**
+     * @param  array<string, mixed>  $slot
+     * @return array<string, mixed>
+     */
+    private function normalizeAssetSlot(array $slot): array
+    {
+        $slotId = $this->normalizeSlotId($slot['slot_id'] ?? $slot['slotId'] ?? null);
+        $label = $this->normalizeNullableText($slot['label'] ?? null) ?? '';
+        $aspectRatio = $this->normalizeNullableText($slot['aspect_ratio'] ?? $slot['aspectRatio'] ?? null) ?? '';
+        $status = strtolower(trim((string) ($slot['status'] ?? '')));
+        $assetRef = $this->normalizeAssetRef($slot['asset_ref'] ?? $slot['assetRef'] ?? null);
+        $alt = $this->normalizeNullableText($slot['alt'] ?? null);
+        $meta = is_array($slot['meta'] ?? null) ? $slot['meta'] : null;
+
+        return [
+            'slot_id' => $slotId,
+            'label' => $label,
+            'aspect_ratio' => $aspectRatio,
+            'status' => $status,
+            'asset_ref' => $assetRef,
+            'alt' => $alt,
+            'meta' => $meta,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $assetRef
+     * @return array<string, string|null>|null
+     */
+    private function normalizeAssetRef(mixed $assetRef): ?array
+    {
+        if (! is_array($assetRef)) {
+            return null;
+        }
+
+        $provider = $this->normalizeNullableText($assetRef['provider'] ?? null);
+        $path = $this->normalizeNullableText($assetRef['path'] ?? null);
+        $url = $this->normalizeNullableText($assetRef['url'] ?? null);
+        $version = $this->normalizeNullableText($assetRef['version'] ?? null);
+        $checksum = $this->normalizeNullableText($assetRef['checksum'] ?? null);
+
+        if ($provider === null && $path === null && $url === null && $version === null && $checksum === null) {
+            return null;
+        }
+
+        return [
+            'provider' => $provider,
+            'path' => $path,
+            'url' => $url,
+            'version' => $version,
+            'checksum' => $checksum,
+        ];
+    }
+
+    private function normalizeSlotId(mixed $slotId): string
+    {
+        $candidate = strtolower(trim((string) $slotId));
+
+        return match ($candidate) {
+            'hero.cover' => 'hero-illustration',
+            'chapter.career.banner' => 'career-illustration',
+            'traits-summary-asset' => 'traits-summary-illustration',
+            'final-offer-asset' => 'final-offer-illustration',
+            default => $candidate,
+        };
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $assetSlots
+     * @return array<int, array<string, mixed>>
+     */
+    private function sortAssetSlotsBySchemaOrder(array $assetSlots): array
+    {
+        $indexMap = [];
+        foreach (self::ALLOWED_SLOT_IDS as $index => $slotId) {
+            $indexMap[$slotId] = $index;
+        }
+
+        usort($assetSlots, static function (array $left, array $right) use ($indexMap): int {
+            $leftSlotId = strtolower(trim((string) ($left['slot_id'] ?? '')));
+            $rightSlotId = strtolower(trim((string) ($right['slot_id'] ?? '')));
+
+            $leftIndex = $indexMap[$leftSlotId] ?? PHP_INT_MAX;
+            $rightIndex = $indexMap[$rightSlotId] ?? PHP_INT_MAX;
+
+            if ($leftIndex === $rightIndex) {
+                return $leftSlotId <=> $rightSlotId;
+            }
+
+            return $leftIndex <=> $rightIndex;
+        });
+
+        return array_values($assetSlots);
+    }
+
+    private function normalizeNullableText(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
     }
 };

--- a/backend/database/migrations/2026_04_01_100000_normalize_personality_clone_asset_slots_schema.php
+++ b/backend/database/migrations/2026_04_01_100000_normalize_personality_clone_asset_slots_schema.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('personality_profile_variant_clone_contents')) {
+            return;
+        }
+
+        DB::table('personality_profile_variant_clone_contents')
+            ->select(['id', 'asset_slots_json'])
+            ->orderBy('id')
+            ->chunkById(200, function ($rows): void {
+                foreach ($rows as $row) {
+                    $raw = json_decode((string) ($row->asset_slots_json ?? '[]'), true);
+                    if (! is_array($raw)) {
+                        $raw = [];
+                    }
+
+                    $normalized = PersonalityDesktopCloneAssetSlotSupport::normalizeAssetSlots($raw);
+
+                    if ($normalized === $raw) {
+                        continue;
+                    }
+
+                    DB::table('personality_profile_variant_clone_contents')
+                        ->where('id', (int) $row->id)
+                        ->update([
+                            'asset_slots_json' => json_encode($normalized, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                            'updated_at' => now(),
+                        ]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/mbti-desktop-clone-owner.md
+++ b/backend/docs/mbti-desktop-clone-owner.md
@@ -1,4 +1,4 @@
-# MBTI Desktop Clone Content Owner (32 FullCode)
+# MBTI Desktop Clone Content + Asset Slot Owner (32 FullCode)
 
 ## 1. Owner 挂载位置
 MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
@@ -37,7 +37,7 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 
 - unique(`personality_profile_variant_id`, `template_key`)
 
-## 4. Storage Owner 负责字段
+## 4. Storage Owner 负责字段（正文 vs 资产）
 `content_json` 仅承载 desktop clone authored 内容，覆盖：
 
 - `hero.summary`
@@ -49,15 +49,38 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 - `chapters.relationships`
 - `finalOffer`
 
-`asset_slots_json` 为后续真实资产 owner 预留结构：
+`asset_slots_json` 为 desktop clone 资产引用 owner（挂在 clone content owner 内，不另起平台）：
 
-- `slotId`
+- `slot_id`
 - `label`
-- `aspectRatio`
+- `aspect_ratio`
 - `status`
-- `assetRef`（nullable）
+- `asset_ref`（nullable）
 - `alt`（nullable）
 - `meta`（nullable）
+
+`status` 语义：
+
+- `placeholder`：槽位存在，但还未绑定真实资产 ref（允许 `asset_ref = null`）
+- `ready`：槽位已可用，必须绑定合法 `asset_ref`
+- `disabled`：槽位暂不对外投放（可保留历史 ref，也可为 null）
+
+`asset_ref` 最小结构：
+
+- `provider`（`oss` / `cdn` / `internal` / `placeholder`）
+- `path` 或 `url`（`ready` 至少一个非空）
+- `version`（nullable）
+- `checksum`（nullable）
+
+固定 slot_id（v1 白名单）：
+
+- `hero-illustration`
+- `traits-illustration`
+- `traits-summary-illustration`
+- `career-illustration`
+- `growth-illustration`
+- `relationships-illustration`
+- `final-offer-illustration`
 
 ## 5. 继续属于 Runtime 的字段
 以下仍由结果 runtime/projection 提供，不进入 clone content owner：
@@ -93,6 +116,14 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 - `asset_slots`
 - `_meta`（authority_source / route_mode / route type 等）
 
+`asset_slots` 发布契约：
+
+- published only
+- fullCode exact
+- no baseCode fallback
+- placeholder slot 也必须完整返回，不吞字段
+- ready slot 返回可消费 `asset_ref`
+
 ## 7. Seed 覆盖范围
 当前基线导入覆盖：
 
@@ -104,10 +135,9 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 
 ## 8. 当前未覆盖
 - `en` locale backfill
-- 真实 asset refs（对象存储接入）
+- 真实 AI 资产生成/上传与批处理
+- `fap-web` asset slot consumption cutover
 
-## 9. 下一步 PR
-下一张卡在 `fap-web` 执行 consumer 切换：
-
-- resolver 切到上述 published read contract
-- 前端本地 registry 从 runtime owner 降级为迁移遗留/参考源
+## 9. 下一步 PR 顺序
+1. `fap-web`：desktop clone asset slot consumption cutover（前端开始消费 `asset_slots`）
+2. `fap-api` 或离线管线：AI 资产生成 + asset_ref 回填（仅数据替换，不改 schema）

--- a/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\PersonalityCms;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariant;
 use App\Models\PersonalityProfileVariantCloneContent;
+use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
@@ -50,6 +51,17 @@ final class PersonalityDesktopCloneBaselineImportTest extends TestCase
                 )
                 ->distinct('personality_profile_variants.runtime_type_code')
                 ->count('personality_profile_variants.runtime_type_code'),
+        );
+
+        $first = PersonalityProfileVariantCloneContent::query()->orderBy('id')->firstOrFail();
+        $slotIds = array_column((array) $first->asset_slots_json, 'slot_id');
+
+        $this->assertSame(PersonalityDesktopCloneAssetSlotSupport::allowedSlotIds(), $slotIds);
+        $this->assertSame(
+            0,
+            collect((array) $first->asset_slots_json)
+                ->where('status', PersonalityDesktopCloneAssetSlotSupport::STATUS_READY)
+                ->count(),
         );
 
         $this->artisan('personality:import-desktop-clone-baseline', [

--- a/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneOpsResourceTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneOpsResourceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\PersonalityCms;
+
+use Tests\TestCase;
+
+final class PersonalityDesktopCloneOpsResourceTest extends TestCase
+{
+    public function test_ops_resource_exposes_asset_slot_fields_for_minimal_management(): void
+    {
+        $source = file_get_contents(app_path('Filament/Ops/Resources/PersonalityVariantCloneContentResource.php'));
+
+        $this->assertIsString($source);
+        $this->assertStringContainsString("Repeater::make('asset_slots_json')", $source);
+        $this->assertStringContainsString("Select::make('slot_id')", $source);
+        $this->assertStringContainsString("TextInput::make('aspect_ratio')", $source);
+        $this->assertStringContainsString("Select::make('status')", $source);
+        $this->assertStringContainsString("TextInput::make('asset_ref.provider')", $source);
+        $this->assertStringContainsString("TextInput::make('asset_ref.path')", $source);
+        $this->assertStringContainsString("TextInput::make('asset_ref.url')", $source);
+        $this->assertStringContainsString("TextInput::make('alt')", $source);
+    }
+}

--- a/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneSchemaModelTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneSchemaModelTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\PersonalityCms;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariant;
 use App\Models\PersonalityProfileVariantCloneContent;
+use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
@@ -85,10 +86,54 @@ final class PersonalityDesktopCloneSchemaModelTest extends TestCase
             'content_json' => $this->validContent('entp-a'),
             'asset_slots_json' => [
                 [
-                    'slotId' => 'hero-cover',
-                    // missing required keys label/aspectRatio/status + nullable fields with present rule
+                    'slot_id' => 'hero-cover',
+                    'label' => 'Hero',
+                    'aspect_ratio' => '16:9',
+                    'status' => 'placeholder',
+                    'asset_ref' => null,
+                    'alt' => null,
+                    'meta' => null,
                 ],
             ],
+        ]);
+    }
+
+    public function test_ready_slot_requires_asset_ref(): void
+    {
+        $variant = $this->seedVariant('ENTJ', 'A', 'zh-CN');
+
+        $this->expectException(ValidationException::class);
+
+        $assetSlots = $this->validAssetSlots();
+        $assetSlots[0]['status'] = PersonalityDesktopCloneAssetSlotSupport::STATUS_READY;
+        $assetSlots[0]['asset_ref'] = null;
+
+        PersonalityProfileVariantCloneContent::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'template_key' => PersonalityProfileVariantCloneContent::TEMPLATE_KEY_MBTI_DESKTOP_CLONE_V1,
+            'status' => PersonalityProfileVariantCloneContent::STATUS_PUBLISHED,
+            'schema_version' => 'v1',
+            'content_json' => $this->validContent('entj-a'),
+            'asset_slots_json' => $assetSlots,
+        ]);
+    }
+
+    public function test_invalid_aspect_ratio_is_rejected(): void
+    {
+        $variant = $this->seedVariant('ENFP', 'T', 'zh-CN');
+
+        $this->expectException(ValidationException::class);
+
+        $assetSlots = $this->validAssetSlots();
+        $assetSlots[0]['aspect_ratio'] = '0:160';
+
+        PersonalityProfileVariantCloneContent::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'template_key' => PersonalityProfileVariantCloneContent::TEMPLATE_KEY_MBTI_DESKTOP_CLONE_V1,
+            'status' => PersonalityProfileVariantCloneContent::STATUS_PUBLISHED,
+            'schema_version' => 'v1',
+            'content_json' => $this->validContent('enfp-t'),
+            'asset_slots_json' => $assetSlots,
         ]);
     }
 
@@ -245,20 +290,65 @@ final class PersonalityDesktopCloneSchemaModelTest extends TestCase
     {
         return [
             [
-                'slotId' => 'hero.cover',
-                'label' => 'Hero cover image',
-                'aspectRatio' => '16:9',
-                'status' => 'placeholder',
-                'assetRef' => null,
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_HERO_ILLUSTRATION,
+                'label' => 'Hero illustration',
+                'aspect_ratio' => '236:160',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
                 'alt' => null,
                 'meta' => null,
             ],
             [
-                'slotId' => 'chapter.career.banner',
-                'label' => 'Career chapter banner',
-                'aspectRatio' => '4:3',
-                'status' => 'placeholder',
-                'assetRef' => null,
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_TRAITS_ILLUSTRATION,
+                'label' => 'Traits illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_TRAITS_SUMMARY_ILLUSTRATION,
+                'label' => 'Traits summary illustration',
+                'aspect_ratio' => '240:118',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_CAREER_ILLUSTRATION,
+                'label' => 'Career illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_GROWTH_ILLUSTRATION,
+                'label' => 'Growth illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_RELATIONSHIPS_ILLUSTRATION,
+                'label' => 'Relationships illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_FINAL_OFFER_ILLUSTRATION,
+                'label' => 'Final offer illustration',
+                'aspect_ratio' => '252:220',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
                 'alt' => null,
                 'meta' => null,
             ],

--- a/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneSchemaModelTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneSchemaModelTest.php
@@ -153,6 +153,36 @@ final class PersonalityDesktopCloneSchemaModelTest extends TestCase
         ]);
     }
 
+    public function test_legacy_asset_slot_shape_is_normalized_to_canonical_schema(): void
+    {
+        $variant = $this->seedVariant('ISTJ', 'T', 'zh-CN');
+
+        $record = PersonalityProfileVariantCloneContent::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'template_key' => PersonalityProfileVariantCloneContent::TEMPLATE_KEY_MBTI_DESKTOP_CLONE_V1,
+            'status' => PersonalityProfileVariantCloneContent::STATUS_PUBLISHED,
+            'schema_version' => 'v1',
+            'content_json' => $this->validContent('istj-t'),
+            'asset_slots_json' => $this->legacyAssetSlots(),
+        ])->fresh();
+
+        $this->assertNotNull($record);
+
+        $assetSlots = is_array($record->asset_slots_json) ? $record->asset_slots_json : [];
+        $this->assertCount(7, $assetSlots);
+        $this->assertSame(
+            PersonalityDesktopCloneAssetSlotSupport::allowedSlotIds(),
+            array_column($assetSlots, 'slot_id'),
+        );
+
+        $hero = $assetSlots[0];
+        $this->assertArrayHasKey('slot_id', $hero);
+        $this->assertArrayNotHasKey('slotId', $hero);
+        $this->assertSame('236:160', $hero['aspect_ratio']);
+        $this->assertArrayHasKey('asset_ref', $hero);
+        $this->assertArrayNotHasKey('assetRef', $hero);
+    }
+
     private function seedVariant(string $baseCode, string $variantCode, string $locale): PersonalityProfileVariant
     {
         $normalizedBase = strtoupper($baseCode);
@@ -349,6 +379,78 @@ final class PersonalityDesktopCloneSchemaModelTest extends TestCase
                 'aspect_ratio' => '252:220',
                 'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
                 'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function legacyAssetSlots(): array
+    {
+        return [
+            [
+                'slotId' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_HERO_ILLUSTRATION,
+                'label' => 'Hero illustration',
+                'aspectRatio' => '236:160',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'assetRef' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slotId' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_TRAITS_ILLUSTRATION,
+                'label' => 'Traits illustration',
+                'aspectRatio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'assetRef' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slotId' => 'traits-summary-asset',
+                'label' => 'Traits summary illustration',
+                'aspectRatio' => '240:118',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'assetRef' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slotId' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_CAREER_ILLUSTRATION,
+                'label' => 'Career illustration',
+                'aspectRatio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'assetRef' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slotId' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_GROWTH_ILLUSTRATION,
+                'label' => 'Growth illustration',
+                'aspectRatio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'assetRef' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slotId' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_RELATIONSHIPS_ILLUSTRATION,
+                'label' => 'Relationships illustration',
+                'aspectRatio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'assetRef' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slotId' => 'final-offer-asset',
+                'label' => 'Final offer illustration',
+                'aspectRatio' => '252:220',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'assetRef' => null,
                 'alt' => null,
                 'meta' => null,
             ],

--- a/backend/tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\V0_5;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariant;
 use App\Models\PersonalityProfileVariantCloneContent;
+use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -52,7 +53,13 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             ->assertJsonPath('base_code', 'INFJ')
             ->assertJsonPath('locale', 'zh-CN')
             ->assertJsonPath('content.hero.summary', 'hero summary infj-a')
-            ->assertJsonPath('asset_slots.0.slotId', 'hero.cover')
+            ->assertJsonPath('asset_slots.0.slot_id', PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_HERO_ILLUSTRATION)
+            ->assertJsonPath('asset_slots.0.status', PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER)
+            ->assertJsonPath('asset_slots.0.asset_ref', null)
+            ->assertJsonPath('asset_slots.1.slot_id', PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_TRAITS_ILLUSTRATION)
+            ->assertJsonPath('asset_slots.1.status', PersonalityDesktopCloneAssetSlotSupport::STATUS_READY)
+            ->assertJsonPath('asset_slots.1.asset_ref.provider', PersonalityDesktopCloneAssetSlotSupport::ASSET_PROVIDER_CDN)
+            ->assertJsonPath('asset_slots.1.asset_ref.path', 'mbti/desktop/traits/infj-a/v1.webp')
             ->assertJsonPath('_meta.authority_source', 'personality_profile_variant_clone_contents')
             ->assertJsonPath('_meta.route_mode', 'full_code_exact')
             ->assertJsonPath('_meta.public_route_type', '32-type');
@@ -261,20 +268,73 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
     {
         return [
             [
-                'slotId' => 'hero.cover',
-                'label' => 'Hero cover image',
-                'aspectRatio' => '16:9',
-                'status' => 'placeholder',
-                'assetRef' => null,
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_HERO_ILLUSTRATION,
+                'label' => 'Hero illustration',
+                'aspect_ratio' => '236:160',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
                 'alt' => null,
                 'meta' => null,
             ],
             [
-                'slotId' => 'chapter.career.banner',
-                'label' => 'Career chapter banner',
-                'aspectRatio' => '4:3',
-                'status' => 'placeholder',
-                'assetRef' => null,
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_TRAITS_ILLUSTRATION,
+                'label' => 'Traits illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_READY,
+                'asset_ref' => [
+                    'provider' => PersonalityDesktopCloneAssetSlotSupport::ASSET_PROVIDER_CDN,
+                    'path' => 'mbti/desktop/traits/infj-a/v1.webp',
+                    'url' => null,
+                    'version' => 'v1',
+                    'checksum' => 'sha256:abc123',
+                ],
+                'alt' => 'Traits illustration',
+                'meta' => [
+                    'source' => 'seed',
+                ],
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_TRAITS_SUMMARY_ILLUSTRATION,
+                'label' => 'Traits summary illustration',
+                'aspect_ratio' => '240:118',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_CAREER_ILLUSTRATION,
+                'label' => 'Career illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_GROWTH_ILLUSTRATION,
+                'label' => 'Growth illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_RELATIONSHIPS_ILLUSTRATION,
+                'label' => 'Relationships illustration',
+                'aspect_ratio' => '636:148',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
+                'alt' => null,
+                'meta' => null,
+            ],
+            [
+                'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_FINAL_OFFER_ILLUSTRATION,
+                'label' => 'Final offer illustration',
+                'aspect_ratio' => '252:220',
+                'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER,
+                'asset_ref' => null,
                 'alt' => null,
                 'meta' => null,
             ],

--- a/backend/tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php
@@ -44,7 +44,7 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
         $this->createCloneContent($infjA, 'infj-a', PersonalityProfileVariantCloneContent::STATUS_PUBLISHED);
         $this->createCloneContent($infjT, 'infj-t', PersonalityProfileVariantCloneContent::STATUS_PUBLISHED);
 
-        $this->getJson('/api/v0.5/personality/infj-a/desktop-clone?locale=zh-CN')
+        $response = $this->getJson('/api/v0.5/personality/infj-a/desktop-clone?locale=zh-CN')
             ->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('template_key', PersonalityProfileVariantCloneContent::TEMPLATE_KEY_MBTI_DESKTOP_CLONE_V1)
@@ -63,6 +63,14 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             ->assertJsonPath('_meta.authority_source', 'personality_profile_variant_clone_contents')
             ->assertJsonPath('_meta.route_mode', 'full_code_exact')
             ->assertJsonPath('_meta.public_route_type', '32-type');
+
+        $assetSlots = $response->json('asset_slots');
+        $this->assertIsArray($assetSlots);
+        $this->assertCount(7, $assetSlots);
+        $this->assertSame(
+            PersonalityDesktopCloneAssetSlotSupport::allowedSlotIds(),
+            array_column($assetSlots, 'slot_id'),
+        );
 
         $this->getJson('/api/v0.5/personality/infj-t/desktop-clone?locale=zh-CN')
             ->assertOk()


### PR DESCRIPTION
## Summary
This PR upgrades MBTI Desktop Clone `asset_slots_json` from placeholder metadata to an authoritative, validated slot owner model under the existing `PersonalityProfileVariantCloneContent` domain.

It keeps owner boundaries unchanged:
- `content_json` remains authored long-form content owner
- `asset_slots_json` becomes authoritative slot->asset_ref owner
- runtime truth (`bars/actions/unlock/price/fullCode`) remains outside storage owner

## Owner Mounting (No Second Platform)
Asset ownership is still mounted in the existing personality owner lineage:
- `personality_profiles`
- `personality_profile_variants`
- `personality_profile_variant_clone_contents`

No separate DAM/content owner platform was introduced.

## Changes
### Migration
- `backend/database/migrations/2026_04_01_100000_normalize_personality_clone_asset_slots_schema.php`
  - forward-normalizes existing `asset_slots_json` rows to canonical schema/keys.

### Model / Domain
- `backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php` (new)
  - canonical slot whitelist
  - status whitelist (`placeholder|ready|disabled`)
  - provider whitelist (`oss|cdn|internal|placeholder`)
  - legacy key compatibility normalization (`slotId`/`slot_id`, legacy slot ids)
  - canonical ordering helpers
- `backend/app/PersonalityCms/DesktopClone/PersonalityVariantCloneContentValidator.php`
  - authoritative validation for `asset_slots_json`
  - rejects illegal slot ids/aspect ratios/status values
  - enforces `ready => asset_ref non-null + provider + (path|url)`
  - enforces exact slot_id set for `mbti_desktop_clone_v1`
- `backend/app/Models/PersonalityProfileVariantCloneContent.php`
  - persists normalized asset slot payload during save.

### Importer / Baseline Compatibility
- `backend/app/PersonalityCms/DesktopClone/Baseline/PersonalityDesktopCloneBaselineNormalizer.php`
- `backend/app/PersonalityCms/DesktopClone/Baseline/PersonalityDesktopCloneBaselineImporter.php`
  - importer now normalizes old baseline slot structures to new canonical schema and remains idempotent.

### Public Read Contract
- `backend/app/Services/Cms/PersonalityDesktopCloneContentService.php`
  - published API now returns canonical `asset_slots` structure consistently.

### Ops / Filament
- `backend/app/Filament/Ops/Resources/PersonalityVariantCloneContentResource.php`
  - upgraded from loose JSON text input to minimal manageable slot schema (Repeater)
  - can edit: `slot_id/status/aspect_ratio/asset_ref/alt/meta`
  - supports clear placeholder vs ready operations.

### Tests
- `backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneSchemaModelTest.php`
- `backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php`
- `backend/tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php`
- `backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneOpsResourceTest.php` (new)

### Docs
- `backend/docs/mbti-desktop-clone-owner.md`
  - clarified content owner vs asset slot owner boundary
  - documented slot schema, slot whitelist, status semantics
  - documented pending scope and next PR order (`fap-web` consumption cutover).

## New Asset Slot Schema
Each published slot returns:
- `slot_id`
- `label`
- `aspect_ratio`
- `status`
- `asset_ref`
- `alt`
- `meta`

Supported slot_id set:
- `hero-illustration`
- `traits-illustration`
- `traits-summary-illustration`
- `career-illustration`
- `growth-illustration`
- `relationships-illustration`
- `final-offer-illustration`

Status semantics:
- `placeholder`: slot exists, no real ref required
- `ready`: requires valid `asset_ref`
- `disabled`: intentionally not active

## API Contract Example
`GET /api/v0.5/personality/infj-a/desktop-clone?locale=zh-CN`

```json
{
  "ok": true,
  "template_key": "mbti_desktop_clone_v1",
  "schema_version": "v1",
  "full_code": "INFJ-A",
  "base_code": "INFJ",
  "locale": "zh-CN",
  "asset_slots": [
    {
      "slot_id": "hero-illustration",
      "label": "Hero illustration",
      "aspect_ratio": "236:160",
      "status": "placeholder",
      "asset_ref": null,
      "alt": null,
      "meta": null
    },
    {
      "slot_id": "traits-illustration",
      "label": "Traits illustration",
      "aspect_ratio": "636:148",
      "status": "ready",
      "asset_ref": {
        "provider": "cdn",
        "path": "mbti/desktop/traits/infj-a/v1.webp",
        "url": null,
        "version": "v1",
        "checksum": "sha256:abc123"
      },
      "alt": "Traits illustration",
      "meta": {
        "source": "seed"
      }
    }
  ],
  "_meta": {
    "authority_source": "personality_profile_variant_clone_contents",
    "route_mode": "full_code_exact",
    "public_route_type": "32-type"
  }
}
```

## Baseline Source & Compatibility
Baseline source remains the previously migrated 32 fullCode authored content package (originated from `fap-web`).
This PR keeps import compatible with old slot keys and does **not** fabricate ready assets.

## Runtime / Non-goals (Unchanged)
Still runtime-owned (not moved here):
- bars/dimensions
- tools/actions
- unlock/purchase
- runtime price
- attempt/user runtime state

Still out of scope:
- AI image generation/upload
- object storage workflow
- `fap-web` consumption cutover

## Verification
Executed in `backend/`:
- `php artisan test tests/Feature/PersonalityCms/PersonalityDesktopCloneSchemaModelTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneOpsResourceTest.php`
- `./vendor/bin/pint --test app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php app/PersonalityCms/DesktopClone/PersonalityVariantCloneContentValidator.php app/PersonalityCms/DesktopClone/Baseline/PersonalityDesktopCloneBaselineImporter.php app/PersonalityCms/DesktopClone/Baseline/PersonalityDesktopCloneBaselineNormalizer.php app/Models/PersonalityProfileVariantCloneContent.php app/Services/Cms/PersonalityDesktopCloneContentService.php app/Filament/Ops/Resources/PersonalityVariantCloneContentResource.php tests/Feature/PersonalityCms/PersonalityDesktopCloneSchemaModelTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneOpsResourceTest.php database/migrations/2026_04_01_100000_normalize_personality_clone_asset_slots_schema.php`
