### PR TITLE
feat(mbti): add canonical projection axis fields

### DIFF
--- a/backend/app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php
+++ b/backend/app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php
@@ -6,6 +6,7 @@ namespace App\Services\Mbti;
 
 use App\Contracts\MbtiPublicResultAuthoritySource;
 use App\Contracts\MbtiPublicResultPayloadBuilder;
+use App\Support\Mbti\MbtiAxisStrengthBand;
 use App\Support\Mbti\MbtiCanonicalSectionRegistry;
 use App\Support\Mbti\MbtiPublicTypeIdentity;
 use InvalidArgumentException;
@@ -311,7 +312,7 @@ final class MbtiCanonicalPublicResultPayloadBuilder implements MbtiPublicResultP
                     $normalized[$axisId]['pct'] = $scorePct >= 50 ? $scorePct : 100 - $scorePct;
                 }
 
-                $ordered[] = $normalized[$axisId];
+                $ordered[] = $this->enrichCanonicalDimension($normalized[$axisId]);
             }
         }
 
@@ -543,6 +544,75 @@ final class MbtiCanonicalPublicResultPayloadBuilder implements MbtiPublicResultP
             'TF' => ['T', 'F'],
             'JP' => ['J', 'P'],
             default => ['A', 'T'],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $dimension
+     * @return array<string, mixed>
+     */
+    private function enrichCanonicalDimension(array $dimension): array
+    {
+        $axisId = strtoupper(trim((string) ($dimension['id'] ?? $dimension['code'] ?? '')));
+        if ($axisId === '') {
+            return $dimension;
+        }
+
+        [$leftCode, $rightCode] = $this->axisLetters($axisId);
+        $axisTitle = $this->nullableText($dimension['label'] ?? $dimension['name'] ?? null);
+        if ($axisTitle === null || strtoupper($axisTitle) === $axisId) {
+            $axisTitle = $this->defaultAxisTitle($axisId);
+        }
+        [$defaultLeftPole, $defaultRightPole] = $this->defaultAxisPoles($axisId);
+        $leftPole = $this->nullableText($dimension['axis_left'] ?? null) ?? $defaultLeftPole;
+        $rightPole = $this->nullableText($dimension['axis_right'] ?? null) ?? $defaultRightPole;
+        $rawFirstPolePct = $this->normalizePercent($dimension['score_pct'] ?? null);
+        $dominantPole = $this->nullableText($dimension['side'] ?? null);
+        $dominantPct = $this->normalizePercent($dimension['pct'] ?? null);
+        $state = $this->nullableText($dimension['state'] ?? null);
+        $dominantLabel = $this->nullableText($dimension['side_label'] ?? null);
+        if ($dominantLabel === null && $dominantPole !== null) {
+            $dominantLabel = strtoupper($dominantPole) === $leftCode ? $leftPole : $rightPole;
+        }
+
+        return array_merge($dimension, [
+            'axis_code' => $axisId,
+            'axis_title' => $axisTitle,
+            'left_pole' => $leftPole,
+            'right_pole' => $rightPole,
+            'left_code' => $leftCode,
+            'right_code' => $rightCode,
+            'raw_first_pole_pct' => $rawFirstPolePct,
+            'dominant_pole' => $dominantPole,
+            'dominant_label' => $dominantLabel,
+            'dominant_pct' => $dominantPct,
+            'opposite_pct' => is_int($dominantPct) ? max(0, min(100, 100 - $dominantPct)) : null,
+            'strength_band' => MbtiAxisStrengthBand::fromDominantPercent($dominantPct, $state),
+        ]);
+    }
+
+    private function defaultAxisTitle(string $axisId): string
+    {
+        return match ($axisId) {
+            'EI' => 'Energy',
+            'SN' => 'Information',
+            'TF' => 'Decision',
+            'JP' => 'Lifestyle',
+            default => 'Identity',
+        };
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    private function defaultAxisPoles(string $axisId): array
+    {
+        return match ($axisId) {
+            'EI' => ['Extraversion', 'Introversion'],
+            'SN' => ['Sensing', 'Intuition'],
+            'TF' => ['Thinking', 'Feeling'],
+            'JP' => ['Judging', 'Perceiving'],
+            default => ['Assertive', 'Turbulent'],
         };
     }
 

--- a/backend/app/Services/Mbti/MbtiPublicProjectionService.php
+++ b/backend/app/Services/Mbti/MbtiPublicProjectionService.php
@@ -9,6 +9,7 @@ use App\Models\PersonalityProfileVariant;
 use App\Models\Result;
 use App\Services\Mbti\Adapters\MbtiPersonalityProfileAuthoritySourceAdapter;
 use App\Services\Mbti\Adapters\MbtiReportAuthoritySourceAdapter;
+use App\Support\Mbti\MbtiAxisStrengthBand;
 use App\Support\Mbti\MbtiPublicTypeIdentity;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -704,7 +705,7 @@ final class MbtiPublicProjectionService
                 $dimensions[$axisId]['pct'] = $scorePct >= 50 ? $scorePct : 100 - $scorePct;
             }
 
