### PR TITLE
feat(mbti): add desktop clone traits unlock content

### DIFF
--- a/backend/app/PersonalityCms/DesktopClone/PersonalityVariantCloneContentValidator.php
+++ b/backend/app/PersonalityCms/DesktopClone/PersonalityVariantCloneContentValidator.php
@@ -155,6 +155,52 @@ final class PersonalityVariantCloneContentValidator
             'content.chapters.growth.influentialTraits.*.colorKey' => ['nullable', 'in:blue,gold,green,purple,red'],
             'content.chapters.relationships.influentialTraits.*.colorKey' => ['nullable', 'in:blue,gold,green,purple,red'],
 
+            'content.chapters.career.traits_unlock' => ['required', 'array'],
+            'content.chapters.growth.traits_unlock' => ['required', 'array'],
+            'content.chapters.relationships.traits_unlock' => ['required', 'array'],
+            'content.chapters.career.traits_unlock.title' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.title' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.title' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.intro' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.intro' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.intro' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items' => ['required', 'array', 'size:4'],
+            'content.chapters.growth.traits_unlock.items' => ['required', 'array', 'size:4'],
+            'content.chapters.relationships.traits_unlock.items' => ['required', 'array', 'size:4'],
+            'content.chapters.career.traits_unlock.items.*.id' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.id' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.id' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.label' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.label' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.label' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.role' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.role' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.role' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.definition' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.definition' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.definition' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.why_it_matters' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.why_it_matters' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.why_it_matters' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.career_expression' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.growth_expression' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.relationship_expression' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.career_advantage' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.growth_advantage' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.relationship_advantage' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.overuse_risk' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.overuse_risk' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.overuse_risk' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.real_world_signal' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.real_world_signal' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.real_world_signal' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.upgrade_hint' => ['required', 'string'],
+            'content.chapters.growth.traits_unlock.items.*.upgrade_hint' => ['required', 'string'],
+            'content.chapters.relationships.traits_unlock.items.*.upgrade_hint' => ['required', 'string'],
+            'content.chapters.career.traits_unlock.items.*.links_to_existing_blocks' => ['required', 'array', 'min:1'],
+            'content.chapters.growth.traits_unlock.items.*.links_to_existing_blocks' => ['required', 'array', 'min:1'],
+            'content.chapters.relationships.traits_unlock.items.*.links_to_existing_blocks' => ['required', 'array', 'min:1'],
+
             'content.chapters.career.visibleBlocks' => ['required', 'array', 'min:1', 'max:2'],
             'content.chapters.growth.visibleBlocks' => ['required', 'array', 'min:1', 'max:2'],
             'content.chapters.relationships.visibleBlocks' => ['required', 'array', 'min:1', 'max:2'],
@@ -235,7 +281,7 @@ final class PersonalityVariantCloneContentValidator
             'asset_slots.*.meta' => ['present', 'nullable', 'array'],
         ]);
 
-        $validator->after(function ($validator) use ($normalizedAssetSlots): void {
+        $validator->after(function ($validator) use ($normalizedAssetSlots, $contentJson): void {
             $slotIds = [];
 
             foreach ($normalizedAssetSlots as $index => $slot) {
@@ -285,6 +331,11 @@ final class PersonalityVariantCloneContentValidator
                     'Asset slots must contain the exact allowed slot_id set for mbti_desktop_clone_v1.',
                 );
             }
+
+            foreach (['career', 'growth', 'relationships'] as $chapterKey) {
+                $this->assertTraitsUnlockLabelsAligned($validator, $contentJson, $chapterKey);
+                $this->assertTraitsUnlockLinksShape($validator, $contentJson, $chapterKey);
+            }
         });
 
         if ($validator->fails()) {
@@ -292,5 +343,63 @@ final class PersonalityVariantCloneContentValidator
         }
 
         return PersonalityDesktopCloneAssetSlotSupport::sortAssetSlotsBySchemaOrder($normalizedAssetSlots);
+    }
+
+    /**
+     * @param  array<string, mixed>  $contentJson
+     */
+    private function assertTraitsUnlockLabelsAligned($validator, array $contentJson, string $chapterKey): void
+    {
+        $traitLabels = array_map(
+            static fn (mixed $trait): string => trim((string) (is_array($trait) ? ($trait['label'] ?? '') : '')),
+            (array) data_get($contentJson, sprintf('chapters.%s.influentialTraits', $chapterKey), []),
+        );
+        $unlockLabels = array_map(
+            static fn (mixed $item): string => trim((string) (is_array($item) ? ($item['label'] ?? '') : '')),
+            (array) data_get($contentJson, sprintf('chapters.%s.traits_unlock.items', $chapterKey), []),
+        );
+
+        if ($traitLabels !== $unlockLabels) {
+            $validator->errors()->add(
+                sprintf('content.chapters.%s.traits_unlock.items', $chapterKey),
+                sprintf('Traits unlock labels must match influentialTraits order for chapter %s.', $chapterKey),
+            );
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $contentJson
+     */
+    private function assertTraitsUnlockLinksShape($validator, array $contentJson, string $chapterKey): void
+    {
+        $items = (array) data_get($contentJson, sprintf('chapters.%s.traits_unlock.items', $chapterKey), []);
+
+        foreach ($items as $index => $item) {
+            $links = is_array($item) ? ($item['links_to_existing_blocks'] ?? null) : null;
+
+            if (! is_array($links) || $links === []) {
+                continue;
+            }
+
+            foreach ($links as $linkKey => $paths) {
+                if (! is_array($paths) || $paths === []) {
+                    $validator->errors()->add(
+                        sprintf('content.chapters.%s.traits_unlock.items.%d.links_to_existing_blocks.%s', $chapterKey, $index, $linkKey),
+                        'Traits unlock link groups must be non-empty string arrays.',
+                    );
+
+                    continue;
+                }
+
+                foreach ($paths as $pathIndex => $path) {
+                    if (trim((string) $path) === '') {
+                        $validator->errors()->add(
+                            sprintf('content.chapters.%s.traits_unlock.items.%d.links_to_existing_blocks.%s.%d', $chapterKey, $index, $linkKey, $pathIndex),
+                            'Traits unlock link paths must be non-empty strings.',
+                        );
+                    }
+                }
+            }
+        }
     }
 }

--- a/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php
@@ -78,6 +78,21 @@ final class PersonalityDesktopCloneBaselineImportTest extends TestCase
         $this->assertNotEmpty((array) data_get($infjAContent, 'content_json.chapters.growth.what_drains.items'));
         $this->assertNotEmpty((array) data_get($infjAContent, 'content_json.chapters.relationships.superpowers.items'));
         $this->assertNotEmpty((array) data_get($infjAContent, 'content_json.chapters.relationships.pitfalls.items'));
+        $this->assertNotSame('', trim((string) data_get($infjAContent, 'content_json.chapters.career.traits_unlock.title')));
+        $this->assertNotSame('', trim((string) data_get($infjAContent, 'content_json.chapters.growth.traits_unlock.title')));
+        $this->assertNotSame('', trim((string) data_get($infjAContent, 'content_json.chapters.relationships.traits_unlock.title')));
+        $this->assertSame(
+            data_get($infjAContent, 'content_json.chapters.career.influentialTraits.0.label'),
+            data_get($infjAContent, 'content_json.chapters.career.traits_unlock.items.0.label'),
+        );
+        $this->assertSame(
+            data_get($infjAContent, 'content_json.chapters.growth.influentialTraits.0.label'),
+            data_get($infjAContent, 'content_json.chapters.growth.traits_unlock.items.0.label'),
+        );
+        $this->assertSame(
+            data_get($infjAContent, 'content_json.chapters.relationships.influentialTraits.0.label'),
+            data_get($infjAContent, 'content_json.chapters.relationships.traits_unlock.items.0.label'),
+        );
 
         $this->assertNotSame('', trim((string) data_get($entjTContent, 'content_json.letters_intro.headline')));
         $this->assertNotSame('', trim((string) data_get($istpAContent, 'content_json.chapters.career.matched_jobs.summary')));

--- a/backend/tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php
@@ -57,6 +57,13 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             'is_published' => true,
             'published_at' => now()->subMinute(),
         ]);
