### PR TITLE
Expose exact MBTI delivery target on order reads

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -184,6 +184,7 @@ class CommerceController extends Controller
             $status === 'pending' && ($request->boolean('include_payment_action') || $paymentRecoveryVerified),
             $paymentRecoveryToken
         );
+        $exactResultEntry = $this->mbtiAccessHubBuilder->buildExactResultEntryForOrder($order);
         if ($status === 'pending') {
             $order = $this->orders->findOrderByOrderNo((string) ($order->order_no ?? ''), $orgId) ?? $order;
             $status = $this->resolvePublicOrderStatus($order);
@@ -212,6 +213,7 @@ class CommerceController extends Controller
             'payment_attempts_count' => $paymentAttemptSummary['count'],
             'latest_payment_attempt' => $paymentAttemptSummary['latest'],
             'delivery' => $delivery['delivery'],
+            'exact_result_entry' => $exactResultEntry,
         ];
 
         if ($ownershipVerified) {
@@ -579,6 +581,7 @@ class CommerceController extends Controller
             $status === 'pending',
             $paymentRecoveryToken
         );
+        $exactResultEntry = $this->mbtiAccessHubBuilder->buildExactResultEntryForOrder($order);
         if ($status === 'pending') {
             $order = $this->orders->findOrderByOrderNo((string) ($order->order_no ?? $orderNo), $orgId) ?? $order;
             $status = $this->resolvePublicOrderStatus($order);
@@ -606,6 +609,7 @@ class CommerceController extends Controller
             'payment_attempts_count' => $paymentAttemptSummary['count'],
             'latest_payment_attempt' => $paymentAttemptSummary['latest'],
             'delivery' => $delivery['delivery'],
+            'exact_result_entry' => $exactResultEntry,
         ];
 
         $mbtiAccessHub = $this->mbtiAccessHubBuilder->buildForLookupHit($order);
@@ -1310,6 +1314,11 @@ class CommerceController extends Controller
     private function isProviderEnabled(string $provider): bool
     {
         return $this->paymentProviders->isEnabled($provider);
+    }
+
+    private function isStubEnabled(): bool
+    {
+        return app()->environment(['local', 'testing']) && config('payments.allow_stub') === true;
     }
 
     private function resolveRequestId(Request $request): string

--- a/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
+++ b/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Commerce;
 
 use App\Models\Attempt;
+use App\Models\UnifiedAccessProjection;
 use App\Services\Report\ReportAccess;
 use Illuminate\Support\Facades\DB;
 
@@ -97,33 +98,30 @@ final class MbtiAccessHubBuilder
         $delivery = $this->presentDelivery($order);
         $reportUrl = $this->stringOrNull($delivery['report_url'] ?? null);
         $reportPdfUrl = $this->stringOrNull($delivery['report_pdf_url'] ?? null);
