### PR TITLE
docs/test(mbti): SOFT_ONLY compatibility semantics convergence for desktop clone modules

### DIFF
--- a/backend/docs/mbti-desktop-clone-owner.md
+++ b/backend/docs/mbti-desktop-clone-owner.md
@@ -53,7 +53,7 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 - `chapters.relationships`
 - `finalOffer`
 
-当前 P0 主链已 authoritative 挂载（本 PR）：
+当前 canonical 主链已 authoritative 挂载（desktop main flow 以这些模块为准）：
 
 - `letters_intro`
 - `overview`
@@ -66,7 +66,7 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 - `chapters.career.matched_jobs`
 - `chapters.career.matched_guides`
 
-当前 P1 深层模块已 authoritative 挂载：
+以下字段为 deprecated transition fields（compatibility retained）：
 
 - `chapters.career.career_ideas`
 - `chapters.career.work_styles`
@@ -74,6 +74,14 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 - `chapters.growth.what_drains`
 - `chapters.relationships.superpowers`
 - `chapters.relationships.pitfalls`
+
+过渡语义（必须同时成立）：
+
+1. 以上 6 个字段仍由 authoritative owner 持有。
+2. 以上 6 个字段仍由 public API 返回。
+3. 当前 `fap-web` desktop main flow 已不再主链渲染这些字段。
+4. 保留目的仅为兼容与过渡，不代表当前 canonical 展示系统。
+5. 未来若进入 hard convergence，必须先完成 consumer/tests/import chain 清理。
 
 `asset_slots_json` 为 desktop clone 资产引用 owner（挂在 clone content owner 内，不另起平台）：
 
@@ -151,13 +159,19 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 - placeholder slot 也必须完整返回，不吞字段
 - ready slot 返回可消费 `asset_ref`
 
+compatibility 字段契约（当前阶段）：
+
+- `career_ideas` / `work_styles` / `what_energizes` / `what_drains` / `superpowers` / `pitfalls` 继续返回
+- 返回仅用于兼容过渡，不能据此推断前端主链仍渲染
+
 ## 7. Seed 覆盖范围
 当前基线导入覆盖：
 
 - 32 个 fullCode（A/T）
 - `zh-CN`
 - `template_key = mbti_desktop_clone_v1`
-- P0 + P1 模块完整性门禁（缺 fullCode / 缺关键模块直接失败）
+- canonical 主链 + compatibility 字段完整性门禁（缺 fullCode / 缺关键模块直接失败）
+- 当前 import required path 仍包含上述 6 个兼容字段，removal gate 尚未满足
 
 导入来源：`fap-web` 当前已 authored 32 型 desktop clone 内容，转存为 `fap-api` 仓内 baseline（JSON）。
 
@@ -166,7 +180,7 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 - 真实 AI 资产生成/上传与批处理
 - runtime personalization（`selection_fingerprint` / `evidence` / `adaptive` / `memory`）
 
-## 9. 下一步 PR 顺序
-1. `fap-web`：desktop clone P1 深层模块消费接入（`career_ideas/work_styles`、`what_energizes/what_drains`、`superpowers/pitfalls`）
-2. `fap-api` 或 runtime 管线：同型内 runtime personalization 挂载（不改静态 owner）
-3. `fap-api` 或离线管线：AI 资产生成 + asset_ref 回填（仅数据替换，不改 schema）
+## 9. 后续 hard convergence 前置条件
+1. 清理 `fap-web` 对上述 6 个兼容字段的 consumer 与契约语义依赖。
+2. 清理 `fap-api` 测试与 baseline import required chain 对上述 6 个字段的 removal 阻塞。
+3. 在 consumer/tests/import chain 全部收敛后，单独发起 hard convergence PR。

