### PR TITLE
[codex] mbti desktop clone traits label v2

### DIFF
--- a/content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json
+++ b/content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json
@@ -44,25 +44,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "架构",
+                "label": "架构感",
                 "body": "先搭整体框架",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "预判",
+                "label": "预见性",
                 "body": "先看长期后果",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "标准",
+                "label": "标准意识",
                 "body": "先定质量门槛",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "独立",
+                "label": "自主性",
                 "body": "独立完成判断",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -250,25 +250,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "校准",
+                "label": "反思",
                 "body": "持续修正方法",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "复盘",
+                "label": "迭代",
                 "body": "把经验归档",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "边界感",
                 "body": "安排恢复窗口",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "定力",
                 "body": "避免过量消耗",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -456,19 +456,19 @@
             ],
             "influentialTraits": [
               {
-                "label": "可靠",
+                "label": "忠诚感",
                 "body": "重视一致性",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "边界要清楚",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "判断",
+                "label": "判断力",
                 "body": "先看长期走势",
                 "colorKey": "green",
                 "isPlaceholder": false
@@ -769,25 +769,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "架构",
+                "label": "架构感",
                 "body": "先搭整体框架",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "预判",
+                "label": "预见性",
                 "body": "先看长期后果",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "标准",
+                "label": "完善欲",
                 "body": "先定质量门槛",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "独立",
+                "label": "自我校准",
                 "body": "独立完成判断",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -975,25 +975,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "校准",
+                "label": "反思",
                 "body": "持续修正方法",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "复盘",
+                "label": "迭代",
                 "body": "把经验归档",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "完善欲",
                 "body": "安排恢复窗口",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "自我觉察",
                 "body": "避免过量消耗",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -1181,25 +1181,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "可靠",
+                "label": "忠诚感",
                 "body": "重视一致性",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "边界要清楚",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "判断",
+                "label": "保留性",
                 "body": "先看长期走势",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "克制",
+                "label": "敏感度",
                 "body": "表达不过量",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -1494,25 +1494,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "建模",
+                "label": "建模思维",
                 "body": "先建解释模型",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "抽象",
+                "label": "抽象感",
                 "body": "先看底层原理",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "好奇",
+                "label": "求真欲",
                 "body": "不断追问假设",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "弹性",
+                "label": "灵活性",
                 "body": "愿意重新修正",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -1700,13 +1700,13 @@
             ],
             "influentialTraits": [
               {
-                "label": "迭代",
+                "label": "好奇心",
                 "body": "允许先做后改",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "学习",
+                "label": "学习力",
                 "body": "持续吸收新模型",
                 "colorKey": "gold",
                 "isPlaceholder": false
@@ -1718,7 +1718,7 @@
                 "isPlaceholder": false
               },
               {
-                "label": "独处",
+                "label": "独处力",
                 "body": "靠安静恢复",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -1906,25 +1906,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "真实",
+                "label": "真实感",
                 "body": "讨论要诚实",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "空间",
+                "label": "空间感",
                 "body": "需要独立空间",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "好奇",
+                "label": "好奇心",
                 "body": "愿意理解差异",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "松弛",
+                "label": "松弛感",
                 "body": "不喜欢过度黏连",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -2219,25 +2219,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "建模",
+                "label": "建模思维",
                 "body": "先建解释模型",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "抽象",
+                "label": "抽象感",
                 "body": "先看底层原理",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "好奇",
+                "label": "质疑精神",
                 "body": "不断追问假设",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "弹性",
+                "label": "游离感",
                 "body": "愿意重新修正",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -2425,25 +2425,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "迭代",
+                "label": "好奇心",
                 "body": "允许先做后改",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "学习",
+                "label": "学习力",
                 "body": "持续吸收新模型",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "弹性",
+                "label": "自我追问",
                 "body": "愿意修正判断",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "独处",
+                "label": "观察力",
                 "body": "靠安静恢复",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -2631,25 +2631,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "真实",
+                "label": "真实感",
                 "body": "讨论要诚实",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "空间",
+                "label": "空间感",
                 "body": "需要独立空间",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "好奇",
+                "label": "迟疑感",
                 "body": "愿意理解差异",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "松弛",
+                "label": "抽离感",
                 "body": "不喜欢过度黏连",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -2944,25 +2944,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "决断",
+                "label": "决断性",
                 "body": "先抓主轴",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "统筹",
+                "label": "统筹感",
                 "body": "把资源排直",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "推进",
+                "label": "抱负",
                 "body": "拒绝空转",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "野心",
+                "label": "领导欲",
                 "body": "偏向高杠杆",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -3150,25 +3150,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "升级",
+                "label": "进取心",
                 "body": "不断优化系统",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "节奏感",
                 "body": "知道何时调速",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "授权",
+                "label": "授权意识",
                 "body": "让别人进入节奏",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "恢复力",
                 "body": "别只靠硬扛",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -3356,25 +3356,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "直接",
+                "label": "直接性",
                 "body": "问题先说清",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "保护",
+                "label": "担当感",
                 "body": "愿意承担",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "标准",
+                "label": "标准感",
                 "body": "关系要可靠",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "调速",
+                "label": "承诺感",
                 "body": "学会慢一点",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -3669,25 +3669,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "决断",
+                "label": "决断性",
                 "body": "先抓主轴",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "统筹",
+                "label": "统筹感",
                 "body": "把资源排直",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "推进",
+                "label": "完善欲",
                 "body": "拒绝空转",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "野心",
+                "label": "紧迫感",
                 "body": "偏向高杠杆",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -3875,25 +3875,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "升级",
+                "label": "进取心",
                 "body": "不断优化系统",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "节奏感",
                 "body": "知道何时调速",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "授权",
+                "label": "自我校正",
                 "body": "让别人进入节奏",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "韧性",
                 "body": "别只靠硬扛",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -4081,25 +4081,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "直接",
+                "label": "直接性",
                 "body": "问题先说清",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "保护",
+                "label": "高标准",
                 "body": "愿意承担",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "标准",
+                "label": "压强感",
                 "body": "关系要可靠",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "调速",
+                "label": "调节力",
                 "body": "学会慢一点",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -4394,25 +4394,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "重构",
+                "label": "重构欲",
                 "body": "先改写问题",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "试探",
+                "label": "试探精神",
                 "body": "先试再收束",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "说服",
+                "label": "说服力",
                 "body": "会推动局面",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "联想",
+                "label": "机变性",
                 "body": "跨域连接快",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -4600,25 +4600,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "筛选",
+                "label": "发散力",
                 "body": "学会关掉选项",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "复盘",
+                "label": "筛选力",
                 "body": "把试验变经验",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "收束",
+                "label": "机变性",
                 "body": "让点子落地",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "耐心",
+                "label": "收束力",
                 "body": "允许慢一点",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -4806,25 +4806,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "新鲜",
+                "label": "新鲜感",
                 "body": "关系要有活性",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "讨论",
+                "label": "讨论欲",
                 "body": "喜欢来回碰撞",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "弹性",
+                "label": "机智感",
                 "body": "不爱固定剧本",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "转向",
+                "label": "弹性",
                 "body": "随时改打法",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -5119,25 +5119,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "重构",
+                "label": "重构欲",
                 "body": "先改写问题",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "试探",
+                "label": "试探精神",
                 "body": "先试再收束",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "说服",
+                "label": "质疑精神",
                 "body": "会推动局面",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "联想",
+                "label": "跳脱感",
                 "body": "跨域连接快",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -5325,25 +5325,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "筛选",
+                "label": "发散力",
                 "body": "学会关掉选项",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "复盘",
+                "label": "筛选力",
                 "body": "把试验变经验",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "收束",
+                "label": "自我追问",
                 "body": "让点子落地",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "耐心",
+                "label": "适应力",
                 "body": "允许慢一点",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -5531,25 +5531,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "新鲜",
+                "label": "新鲜感",
                 "body": "关系要有活性",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "讨论",
+                "label": "讨论欲",
                 "body": "喜欢来回碰撞",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "弹性",
+                "label": "摇摆感",
                 "body": "不爱固定剧本",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "转向",
+                "label": "抽离感",
                 "body": "随时改打法",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -5844,25 +5844,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "洞察",
+                "label": "洞察力",
                 "body": "先看深层动因",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "共情",
+                "label": "使命感",
                 "body": "理解人的处境",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "整合",
+                "label": "共情力",
                 "body": "把碎片连成线",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "克制",
+                "label": "愿景感",
                 "body": "不过度外放",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -6056,19 +6056,19 @@
                 "isPlaceholder": false
               },
               {
-                "label": "理想",
+                "label": "韧性",
                 "body": "追求一致与意义",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "学会保留自己",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "耐心",
+                "label": "整合力",
                 "body": "按节奏成长",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -6256,25 +6256,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "真诚",
+                "label": "真诚感",
                 "body": "关系要有真实感",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "耐心",
+                "label": "忠诚感",
                 "body": "愿意慢慢理解",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "深度",
+                "label": "深度感",
                 "body": "偏好高质量连接",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "体察力",
                 "body": "需要被尊重",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -6569,25 +6569,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "洞察",
+                "label": "洞察力",
                 "body": "先看深层动因",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "共情",
+                "label": "使命感",
                 "body": "理解人的处境",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "整合",
+                "label": "理想主义",
                 "body": "把碎片连成线",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "克制",
+                "label": "自我要求",
                 "body": "不过度外放",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -6781,19 +6781,19 @@
                 "isPlaceholder": false
               },
               {
-                "label": "理想",
+                "label": "理想感",
                 "body": "追求一致与意义",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "自我觉察",
                 "body": "学会保留自己",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "耐心",
+                "label": "边界感",
                 "body": "按节奏成长",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -6981,25 +6981,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "真诚",
+                "label": "真诚感",
                 "body": "关系要有真实感",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "耐心",
+                "label": "忠诚感",
                 "body": "愿意慢慢理解",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "深度",
+                "label": "高期待",
                 "body": "偏好高质量连接",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "敏感度",
                 "body": "需要被尊重",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -7294,25 +7294,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "价值",
+                "label": "价值感",
                 "body": "先看是否认同",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "共感",
+                "label": "共感力",
                 "body": "对人很敏锐",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "表达",
+                "label": "表达欲",
                 "body": "适合深层传达",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "坚持",
+                "label": "坚持度",
                 "body": "内在标准稳定",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -7506,19 +7506,19 @@
                 "isPlaceholder": false
               },
               {
-                "label": "感受",
+                "label": "感受力",
                 "body": "保留情绪信息",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "学会及时说不",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "沉淀",
+                "label": "沉淀力",
                 "body": "慢慢形成方法",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -7706,25 +7706,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "真实",
+                "label": "真实感",
                 "body": "关系要真诚",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "柔软",
+                "label": "柔软度",
                 "body": "需要被理解",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "深度感",
                 "body": "不想被压迫",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "深度",
+                "label": "忠诚感",
                 "body": "偏好深连接",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -8019,25 +8019,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "价值",
+                "label": "价值感",
                 "body": "先看是否认同",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "共感",
+                "label": "共感力",
                 "body": "对人很敏锐",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "表达",
+                "label": "理想主义",
                 "body": "适合深层传达",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "坚持",
+                "label": "敏感性",
                 "body": "内在标准稳定",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -8231,19 +8231,19 @@
                 "isPlaceholder": false
               },
               {
-                "label": "感受",
+                "label": "感受力",
                 "body": "保留情绪信息",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "理想感",
                 "body": "学会及时说不",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "沉淀",
+                "label": "自我觉察",
                 "body": "慢慢形成方法",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -8431,25 +8431,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "真实",
+                "label": "真实感",
                 "body": "关系要真诚",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "柔软",
+                "label": "柔软度",
                 "body": "需要被理解",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "易受伤感",
                 "body": "不想被压迫",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "深度",
+                "label": "回避感",
                 "body": "偏好深连接",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -8744,25 +8744,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "共识",
+                "label": "共识感",
                 "body": "会搭共识",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "反馈",
+                "label": "反馈意识",
                 "body": "知道怎么提醒",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "带动",
+                "label": "带动力",
                 "body": "能把人带起来",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "陪跑",
+                "label": "愿景感",
                 "body": "擅长长期支持",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -8950,25 +8950,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "承担",
+                "label": "承担感",
                 "body": "愿意往前站",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "要学会保留自己",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "修复",
+                "label": "修复力",
                 "body": "会收拾关系张力",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "调速",
+                "label": "调节力",
                 "body": "别一直满档",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -9156,25 +9156,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "照顾",
+                "label": "照顾力",
                 "body": "会主动接住人",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "带动",
+                "label": "带动力",
                 "body": "想让关系变好",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "回应",
+                "label": "回应力",
                 "body": "对节奏很敏锐",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "承诺感",
                 "body": "需要被反向照顾",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -9469,25 +9469,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "共识",
+                "label": "共识感",
                 "body": "会搭共识",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "反馈",
+                "label": "反馈意识",
                 "body": "知道怎么提醒",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "带动",
+                "label": "责任感",
                 "body": "能把人带起来",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "陪跑",
+                "label": "自我消耗",
                 "body": "擅长长期支持",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -9675,25 +9675,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "承担",
+                "label": "承担感",
                 "body": "愿意往前站",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "要学会保留自己",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "修复",
+                "label": "自我觉察",
                 "body": "会收拾关系张力",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "调速",
+                "label": "修复力",
                 "body": "别一直满档",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -9881,25 +9881,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "照顾",
+                "label": "照顾力",
                 "body": "会主动接住人",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "带动",
+                "label": "带动力",
                 "body": "想让关系变好",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "回应",
+                "label": "期待感",
                 "body": "对节奏很敏锐",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "过度付出",
                 "body": "需要被反向照顾",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -10194,25 +10194,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "连接",
+                "label": "创意感",
                 "body": "会把人连起来",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "点亮",
+                "label": "连接力",
                 "body": "能激活现场",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "探索",
+                "label": "探索欲",
                 "body": "看见新机会",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "转译",
+                "label": "感染力",
                 "body": "会讲成别人懂",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -10406,19 +10406,19 @@
                 "isPlaceholder": false
               },
               {
-                "label": "取舍",
+                "label": "取舍力",
                 "body": "学会关掉选项",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "回访",
+                "label": "回弹力",
                 "body": "把热度接下去",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "节奏感",
                 "body": "避免过满",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -10606,25 +10606,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "热情",
+                "label": "热情度",
                 "body": "先把关系点亮",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "真诚",
+                "label": "真诚感",
                 "body": "喜欢有真实感",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "探索",
+                "label": "共鸣力",
                 "body": "愿意一起试新东西",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "回访",
+                "label": "自由感",
                 "body": "需要练习持续感",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -10919,25 +10919,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "连接",
+                "label": "创意感",
                 "body": "会把人连起来",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "点亮",
+                "label": "连接力",
                 "body": "能激活现场",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "探索",
+                "label": "发散性",
                 "body": "看见新机会",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "转译",
+                "label": "游移感",
                 "body": "会讲成别人懂",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -11131,19 +11131,19 @@
                 "isPlaceholder": false
               },
               {
-                "label": "取舍",
+                "label": "取舍力",
                 "body": "学会关掉选项",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "回访",
+                "label": "自我追问",
                 "body": "把热度接下去",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "节奏感",
                 "body": "避免过满",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -11331,25 +11331,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "热情",
+                "label": "热情度",
                 "body": "先把关系点亮",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "真诚",
+                "label": "真诚感",
                 "body": "喜欢有真实感",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "探索",
+                "label": "理想化",
                 "body": "愿意一起试新东西",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "回访",
+                "label": "逃避感",
                 "body": "需要练习持续感",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -11644,25 +11644,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "流程",
+                "label": "流程意识",
                 "body": "重视执行顺序",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "责任",
+                "label": "责任感",
                 "body": "边界要明确",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "细节",
+                "label": "细节感",
                 "body": "会补齐漏洞",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "闭环",
+                "label": "闭环意识",
                 "body": "事情要收住",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -11850,13 +11850,13 @@
             ],
             "influentialTraits": [
               {
-                "label": "稳定",
+                "label": "稳定性",
                 "body": "重视可预测性",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "复盘",
+                "label": "复盘力",
                 "body": "会回看流程",
                 "colorKey": "gold",
                 "isPlaceholder": false
@@ -11868,7 +11868,7 @@
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "恢复力",
                 "body": "不要只靠硬撑",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -12056,25 +12056,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "可靠",
+                "label": "可靠感",
                 "body": "重视兑现",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "关系要清楚",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "责任",
+                "label": "责任感",
                 "body": "愿意长期负责",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "克制",
+                "label": "稳定性",
                 "body": "不爱夸张表达",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -12369,25 +12369,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "流程",
+                "label": "流程意识",
                 "body": "重视执行顺序",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "责任",
+                "label": "责任感",
                 "body": "边界要明确",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "细节",
+                "label": "谨慎度",
                 "body": "会补齐漏洞",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "闭环",
+                "label": "自压感",
                 "body": "事情要收住",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -12575,25 +12575,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "稳定",
+                "label": "稳定性",
                 "body": "重视可预测性",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "复盘",
+                "label": "复盘力",
                 "body": "会回看流程",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "弹性",
+                "label": "谨慎度",
                 "body": "学会留余地",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "自我调节",
                 "body": "不要只靠硬撑",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -12781,25 +12781,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "可靠",
+                "label": "可靠感",
                 "body": "重视兑现",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "关系要清楚",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "责任",
+                "label": "压抑感",
                 "body": "愿意长期负责",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "克制",
+                "label": "挑剔性",
                 "body": "不爱夸张表达",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -13094,19 +13094,19 @@
             ],
             "influentialTraits": [
               {
-                "label": "照看",
+                "label": "照看力",
                 "body": "会留意细节",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "稳定",
+                "label": "稳定感",
                 "body": "持续把事做稳",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "责任",
+                "label": "责任感",
                 "body": "愿意补位",
                 "colorKey": "green",
                 "isPlaceholder": false
@@ -13300,25 +13300,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "照顾",
+                "label": "照顾力",
                 "body": "会先想到别人",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "需要更早说出",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "恢复力",
                 "body": "别总排到最后",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "稳定",
+                "label": "稳定性",
                 "body": "按节奏修正",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -13506,25 +13506,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "细致",
+                "label": "细致感",
                 "body": "会记得很多细节",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "稳定",
+                "label": "稳定感",
                 "body": "关系要可依赖",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "照顾",
+                "label": "照顾力",
                 "body": "会主动补位",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "忠诚感",
                 "body": "也需要被照顾",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -13819,25 +13819,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "照看",
+                "label": "照看力",
                 "body": "会留意细节",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "稳定",
+                "label": "稳定感",
                 "body": "持续把事做稳",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "责任",
+                "label": "顾虑感",
                 "body": "愿意补位",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "耐心",
+                "label": "过度承担",
                 "body": "能长期陪跑",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -14025,25 +14025,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "照顾",
+                "label": "照顾力",
                 "body": "会先想到别人",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "需要更早说出",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "自我觉察",
                 "body": "别总排到最后",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "稳定",
+                "label": "稳定性",
                 "body": "按节奏修正",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -14231,25 +14231,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "细致",
+                "label": "细致感",
                 "body": "会记得很多细节",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "稳定",
+                "label": "稳定感",
                 "body": "关系要可依赖",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "照顾",
+                "label": "讨好倾向",
                 "body": "会主动补位",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "敏感度",
                 "body": "也需要被照顾",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -14544,25 +14544,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "执行",
+                "label": "执行力",
                 "body": "先把事落下去",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "标准",
+                "label": "标准意识",
                 "body": "结果要过线",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "统筹",
+                "label": "统筹感",
                 "body": "分工要清楚",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "压进",
+                "label": "推进力",
                 "body": "会推着往前",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -14750,25 +14750,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "标准",
+                "label": "标准意识",
                 "body": "先定要求",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "承接",
+                "label": "承接力",
                 "body": "学会让人接住",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "调配",
+                "label": "调配力",
                 "body": "资源要重分配",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "恢复力",
                 "body": "别总压满自己",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -14956,25 +14956,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "可靠",
+                "label": "可靠感",
                 "body": "说到做到",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "直接",
+                "label": "直接性",
                 "body": "问题会说清",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "责任",
+                "label": "责任感",
                 "body": "愿意往前站",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "承接",
+                "label": "主导感",
                 "body": "需要更柔一些",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -15269,25 +15269,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "执行",
+                "label": "执行力",
                 "body": "先把事落下去",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "标准",
+                "label": "标准意识",
                 "body": "结果要过线",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "统筹",
+                "label": "掌控欲",
                 "body": "分工要清楚",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "压进",
+                "label": "压强感",
                 "body": "会推着往前",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -15475,25 +15475,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "标准",
+                "label": "标准意识",
                 "body": "先定要求",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "承接",
+                "label": "承接力",
                 "body": "学会让人接住",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "调配",
+                "label": "自我校正",
                 "body": "资源要重分配",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "警觉性",
                 "body": "别总压满自己",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -15681,25 +15681,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "可靠",
+                "label": "可靠感",
                 "body": "说到做到",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "直接",
+                "label": "直接性",
                 "body": "问题会说清",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "责任",
+                "label": "控制欲",
                 "body": "愿意往前站",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "承接",
+                "label": "不耐感",
                 "body": "需要更柔一些",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -15994,25 +15994,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "组织",
+                "label": "组织感",
                 "body": "会把现场安排好",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "照顾",
+                "label": "照顾力",
                 "body": "知道谁需要回应",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "执行",
+                "label": "执行力",
                 "body": "会把细节补齐",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "稳定",
+                "label": "协调意识",
                 "body": "想让局面更顺",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -16200,25 +16200,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "照顾",
+                "label": "照顾力",
                 "body": "会主动补位",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "取舍",
+                "label": "取舍力",
                 "body": "要学会筛选",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "别全都接住",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "恢复力",
                 "body": "也要轮到自己",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -16406,25 +16406,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "回应",
+                "label": "回应力",
                 "body": "会及时接住",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "陪伴",
+                "label": "陪伴感",
                 "body": "在场感强",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "安排",
+                "label": "安排力",
                 "body": "会把细节照顾好",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "承诺感",
                 "body": "也需要被照顾",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -16719,25 +16719,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "组织",
+                "label": "组织感",
                 "body": "会把现场安排好",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "照顾",
+                "label": "照顾力",
                 "body": "知道谁需要回应",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "执行",
+                "label": "迎合倾向",
                 "body": "会把细节补齐",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "稳定",
+                "label": "过度负责",
                 "body": "想让局面更顺",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -16925,25 +16925,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "照顾",
+                "label": "照顾力",
                 "body": "会主动补位",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "取舍",
+                "label": "取舍力",
                 "body": "要学会筛选",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "自我觉察",
                 "body": "别全都接住",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "敏感度",
                 "body": "也要轮到自己",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -17131,25 +17131,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "回应",
+                "label": "回应力",
                 "body": "会及时接住",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "陪伴",
+                "label": "陪伴感",
                 "body": "在场感强",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "安排",
+                "label": "讨好倾向",
                 "body": "会把细节照顾好",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "高期待",
                 "body": "也需要被照顾",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -17444,25 +17444,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "排障",
+                "label": "排障力",
                 "body": "先定位问题",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "工具",
+                "label": "工具感",
                 "body": "会找最顺手的解法",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "冷静",
+                "label": "冷静度",
                 "body": "现场不易慌",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "灵活",
+                "label": "独立性",
                 "body": "会边试边调",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -17650,25 +17650,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "复盘",
+                "label": "复盘力",
                 "body": "把经验沉下去",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "节奏感",
                 "body": "给自己留一点计划",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "空间",
+                "label": "空间感",
                 "body": "需要独立恢复",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "收束",
+                "label": "收束力",
                 "body": "别只顾眼前解法",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -17856,25 +17856,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "自在",
+                "label": "自在感",
                 "body": "不爱被管",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "实际",
+                "label": "现实感",
                 "body": "会用行动表达",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "冷静",
+                "label": "边界感",
                 "body": "问题来时先处理",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "可靠感",
                 "body": "需要被尊重",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -18169,25 +18169,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "排障",
+                "label": "排障力",
                 "body": "先定位问题",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "工具",
+                "label": "工具感",
                 "body": "会找最顺手的解法",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "冷静",
+                "label": "抽离感",
                 "body": "现场不易慌",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "灵活",
+                "label": "低耐心",
                 "body": "会边试边调",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -18375,25 +18375,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "复盘",
+                "label": "复盘力",
                 "body": "把经验沉下去",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "节奏感",
                 "body": "给自己留一点计划",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "空间",
+                "label": "警觉性",
                 "body": "需要独立恢复",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "收束",
+                "label": "收束力",
                 "body": "别只顾眼前解法",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -18581,25 +18581,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "自在",
+                "label": "自在感",
                 "body": "不爱被管",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "实际",
+                "label": "现实感",
                 "body": "会用行动表达",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "冷静",
+                "label": "疏离感",
                 "body": "问题来时先处理",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "防御性",
                 "body": "需要被尊重",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -18894,25 +18894,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "审美",
+                "label": "审美感",
                 "body": "会分辨细微差别",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "体验",
+                "label": "体验感",
                 "body": "看重真实感受",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "打磨",
+                "label": "打磨欲",
                 "body": "会慢慢做好",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "柔韧",
+                "label": "真诚性",
                 "body": "不靠硬推",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -19100,25 +19100,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "感受",
+                "label": "感受力",
                 "body": "先听见自己",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "更早表达限制",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "节奏感",
                 "body": "按自己的拍子",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "恢复力",
                 "body": "需要安静空间",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -19306,25 +19306,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "温柔",
+                "label": "温柔度",
                 "body": "不靠压强靠陪伴",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "真实",
+                "label": "真实感",
                 "body": "关系要自然",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "感受",
+                "label": "感受力",
                 "body": "对细节很敏锐",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "陪伴感",
                 "body": "不想被强迫",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -19619,25 +19619,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "审美",
+                "label": "审美感",
                 "body": "会分辨细微差别",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "体验",
+                "label": "体验感",
                 "body": "看重真实感受",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "打磨",
+                "label": "敏感性",
                 "body": "会慢慢做好",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "柔韧",
+                "label": "犹疑感",
                 "body": "不靠硬推",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -19825,25 +19825,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "感受",
+                "label": "感受力",
                 "body": "先听见自己",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "更早表达限制",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "敏感度",
                 "body": "按自己的拍子",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "自我觉察",
                 "body": "需要安静空间",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -20031,25 +20031,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "温柔",
+                "label": "温柔度",
                 "body": "不靠压强靠陪伴",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "真实",
+                "label": "真实感",
                 "body": "关系要自然",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "感受",
+                "label": "易受伤感",
                 "body": "对细节很敏锐",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "退避感",
                 "body": "不想被强迫",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -20344,25 +20344,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "行动",
+                "label": "行动力",
                 "body": "先把局面推起来",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "应变",
+                "label": "应变力",
                 "body": "现场会转向",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "谈判",
+                "label": "谈判力",
                 "body": "敢去拿结果",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "试错",
+                "label": "结果导向",
                 "body": "不怕先试一版",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -20550,25 +20550,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "抓机会",
+                "label": "机会感",
                 "body": "先看能动哪里",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "止损",
+                "label": "止损力",
                 "body": "学会及时收手",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "复盘",
+                "label": "回弹力",
                 "body": "别只顾下一场",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "节奏感",
                 "body": "让结果能续上",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -20756,25 +20756,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "直接",
+                "label": "直接性",
                 "body": "喜欢当场说清",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "行动",
+                "label": "行动力",
                 "body": "会用动作表达",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "活力",
+                "label": "活力感",
                 "body": "关系要有现场感",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "松弛感",
                 "body": "不爱被拖着走",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -21069,25 +21069,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "行动",
+                "label": "行动力",
                 "body": "先把局面推起来",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "应变",
+                "label": "应变力",
                 "body": "现场会转向",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "谈判",
+                "label": "冒险性",
                 "body": "敢去拿结果",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "试错",
+                "label": "刺激感",
                 "body": "不怕先试一版",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -21275,25 +21275,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "抓机会",
+                "label": "机会感",
                 "body": "先看能动哪里",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "止损",
+                "label": "止损力",
                 "body": "学会及时收手",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "复盘",
+                "label": "警觉性",
                 "body": "别只顾下一场",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "节奏",
+                "label": "回弹力",
                 "body": "让结果能续上",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -21481,25 +21481,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "直接",
+                "label": "直接性",
                 "body": "喜欢当场说清",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "行动",
+                "label": "行动力",
                 "body": "会用动作表达",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "活力",
+                "label": "不耐感",
                 "body": "关系要有现场感",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "抽离感",
                 "body": "不爱被拖着走",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -21794,25 +21794,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "带入",
+                "label": "带动感",
                 "body": "会让人进场",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "回应",
+                "label": "回应力",
                 "body": "对现场很敏锐",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "关系",
+                "label": "关系感",
                 "body": "能快速拉近",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "体验",
+                "label": "体验欲",
                 "body": "重视真实感受",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -22006,19 +22006,19 @@
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "别把自己用满",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "回访",
+                "label": "回弹力",
                 "body": "把关系接下去",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "恢复力",
                 "body": "给自己留空档",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -22206,7 +22206,7 @@
             ],
             "influentialTraits": [
               {
-                "label": "陪伴",
+                "label": "陪伴感",
                 "body": "在场感很强",
                 "colorKey": "blue",
                 "isPlaceholder": false
@@ -22218,13 +22218,13 @@
                 "isPlaceholder": false
               },
               {
-                "label": "回应",
+                "label": "回应力",
                 "body": "喜欢有回声",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "亲近感",
                 "body": "需要后天练习",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -22519,25 +22519,25 @@
             ],
             "influentialTraits": [
               {
-                "label": "带入",
+                "label": "带动感",
                 "body": "会让人进场",
                 "colorKey": "blue",
                 "isPlaceholder": false
               },
               {
-                "label": "回应",
+                "label": "回应力",
                 "body": "对现场很敏锐",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "关系",
+                "label": "分心性",
                 "body": "能快速拉近",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "体验",
+                "label": "回避倾向",
                 "body": "重视真实感受",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -22731,19 +22731,19 @@
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "边界感",
                 "body": "别把自己用满",
                 "colorKey": "gold",
                 "isPlaceholder": false
               },
               {
-                "label": "回访",
+                "label": "敏感度",
                 "body": "把关系接下去",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "恢复",
+                "label": "回弹力",
                 "body": "给自己留空档",
                 "colorKey": "purple",
                 "isPlaceholder": false
@@ -22931,7 +22931,7 @@
             ],
             "influentialTraits": [
               {
-                "label": "陪伴",
+                "label": "陪伴感",
                 "body": "在场感很强",
                 "colorKey": "blue",
                 "isPlaceholder": false
@@ -22943,13 +22943,13 @@
                 "isPlaceholder": false
               },
               {
-                "label": "回应",
+                "label": "敏感度",
                 "body": "喜欢有回声",
                 "colorKey": "green",
                 "isPlaceholder": false
               },
               {
-                "label": "边界",
+                "label": "依赖感",
                 "body": "需要后天练习",
                 "colorKey": "purple",
                 "isPlaceholder": false


### PR DESCRIPTION
## Summary
This PR updates the authoritative zh-CN MBTI desktop clone content source for Influential Traits labels.

The existing desktop clone pipeline already reads authored baseline content, imports it into `personality_profile_variant_clone_contents`, and exposes it through the public desktop clone API without frontend-derived trait generation. The issue was that the authored `influentialTraits[*].label` values were still effectively base-code shared, so `A/T` pairs exposed the same trait labels in Career, Growth, and Relationships.

This change replaces those authored labels in `content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json` for all 32 full codes so that the trait labels now match the requested v2 full-code-specific matrix.

## User Impact
Users reading the MBTI Desktop clone result will now receive chapter-level Influential Traits labels that differ between `A` and `T` variants where specified. The change affects only the authored zh-CN desktop clone content source and flows through the existing import -> owner -> API chain.

## Root Cause
The route and owner storage were already `full_code_exact`, but the underlying authored traits labels remained duplicated across `A/T` pairs in the committed baseline content.

## Fix
- Replaced `content_json.chapters.career.influentialTraits[*].label` for all 32 zh-CN full codes
- Replaced `content_json.chapters.growth.influentialTraits[*].label` for all 32 zh-CN full codes
- Replaced `content_json.chapters.relationships.influentialTraits[*].label` for all 32 zh-CN full codes
- Left `body`, `colorKey`, `isPlaceholder`, item count, and item order unchanged
- Did not change schema, routes, importer behavior, API shape, frontend render logic, runtime fallback, or unrelated chapter content

## Follow-up
Follow-up is still needed for `influentialTraits[*].body` copy. This PR intentionally leaves the old body strings untouched, so some updated labels are now paired with legacy body text that may no longer be fully semantically aligned.

## Verification
- `php artisan route:list --path=api/v0.5/personality`
- `php artisan migrate --force`
- `php artisan personality:import-local-baseline --locale=zh-CN --status=published --upsert`
- `php artisan personality:import-desktop-clone-baseline --locale=zh-CN --status=published --upsert`
- Sample API verification for `ENTJ-A`, `ENTJ-T`, `INFJ-A`, `INFJ-T`
- `php artisan test tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php`
- `./vendor/bin/pint --test tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`