-        $canViewReport = (bool) ($delivery['can_view_report'] ?? false);
-        $canDownloadPdf = (bool) ($delivery['can_download_pdf'] ?? false);
+        $exactResultEntry = $this->buildExactResultEntry($attemptId, (int) ($order->org_id ?? 0));
+        $canViewReport = (bool) ($exactResultEntry['ready_to_enter'] ?? false);
+        $canDownloadPdf = $this->normalizeProjectionState((string) ($exactResultEntry['pdf_state'] ?? 'missing'), 'pdf') === 'ready';
         $canRequestClaimEmail = (bool) ($delivery['can_request_claim_email'] ?? false);
         $canResend = (bool) ($delivery['can_resend'] ?? false);
         $attribution = $this->orders->extractAttributionFromOrder($order);
 
         return [
-            'access_state' => $this->resolveDeliveryAccessState(
-                $order,
-                $canViewReport,
-                $canRequestClaimEmail,
-                $canResend
-            ),
+            'access_state' => $this->stringOrNull($exactResultEntry['access_state'] ?? null)
+                ?? $this->resolveDeliveryAccessState($order, $canViewReport, $canRequestClaimEmail, $canResend),
             'report_access' => [
                 'can_view_report' => $canViewReport,
                 'attempt_id' => $attemptId,
                 'order_no' => $this->stringOrNull($order->order_no ?? null),
                 'report_url' => $reportUrl,
-                'source' => $reportUrl !== null
-                    ? ReportAccess::ACCESS_HUB_SOURCE_ORDER_DELIVERY
+                'source' => $reportUrl !== null && $exactResultEntry !== null
+                    ? ReportAccess::ACCESS_HUB_SOURCE_REPORT_GATE
                     : ReportAccess::ACCESS_HUB_SOURCE_NONE,
             ],
             'pdf_access' => [
                 'can_download_pdf' => $canDownloadPdf,
                 'report_pdf_url' => $reportPdfUrl,
-                'source' => $reportPdfUrl !== null
-                    ? ReportAccess::ACCESS_HUB_SOURCE_ORDER_DELIVERY
+                'source' => $reportPdfUrl !== null && $exactResultEntry !== null
+                    ? ReportAccess::ACCESS_HUB_SOURCE_REPORT_GATE
                     : ReportAccess::ACCESS_HUB_SOURCE_NONE,
             ],
             'recovery' => $this->buildRecoveryBlock(
@@ -134,7 +132,21 @@ final class MbtiAccessHubBuilder
                 $attribution
             ),
             'workspace_lite' => $this->buildWorkspaceLiteBlock($attemptId),
+            'exact_result_entry' => $exactResultEntry,
         ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function buildExactResultEntryForOrder(object $order): ?array
+    {
+        $attemptId = $this->resolveMbtiAttemptIdForOrder($order);
+        if ($attemptId === null) {
+            return null;
+        }
+
+        return $this->buildExactResultEntry($attemptId, (int) ($order->org_id ?? 0));
     }
 
     /**
@@ -234,6 +246,74 @@ final class MbtiAccessHubBuilder
         return $this->stringOrNull($attempt->id ?? null);
     }
 
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function buildExactResultEntry(string $attemptId, int $orgId): ?array
+    {
+        $attempt = DB::table('attempts')
+            ->where('org_id', $orgId)
+            ->where('id', $attemptId)
+            ->first(['id', 'scale_code']);
+
+        if (! $attempt || ! $this->isMbtiScale($attempt->scale_code ?? null)) {
+            return null;
+        }
+
+        $resultExists = DB::table('results')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->exists();
+        $projection = UnifiedAccessProjection::query()->where('attempt_id', $attemptId)->first();
+        $payload = is_array($projection?->payload_json) ? $projection->payload_json : [];
+        $accessState = $this->normalizeProjectionState(
+            (string) ($projection?->access_state ?? ($resultExists ? 'locked' : 'pending')),
+            'access'
+        );
+        $reportState = $this->normalizeProjectionState(
+            (string) ($projection?->report_state ?? ($resultExists ? 'ready' : 'pending')),
+            'report'
+        );
+        $pdfState = $this->normalizeProjectionState(
+            (string) ($projection?->pdf_state ?? 'missing'),
+            'pdf'
+        );
+        $pageHref = $this->supportsPageEntry($accessState, $reportState)
+            ? $this->resultPagePathForAttemptId($attemptId)
+            : null;
+        $readyToEnter = $accessState === 'ready' && $reportState === 'ready' && $pageHref !== null;
+
+        return [
+            'attempt_id' => $attemptId,
+            'access_state' => $accessState,
+            'report_state' => $reportState,
+            'pdf_state' => $pdfState,
+            'reason_code' => $this->stringOrNull(
+                $projection?->reason_code ?? ($resultExists ? 'projection_missing_result_ready' : 'projection_missing_result_pending')
+            ),
+            'access_level' => $this->stringOrNull($payload['access_level'] ?? null),
+            'variant' => $this->stringOrNull($payload['variant'] ?? null),
+            'projection_version' => (int) ($projection?->projection_version ?? 1),
+            'modules_allowed' => $this->normalizeStringArray($payload['modules_allowed'] ?? null),
+            'modules_preview' => $this->normalizeStringArray($payload['modules_preview'] ?? null),
+            'ready_to_enter' => $readyToEnter,
+            'source' => ReportAccess::ACCESS_HUB_SOURCE_REPORT_GATE,
+            'actions' => [
+                'page_href' => $pageHref,
+                'pdf_href' => $this->supportsPdfDownload($accessState, $pdfState)
+                    ? $this->attemptReportPdfUrl($attemptId)
+                    : null,
+                'wait_href' => $this->isWaitingState($reportState) ? $this->resultPagePathForAttemptId($attemptId) : null,
+                'history_href' => '/history/mbti',
+                'lookup_href' => '/orders/lookup',
+            ],
+            'meta' => [
+                'produced_at' => optional($projection?->produced_at)->toIso8601String(),
+                'refreshed_at' => optional($projection?->refreshed_at)->toIso8601String(),
+            ],
+        ];
+    }
+
     private function attemptReportUrl(?string $attemptId): ?string
     {
         return $attemptId !== null
@@ -246,6 +326,11 @@ final class MbtiAccessHubBuilder
         return $attemptId !== null
             ? "/api/v0.3/attempts/{$attemptId}/report.pdf"
             : null;
+    }
+
+    private function resultPagePathForAttemptId(string $attemptId): string
+    {
+        return "/result/{$attemptId}";
     }
 
     private function isPendingStatus(object $order): bool
@@ -264,6 +349,61 @@ final class MbtiAccessHubBuilder
     private function isMbtiScale(mixed $scaleCode): bool
     {
         return strtoupper(trim((string) $scaleCode)) === ReportAccess::SCALE_MBTI;
+    }
+
+    private function supportsPageEntry(string $accessState, string $reportState): bool
+    {
+        return ! in_array($this->normalizeProjectionState($accessState, 'access'), ['deleted', 'expired'], true)
+            && ! in_array($this->normalizeProjectionState($reportState, 'report'), ['deleted', 'expired', 'unavailable'], true);
+    }
+
+    private function supportsPdfDownload(string $accessState, string $pdfState): bool
+    {
+        return $this->normalizeProjectionState($accessState, 'access') === 'ready'
+            && $this->normalizeProjectionState($pdfState, 'pdf') === 'ready';
+    }
+
+    private function isWaitingState(string $state): bool
+    {
+        return in_array($this->normalizeProjectionState($state, 'report'), ['pending', 'restoring'], true);
+    }
+
+    private function normalizeProjectionState(string $state, string $kind): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match (true) {
+            $normalized === 'ready' => 'ready',
+            in_array($normalized, ['pending', 'generating', 'queued', 'running', 'submitted'], true) => 'pending',
+            in_array($normalized, ['restoring', 'rehydrating'], true) => 'restoring',
+            in_array($normalized, ['deleted', 'purged', 'anonymized'], true) => 'deleted',
+            $normalized === 'expired' => 'expired',
+            $kind === 'access' && in_array($normalized, ['locked', 'recovery_available'], true) => 'locked',
+            in_array($normalized, ['missing', 'unavailable', 'archived', 'shrunk', 'failed', 'blocked'], true) => 'unavailable',
+            default => $kind === 'access' ? 'locked' : 'unavailable',
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeStringArray(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $item) {
+            $normalized = $this->stringOrNull($item);
+            if ($normalized === null) {
+                continue;
+            }
+
+            $items[$normalized] = $normalized;
+        }
+
+        return array_values($items);
     }
 
     private function stringOrNull(mixed $value): ?string

--- a/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
@@ -81,6 +81,19 @@ final class CommerceOrderLookupSecurityTest extends TestCase
                 'compare_invite_id' => $compareInviteId,
             ],
         ]);
+        $this->insertResult($attemptId);
+        $this->insertProjection($attemptId, [
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'ready',
+            'reason_code' => 'entitlement_granted',
+            'payload_json' => [
+                'access_level' => 'full',
+                'variant' => 'full',
+                'modules_allowed' => ['core_full', 'career', 'relationships'],
+                'modules_preview' => [],
+            ],
+        ]);
 
         $response = $this->postJson('/api/v0.3/orders/lookup', [
             'order_no' => $orderNo,
@@ -92,9 +105,9 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
             ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
             ->assertJsonPath('mbti_access_hub_v1.report_access.order_no', $orderNo)
-            ->assertJsonPath('mbti_access_hub_v1.report_access.source', 'order_delivery')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.source', 'report_gate')
             ->assertJsonPath('mbti_access_hub_v1.pdf_access.can_download_pdf', true)
-            ->assertJsonPath('mbti_access_hub_v1.pdf_access.source', 'order_delivery')
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.source', 'report_gate')
             ->assertJsonPath('mbti_access_hub_v1.recovery.can_lookup_order', true)
             ->assertJsonPath('mbti_access_hub_v1.recovery.can_request_claim_email', true)
             ->assertJsonPath('mbti_access_hub_v1.recovery.can_resend', true)
@@ -103,7 +116,10 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ->assertJsonPath('mbti_access_hub_v1.recovery.compare_invite_id', $compareInviteId)
             ->assertJsonPath('mbti_access_hub_v1.workspace_lite.has_entry', true)
             ->assertJsonPath('mbti_access_hub_v1.workspace_lite.entry_kind', 'mbti_history')
-            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId);
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.ready_to_enter', true)
+            ->assertJsonPath('exact_result_entry.actions.page_href', "/result/{$attemptId}");
     }
 
     public function test_lookup_with_token_owner_works_without_email(): void
@@ -212,6 +228,58 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             'dir_version' => 'v1',
             'content_package_version' => 'v1',
             'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertResult(string $attemptId): void
+    {
+        DB::table('results')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => json_encode([], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'scores_pct' => json_encode([], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'axis_states' => json_encode([], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'content_package_version' => 'result-v1',
+            'result_json' => json_encode(['summary' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => 'result-score-v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param array{
+     *   access_state:string,
+     *   report_state:string,
+     *   pdf_state:string,
+     *   reason_code:string,
+     *   payload_json:array<string,mixed>
+     * } $overrides
+     */
+    private function insertProjection(string $attemptId, array $overrides): void
+    {
+        DB::table('unified_access_projections')->insert([
+            'attempt_id' => $attemptId,
+            'access_state' => $overrides['access_state'],
+            'report_state' => $overrides['report_state'],
+            'pdf_state' => $overrides['pdf_state'],
+            'reason_code' => $overrides['reason_code'],
+            'projection_version' => 1,
+            'actions_json' => json_encode(['report' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_json' => json_encode($overrides['payload_json'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'produced_at' => now(),
+            'refreshed_at' => now(),
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -83,6 +83,19 @@ final class CommerceOrderReadFallbackTest extends TestCase
         $attemptId = (string) Str::uuid();
         $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI');
         $this->insertOrderForOwner($orderNo, $attemptId, 'paid');
+        $this->insertResult($attemptId);
+        $this->insertProjection($attemptId, [
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'ready',
+            'reason_code' => 'entitlement_granted',
+            'payload_json' => [
+                'access_level' => 'full',
+                'variant' => 'full',
+                'modules_allowed' => ['core_full', 'career', 'relationships'],
+                'modules_preview' => [],
+            ],
+        ]);
 
         $token = $this->issueAnonToken(self::ANON_OWNER);
         $response = $this->withHeaders([
@@ -95,17 +108,50 @@ final class CommerceOrderReadFallbackTest extends TestCase
             ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
             ->assertJsonPath('mbti_access_hub_v1.report_access.order_no', $orderNo)
             ->assertJsonPath('mbti_access_hub_v1.report_access.report_url', "/api/v0.3/attempts/{$attemptId}/report")
-            ->assertJsonPath('mbti_access_hub_v1.report_access.source', 'order_delivery')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.source', 'report_gate')
             ->assertJsonPath('mbti_access_hub_v1.pdf_access.can_download_pdf', true)
             ->assertJsonPath('mbti_access_hub_v1.pdf_access.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
-            ->assertJsonPath('mbti_access_hub_v1.pdf_access.source', 'order_delivery')
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.source', 'report_gate')
             ->assertJsonPath('mbti_access_hub_v1.recovery.can_lookup_order', true)
             ->assertJsonPath('mbti_access_hub_v1.recovery.can_request_claim_email', false)
             ->assertJsonPath('mbti_access_hub_v1.recovery.can_resend', false)
             ->assertJsonPath('mbti_access_hub_v1.recovery.attempt_id', $attemptId)
             ->assertJsonPath('mbti_access_hub_v1.workspace_lite.has_entry', true)
             ->assertJsonPath('mbti_access_hub_v1.workspace_lite.entry_kind', 'mbti_history')
-            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId);
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.exact_result_entry.access_state', 'ready')
+            ->assertJsonPath('mbti_access_hub_v1.exact_result_entry.report_state', 'ready')
+            ->assertJsonPath('mbti_access_hub_v1.exact_result_entry.ready_to_enter', true)
+            ->assertJsonPath('mbti_access_hub_v1.exact_result_entry.actions.page_href', "/result/{$attemptId}")
+            ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.ready_to_enter', true)
+            ->assertJsonPath('exact_result_entry.actions.page_href', "/result/{$attemptId}");
+    }
+
+    public function test_paid_mbti_order_exposes_exact_result_entry_without_claiming_ready_before_projection_unlocks(): void
+    {
+        $orderNo = 'ord_fallback_mbti_pending_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'paid');
+
+        $token = $this->issueAnonToken(self::ANON_OWNER);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('grant_state', 'not_started')
+            ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.access_state', 'pending')
+            ->assertJsonPath('exact_result_entry.report_state', 'pending')
+            ->assertJsonPath('exact_result_entry.ready_to_enter', false)
+            ->assertJsonPath('exact_result_entry.actions.page_href', "/result/{$attemptId}")
+            ->assertJsonPath('exact_result_entry.actions.wait_href', "/result/{$attemptId}")
+            ->assertJsonPath('mbti_access_hub_v1.access_state', 'pending')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', false);
     }
 
     public function test_valid_payment_recovery_token_reads_pending_order_without_owner_identity(): void
@@ -259,6 +305,58 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'dir_version' => 'v1',
             'content_package_version' => 'v1',
             'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertResult(string $attemptId): void
+    {
+        DB::table('results')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => json_encode([], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'scores_pct' => json_encode([], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'axis_states' => json_encode([], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'content_package_version' => 'result-v1',
+            'result_json' => json_encode(['summary' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => 'result-score-v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param array{
+     *   access_state:string,
+     *   report_state:string,
+     *   pdf_state:string,
+     *   reason_code:string,
+     *   payload_json:array<string,mixed>
+     * } $overrides
+     */
+    private function insertProjection(string $attemptId, array $overrides): void
+    {
+        DB::table('unified_access_projections')->insert([
+            'attempt_id' => $attemptId,
+            'access_state' => $overrides['access_state'],
+            'report_state' => $overrides['report_state'],
+            'pdf_state' => $overrides['pdf_state'],
+            'reason_code' => $overrides['reason_code'],
+            'projection_version' => 1,
+            'actions_json' => json_encode(['report' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_json' => json_encode($overrides['payload_json'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'produced_at' => now(),
+            'refreshed_at' => now(),
             'created_at' => now(),
             'updated_at' => now(),
         ]);


### PR DESCRIPTION
## Summary
- expose an exact MBTI result entry on order and lookup payloads using the same attempt report-access truth
- keep order payment status separate from exact result readiness
- cover paid+ready and paid+not-ready order payloads in backend tests

## Scope
- fap-api only
- no content changes
- no payment provider integration changes
- no result-page unlock gate changes

## Verification
- php artisan test tests/Feature/V0_3/CommerceOrderReadFallbackTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
- php artisan test tests/Feature/V0_3/CommerceOrderIdempotencyTest.php --filter=stub_order_entrypoints_are_rejected