-            $ordered[] = $dimensions[$axisId];
+            $ordered[] = $this->enrichCanonicalDimension($dimensions[$axisId]);
         }
 
         return $ordered;
@@ -750,6 +751,7 @@ final class MbtiPublicProjectionService
                 ?? $dimensions[$index]['pct'];
             $dimensions[$index]['state'] = $this->nullableText($legacy['state'] ?? null)
                 ?? $dimensions[$index]['state'];
+            $dimensions[$index] = $this->enrichCanonicalDimension($dimensions[$index]);
         }
 
         return $dimensions;
@@ -783,6 +785,46 @@ final class MbtiPublicProjectionService
             'JP' => ['J', 'P'],
             default => ['A', 'T'],
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $dimension
+     * @return array<string, mixed>
+     */
+    private function enrichCanonicalDimension(array $dimension): array
+    {
+        $axisId = strtoupper(trim((string) ($dimension['id'] ?? $dimension['code'] ?? '')));
+        if ($axisId === '') {
+            return $dimension;
+        }
+
+        [$leftCode, $rightCode] = $this->axisLetters($axisId);
+        $axisTitle = $this->nullableText($dimension['label'] ?? $dimension['name'] ?? null) ?? $axisId;
+        $leftPole = $this->nullableText($dimension['axis_left'] ?? null);
+        $rightPole = $this->nullableText($dimension['axis_right'] ?? null);
+        $rawFirstPolePct = $this->normalizePercent($dimension['score_pct'] ?? null);
+        $dominantPole = $this->nullableText($dimension['side'] ?? null);
+        $dominantPct = $this->normalizePercent($dimension['pct'] ?? null);
+        $state = $this->nullableText($dimension['state'] ?? null);
+        $dominantLabel = $this->nullableText($dimension['side_label'] ?? null);
+        if ($dominantLabel === null && $dominantPole !== null) {
+            $dominantLabel = strtoupper($dominantPole) === $leftCode ? $leftPole : $rightPole;
+        }
+
+        return array_merge($dimension, [
+            'axis_code' => $axisId,
+            'axis_title' => $axisTitle,
+            'left_pole' => $leftPole,
+            'right_pole' => $rightPole,
+            'left_code' => $leftCode,
+            'right_code' => $rightCode,
+            'raw_first_pole_pct' => $rawFirstPolePct,
+            'dominant_pole' => $dominantPole,
+            'dominant_label' => $dominantLabel,
+            'dominant_pct' => $dominantPct,
+            'opposite_pct' => is_int($dominantPct) ? max(0, min(100, 100 - $dominantPct)) : null,
+            'strength_band' => MbtiAxisStrengthBand::fromDominantPercent($dominantPct, $state),
+        ]);
     }
 
     private function normalizeLocale(string $locale): string

--- a/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
+++ b/backend/app/Services/Mbti/MbtiResultPersonalizationService.php
@@ -9,6 +9,7 @@ use App\Services\AI\ControlledNarrativeLayerService;
 use App\Services\Comparative\VersionedComparativeNormingLayerService;
 use App\Services\Content\ContentPacksIndex;
 use App\Services\Content\CulturalCalibrationLayerService;