+        $entjA = $this->createVariant($entjProfile, [
+            'canonical_type_code' => 'ENTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'ENTJ-A',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
         $entjT = $this->createVariant($entjProfile, [
             'canonical_type_code' => 'ENTJ',
             'variant_code' => 'T',
@@ -74,6 +81,7 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
 
         $this->createCloneContent($infjA, 'infj-a', PersonalityProfileVariantCloneContent::STATUS_PUBLISHED);
         $this->createCloneContent($infjT, 'infj-t', PersonalityProfileVariantCloneContent::STATUS_PUBLISHED);
+        $this->createCloneContent($entjA, 'entj-a', PersonalityProfileVariantCloneContent::STATUS_PUBLISHED);
         $this->createCloneContent($entjT, 'entj-t', PersonalityProfileVariantCloneContent::STATUS_PUBLISHED);
         $this->createCloneContent($istpA, 'istp-a', PersonalityProfileVariantCloneContent::STATUS_PUBLISHED);
 
@@ -107,6 +115,10 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             ->assertJsonPath('content.chapters.growth.what_drains.items.0.description', 'what drains description 1 infj-a')
             ->assertJsonPath('content.chapters.relationships.superpowers.title', 'superpowers infj-a')
             ->assertJsonPath('content.chapters.relationships.pitfalls.items.0.description', 'pitfalls description 1 infj-a')
+            ->assertJsonPath('content.chapters.career.traits_unlock.title', 'career traits unlock title infj-a')
+            ->assertJsonPath('content.chapters.career.traits_unlock.items.0.label', 'career trait 1 infj-a')
+            ->assertJsonPath('content.chapters.growth.traits_unlock.items.0.label', 'growth trait 1 infj-a')
+            ->assertJsonPath('content.chapters.relationships.traits_unlock.items.0.label', 'relationships trait 1 infj-a')
             ->assertJsonPath('asset_slots.0.slot_id', PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_HERO_ILLUSTRATION)
             ->assertJsonPath('asset_slots.0.status', PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER)
             ->assertJsonPath('asset_slots.0.asset_ref', null)
@@ -130,7 +142,20 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('full_code', 'INFJ-T')
-            ->assertJsonPath('content.hero.summary', 'hero summary infj-t');
+            ->assertJsonPath('content.hero.summary', 'hero summary infj-t')
+            ->assertJsonPath('content.chapters.career.traits_unlock.title', 'career traits unlock title infj-t')
+            ->assertJsonPath('content.chapters.career.traits_unlock.items.0.label', 'career trait 1 infj-t')
+            ->assertJsonPath('content.chapters.growth.traits_unlock.items.0.label', 'growth trait 1 infj-t')
+            ->assertJsonPath('content.chapters.relationships.traits_unlock.items.0.label', 'relationships trait 1 infj-t');
+
+        $this->getJson('/api/v0.5/personality/entj-a/desktop-clone?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('full_code', 'ENTJ-A')
+            ->assertJsonPath('content.chapters.career.traits_unlock.title', 'career traits unlock title entj-a')
+            ->assertJsonPath('content.chapters.career.traits_unlock.items.0.label', 'career trait 1 entj-a')
+            ->assertJsonPath('content.chapters.growth.traits_unlock.items.0.label', 'growth trait 1 entj-a')
+            ->assertJsonPath('content.chapters.relationships.traits_unlock.items.0.label', 'relationships trait 1 entj-a');
 
         $this->getJson('/api/v0.5/personality/entj-t/desktop-clone?locale=zh-CN')
             ->assertOk()
@@ -138,7 +163,11 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             ->assertJsonPath('full_code', 'ENTJ-T')
             ->assertJsonPath('content.letters_intro.headline', 'letters headline entj-t')
             ->assertJsonPath('content.chapters.career.matched_jobs.job_examples.0', 'job example 1 entj-t')
-            ->assertJsonPath('content.chapters.growth.what_energizes.items.0.description', 'what energizes description 1 entj-t');
+            ->assertJsonPath('content.chapters.growth.what_energizes.items.0.description', 'what energizes description 1 entj-t')
+            ->assertJsonPath('content.chapters.career.traits_unlock.title', 'career traits unlock title entj-t')
+            ->assertJsonPath('content.chapters.career.traits_unlock.items.0.label', 'career trait 1 entj-t')
+            ->assertJsonPath('content.chapters.growth.traits_unlock.items.0.label', 'growth trait 1 entj-t')
+            ->assertJsonPath('content.chapters.relationships.traits_unlock.items.0.label', 'relationships trait 1 entj-t');
 
         $this->getJson('/api/v0.5/personality/istp-a/desktop-clone?locale=zh-CN')
             ->assertOk()
@@ -158,7 +187,7 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
             '--upsert' => true,
         ])->assertExitCode(0);
 
-        foreach (['INFJ-A', 'ENTJ-T', 'ISTP-A'] as $fullCode) {
+        foreach (['ENTJ-A', 'ENTJ-T', 'INFJ-A', 'INFJ-T'] as $fullCode) {
             $response = $this->getJson('/api/v0.5/personality/'.strtolower($fullCode).'/desktop-clone?locale=zh-CN')
                 ->assertOk()
                 ->assertJsonPath('ok', true)
@@ -199,6 +228,24 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
                 $content,
                 'chapters.relationships.pitfalls',
                 $fullCode,
+            );
+            $this->assertNotSame('', trim((string) data_get($content, 'chapters.career.traits_unlock.title')));
+            $this->assertNotSame('', trim((string) data_get($content, 'chapters.growth.traits_unlock.title')));
+            $this->assertNotSame('', trim((string) data_get($content, 'chapters.relationships.traits_unlock.title')));
+            $this->assertSame(
+                data_get($content, 'chapters.career.influentialTraits.0.label'),
+                data_get($content, 'chapters.career.traits_unlock.items.0.label'),
+                sprintf('%s career traits_unlock first label must align with row label', $fullCode),
+            );
+            $this->assertSame(
+                data_get($content, 'chapters.growth.influentialTraits.0.label'),
+                data_get($content, 'chapters.growth.traits_unlock.items.0.label'),
+                sprintf('%s growth traits_unlock first label must align with row label', $fullCode),
+            );
+            $this->assertSame(
+                data_get($content, 'chapters.relationships.influentialTraits.0.label'),
+                data_get($content, 'chapters.relationships.traits_unlock.items.0.label'),
+                sprintf('%s relationships traits_unlock first label must align with row label', $fullCode),
             );
         }
     }
@@ -385,6 +432,7 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
                     'items' => $this->chapterItems($chapter.' visible item', $tag),
                 ],
             ],