--- a/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php
@@ -16,7 +16,7 @@ final class PersonalityDesktopCloneBaselineImportTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_import_publishes_32_full_code_zh_clone_content_and_is_idempotent(): void
+    public function test_import_publishes_32_full_code_zh_clone_content_with_compatibility_fields_and_is_idempotent(): void
     {
         $this->seedZhVariantsForAllMbtiBaseTypes();
 
@@ -70,6 +70,8 @@ final class PersonalityDesktopCloneBaselineImportTest extends TestCase
         $this->assertIsString(data_get($infjAContent, 'content_json.chapters.career.matched_jobs.fit_bucket'));
         $this->assertNotEmpty((array) data_get($infjAContent, 'content_json.chapters.career.matched_jobs.job_examples'));
         $this->assertIsString(data_get($infjAContent, 'content_json.chapters.career.matched_guides.summary'));
+        // These modules are compatibility transition fields and must remain present
+        // until removal gates are satisfied across import/consumer/tests.
         $this->assertNotEmpty((array) data_get($infjAContent, 'content_json.chapters.career.career_ideas.items'));
         $this->assertNotEmpty((array) data_get($infjAContent, 'content_json.chapters.career.work_styles.items'));
         $this->assertNotEmpty((array) data_get($infjAContent, 'content_json.chapters.growth.what_energizes.items'));
@@ -233,7 +235,7 @@ final class PersonalityDesktopCloneBaselineImportTest extends TestCase
         $this->assertSame(0, PersonalityProfileVariantCloneContent::query()->count());
     }
 
-    public function test_import_fails_when_personality_source_is_missing_required_p1_section(): void
+    public function test_import_fails_when_personality_source_is_missing_required_compatibility_section(): void
     {
         $this->seedZhVariantsForAllMbtiBaseTypes();
 

--- a/backend/tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php
@@ -15,7 +15,7 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_published_desktop_clone_is_readable_by_full_code_and_exposes_p0_and_p1_modules(): void
+    public function test_published_desktop_clone_is_readable_by_full_code_and_keeps_compatibility_fields_exposed(): void
     {
         $infjProfile = $this->createProfile([
             'type_code' => 'INFJ',
@@ -99,6 +99,8 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             ->assertJsonPath('content.chapters.relationships.weaknesses.items.0.description', 'relationships weaknesses description 1 infj-a')
             ->assertJsonPath('content.chapters.career.matched_jobs.fit_bucket', 'primary')
             ->assertJsonPath('content.chapters.career.matched_guides.fit_reason', 'career fit reason infj-a')
+            // Compatibility transition fields stay exposed by public API.
+            // Their presence does not imply desktop main flow still renders them.
             ->assertJsonPath('content.chapters.career.career_ideas.title', 'career ideas infj-a')
             ->assertJsonPath('content.chapters.career.work_styles.items.0.description', 'work styles description 1 infj-a')
             ->assertJsonPath('content.chapters.growth.what_energizes.title', 'what energizes infj-a')
@@ -146,7 +148,7 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             ->assertJsonPath('content.chapters.relationships.pitfalls.items.0.description', 'pitfalls description 1 istp-a');
     }
 
-    public function test_imported_baseline_public_api_exposes_p1_modules_for_sample_full_codes(): void
+    public function test_imported_baseline_public_api_keeps_compatibility_fields_for_sample_full_codes(): void
     {
         $this->seedZhVariantsForAllMbtiBaseTypes();
 
@@ -166,6 +168,8 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             $content = $response->json('content');
             $this->assertIsArray($content);
 
+            // Compatibility transition fields are still required in the published API payload.
+            // This contract only verifies compatibility exposure, not frontend render priority.
             $this->assertItemModuleShape(
                 $content,
                 'chapters.career.career_ideas',


### PR DESCRIPTION
## Summary\n- mark 6 deprecated desktop clone modules as compatibility-retained transition fields in owner contract doc\n- clarify API test semantics: fields remain exposed for compatibility, not frontend main-flow rendering\n- clarify baseline import test semantics: required path remains until removal gate is satisfied\n\n## Scope\n- SOFT_ONLY only (no hard convergence)\n- no field removal\n- no validator/hydrator/normalizer required-chain changes\n- no public API shape change\n\n## Verification\n- php artisan test tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php\n- ./vendor/bin/pint --test tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php\n- php artisan route:list --path=api/v0.5/personality\n- php artisan migrate --force\n- bash backend/scripts/ci_verify_mbti.sh