### PR TITLE
fix(deploy): default to repo-known ssh identities

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -49,6 +49,14 @@ Truth Source: `backend/composer.json` / `backend/package.json` / `backend/config
 ## 4. 配置清单（上线必填）
 以 `backend/.env.example` 为模板，生产必须由密钥系统注入。
 
+Deployer SSH 约定：
+- 默认 production 仍走 `DEPLOY_HOST_PROD=122.152.221.126`、`DEPLOY_USER_PROD=ubuntu`
+- 若本机存在 `~/.ssh/fap_prod` 或 `~/.ssh/fap_api_gha`，`deploy.php` 会自动将其作为 production `IdentityFile`
+- staging 若本机存在 `~/.ssh/fap_actions_staging`，会自动作为 staging `IdentityFile`
+- 如需显式覆盖，使用：
+  - `DEPLOY_IDENTITY_FILE_PROD=/abs/path/to/key`
+  - `DEPLOY_IDENTITY_FILE_STG=/abs/path/to/key`
+
 ### 4.1 基础与数据库
 - `APP_ENV=production`
 - `APP_DEBUG=false`
@@ -233,8 +241,10 @@ if ($after > $maxDepth || ($after - $before) > $maxGrowth || $recentPending > $m
 
 ### 5.2 Deployer rerun / failed release hygiene
 - Deployer release name 必须唯一；若上一轮失败残留了 `releases/93`，下一次 rerun 必须使用新的 `release_name`，例如：
-  - `vendor/bin/dep deploy production -o release_name=94`
-  - 或 `vendor/bin/dep deploy production -o release_name=$(date +%Y%m%d%H%M%S)`
+- `vendor/bin/dep deploy production -o release_name=94`
+- 或 `vendor/bin/dep deploy production -o release_name=$(date +%Y%m%d%H%M%S)`
+- 如需显式指定 key：
+  - `DEPLOY_IDENTITY_FILE_PROD=~/.ssh/fap_prod vendor/bin/dep deploy production -o release_name=$(date +%Y%m%d%H%M%S)`
 - `release 93 already exists` 不是成功上线，只表示失败残留目录未被复用。
 - 若 `releases/93` 不是 `current` 指向目标，且该 release 从未成功切换为 active release，则可安全清理：
   - `test "$(readlink -f current)" != "$(readlink -f releases/93)"`

--- a/deploy.php
+++ b/deploy.php
@@ -79,10 +79,42 @@ set('legacy_queue_systemd_disable', true);
 
 /**
  * ======================================================
+ * SSH identity helpers
+ * ======================================================
+ */
+function resolveDeployIdentityFile(string $envKey, array $candidates = []): ?string
+{
+    $fromEnv = getenv($envKey);
+    if (is_string($fromEnv) && trim($fromEnv) !== '') {
+        return trim($fromEnv);
+    }
+
+    foreach ($candidates as $candidate) {
+        $expanded = preg_replace('/^~/', getenv('HOME') ?: '', $candidate);
+        if (is_string($expanded) && $expanded !== '' && is_file($expanded)) {
+            return $candidate;
+        }
+    }
+
+    return null;
+}
+
+$productionIdentityFile = resolveDeployIdentityFile('DEPLOY_IDENTITY_FILE_PROD', [
+    '~/.ssh/fap_prod',
+    '~/.ssh/fap_api_gha',
+]);
+
+$stagingIdentityFile = resolveDeployIdentityFile('DEPLOY_IDENTITY_FILE_STG', [
+    '~/.ssh/fap_actions_staging',
+]);
+
+/**
+ * ======================================================
  * Hosts
  * ======================================================
  */
-host('production')
+/** @var \Deployer\Host\Host $productionHost */
+$productionHost = host('production')
     ->setHostname(getenv('DEPLOY_HOST_PROD') ?: '122.152.221.126')
     ->setRemoteUser(getenv('DEPLOY_USER_PROD') ?: 'ubuntu')
     ->setPort((int)(getenv('DEPLOY_PORT_PROD') ?: 22))
@@ -92,7 +124,12 @@ host('production')
     ->set('nginx_site', '/etc/nginx/sites-enabled/fap-api')
     ->set('php_fpm_service', getenv('PHP_FPM_SERVICE_PROD') ?: 'php8.4-fpm');
 
-host('staging')
+if ($productionIdentityFile !== null) {
+    $productionHost->setIdentityFile($productionIdentityFile);
+}
+
+/** @var \Deployer\Host\Host $stagingHost */
+$stagingHost = host('staging')
     ->setHostname(getenv('DEPLOY_HOST_STG') ?: 'staging.fermatmind.com')
     ->setRemoteUser(getenv('DEPLOY_USER_STG') ?: 'ubuntu')
     ->setPort((int)(getenv('DEPLOY_PORT_STG') ?: 22))
@@ -101,6 +138,10 @@ host('staging')
     ->set('ops_entry_host', getenv('OPS_ENTRY_HOST_STG') ?: '')
     ->set('nginx_site', '/etc/nginx/sites-enabled/fap-api-staging')
     ->set('php_fpm_service', getenv('PHP_FPM_SERVICE_STG') ?: 'php8.4-fpm');
+
+if ($stagingIdentityFile !== null) {
+    $stagingHost->setIdentityFile($stagingIdentityFile);
+}
 
 task('guard:ops-theme-asset', function () {
     $asset = '{{release_path}}/backend/public/css/app/ops-theme.css';


### PR DESCRIPTION
## Summary
- add deploy-time SSH identity auto-discovery for production and staging hosts
- default production to repo-known keys (`~/.ssh/fap_prod`, `~/.ssh/fap_api_gha`) when present
- document the deploy SSH contract and explicit key override usage in `README_DEPLOY.md`

## Why
Production deploys were depending on the caller's ambient SSH config for host/IP identity selection. On this machine that resolved to the wrong user/key path for `122.152.221.126`, which caused lock/debug churn and sudo failures on the wrong account.

This PR keeps the existing host/user defaults, but makes the repo choose the intended identity file when it exists locally, while still allowing explicit env overrides and keeping CI compatible.

## Tests
- `php -l deploy.php`
- `vendor/bin/dep run 'whoami; php -m | grep -i "^redis$" || true' production`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --force`
- `curl -I https://fermatmind.com`
- `curl -I https://ops.fermatmind.com/ops`
- `bash backend/scripts/ci_verify_mbti.sh`