+            'traits_unlock' => $this->validTraitsUnlock($chapter, $tag),
             'lockedBlocks' => [
                 [
                     'title' => $chapter.' locked 1 '.$tag,
@@ -461,6 +509,60 @@ final class PersonalityDesktopClonePublicApiTest extends TestCase
         }
 
         return $payload;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validTraitsUnlock(string $chapter, string $tag): array
+    {
+        $expressionField = match ($chapter) {
+            'career' => 'career_expression',
+            'growth' => 'growth_expression',
+            default => 'relationship_expression',
+        };
+        $advantageField = match ($chapter) {
+            'career' => 'career_advantage',
+            'growth' => 'growth_advantage',
+            default => 'relationship_advantage',
+        };
+        $links = match ($chapter) {
+            'career' => [
+                'summary' => ['career.summary'],
+                'strengths' => ['career.advantages'],
+                'weaknesses' => ['career.weaknesses'],
+            ],
+            'growth' => [
+                'summary' => ['growth.summary'],
+                'strengths' => ['growth.strengths'],
+                'weaknesses' => ['growth.weaknesses'],
+            ],
+            default => [
+                'summary' => ['relationships.summary'],
+                'strengths' => ['relationships.strengths'],
+                'weaknesses' => ['relationships.weaknesses'],
+            ],
+        };
+
+        return [
+            'title' => sprintf('%s traits unlock title %s', $chapter, $tag),
+            'intro' => sprintf('%s traits unlock intro %s', $chapter, $tag),
+            'items' => array_map(function (int $index) use ($chapter, $tag, $expressionField, $advantageField, $links): array {
+                return [
+                    'id' => sprintf('%s-trait-%d', $chapter, $index),
+                    'label' => sprintf('%s trait %d %s', $chapter, $index, $tag),
+                    'role' => sprintf('%s-role-%d', $chapter, $index),
+                    'definition' => sprintf('%s definition %d %s', $chapter, $index, $tag),
+                    'why_it_matters' => sprintf('%s why it matters %d %s', $chapter, $index, $tag),
+                    $expressionField => sprintf('%s expression %d %s', $chapter, $index, $tag),
+                    $advantageField => sprintf('%s advantage %d %s', $chapter, $index, $tag),
+                    'overuse_risk' => sprintf('%s overuse risk %d %s', $chapter, $index, $tag),
+                    'real_world_signal' => sprintf('%s signal %d %s', $chapter, $index, $tag),
+                    'upgrade_hint' => sprintf('%s upgrade hint %d %s', $chapter, $index, $tag),
+                    'links_to_existing_blocks' => $links,
+                ];
+            }, [1, 2, 3, 4]),
+        ];
     }
 
     /**

--- a/content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json
+++ b/content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json
@@ -241,7 +241,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "架构感",
+                  "role": "career_lens",
+                  "definition": "「架构感」意味着你在职业场景中会优先从结构、长期布局与关键判断这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用架构感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果架构感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让架构感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "预见性",
+                  "role": "working_method",
+                  "definition": "「预见性」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕预见性去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果预见性过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免预见性变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "标准意识",
+                  "role": "inner_drive",
+                  "definition": "「标准意识」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对标准意识相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果标准意识被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现标准意识？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把标准意识转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "自主性",
+                  "role": "career_orientation",
+                  "definition": "「自主性」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合自主性的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖自主性，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合自主性”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -447,7 +569,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "反思",
+                  "role": "inner_processing",
+                  "definition": "反思会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让反思只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "迭代",
+                  "role": "growth_engine",
+                  "definition": "迭代会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把迭代和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "边界感",
+                  "role": "self_regulation",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "定力",
+                  "role": "recovery_pattern",
+                  "definition": "定力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活定力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -653,7 +897,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "忠诚感",
+                  "role": "connection_style",
+                  "definition": "忠诚感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把忠诚感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "边界感",
+                  "role": "trust_pattern",
+                  "definition": "边界感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把边界感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "判断力",
+                  "role": "emotional_response",
+                  "definition": "判断力会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别判断力最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "克制",
+                  "role": "relational_tension",
+                  "definition": "克制会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把克制说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -966,7 +1332,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "架构感",
+                  "role": "career_lens",
+                  "definition": "「架构感」意味着你在职业场景中会优先从结构、长期布局与关键判断这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用架构感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果架构感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让架构感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "预见性",
+                  "role": "working_method",
+                  "definition": "「预见性」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕预见性去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果预见性过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免预见性变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "完善欲",
+                  "role": "inner_drive",
+                  "definition": "「完善欲」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对完善欲相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果完善欲被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现完善欲？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把完善欲转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "自我校准",
+                  "role": "career_orientation",
+                  "definition": "「自我校准」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合自我校准的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖自我校准，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合自我校准”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -1172,7 +1660,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "反思",
+                  "role": "inner_processing",
+                  "definition": "反思会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让反思只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "迭代",
+                  "role": "growth_engine",
+                  "definition": "迭代会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把迭代和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "完善欲",
+                  "role": "self_regulation",
+                  "definition": "完善欲会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活完善欲，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "自我觉察",
+                  "role": "recovery_pattern",
+                  "definition": "自我觉察会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我觉察只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -1378,7 +1988,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "忠诚感",
+                  "role": "connection_style",
+                  "definition": "忠诚感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把忠诚感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "边界感",
+                  "role": "trust_pattern",
+                  "definition": "边界感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把边界感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "保留性",
+                  "role": "emotional_response",
+                  "definition": "保留性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别保留性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "敏感度",
+                  "role": "relational_tension",
+                  "definition": "敏感度会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别敏感度最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -1691,7 +2423,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "建模思维",
+                  "role": "career_lens",
+                  "definition": "「建模思维」意味着你在职业场景中会优先从模型、原理与逻辑自洽这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用建模思维对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果建模思维被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让建模思维发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "抽象感",
+                  "role": "working_method",
+                  "definition": "「抽象感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕抽象感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果抽象感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免抽象感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "求真欲",
+                  "role": "inner_drive",
+                  "definition": "「求真欲」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对求真欲相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果求真欲被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现求真欲？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把求真欲转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "灵活性",
+                  "role": "career_orientation",
+                  "definition": "「灵活性」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合灵活性的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖灵活性，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合灵活性”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -1897,7 +2751,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "好奇心",
+                  "role": "inner_processing",
+                  "definition": "好奇心会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把好奇心和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "学习力",
+                  "role": "growth_engine",
+                  "definition": "学习力会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把学习力和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "弹性",
+                  "role": "self_regulation",
+                  "definition": "弹性会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活弹性，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "独处力",
+                  "role": "recovery_pattern",
+                  "definition": "独处力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活独处力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -2103,7 +3079,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "真实感",
+                  "role": "connection_style",
+                  "definition": "真实感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别真实感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "空间感",
+                  "role": "trust_pattern",
+                  "definition": "空间感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把空间感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "好奇心",
+                  "role": "emotional_response",
+                  "definition": "好奇心会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别好奇心最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "松弛感",
+                  "role": "relational_tension",
+                  "definition": "松弛感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把松弛感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -2416,7 +3514,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "建模思维",
+                  "role": "career_lens",
+                  "definition": "「建模思维」意味着你在职业场景中会优先从模型、原理与逻辑自洽这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用建模思维对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果建模思维被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让建模思维发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "抽象感",
+                  "role": "working_method",
+                  "definition": "「抽象感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕抽象感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果抽象感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免抽象感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "质疑精神",
+                  "role": "inner_drive",
+                  "definition": "「质疑精神」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对质疑精神相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果质疑精神被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现质疑精神？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把质疑精神转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "游离感",
+                  "role": "career_orientation",
+                  "definition": "「游离感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合游离感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖游离感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合游离感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -2622,7 +3842,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "好奇心",
+                  "role": "inner_processing",
+                  "definition": "好奇心会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把好奇心和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "学习力",
+                  "role": "growth_engine",
+                  "definition": "学习力会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把学习力和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "自我追问",
+                  "role": "self_regulation",
+                  "definition": "自我追问会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我追问只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "观察力",
+                  "role": "recovery_pattern",
+                  "definition": "观察力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活观察力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -2828,7 +4170,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "真实感",
+                  "role": "connection_style",
+                  "definition": "真实感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别真实感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "空间感",
+                  "role": "trust_pattern",
+                  "definition": "空间感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把空间感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "迟疑感",
+                  "role": "emotional_response",
+                  "definition": "迟疑感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别迟疑感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "抽离感",
+                  "role": "relational_tension",
+                  "definition": "抽离感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别抽离感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -3141,7 +4605,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "决断性",
+                  "role": "career_lens",
+                  "definition": "「决断性」意味着你在职业场景中会优先从决策、统筹与结果推进这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用决断性对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果决断性被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让决断性发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "统筹感",
+                  "role": "working_method",
+                  "definition": "「统筹感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕统筹感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果统筹感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免统筹感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "抱负",
+                  "role": "inner_drive",
+                  "definition": "「抱负」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对抱负相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果抱负被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现抱负？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把抱负转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "领导欲",
+                  "role": "career_orientation",
+                  "definition": "「领导欲」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合领导欲的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖领导欲，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合领导欲”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -3347,7 +4933,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "进取心",
+                  "role": "inner_processing",
+                  "definition": "进取心会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活进取心，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "节奏感",
+                  "role": "growth_engine",
+                  "definition": "节奏感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把节奏感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "授权意识",
+                  "role": "self_regulation",
+                  "definition": "授权意识会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活授权意识，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "恢复力",
+                  "role": "recovery_pattern",
+                  "definition": "恢复力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把恢复力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -3553,7 +5261,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "直接性",
+                  "role": "connection_style",
+                  "definition": "直接性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别直接性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "担当感",
+                  "role": "trust_pattern",
+                  "definition": "担当感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别担当感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "标准感",
+                  "role": "emotional_response",
+                  "definition": "标准感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别标准感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "承诺感",
+                  "role": "relational_tension",
+                  "definition": "承诺感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把承诺感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -3866,7 +5696,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "决断性",
+                  "role": "career_lens",
+                  "definition": "「决断性」意味着你在职业场景中会优先从决策、统筹与结果推进这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用决断性对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果决断性被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让决断性发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "统筹感",
+                  "role": "working_method",
+                  "definition": "「统筹感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕统筹感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果统筹感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免统筹感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "完善欲",
+                  "role": "inner_drive",
+                  "definition": "「完善欲」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对完善欲相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果完善欲被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现完善欲？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把完善欲转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "紧迫感",
+                  "role": "career_orientation",
+                  "definition": "「紧迫感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合紧迫感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖紧迫感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合紧迫感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -4072,7 +6024,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "进取心",
+                  "role": "inner_processing",
+                  "definition": "进取心会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活进取心，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "节奏感",
+                  "role": "growth_engine",
+                  "definition": "节奏感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把节奏感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "自我校正",
+                  "role": "self_regulation",
+                  "definition": "自我校正会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我校正只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "韧性",
+                  "role": "recovery_pattern",
+                  "definition": "韧性会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活韧性，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -4278,7 +6352,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "直接性",
+                  "role": "connection_style",
+                  "definition": "直接性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别直接性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "高标准",
+                  "role": "trust_pattern",
+                  "definition": "高标准会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别高标准最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "压强感",
+                  "role": "emotional_response",
+                  "definition": "压强感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别压强感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "调节力",
+                  "role": "relational_tension",
+                  "definition": "调节力会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别调节力最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -4591,7 +6787,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "重构欲",
+                  "role": "career_lens",
+                  "definition": "「重构欲」意味着你在职业场景中会优先从重构旧解法与试验新路径这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用重构欲对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果重构欲被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让重构欲发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "试探精神",
+                  "role": "working_method",
+                  "definition": "「试探精神」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕试探精神去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果试探精神过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免试探精神变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "说服力",
+                  "role": "inner_drive",
+                  "definition": "「说服力」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对说服力相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果说服力被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现说服力？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把说服力转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "机变性",
+                  "role": "career_orientation",
+                  "definition": "「机变性」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合机变性的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖机变性，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合机变性”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -4797,7 +7115,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "发散力",
+                  "role": "inner_processing",
+                  "definition": "发散力会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把发散力和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "筛选力",
+                  "role": "growth_engine",
+                  "definition": "筛选力会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把筛选力和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "机变性",
+                  "role": "self_regulation",
+                  "definition": "机变性会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活机变性，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "收束力",
+                  "role": "recovery_pattern",
+                  "definition": "收束力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把收束力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -5003,7 +7443,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "新鲜感",
+                  "role": "connection_style",
+                  "definition": "新鲜感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别新鲜感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "讨论欲",
+                  "role": "trust_pattern",
+                  "definition": "讨论欲会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别讨论欲最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "机智感",
+                  "role": "emotional_response",
+                  "definition": "机智感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别机智感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "弹性",
+                  "role": "relational_tension",
+                  "definition": "弹性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别弹性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -5316,7 +7878,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "重构欲",
+                  "role": "career_lens",
+                  "definition": "「重构欲」意味着你在职业场景中会优先从重构旧解法与试验新路径这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用重构欲对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果重构欲被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让重构欲发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "试探精神",
+                  "role": "working_method",
+                  "definition": "「试探精神」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕试探精神去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果试探精神过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免试探精神变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "质疑精神",
+                  "role": "inner_drive",
+                  "definition": "「质疑精神」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对质疑精神相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果质疑精神被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现质疑精神？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把质疑精神转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "跳脱感",
+                  "role": "career_orientation",
+                  "definition": "「跳脱感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合跳脱感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖跳脱感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合跳脱感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -5522,7 +8206,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "发散力",
+                  "role": "inner_processing",
+                  "definition": "发散力会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把发散力和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "筛选力",
+                  "role": "growth_engine",
+                  "definition": "筛选力会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把筛选力和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "自我追问",
+                  "role": "self_regulation",
+                  "definition": "自我追问会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我追问只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "适应力",
+                  "role": "recovery_pattern",
+                  "definition": "适应力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活适应力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -5728,7 +8534,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "新鲜感",
+                  "role": "connection_style",
+                  "definition": "新鲜感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别新鲜感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "讨论欲",
+                  "role": "trust_pattern",
+                  "definition": "讨论欲会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别讨论欲最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "摇摆感",
+                  "role": "emotional_response",
+                  "definition": "摇摆感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别摇摆感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "抽离感",
+                  "role": "relational_tension",
+                  "definition": "抽离感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别抽离感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -6041,7 +8969,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "洞察力",
+                  "role": "career_lens",
+                  "definition": "「洞察力」意味着你在职业场景中会优先从洞察人心、意义与长期方向这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用洞察力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果洞察力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让洞察力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "使命感",
+                  "role": "working_method",
+                  "definition": "「使命感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕使命感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果使命感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免使命感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "共情力",
+                  "role": "inner_drive",
+                  "definition": "「共情力」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对共情力相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果共情力被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现共情力？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把共情力转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "愿景感",
+                  "role": "career_orientation",
+                  "definition": "「愿景感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合愿景感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖愿景感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合愿景感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -6247,7 +9297,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "反思",
+                  "role": "inner_processing",
+                  "definition": "反思会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让反思只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "韧性",
+                  "role": "growth_engine",
+                  "definition": "韧性会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活韧性，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "边界感",
+                  "role": "self_regulation",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "整合力",
+                  "role": "recovery_pattern",
+                  "definition": "整合力会推动你持续吸收新经验、重组旧认知，让成长更像一次次升级而不是原地重复。",
+                  "why_it_matters": "它决定了你会不会主动拉开认知差距，把一次经历变成更长期的成长资本。",
+                  "growth_expression": "在成长场景里，它常表现为你愿意主动学习、尝试新方法，并把分散经验重新整理成自己的路径。",
+                  "growth_advantage": "这会提升你的成长速度和延展性，让你不容易被单一路径或旧方法困住。",
+                  "overuse_risk": "如果它失衡，可能会让你不断开新方向、追新方法，却迟迟难以沉淀真正稳定的成果。",
+                  "real_world_signal": "只要碰到新问题或新机会，你就很容易冒出“我还想再学一点、再试一下”的冲动。",
+                  "upgrade_hint": "把整合力和阶段目标绑定使用，每次只推进一两件最值得升级的事，别同时拉太多支线。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -6453,7 +9625,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "真诚感",
+                  "role": "connection_style",
+                  "definition": "真诚感会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让真诚感不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "忠诚感",
+                  "role": "trust_pattern",
+                  "definition": "忠诚感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把忠诚感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "深度感",
+                  "role": "emotional_response",
+                  "definition": "深度感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别深度感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "体察力",
+                  "role": "relational_tension",
+                  "definition": "体察力会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让体察力不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -6766,7 +10060,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "洞察力",
+                  "role": "career_lens",
+                  "definition": "「洞察力」意味着你在职业场景中会优先从洞察人心、意义与长期方向这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用洞察力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果洞察力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让洞察力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "使命感",
+                  "role": "working_method",
+                  "definition": "「使命感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕使命感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果使命感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免使命感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "理想主义",
+                  "role": "inner_drive",
+                  "definition": "「理想主义」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对理想主义相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果理想主义被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现理想主义？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把理想主义转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "自我要求",
+                  "role": "career_orientation",
+                  "definition": "「自我要求」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合自我要求的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖自我要求，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合自我要求”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -6972,7 +10388,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "反思",
+                  "role": "inner_processing",
+                  "definition": "反思会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让反思只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "理想感",
+                  "role": "growth_engine",
+                  "definition": "理想感会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活理想感，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "自我觉察",
+                  "role": "self_regulation",
+                  "definition": "自我觉察会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我觉察只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "边界感",
+                  "role": "recovery_pattern",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -7178,7 +10716,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "真诚感",
+                  "role": "connection_style",
+                  "definition": "真诚感会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让真诚感不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "忠诚感",
+                  "role": "trust_pattern",
+                  "definition": "忠诚感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把忠诚感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "高期待",
+                  "role": "emotional_response",
+                  "definition": "高期待会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别高期待最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "敏感度",
+                  "role": "relational_tension",
+                  "definition": "敏感度会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别敏感度最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -7491,7 +11151,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "价值感",
+                  "role": "career_lens",
+                  "definition": "「价值感」意味着你在职业场景中会优先从价值一致、表达与内在认同这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用价值感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果价值感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让价值感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "共感力",
+                  "role": "working_method",
+                  "definition": "「共感力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕共感力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果共感力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免共感力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "表达欲",
+                  "role": "inner_drive",
+                  "definition": "「表达欲」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对表达欲相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果表达欲被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现表达欲？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把表达欲转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "坚持度",
+                  "role": "career_orientation",
+                  "definition": "「坚持度」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合坚持度的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖坚持度，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合坚持度”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -7697,7 +11479,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "真诚",
+                  "role": "inner_processing",
+                  "definition": "真诚会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活真诚，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "感受力",
+                  "role": "growth_engine",
+                  "definition": "感受力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活感受力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "边界感",
+                  "role": "self_regulation",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "沉淀力",
+                  "role": "recovery_pattern",
+                  "definition": "沉淀力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活沉淀力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -7903,7 +11807,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "真实感",
+                  "role": "connection_style",
+                  "definition": "真实感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别真实感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "柔软度",
+                  "role": "trust_pattern",
+                  "definition": "柔软度会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别柔软度最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "深度感",
+                  "role": "emotional_response",
+                  "definition": "深度感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别深度感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "忠诚感",
+                  "role": "relational_tension",
+                  "definition": "忠诚感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把忠诚感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -8216,7 +12242,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "价值感",
+                  "role": "career_lens",
+                  "definition": "「价值感」意味着你在职业场景中会优先从价值一致、表达与内在认同这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用价值感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果价值感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让价值感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "共感力",
+                  "role": "working_method",
+                  "definition": "「共感力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕共感力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果共感力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免共感力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "理想主义",
+                  "role": "inner_drive",
+                  "definition": "「理想主义」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对理想主义相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果理想主义被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现理想主义？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把理想主义转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "敏感性",
+                  "role": "career_orientation",
+                  "definition": "「敏感性」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合敏感性的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖敏感性，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合敏感性”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -8422,7 +12570,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "真诚",
+                  "role": "inner_processing",
+                  "definition": "真诚会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活真诚，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "感受力",
+                  "role": "growth_engine",
+                  "definition": "感受力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活感受力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "理想感",
+                  "role": "self_regulation",
+                  "definition": "理想感会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活理想感，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "自我觉察",
+                  "role": "recovery_pattern",
+                  "definition": "自我觉察会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我觉察只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -8628,7 +12898,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "真实感",
+                  "role": "connection_style",
+                  "definition": "真实感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别真实感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "柔软度",
+                  "role": "trust_pattern",
+                  "definition": "柔软度会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别柔软度最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "易受伤感",
+                  "role": "emotional_response",
+                  "definition": "易受伤感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别易受伤感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "回避感",
+                  "role": "relational_tension",
+                  "definition": "回避感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别回避感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -8941,7 +13333,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "共识感",
+                  "role": "career_lens",
+                  "definition": "「共识感」意味着你在职业场景中会优先从凝聚共识、带动他人与推动成长这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用共识感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果共识感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让共识感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "反馈意识",
+                  "role": "working_method",
+                  "definition": "「反馈意识」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕反馈意识去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果反馈意识过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免反馈意识变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "带动力",
+                  "role": "inner_drive",
+                  "definition": "「带动力」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对带动力相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果带动力被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现带动力？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把带动力转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "愿景感",
+                  "role": "career_orientation",
+                  "definition": "「愿景感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合愿景感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖愿景感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合愿景感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -9147,7 +13661,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "承担感",
+                  "role": "inner_processing",
+                  "definition": "承担感会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活承担感，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "边界感",
+                  "role": "growth_engine",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "修复力",
+                  "role": "self_regulation",
+                  "definition": "修复力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活修复力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "调节力",
+                  "role": "recovery_pattern",
+                  "definition": "调节力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把调节力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -9353,7 +13989,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "照顾力",
+                  "role": "connection_style",
+                  "definition": "照顾力会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让照顾力不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "带动力",
+                  "role": "trust_pattern",
+                  "definition": "带动力会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别带动力最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "回应力",
+                  "role": "emotional_response",
+                  "definition": "回应力会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让回应力不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "承诺感",
+                  "role": "relational_tension",
+                  "definition": "承诺感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把承诺感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -9666,7 +14424,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "共识感",
+                  "role": "career_lens",
+                  "definition": "「共识感」意味着你在职业场景中会优先从凝聚共识、带动他人与推动成长这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用共识感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果共识感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让共识感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "反馈意识",
+                  "role": "working_method",
+                  "definition": "「反馈意识」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕反馈意识去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果反馈意识过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免反馈意识变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "责任感",
+                  "role": "inner_drive",
+                  "definition": "「责任感」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对责任感相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果责任感被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现责任感？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把责任感转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "自我消耗",
+                  "role": "career_orientation",
+                  "definition": "「自我消耗」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合自我消耗的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖自我消耗，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合自我消耗”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -9872,7 +14752,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "承担感",
+                  "role": "inner_processing",
+                  "definition": "承担感会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活承担感，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "边界感",
+                  "role": "growth_engine",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "自我觉察",
+                  "role": "self_regulation",
+                  "definition": "自我觉察会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我觉察只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "修复力",
+                  "role": "recovery_pattern",
+                  "definition": "修复力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活修复力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -10078,7 +15080,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "照顾力",
+                  "role": "connection_style",
+                  "definition": "照顾力会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让照顾力不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "带动力",
+                  "role": "trust_pattern",
+                  "definition": "带动力会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别带动力最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "期待感",
+                  "role": "emotional_response",
+                  "definition": "期待感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别期待感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "过度付出",
+                  "role": "relational_tension",
+                  "definition": "过度付出会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别过度付出最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -10391,7 +15515,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "创意感",
+                  "role": "career_lens",
+                  "definition": "「创意感」意味着你在职业场景中会优先从创意连接、探索可能与激发热情这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用创意感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果创意感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让创意感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "连接力",
+                  "role": "working_method",
+                  "definition": "「连接力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕连接力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果连接力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免连接力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "探索欲",
+                  "role": "inner_drive",
+                  "definition": "「探索欲」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对探索欲相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果探索欲被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现探索欲？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把探索欲转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "感染力",
+                  "role": "career_orientation",
+                  "definition": "「感染力」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合感染力的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖感染力，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合感染力”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -10597,7 +15843,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "热度",
+                  "role": "inner_processing",
+                  "definition": "热度会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活热度，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "取舍力",
+                  "role": "growth_engine",
+                  "definition": "取舍力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活取舍力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "回弹力",
+                  "role": "self_regulation",
+                  "definition": "回弹力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把回弹力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "节奏感",
+                  "role": "recovery_pattern",
+                  "definition": "节奏感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把节奏感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -10803,7 +16171,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "热情度",
+                  "role": "connection_style",
+                  "definition": "热情度会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让热情度不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "真诚感",
+                  "role": "trust_pattern",
+                  "definition": "真诚感会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让真诚感不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "共鸣力",
+                  "role": "emotional_response",
+                  "definition": "共鸣力会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让共鸣力不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "自由感",
+                  "role": "relational_tension",
+                  "definition": "自由感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把自由感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -11116,7 +16606,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "创意感",
+                  "role": "career_lens",
+                  "definition": "「创意感」意味着你在职业场景中会优先从创意连接、探索可能与激发热情这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用创意感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果创意感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让创意感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "连接力",
+                  "role": "working_method",
+                  "definition": "「连接力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕连接力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果连接力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免连接力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "发散性",
+                  "role": "inner_drive",
+                  "definition": "「发散性」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对发散性相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果发散性被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现发散性？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把发散性转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "游移感",
+                  "role": "career_orientation",
+                  "definition": "「游移感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合游移感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖游移感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合游移感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -11322,7 +16934,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "热度",
+                  "role": "inner_processing",
+                  "definition": "热度会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活热度，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "取舍力",
+                  "role": "growth_engine",
+                  "definition": "取舍力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活取舍力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "自我追问",
+                  "role": "self_regulation",
+                  "definition": "自我追问会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我追问只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "节奏感",
+                  "role": "recovery_pattern",
+                  "definition": "节奏感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把节奏感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -11528,7 +17262,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "热情度",
+                  "role": "connection_style",
+                  "definition": "热情度会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让热情度不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "真诚感",
+                  "role": "trust_pattern",
+                  "definition": "真诚感会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让真诚感不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "理想化",
+                  "role": "emotional_response",
+                  "definition": "理想化会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别理想化最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "逃避感",
+                  "role": "relational_tension",
+                  "definition": "逃避感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别逃避感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -11841,7 +17697,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "流程意识",
+                  "role": "career_lens",
+                  "definition": "「流程意识」意味着你在职业场景中会优先从流程、责任与可靠交付这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用流程意识对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果流程意识被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让流程意识发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "责任感",
+                  "role": "working_method",
+                  "definition": "「责任感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕责任感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果责任感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免责任感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "细节感",
+                  "role": "inner_drive",
+                  "definition": "「细节感」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对细节感相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果细节感被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现细节感？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把细节感转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "闭环意识",
+                  "role": "career_orientation",
+                  "definition": "「闭环意识」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合闭环意识的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖闭环意识，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合闭环意识”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -12047,7 +18025,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "稳定性",
+                  "role": "inner_processing",
+                  "definition": "稳定性会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把稳定性写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "复盘力",
+                  "role": "growth_engine",
+                  "definition": "复盘力会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让复盘力只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "弹性",
+                  "role": "self_regulation",
+                  "definition": "弹性会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活弹性，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "恢复力",
+                  "role": "recovery_pattern",
+                  "definition": "恢复力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把恢复力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -12253,7 +18353,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "可靠感",
+                  "role": "connection_style",
+                  "definition": "可靠感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把可靠感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "边界感",
+                  "role": "trust_pattern",
+                  "definition": "边界感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把边界感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "责任感",
+                  "role": "emotional_response",
+                  "definition": "责任感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把责任感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "稳定性",
+                  "role": "relational_tension",
+                  "definition": "稳定性会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把稳定性转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -12566,7 +18788,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "流程意识",
+                  "role": "career_lens",
+                  "definition": "「流程意识」意味着你在职业场景中会优先从流程、责任与可靠交付这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用流程意识对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果流程意识被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让流程意识发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "责任感",
+                  "role": "working_method",
+                  "definition": "「责任感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕责任感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果责任感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免责任感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "谨慎度",
+                  "role": "inner_drive",
+                  "definition": "「谨慎度」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对谨慎度相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果谨慎度被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现谨慎度？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把谨慎度转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "自压感",
+                  "role": "career_orientation",
+                  "definition": "「自压感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合自压感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖自压感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合自压感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -12772,7 +19116,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "稳定性",
+                  "role": "inner_processing",
+                  "definition": "稳定性会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把稳定性写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "复盘力",
+                  "role": "growth_engine",
+                  "definition": "复盘力会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让复盘力只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "谨慎度",
+                  "role": "self_regulation",
+                  "definition": "谨慎度会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活谨慎度，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "自我调节",
+                  "role": "recovery_pattern",
+                  "definition": "自我调节会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把自我调节写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -12978,7 +19444,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "可靠感",
+                  "role": "connection_style",
+                  "definition": "可靠感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把可靠感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "边界感",
+                  "role": "trust_pattern",
+                  "definition": "边界感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把边界感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "压抑感",
+                  "role": "emotional_response",
+                  "definition": "压抑感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别压抑感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "挑剔性",
+                  "role": "relational_tension",
+                  "definition": "挑剔性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别挑剔性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -13291,7 +19879,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "照看力",
+                  "role": "career_lens",
+                  "definition": "「照看力」意味着你在职业场景中会优先从稳定支持、照看细节与长期配合这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用照看力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果照看力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让照看力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "稳定感",
+                  "role": "working_method",
+                  "definition": "「稳定感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕稳定感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果稳定感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免稳定感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "责任感",
+                  "role": "inner_drive",
+                  "definition": "「责任感」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对责任感相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果责任感被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现责任感？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把责任感转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "耐心",
+                  "role": "career_orientation",
+                  "definition": "「耐心」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合耐心的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖耐心，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合耐心”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -13497,7 +20207,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "照顾力",
+                  "role": "inner_processing",
+                  "definition": "照顾力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活照顾力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "边界感",
+                  "role": "growth_engine",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "恢复力",
+                  "role": "self_regulation",
+                  "definition": "恢复力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把恢复力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "稳定性",
+                  "role": "recovery_pattern",
+                  "definition": "稳定性会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把稳定性写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -13703,7 +20535,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "细致感",
+                  "role": "connection_style",
+                  "definition": "细致感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别细致感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "稳定感",
+                  "role": "trust_pattern",
+                  "definition": "稳定感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把稳定感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "照顾力",
+                  "role": "emotional_response",
+                  "definition": "照顾力会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让照顾力不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "忠诚感",
+                  "role": "relational_tension",
+                  "definition": "忠诚感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把忠诚感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -14016,7 +20970,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "照看力",
+                  "role": "career_lens",
+                  "definition": "「照看力」意味着你在职业场景中会优先从稳定支持、照看细节与长期配合这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用照看力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果照看力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让照看力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "稳定感",
+                  "role": "working_method",
+                  "definition": "「稳定感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕稳定感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果稳定感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免稳定感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "顾虑感",
+                  "role": "inner_drive",
+                  "definition": "「顾虑感」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对顾虑感相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果顾虑感被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现顾虑感？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把顾虑感转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "过度承担",
+                  "role": "career_orientation",
+                  "definition": "「过度承担」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合过度承担的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖过度承担，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合过度承担”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -14222,7 +21298,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "照顾力",
+                  "role": "inner_processing",
+                  "definition": "照顾力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活照顾力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "边界感",
+                  "role": "growth_engine",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "自我觉察",
+                  "role": "self_regulation",
+                  "definition": "自我觉察会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我觉察只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "稳定性",
+                  "role": "recovery_pattern",
+                  "definition": "稳定性会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把稳定性写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -14428,7 +21626,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "细致感",
+                  "role": "connection_style",
+                  "definition": "细致感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别细致感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "稳定感",
+                  "role": "trust_pattern",
+                  "definition": "稳定感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把稳定感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "讨好倾向",
+                  "role": "emotional_response",
+                  "definition": "讨好倾向会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别讨好倾向最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "敏感度",
+                  "role": "relational_tension",
+                  "definition": "敏感度会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别敏感度最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -14741,7 +22061,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "执行力",
+                  "role": "career_lens",
+                  "definition": "「执行力」意味着你在职业场景中会优先从执行、标准与组织推进这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用执行力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果执行力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让执行力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "标准意识",
+                  "role": "working_method",
+                  "definition": "「标准意识」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕标准意识去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果标准意识过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免标准意识变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "统筹感",
+                  "role": "inner_drive",
+                  "definition": "「统筹感」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对统筹感相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果统筹感被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现统筹感？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把统筹感转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "推进力",
+                  "role": "career_orientation",
+                  "definition": "「推进力」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合推进力的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖推进力，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合推进力”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -14947,7 +22389,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "标准意识",
+                  "role": "inner_processing",
+                  "definition": "标准意识会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活标准意识，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "承接力",
+                  "role": "growth_engine",
+                  "definition": "承接力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活承接力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "调配力",
+                  "role": "self_regulation",
+                  "definition": "调配力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活调配力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "恢复力",
+                  "role": "recovery_pattern",
+                  "definition": "恢复力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把恢复力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -15153,7 +22717,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "可靠感",
+                  "role": "connection_style",
+                  "definition": "可靠感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把可靠感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "直接性",
+                  "role": "trust_pattern",
+                  "definition": "直接性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别直接性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "责任感",
+                  "role": "emotional_response",
+                  "definition": "责任感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把责任感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "主导感",
+                  "role": "relational_tension",
+                  "definition": "主导感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别主导感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -15466,7 +23152,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "执行力",
+                  "role": "career_lens",
+                  "definition": "「执行力」意味着你在职业场景中会优先从执行、标准与组织推进这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用执行力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果执行力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让执行力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "标准意识",
+                  "role": "working_method",
+                  "definition": "「标准意识」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕标准意识去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果标准意识过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免标准意识变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "掌控欲",
+                  "role": "inner_drive",
+                  "definition": "「掌控欲」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对掌控欲相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果掌控欲被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现掌控欲？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把掌控欲转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "压强感",
+                  "role": "career_orientation",
+                  "definition": "「压强感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合压强感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖压强感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合压强感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -15672,7 +23480,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "标准意识",
+                  "role": "inner_processing",
+                  "definition": "标准意识会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活标准意识，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "承接力",
+                  "role": "growth_engine",
+                  "definition": "承接力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活承接力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "自我校正",
+                  "role": "self_regulation",
+                  "definition": "自我校正会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我校正只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "警觉性",
+                  "role": "recovery_pattern",
+                  "definition": "警觉性会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活警觉性，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -15878,7 +23808,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "可靠感",
+                  "role": "connection_style",
+                  "definition": "可靠感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把可靠感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "直接性",
+                  "role": "trust_pattern",
+                  "definition": "直接性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别直接性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "控制欲",
+                  "role": "emotional_response",
+                  "definition": "控制欲会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别控制欲最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "不耐感",
+                  "role": "relational_tension",
+                  "definition": "不耐感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别不耐感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -16191,7 +24243,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "组织感",
+                  "role": "career_lens",
+                  "definition": "「组织感」意味着你在职业场景中会优先从组织协同、照顾关系与稳定落地这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用组织感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果组织感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让组织感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "照顾力",
+                  "role": "working_method",
+                  "definition": "「照顾力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕照顾力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果照顾力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免照顾力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "执行力",
+                  "role": "inner_drive",
+                  "definition": "「执行力」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对执行力相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果执行力被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现执行力？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把执行力转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "协调意识",
+                  "role": "career_orientation",
+                  "definition": "「协调意识」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合协调意识的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖协调意识，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合协调意识”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -16397,7 +24571,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "照顾力",
+                  "role": "inner_processing",
+                  "definition": "照顾力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活照顾力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "取舍力",
+                  "role": "growth_engine",
+                  "definition": "取舍力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活取舍力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "边界感",
+                  "role": "self_regulation",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "恢复力",
+                  "role": "recovery_pattern",
+                  "definition": "恢复力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把恢复力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -16603,7 +24899,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "回应力",
+                  "role": "connection_style",
+                  "definition": "回应力会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让回应力不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "陪伴感",
+                  "role": "trust_pattern",
+                  "definition": "陪伴感会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让陪伴感不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "安排力",
+                  "role": "emotional_response",
+                  "definition": "安排力会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别安排力最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "承诺感",
+                  "role": "relational_tension",
+                  "definition": "承诺感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把承诺感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -16916,7 +25334,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "组织感",
+                  "role": "career_lens",
+                  "definition": "「组织感」意味着你在职业场景中会优先从组织协同、照顾关系与稳定落地这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用组织感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果组织感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让组织感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "照顾力",
+                  "role": "working_method",
+                  "definition": "「照顾力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕照顾力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果照顾力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免照顾力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "迎合倾向",
+                  "role": "inner_drive",
+                  "definition": "「迎合倾向」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对迎合倾向相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果迎合倾向被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现迎合倾向？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把迎合倾向转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "过度负责",
+                  "role": "career_orientation",
+                  "definition": "「过度负责」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合过度负责的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖过度负责，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合过度负责”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -17122,7 +25662,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "照顾力",
+                  "role": "inner_processing",
+                  "definition": "照顾力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活照顾力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "取舍力",
+                  "role": "growth_engine",
+                  "definition": "取舍力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活取舍力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "自我觉察",
+                  "role": "self_regulation",
+                  "definition": "自我觉察会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我觉察只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "敏感度",
+                  "role": "recovery_pattern",
+                  "definition": "敏感度会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活敏感度，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -17328,7 +25990,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "回应力",
+                  "role": "connection_style",
+                  "definition": "回应力会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让回应力不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "陪伴感",
+                  "role": "trust_pattern",
+                  "definition": "陪伴感会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让陪伴感不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "讨好倾向",
+                  "role": "emotional_response",
+                  "definition": "讨好倾向会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别讨好倾向最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "高期待",
+                  "role": "relational_tension",
+                  "definition": "高期待会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别高期待最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -17641,7 +26425,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "排障力",
+                  "role": "career_lens",
+                  "definition": "「排障力」意味着你在职业场景中会优先从排障、工具与独立处理问题这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用排障力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果排障力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让排障力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "工具感",
+                  "role": "working_method",
+                  "definition": "「工具感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕工具感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果工具感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免工具感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "冷静度",
+                  "role": "inner_drive",
+                  "definition": "「冷静度」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对冷静度相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果冷静度被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现冷静度？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把冷静度转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "独立性",
+                  "role": "career_orientation",
+                  "definition": "「独立性」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合独立性的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖独立性，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合独立性”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -17847,7 +26753,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "复盘力",
+                  "role": "inner_processing",
+                  "definition": "复盘力会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让复盘力只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "节奏感",
+                  "role": "growth_engine",
+                  "definition": "节奏感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把节奏感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "空间感",
+                  "role": "self_regulation",
+                  "definition": "空间感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把空间感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "收束力",
+                  "role": "recovery_pattern",
+                  "definition": "收束力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把收束力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -18053,7 +27081,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "自在感",
+                  "role": "connection_style",
+                  "definition": "自在感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把自在感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "现实感",
+                  "role": "trust_pattern",
+                  "definition": "现实感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别现实感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "边界感",
+                  "role": "emotional_response",
+                  "definition": "边界感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把边界感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "可靠感",
+                  "role": "relational_tension",
+                  "definition": "可靠感会影响你如何建立长期信任，以及你在关系里会把多大的责任和投入视作理所当然。",
+                  "why_it_matters": "它决定了你在关系里更看重什么，也解释了你为什么会对承诺、一致性和可靠性如此敏感。",
+                  "relationship_expression": "在现实里，它会表现为你更看重说到做到、长期在场、责任承担，以及关系是否值得长期投入。",
+                  "relationship_advantage": "这会让你在关系里更容易成为可靠、可依赖、值得托付的人，也更容易建立深信任。",
+                  "overuse_risk": "如果它失衡，你可能会在不值得的关系里撑太久，或者把责任和期待都压得过重。",
+                  "real_world_signal": "你会下意识留意：这个人是否稳定、是否说到做到、是否值得我把更多心力放进去。",
+                  "upgrade_hint": "把可靠感转成可沟通的标准，而不是默默期待别人自己懂你的在意点。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -18366,7 +27516,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "排障力",
+                  "role": "career_lens",
+                  "definition": "「排障力」意味着你在职业场景中会优先从排障、工具与独立处理问题这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用排障力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果排障力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让排障力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "工具感",
+                  "role": "working_method",
+                  "definition": "「工具感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕工具感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果工具感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免工具感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "抽离感",
+                  "role": "inner_drive",
+                  "definition": "「抽离感」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对抽离感相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果抽离感被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现抽离感？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把抽离感转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "低耐心",
+                  "role": "career_orientation",
+                  "definition": "「低耐心」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合低耐心的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖低耐心，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合低耐心”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -18572,7 +27844,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "复盘力",
+                  "role": "inner_processing",
+                  "definition": "复盘力会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让复盘力只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "节奏感",
+                  "role": "growth_engine",
+                  "definition": "节奏感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把节奏感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "警觉性",
+                  "role": "self_regulation",
+                  "definition": "警觉性会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活警觉性，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "收束力",
+                  "role": "recovery_pattern",
+                  "definition": "收束力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把收束力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -18778,7 +28172,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "自在感",
+                  "role": "connection_style",
+                  "definition": "自在感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把自在感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "现实感",
+                  "role": "trust_pattern",
+                  "definition": "现实感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别现实感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "疏离感",
+                  "role": "emotional_response",
+                  "definition": "疏离感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别疏离感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "防御性",
+                  "role": "relational_tension",
+                  "definition": "防御性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别防御性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -19091,7 +28607,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "审美感",
+                  "role": "career_lens",
+                  "definition": "「审美感」意味着你在职业场景中会优先从审美体验、细腻打磨与真诚表达这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用审美感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果审美感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让审美感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "体验感",
+                  "role": "working_method",
+                  "definition": "「体验感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕体验感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果体验感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免体验感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "打磨欲",
+                  "role": "inner_drive",
+                  "definition": "「打磨欲」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对打磨欲相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果打磨欲被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现打磨欲？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把打磨欲转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "真诚性",
+                  "role": "career_orientation",
+                  "definition": "「真诚性」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合真诚性的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖真诚性，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合真诚性”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -19297,7 +28935,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "感受力",
+                  "role": "inner_processing",
+                  "definition": "感受力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活感受力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "边界感",
+                  "role": "growth_engine",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "节奏感",
+                  "role": "self_regulation",
+                  "definition": "节奏感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把节奏感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "恢复力",
+                  "role": "recovery_pattern",
+                  "definition": "恢复力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把恢复力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -19503,7 +29263,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "温柔度",
+                  "role": "connection_style",
+                  "definition": "温柔度会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让温柔度不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "真实感",
+                  "role": "trust_pattern",
+                  "definition": "真实感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别真实感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "感受力",
+                  "role": "emotional_response",
+                  "definition": "感受力会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别感受力最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "陪伴感",
+                  "role": "relational_tension",
+                  "definition": "陪伴感会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让陪伴感不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -19816,7 +29698,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "审美感",
+                  "role": "career_lens",
+                  "definition": "「审美感」意味着你在职业场景中会优先从审美体验、细腻打磨与真诚表达这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用审美感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果审美感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让审美感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "体验感",
+                  "role": "working_method",
+                  "definition": "「体验感」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕体验感去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果体验感过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免体验感变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "敏感性",
+                  "role": "inner_drive",
+                  "definition": "「敏感性」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对敏感性相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果敏感性被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现敏感性？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把敏感性转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "犹疑感",
+                  "role": "career_orientation",
+                  "definition": "「犹疑感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合犹疑感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖犹疑感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合犹疑感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -20022,7 +30026,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "感受力",
+                  "role": "inner_processing",
+                  "definition": "感受力会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活感受力，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "边界感",
+                  "role": "growth_engine",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "敏感度",
+                  "role": "self_regulation",
+                  "definition": "敏感度会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活敏感度，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "自我觉察",
+                  "role": "recovery_pattern",
+                  "definition": "自我觉察会让你在成长中不断回看自己、修正方法，并从经历里提炼更成熟的判断。",
+                  "why_it_matters": "它决定了你在面对波动和失误时，是停在自责里，还是能逐渐把经历转成更清楚的自我理解。",
+                  "growth_expression": "在现实里，你会更容易在阶段结束后回头看：哪里做对了，哪里偏了，下一次怎样才能更稳。",
+                  "growth_advantage": "这会让你比很多人更早发现自己的偏差和盲区，也更容易在成长中持续变得成熟。",
+                  "overuse_risk": "如果它失衡，容易让你反复盯着自己哪里还不够好，久而久之削弱行动感和满意度。",
+                  "real_world_signal": "事情刚结束，你就会本能地想：这次我真正学到了什么？下次哪里还可以再调一调？",
+                  "upgrade_hint": "给复盘设一个停点，把结论写成下一步动作，不要让自我觉察只停留在反复琢磨。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -20228,7 +30354,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "温柔度",
+                  "role": "connection_style",
+                  "definition": "温柔度会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让温柔度不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "真实感",
+                  "role": "trust_pattern",
+                  "definition": "真实感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别真实感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "易受伤感",
+                  "role": "emotional_response",
+                  "definition": "易受伤感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别易受伤感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "退避感",
+                  "role": "relational_tension",
+                  "definition": "退避感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别退避感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -20541,7 +30789,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "行动力",
+                  "role": "career_lens",
+                  "definition": "「行动力」意味着你在职业场景中会优先从行动、应变与现场拿结果这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用行动力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果行动力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让行动力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "应变力",
+                  "role": "working_method",
+                  "definition": "「应变力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕应变力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果应变力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免应变力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "谈判力",
+                  "role": "inner_drive",
+                  "definition": "「谈判力」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对谈判力相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果谈判力被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现谈判力？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把谈判力转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "结果导向",
+                  "role": "career_orientation",
+                  "definition": "「结果导向」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合结果导向的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖结果导向，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合结果导向”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -20747,7 +31117,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "机会感",
+                  "role": "inner_processing",
+                  "definition": "机会感会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活机会感，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "止损力",
+                  "role": "growth_engine",
+                  "definition": "止损力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把止损力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "回弹力",
+                  "role": "self_regulation",
+                  "definition": "回弹力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把回弹力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "节奏感",
+                  "role": "recovery_pattern",
+                  "definition": "节奏感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把节奏感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -20953,7 +31445,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "直接性",
+                  "role": "connection_style",
+                  "definition": "直接性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别直接性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "行动力",
+                  "role": "trust_pattern",
+                  "definition": "行动力会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别行动力最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "活力感",
+                  "role": "emotional_response",
+                  "definition": "活力感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别活力感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "松弛感",
+                  "role": "relational_tension",
+                  "definition": "松弛感会影响你在亲近与自我之间如何拿捏分寸，让关系既有连接也保留呼吸感。",
+                  "why_it_matters": "它决定了你在关系中能否既不失去自己，也不因为过度防御而错失真正的亲近。",
+                  "relationship_expression": "在现实里，它会表现为你是否需要空间、怎样表达边界，以及你会不会把亲近误当作无条件融合。",
+                  "relationship_advantage": "这会帮助你把关系经营得更轻盈、更稳，也更不容易在亲近里丢掉自己。",
+                  "overuse_risk": "如果它失衡，你可能会要么过度黏连，要么过度退开，让关系很难维持稳定节奏。",
+                  "real_world_signal": "你会很在意这段关系是否既亲近又舒服，还是正在一步步挤压你的空间和节奏。",
+                  "upgrade_hint": "把松弛感说出来，不要总是靠沉默、消失或强撑去维持关系平衡。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -21266,7 +31880,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "行动力",
+                  "role": "career_lens",
+                  "definition": "「行动力」意味着你在职业场景中会优先从行动、应变与现场拿结果这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用行动力对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果行动力被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让行动力发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "应变力",
+                  "role": "working_method",
+                  "definition": "「应变力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕应变力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果应变力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免应变力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "冒险性",
+                  "role": "inner_drive",
+                  "definition": "「冒险性」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对冒险性相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果冒险性被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现冒险性？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把冒险性转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "刺激感",
+                  "role": "career_orientation",
+                  "definition": "「刺激感」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合刺激感的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖刺激感，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合刺激感”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -21472,7 +32208,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "机会感",
+                  "role": "inner_processing",
+                  "definition": "机会感会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活机会感，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "止损力",
+                  "role": "growth_engine",
+                  "definition": "止损力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把止损力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "警觉性",
+                  "role": "self_regulation",
+                  "definition": "警觉性会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活警觉性，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "回弹力",
+                  "role": "recovery_pattern",
+                  "definition": "回弹力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把回弹力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -21678,7 +32536,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "直接性",
+                  "role": "connection_style",
+                  "definition": "直接性会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别直接性最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "行动力",
+                  "role": "trust_pattern",
+                  "definition": "行动力会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别行动力最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "不耐感",
+                  "role": "emotional_response",
+                  "definition": "不耐感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别不耐感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "抽离感",
+                  "role": "relational_tension",
+                  "definition": "抽离感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别抽离感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -21991,7 +32971,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "带动感",
+                  "role": "career_lens",
+                  "definition": "「带动感」意味着你在职业场景中会优先从带动氛围、回应关系与创造体验这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用带动感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果带动感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让带动感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "回应力",
+                  "role": "working_method",
+                  "definition": "「回应力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕回应力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果回应力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免回应力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "关系感",
+                  "role": "inner_drive",
+                  "definition": "「关系感」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对关系感相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果关系感被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现关系感？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把关系感转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "体验欲",
+                  "role": "career_orientation",
+                  "definition": "「体验欲」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合体验欲的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖体验欲，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合体验欲”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -22197,7 +33299,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "热度",
+                  "role": "inner_processing",
+                  "definition": "热度会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活热度，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "边界感",
+                  "role": "growth_engine",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "回弹力",
+                  "role": "self_regulation",
+                  "definition": "回弹力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把回弹力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "恢复力",
+                  "role": "recovery_pattern",
+                  "definition": "恢复力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把恢复力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -22403,7 +33627,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "陪伴感",
+                  "role": "connection_style",
+                  "definition": "陪伴感会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让陪伴感不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "热度",
+                  "role": "trust_pattern",
+                  "definition": "热度会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别热度最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "回应力",
+                  "role": "emotional_response",
+                  "definition": "回应力会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让回应力不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "亲近感",
+                  "role": "relational_tension",
+                  "definition": "亲近感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别亲近感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {
@@ -22716,7 +34062,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你职业判断、推进方式与成就感来源的关键因素。它们不是简单标签，而是在解释：你为什么会这样工作，以及你最容易在哪些地方赢、在哪些地方卡住。",
+              "items": [
+                {
+                  "id": "career_trait_1",
+                  "label": "带动感",
+                  "role": "career_lens",
+                  "definition": "「带动感」意味着你在职业场景中会优先从带动氛围、回应关系与创造体验这一侧理解问题，而不是先被表面事务带着走。",
+                  "why_it_matters": "它影响你面对复杂任务时最先抓取的核心变量，也决定你会先从哪里建立判断框架。",
+                  "career_expression": "在真实工作里，它通常表现为你会率先用带动感对应的视角提炼主线、判断轻重，并据此决定下一步怎么推进。",
+                  "career_advantage": "当岗位需要快速看清局面、明确方向或定义问题时，这会成为你很稳定的优势来源。",
+                  "overuse_risk": "如果带动感被用得过满，你可能会过早锁定判断，忽略那些暂时不显眼却同样关键的信息。",
+                  "real_world_signal": "你会本能地问：这件事真正的主线是什么？我现在最该先抓住哪一个关键变量？",
+                  "upgrade_hint": "在形成第一判断后，刻意再补问一句“我还没看到什么”，能让带动感发挥得更稳。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_2",
+                  "label": "回应力",
+                  "role": "working_method",
+                  "definition": "「回应力」意味着你在推进工作时，会特别关注方法、节奏或协作方式是否足够合理。",
+                  "why_it_matters": "它决定了你如何把想法转成动作，也影响你在团队里更习惯用什么方式推动事情成形。",
+                  "career_expression": "在工作中，它通常表现为你会围绕回应力去安排步骤、划清轻重，或主动调整人与事的配合方式。",
+                  "career_advantage": "当任务需要把混乱收顺、把资源摆正、或让执行节奏稳定下来时，这会非常有价值。",
+                  "overuse_risk": "如果回应力过强，可能会让你不自觉接管流程、压缩他人的试错空间，或对低效特别不耐烦。",
+                  "real_world_signal": "你会下意识去想：顺序是不是还能再理一遍？这件事为什么会卡住？谁和谁的配合需要调整？",
+                  "upgrade_hint": "在亲自接手之前，先分清“我要设计框架”还是“我要自己下场”，能避免回应力变成过度背责。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_3",
+                  "label": "分心性",
+                  "role": "inner_drive",
+                  "definition": "「分心性」意味着你在职业里有一股稳定的内在驱动力，它决定了什么事情最能真正点燃你。",
+                  "why_it_matters": "它解释了你为什么会对某类目标、标准或意义特别投入，也说明你最难妥协的点在哪里。",
+                  "career_expression": "在真实工作中，它常表现为你会对分心性相关的目标特别敏锐，愿意在这些地方投入更多时间、精力与心力。",
+                  "career_advantage": "当岗位能给到这类驱动力足够空间时，你的持续投入度、成长速度和成就感都会明显更高。",
+                  "overuse_risk": "如果分心性被拉得过满，可能会把标准抬得太高，或让你把一次波动放大成“我还不够好”的信号。",
+                  "real_world_signal": "你会反复回到一个问题：这件事有没有体现分心性？如果没有，我为什么还要继续投入？",
+                  "upgrade_hint": "把分心性转成清晰、可衡量的小目标，会比只凭感觉追逐更稳，也更容易长期坚持。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                },
+                {
+                  "id": "career_trait_4",
+                  "label": "回避倾向",
+                  "role": "career_orientation",
+                  "definition": "「回避倾向」意味着你在职业中会自然朝某种位置、状态或协作角色靠拢，这影响你长期最舒服的工作方式。",
+                  "why_it_matters": "它决定了你更容易被什么样的职责吸引，也解释了你在团队里为什么会自然站到某个位置上。",
+                  "career_expression": "在工作里，它常表现为你会主动靠近更符合回避倾向的任务、角色和合作关系，并在这些位置上投入更多。",
+                  "career_advantage": "当岗位与这种倾向一致时，你会更有存在感，也更容易形成稳定的职业成就感。",
+                  "overuse_risk": "如果过度依赖回避倾向，你可能会对不符合自己偏好的工作成分缺乏耐心，或过快否定某些必要阶段。",
+                  "real_world_signal": "你会很快感觉到：这件事是不是符合我真正想长期靠近的那种工作状态与职业角色。",
+                  "upgrade_hint": "定期区分“我真适合回避倾向”和“我只是习惯这种感觉”，能帮助你避免在路径选择上过早固化。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "career.summary"
+                    ],
+                    "strengths": [
+                      "career.advantages"
+                    ],
+                    "weaknesses": [
+                      "career.weaknesses"
+                    ],
+                    "roles": [
+                      "career.preferredRoles"
+                    ],
+                    "upgrade": [
+                      "career.upgradeSuggestions"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "growth": {
             "intro": [
@@ -22922,7 +34390,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你成长节奏、恢复方式与内在调节能力的关键因素。它们不是简单标签，而是在解释：你为什么会这样成长、这样耗损，以及你最容易在哪些地方稳住自己、在哪些地方失速。",
+              "items": [
+                {
+                  "id": "growth_trait_1",
+                  "label": "热度",
+                  "role": "inner_processing",
+                  "definition": "热度会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活热度，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_2",
+                  "label": "边界感",
+                  "role": "growth_engine",
+                  "definition": "边界感会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把边界感写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_3",
+                  "label": "敏感度",
+                  "role": "self_regulation",
+                  "definition": "敏感度会成为你持续推进成长的重要内在动力，决定你在困难时为何还能继续往前走。",
+                  "why_it_matters": "它决定了你在成长路上最容易被什么点燃，也解释了你为何会在某些方向上持续投入。",
+                  "growth_expression": "在现实里，它会表现为你在真正重要的成长议题上更愿意持续用力，即使短期没有立刻回报。",
+                  "growth_advantage": "这会成为你在关键阶段保持投入感和长期韧性的核心来源。",
+                  "overuse_risk": "如果它失衡，可能会让你把成长压力全部压回自己身上，变成长期的内耗或紧绷。",
+                  "real_world_signal": "面对关键选择时，你会明显感到：有些事让我更有生命力，有些事只是在消耗我。",
+                  "upgrade_hint": "先识别哪些情境最能激活敏感度，再把它们更多地放进你的成长主线中。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                },
+                {
+                  "id": "growth_trait_4",
+                  "label": "回弹力",
+                  "role": "recovery_pattern",
+                  "definition": "回弹力会影响你如何分配能量、安排节奏，并在高压与恢复之间找到更可持续的平衡。",
+                  "why_it_matters": "它决定了你的成长能否走得久、走得稳，而不是只在高能量时爆发，在低谷时停摆。",
+                  "growth_expression": "在现实里，它通常表现为你会越来越在意自己的投入强度、恢复空间和推进节奏，不再只靠硬撑。",
+                  "growth_advantage": "这会帮助你减少无谓透支，把成长做成长期工程，而不是一次次消耗式冲刺。",
+                  "overuse_risk": "如果它失衡，可能会让你在过度绷紧与突然松掉之间反复摆动，难以维持稳定输出。",
+                  "real_world_signal": "你会越来越敏锐地察觉：我现在该继续冲、先收一收，还是先恢复一下再推进。",
+                  "upgrade_hint": "把回弹力写进你的日程和边界里，让恢复、减量和重启都成为可执行动作，而不是临时补救。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "growth.summary"
+                    ],
+                    "strengths": [
+                      "growth.strengths"
+                    ],
+                    "weaknesses": [
+                      "growth.weaknesses"
+                    ],
+                    "motivators": [
+                      "growth.motivators"
+                    ],
+                    "drainers": [
+                      "growth.drainers"
+                    ]
+                  }
+                }
+              ]
+            }
           },
           "relationships": {
             "intro": [
@@ -23128,7 +34718,129 @@
                   }
                 ]
               }
-            ]
+            ],
+            "traits_unlock": {
+              "title": "影响因素详解",
+              "intro": "以下 4 项是最影响你建立连接、维持信任、回应他人与保护自己的关键因素。它们不是简单标签，而是在解释：你为什么会这样靠近别人、这样受伤、这样坚持，以及你最容易在哪些地方建立高质量关系、在哪些地方陷入误解或消耗。",
+              "items": [
+                {
+                  "id": "relationship_trait_1",
+                  "label": "陪伴感",
+                  "role": "connection_style",
+                  "definition": "陪伴感会影响你如何靠近别人、回应别人，并让关系带有温度、理解和被看见的感觉。",
+                  "why_it_matters": "它决定了别人靠近你时会感受到怎样的温度，也影响你能否建立高质量的情感连接。",
+                  "relationship_expression": "在现实里，它会表现为你如何表达在乎、怎样回应他人，以及你是否能把关系带入更深的交流层。",
+                  "relationship_advantage": "这会让你的关系更有温度、理解与真实互动，而不只是表面的来往。",
+                  "overuse_risk": "如果它失衡，你可能会因为过度投入、过度照顾或过度敏感而在关系里很快透支。",
+                  "real_world_signal": "你会明显感到：我是不是被接住了、被回应了、被真正当回事了。",
+                  "upgrade_hint": "让陪伴感不仅停留在感受里，也落实成稳定、清楚、可被看见的互动方式。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_2",
+                  "label": "热度",
+                  "role": "trust_pattern",
+                  "definition": "热度会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别热度最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_3",
+                  "label": "敏感度",
+                  "role": "emotional_response",
+                  "definition": "敏感度会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别敏感度最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                },
+                {
+                  "id": "relationship_trait_4",
+                  "label": "依赖感",
+                  "role": "relational_tension",
+                  "definition": "依赖感会影响你在关系压力、误解与拉扯出现时，最自然会进入哪种保护或应对模式。",
+                  "why_it_matters": "它决定了关系遇到压力时，你是更容易修复、对抗，还是后撤与保护自己。",
+                  "relationship_expression": "在现实里，它会表现为你在冲突、失望或不被理解时，最容易进入的关系反应方式。",
+                  "relationship_advantage": "当你能看懂这类倾向时，反而会更早识别风险点，减少关系中的误伤与消耗。",
+                  "overuse_risk": "如果它失衡，关系就容易在压抑、回避、拉扯或突然抽离之间反复循环。",
+                  "real_world_signal": "当关系开始失衡时，你会比很多人更早感觉到自己是在收缩、紧绷还是想抽身。",
+                  "upgrade_hint": "先识别依赖感最容易在哪类关系场景被触发，再提前准备更成熟的回应动作。",
+                  "links_to_existing_blocks": {
+                    "summary": [
+                      "relationships.summary"
+                    ],
+                    "strengths": [
+                      "relationships.strengths"
+                    ],
+                    "weaknesses": [
+                      "relationships.weaknesses"
+                    ],
+                    "advantages": [
+                      "relationships.relAdvantages"
+                    ],
+                    "risks": [
+                      "relationships.relRisks"
+                    ]
+                  }
+                }
+              ]
+            }
           }
         },
         "finalOffer": {


### PR DESCRIPTION
## Summary
- merge the uploaded zh-CN career / growth / relationships traits unlock assets into the authoritative desktop clone baseline
- validate the new `traits_unlock` payload in the desktop clone content validator
- expose the payload through the existing import -> owner -> public API contract
- add backend import/API assertions for `ENTJ-A`, `ENTJ-T`, `INFJ-A`, and `INFJ-T`

## Source files
- `/Users/rainie/Desktop/mbti_career_traits_unlock_v1_32_types.txt`
- `/Users/rainie/Desktop/mbti_growth_traits_unlock_v1_32_types.txt`
- `/Users/rainie/Desktop/mbti_relationships_traits_unlock_v1_32_types.txt`

## Scope
- authoritative source only in `fap-api`
- no schema route migration controller or service contract changes beyond the new payload validation
- no payment / unlock logic changes
- no Big5 / mobile changes

## Verification
- `php artisan route:list --path=api/v0.5/personality`
- `php artisan migrate --force`
- `php artisan personality:import-local-baseline --locale=zh-CN --status=published --upsert`
- `php artisan personality:import-desktop-clone-baseline --locale=zh-CN --status=published --upsert`
- `php artisan test tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php`
- `./vendor/bin/pint --test tests/Feature/V0_5/PersonalityDesktopClonePublicApiTest.php tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`