+use App\Support\Mbti\MbtiAxisStrengthBand;
 
 final class MbtiResultPersonalizationService
 {
@@ -1684,19 +1685,7 @@ final class MbtiResultPersonalizationService
 
     private function resolveBand(int $delta, string $state): string
     {
-        if ($delta < 12) {
-            return 'boundary';
-        }
-
-        if ($delta >= 40 || str_contains(strtolower($state), 'very')) {
-            return 'very_strong';
-        }
-
-        if ($delta >= 25 || strtolower($state) === 'strong') {
-            return 'strong';
-        }
-
-        return 'clear';
+        return MbtiAxisStrengthBand::fromDeltaAndState($delta, $state);
     }
 
     /**

--- a/backend/app/Support/Mbti/MbtiAxisStrengthBand.php
+++ b/backend/app/Support/Mbti/MbtiAxisStrengthBand.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Mbti;
+
+final class MbtiAxisStrengthBand
+{
+    public static function fromDominantPercent(?int $dominantPct, ?string $state): ?string
+    {
+        if (! is_int($dominantPct)) {
+            return null;
+        }
+
+        return self::fromDeltaAndState((int) round(abs($dominantPct - 50)), $state);
+    }
+
+    public static function fromDeltaAndState(int $delta, ?string $state): string
+    {
+        $normalizedState = strtolower(trim((string) $state));
+
+        if ($delta < 12) {
+            return 'boundary';
+        }
+
+        if ($delta >= 40 || str_contains($normalizedState, 'very')) {
+            return 'very_strong';
+        }
+
+        if ($delta >= 25 || $normalizedState === 'strong') {
+            return 'strong';
+        }
+
+        return 'clear';
+    }
+}

--- a/backend/tests/Unit/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilderTest.php
@@ -108,6 +108,27 @@ final class MbtiCanonicalPublicResultPayloadBuilderTest extends TestCase
         );
         $this->assertSame('SN', $payload['dimensions'][1]['id']);
         $this->assertSame('TF', $payload['dimensions'][2]['id']);
+        $this->assertSame('EI', data_get($payload, 'dimensions.0.axis_code'));
+        $this->assertSame('Energy', data_get($payload, 'dimensions.0.axis_title'));
+        $this->assertSame('Extraversion', data_get($payload, 'dimensions.0.left_pole'));
+        $this->assertSame('Introversion', data_get($payload, 'dimensions.0.right_pole'));
+        $this->assertSame('E', data_get($payload, 'dimensions.0.left_code'));
+        $this->assertSame('I', data_get($payload, 'dimensions.0.right_code'));
+        $this->assertSame(62, data_get($payload, 'dimensions.0.raw_first_pole_pct'));
+        $this->assertSame('E', data_get($payload, 'dimensions.0.dominant_pole'));
+        $this->assertSame('Extraversion', data_get($payload, 'dimensions.0.dominant_label'));
+        $this->assertSame(62, data_get($payload, 'dimensions.0.dominant_pct'));
+        $this->assertSame(38, data_get($payload, 'dimensions.0.opposite_pct'));
+        $this->assertSame('clear', data_get($payload, 'dimensions.0.strength_band'));
+        $this->assertSame(49, data_get($payload, 'dimensions.4.raw_first_pole_pct'));
+        $this->assertSame('T', data_get($payload, 'dimensions.4.dominant_pole'));
+        $this->assertSame('Turbulent', data_get($payload, 'dimensions.4.dominant_label'));
+        $this->assertSame(51, data_get($payload, 'dimensions.4.dominant_pct'));
+        $this->assertSame(49, data_get($payload, 'dimensions.4.opposite_pct'));
+        $this->assertSame('boundary', data_get($payload, 'dimensions.4.strength_band'));
+        $this->assertSame(49, data_get($payload, 'dimensions.4.score_pct'));
+        $this->assertSame('T', data_get($payload, 'dimensions.4.side'));
+        $this->assertSame(51, data_get($payload, 'dimensions.4.pct'));
     }
 
     public function test_builder_rejects_base_type_only_resolution_without_silent_fallback(): void

--- a/backend/tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php
@@ -266,6 +266,33 @@ final class MbtiPublicProjectionServiceTest extends TestCase
         );
         $this->assertSame('I', data_get($projection, 'dimensions.0.side'));
         $this->assertSame('clear', data_get($projection, 'dimensions.0.state'));
+        $this->assertSame('EI', data_get($projection, 'dimensions.0.axis_code'));
+        $this->assertSame('Energy', data_get($projection, 'dimensions.0.axis_title'));
+        $this->assertSame('Extraversion', data_get($projection, 'dimensions.0.left_pole'));
+        $this->assertSame('Introversion', data_get($projection, 'dimensions.0.right_pole'));
+        $this->assertSame('E', data_get($projection, 'dimensions.0.left_code'));
+        $this->assertSame('I', data_get($projection, 'dimensions.0.right_code'));
+        $this->assertSame(35, data_get($projection, 'dimensions.0.raw_first_pole_pct'));
+        $this->assertSame('I', data_get($projection, 'dimensions.0.dominant_pole'));
+        $this->assertSame('Introversion', data_get($projection, 'dimensions.0.dominant_label'));
+        $this->assertSame(65, data_get($projection, 'dimensions.0.dominant_pct'));
+        $this->assertSame(35, data_get($projection, 'dimensions.0.opposite_pct'));
+        $this->assertSame('clear', data_get($projection, 'dimensions.0.strength_band'));
+        $this->assertSame('AT', data_get($projection, 'dimensions.4.axis_code'));
+        $this->assertSame('Identity', data_get($projection, 'dimensions.4.axis_title'));
+        $this->assertSame('Assertive', data_get($projection, 'dimensions.4.left_pole'));
+        $this->assertSame('Turbulent', data_get($projection, 'dimensions.4.right_pole'));
+        $this->assertSame('A', data_get($projection, 'dimensions.4.left_code'));
+        $this->assertSame('T', data_get($projection, 'dimensions.4.right_code'));
+        $this->assertSame(58, data_get($projection, 'dimensions.4.raw_first_pole_pct'));
+        $this->assertSame('A', data_get($projection, 'dimensions.4.dominant_pole'));
+        $this->assertSame('Assertive', data_get($projection, 'dimensions.4.dominant_label'));
+        $this->assertSame(58, data_get($projection, 'dimensions.4.dominant_pct'));
+        $this->assertSame(42, data_get($projection, 'dimensions.4.opposite_pct'));
+        $this->assertSame('boundary', data_get($projection, 'dimensions.4.strength_band'));
+        $this->assertSame(58, data_get($projection, 'dimensions.4.score_pct'));
+        $this->assertSame('A', data_get($projection, 'dimensions.4.side'));
+        $this->assertSame(58, data_get($projection, 'dimensions.4.pct'));
         $this->assertSame('MBTI_REPORT_FULL', data_get($projection, 'offer_set.cta.target_sku'));
     }
 


### PR DESCRIPTION
## Summary
- add explicit canonical axis fields to `mbti_public_projection_v1.dimensions[*]`
- preserve all existing projection fields and scorer semantics
- reuse the existing strength band algorithm via a shared backend helper

## Scope
This PR only does projection contract convergence for MBTI first-screen traits.

It does **not**:
- change scorer formulas
- change `scores_pct` semantics
- change frontend code
- remove or rename old fields

## Added fields on each dimension
- `axis_code`
- `axis_title`
- `left_pole`
- `right_pole`
- `left_code`
- `right_code`
- `raw_first_pole_pct`
- `dominant_pole`
- `dominant_label`
- `dominant_pct`
- `opposite_pct`
- `strength_band`

## Verification
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --force`
- `cd backend && php artisan test tests/Unit/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilderTest.php tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php tests/Unit/Services/Mbti/MbtiResultPersonalizationServiceTest.php`
- `cd backend && ./vendor/bin/pint app/Support/Mbti/MbtiAxisStrengthBand.php app/Services/Mbti/MbtiResultPersonalizationService.php app/Services/Mbti/MbtiPublicProjectionService.php app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php tests/Unit/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilderTest.php tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`

## Notes
- `php artisan test` still has pre-existing unrelated failures in non-MBTI suites in this repo snapshot.
- MBTI projection and personalization targeted tests pass.
