### PR TITLE
Repair MBTI exact attempt access projection

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -13,6 +13,7 @@ use App\Repositories\Report\ReportSubjectRepository;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
 use App\Services\BigFive\BigFivePublicProjectionService;
+use App\Services\Access\AttemptUnlockProjectionRepairService;
 use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Mbti\MbtiActionJourneyContractService;
 use App\Services\Mbti\MbtiAdaptiveSelectionService;
@@ -62,6 +63,7 @@ class AttemptReadController extends Controller
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
         private ReportSubjectRepository $reportSubjects,
+        private AttemptUnlockProjectionRepairService $projectionRepair,
     ) {}
 
     /**
@@ -505,6 +507,10 @@ class AttemptReadController extends Controller
             ->where('org_id', $orgId)
             ->where('attempt_id', (string) $attempt->id)
             ->exists();
+        if ($resultExists && strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI') {
+            $this->projectionRepair->repairResultReadyProjectionIfNeeded($orgId, (string) $attempt->id);
+        }
+
         $projection = UnifiedAccessProjection::query()
             ->where('attempt_id', (string) $attempt->id)
             ->first();

--- a/backend/app/Services/Access/AttemptUnlockProjectionRepairService.php
+++ b/backend/app/Services/Access/AttemptUnlockProjectionRepairService.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Access;
+
+use App\Models\UnifiedAccessProjection;
+use App\Services\Commerce\EntitlementManager;
+use App\Services\Report\ReportAccess;
+use App\Services\Storage\UnifiedAccessProjectionWriter;
+use App\Support\SchemaBaseline;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+final class AttemptUnlockProjectionRepairService
+{
+    public function __construct(
+        private readonly UnifiedAccessProjectionWriter $projectionWriter,
+        private readonly EntitlementManager $entitlements,
+    ) {}
+
+    public function repairResultReadyProjectionIfNeeded(int $orgId, string $attemptId): ?UnifiedAccessProjection
+    {
+        $attemptId = trim($attemptId);
+        if ($attemptId === '' || ! SchemaBaseline::hasTable('unified_access_projections')) {
+            return null;
+        }
+
+        $existing = UnifiedAccessProjection::query()
+            ->where('attempt_id', $attemptId)
+            ->first();
+
+        if ($this->isProjectionReady($existing)) {
+            return $existing;
+        }
+
+        if (! $this->resultExists($orgId, $attemptId)) {
+            return $existing;
+        }
+
+        if (! $this->hasActiveUnlockGrant($orgId, $attemptId)) {
+            return $existing;
+        }
+
+        $modulesAllowed = $this->entitlements->getAllowedModulesForAttempt($orgId, $attemptId);
+        $pdfReady = $this->isPdfReady($existing, $attemptId);
+        $patch = [
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => $pdfReady ? 'ready' : 'missing',
+            'reason_code' => 'projection_repaired_from_entitlement',
+            'actions_json' => [
+                'report' => true,
+                'pdf' => $pdfReady,
+                'unlock' => true,
+            ],
+            'payload_json' => [
+                'attempt_id' => $attemptId,
+                'has_active_grant' => true,
+                'result_exists' => true,
+                'repair_source' => 'attempt_unlock_projection_repair',
+                'access_level' => ReportAccess::REPORT_ACCESS_FULL,
+                'variant' => ReportAccess::VARIANT_FULL,
+                'modules_allowed' => $modulesAllowed,
+                'modules_preview' => [],
+            ],
+        ];
+        $meta = [
+            'source_system' => 'attempt_unlock_projection_repair',
+            'source_ref' => 'result#'.$attemptId,
+            'actor_type' => 'system',
+            'actor_id' => 'attempt_unlock_projection_repair',
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ];
+
+        try {
+            $projection = $this->projectionWriter->refreshAttemptProjection($attemptId, $patch, $meta);
+
+            if (! $projection instanceof UnifiedAccessProjection) {
+                $projection = $this->persistProjectionPatch($attemptId, $patch, $existing);
+                Log::warning('ATTEMPT_UNLOCK_PROJECTION_REPAIR_WRITER_UNAVAILABLE', [
+                    'org_id' => $orgId,
+                    'attempt_id' => $attemptId,
+                    'existing_reason_code' => $existing?->reason_code,
+                ]);
+            }
+
+            Log::info('ATTEMPT_UNLOCK_PROJECTION_REPAIRED', [
+                'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'existing_reason_code' => $existing?->reason_code,
+                'pdf_ready' => $pdfReady,
+            ]);
+
+            return $projection ?? $existing;
+        } catch (\Throwable $e) {
+            Log::error('ATTEMPT_UNLOCK_PROJECTION_REPAIR_FAILED', [
+                'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'existing_reason_code' => $existing?->reason_code,
+                'exception' => $e,
+            ]);
+
+            return $existing;
+        }
+    }
+
+    private function isProjectionReady(?UnifiedAccessProjection $projection): bool
+    {
+        if (! $projection instanceof UnifiedAccessProjection) {
+            return false;
+        }
+
+        return strtolower(trim((string) ($projection->access_state ?? ''))) === 'ready'
+            && strtolower(trim((string) ($projection->report_state ?? ''))) === 'ready';
+    }
+
+    private function resultExists(int $orgId, string $attemptId): bool
+    {
+        return DB::table('results')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->exists();
+    }
+
+    private function hasActiveUnlockGrant(int $orgId, string $attemptId): bool
+    {
+        return DB::table('benefit_grants')
+            ->where('org_id', $orgId)
+            ->where('benefit_type', 'report_unlock')
+            ->where('status', 'active')
+            ->where(function ($query) use ($attemptId): void {
+                $query->where('attempt_id', $attemptId)
+                    ->orWhere('scope', 'org');
+            })
+            ->where(function ($query): void {
+                $query->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            })
+            ->exists();
+    }
+
+    private function isPdfReady(?UnifiedAccessProjection $existing, string $attemptId): bool
+    {
+        if ($existing instanceof UnifiedAccessProjection) {
+            $existingState = strtolower(trim((string) ($existing->pdf_state ?? '')));
+            if ($existingState === 'ready') {
+                return true;
+            }
+        }
+
+        if (! SchemaBaseline::hasTable('report_artifact_slots')) {
+            return false;
+        }
+
+        return DB::table('report_artifact_slots')
+            ->where('attempt_id', $attemptId)
+            ->whereIn('slot_code', ['report_pdf_free', 'report_pdf_full'])
+            ->exists();
+    }
+
+    /**
+     * @param  array<string,mixed>  $patch
+     */
+    private function persistProjectionPatch(
+        string $attemptId,
+        array $patch,
+        ?UnifiedAccessProjection $existing
+    ): UnifiedAccessProjection {
+        $now = now();
+
+        return UnifiedAccessProjection::query()->updateOrCreate(
+            ['attempt_id' => $attemptId],
+            [
+                'access_state' => (string) $patch['access_state'],
+                'report_state' => (string) $patch['report_state'],
+                'pdf_state' => (string) $patch['pdf_state'],
+                'reason_code' => (string) $patch['reason_code'],
+                'projection_version' => 1,
+                'actions_json' => is_array($patch['actions_json'] ?? null) ? $patch['actions_json'] : null,
+                'payload_json' => is_array($patch['payload_json'] ?? null) ? $patch['payload_json'] : null,
+                'produced_at' => $existing?->produced_at ?? $now,
+                'refreshed_at' => $now,
+            ]
+        );
+    }
+}

--- a/backend/app/Services/Commerce/EntitlementManager.php
+++ b/backend/app/Services/Commerce/EntitlementManager.php
@@ -5,6 +5,7 @@ namespace App\Services\Commerce;
 use App\Services\Report\ReportAccess;
 use App\Services\Storage\UnifiedAccessProjectionWriter;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class EntitlementManager
@@ -387,7 +388,7 @@ class EntitlementManager
     private function refreshAccessProjection(string $attemptId, array $meta): void
     {
         try {
-            $this->accessProjections->refreshAttemptProjection(
+            $projection = $this->accessProjections->refreshAttemptProjection(
                 $attemptId,
                 [
                     'access_state' => 'ready',
@@ -399,8 +400,25 @@ class EntitlementManager
                 ],
                 $meta
             );
-        } catch (\Throwable) {
-            // Best-effort sidecar only. Preserve entitlement grant behavior.
+
+            if ($projection === null) {
+                Log::warning('ENTITLEMENT_ACCESS_PROJECTION_REFRESH_SKIPPED', [
+                    'attempt_id' => $attemptId,
+                    'source_ref' => $meta['source_ref'] ?? null,
+                    'source_system' => $meta['source_system'] ?? 'entitlement_manager',
+                    'actor_type' => $meta['actor_type'] ?? null,
+                    'actor_id' => $meta['actor_id'] ?? null,
+                ]);
+            }
+        } catch (\Throwable $e) {
+            Log::error('ENTITLEMENT_ACCESS_PROJECTION_REFRESH_FAILED', [
+                'attempt_id' => $attemptId,
+                'source_ref' => $meta['source_ref'] ?? null,
+                'source_system' => $meta['source_system'] ?? 'entitlement_manager',
+                'actor_type' => $meta['actor_type'] ?? null,
+                'actor_id' => $meta['actor_id'] ?? null,
+                'exception' => $e,
+            ]);
         }
     }
 

--- a/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
+++ b/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
@@ -6,6 +6,7 @@ namespace App\Services\Commerce;
 
 use App\Models\Attempt;
 use App\Models\UnifiedAccessProjection;
+use App\Services\Access\AttemptUnlockProjectionRepairService;
 use App\Services\Report\ReportAccess;
 use Illuminate\Support\Facades\DB;
 
@@ -13,6 +14,7 @@ final class MbtiAccessHubBuilder
 {
     public function __construct(
         private OrderManager $orders,
+        private AttemptUnlockProjectionRepairService $projectionRepair,
     ) {}
 
     /**
@@ -264,6 +266,10 @@ final class MbtiAccessHubBuilder
             ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId)
             ->exists();
+        if ($resultExists) {
+            $this->projectionRepair->repairResultReadyProjectionIfNeeded($orgId, $attemptId);
+        }
+
         $projection = UnifiedAccessProjection::query()->where('attempt_id', $attemptId)->first();
         $payload = is_array($projection?->payload_json) ? $projection->payload_json : [];
         $accessState = $this->normalizeProjectionState(

--- a/backend/tests/Feature/Commerce/EntitlementProjectionRefreshObservabilityTest.php
+++ b/backend/tests/Feature/Commerce/EntitlementProjectionRefreshObservabilityTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Services\Commerce\EntitlementManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EntitlementProjectionRefreshObservabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_grant_attempt_unlock_logs_when_projection_refresh_is_skipped_without_losing_the_grant(): void
+    {
+        Log::spy();
+        config()->set('storage_rollout.access_projection_dual_write_enabled', false);
+        config()->set('storage_rollout.receipt_ledger_dual_write_enabled', false);
+
+        /** @var EntitlementManager $manager */
+        $manager = $this->app->make(EntitlementManager::class);
+        $attemptId = (string) Str::uuid();
+
+        $result = $manager->grantAttemptUnlock(
+            0,
+            null,
+            'anon_projection_observability',
+            'MBTI_REPORT_FULL',
+            $attemptId,
+            'ORDER-PROJECTION-OBS'
+        );
+
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+        $this->assertDatabaseHas('benefit_grants', [
+            'attempt_id' => $attemptId,
+            'order_no' => 'ORDER-PROJECTION-OBS',
+            'status' => 'active',
+        ]);
+
+        Log::shouldHaveReceived('warning')->once()->withArgs(
+            static function (string $message, array $context) use ($attemptId): bool {
+                return $message === 'ENTITLEMENT_ACCESS_PROJECTION_REFRESH_SKIPPED'
+                    && (string) ($context['attempt_id'] ?? '') === $attemptId
+                    && (string) ($context['source_ref'] ?? '') === 'ORDER-PROJECTION-OBS';
+            }
+        );
+    }
+}

--- a/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+++ b/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
@@ -85,6 +85,27 @@ final class AttemptReportAccessReadTest extends TestCase
         ]);
     }
 
+    private function createActiveGrant(string $attemptId, string $anonId): void
+    {
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'user_id' => $anonId,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'order_no' => 'ORDER-'.$attemptId,
+            'status' => 'active',
+            'expires_at' => null,
+            'benefit_ref' => $anonId,
+            'benefit_type' => 'report_unlock',
+            'source_order_id' => (string) Str::uuid(),
+            'source_event_id' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
     public function test_it_reads_consumer_report_access_projection_without_changing_report_contracts(): void
     {
         $this->seedScales();
@@ -128,5 +149,175 @@ final class AttemptReportAccessReadTest extends TestCase
         $response->assertJsonPath('actions.history_href', '/history/mbti');
         $response->assertJsonPath('actions.lookup_href', '/orders/lookup');
         $response->assertJsonPath('payload.has_active_grant', true);
+    }
+
+    public function test_it_repairs_missing_ready_projection_from_active_entitlement_when_result_exists(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_repair';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createResult($attemptId);
+        $this->createActiveGrant($attemptId, $anonId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'ready');
+        $response->assertJsonPath('report_state', 'ready');
+        $response->assertJsonPath('reason_code', 'projection_repaired_from_entitlement');
+        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+        $response->assertJsonPath('payload.has_active_grant', true);
+        $response->assertJsonPath('payload.result_exists', true);
+        $response->assertJsonPath('payload.access_level', 'full');
+        $response->assertJsonPath('payload.variant', 'full');
+        $this->assertDatabaseHas('unified_access_projections', [
+            'attempt_id' => $attemptId,
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ]);
+    }
+
+    public function test_it_keeps_result_ready_projection_missing_locked_when_no_active_grant_exists(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_no_grant';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createResult($attemptId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'locked');
+        $response->assertJsonPath('report_state', 'ready');
+        $response->assertJsonPath('reason_code', 'projection_missing_result_ready');
+        $response->assertJsonPath('payload.result_exists', true);
+        $response->assertJsonPath('payload.has_active_grant', null);
+        $this->assertDatabaseMissing('unified_access_projections', [
+            'attempt_id' => $attemptId,
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ]);
+    }
+
+    public function test_it_keeps_projection_missing_pending_when_active_grant_exists_but_result_does_not_exist(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_no_result';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createActiveGrant($attemptId, $anonId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'pending');
+        $response->assertJsonPath('report_state', 'pending');
+        $response->assertJsonPath('reason_code', 'projection_missing_result_pending');
+        $response->assertJsonPath('payload.result_exists', false);
+        $this->assertDatabaseMissing('unified_access_projections', [
+            'attempt_id' => $attemptId,
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ]);
+    }
+
+    public function test_it_does_not_repair_non_mbti_attempts_from_projection_missing_result_ready(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_non_mbti';
+        $token = $this->issueAnonToken($anonId);
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 120,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'content_package_version' => 'attempt-v1',
+            'scoring_spec_version' => 'attempt-score-v1',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v0.3',
+            'type_code' => '',
+            'scores_json' => [],
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'result-v1',
+            'result_json' => ['variant' => 'free'],
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'result-score-v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'user_id' => $anonId,
+            'benefit_code' => 'BIG5_FULL_REPORT',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'order_no' => 'ORDER-'.$attemptId,
+            'status' => 'active',
+            'expires_at' => null,
+            'benefit_ref' => $anonId,
+            'benefit_type' => 'report_unlock',
+            'source_order_id' => (string) Str::uuid(),
+            'source_event_id' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'locked');
+        $response->assertJsonPath('report_state', 'ready');
+        $response->assertJsonPath('reason_code', 'projection_missing_result_ready');
+        $this->assertDatabaseMissing('unified_access_projections', [
+            'attempt_id' => $attemptId,
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ]);
     }
 }

--- a/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
@@ -122,6 +122,39 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ->assertJsonPath('exact_result_entry.actions.page_href', "/result/{$attemptId}");
     }
 
+    public function test_lookup_repairs_exact_result_entry_when_result_exists_and_active_grant_is_present(): void
+    {
+        $orderNo = 'ord_lookup_mbti_repair_'.Str::lower(Str::random(8));
+        $userId = $this->createUser('owner@example.com');
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, (string) $userId, 'MBTI');
+        $this->insertOrderForLookup($orderNo, 'owner@example.com', $attemptId, 'paid', (string) $userId);
+        $this->insertResult($attemptId);
+        $this->insertActiveGrant($attemptId, $orderNo, (string) $userId);
+
+        $response = $this->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => 'owner@example.com',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('mbti_access_hub_v1.access_state', 'ready')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
+            ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.access_state', 'ready')
+            ->assertJsonPath('exact_result_entry.report_state', 'ready')
+            ->assertJsonPath('exact_result_entry.reason_code', 'projection_repaired_from_entitlement')
+            ->assertJsonPath('exact_result_entry.ready_to_enter', true)
+            ->assertJsonPath('exact_result_entry.actions.page_href', "/result/{$attemptId}");
+
+        $this->assertDatabaseHas('unified_access_projections', [
+            'attempt_id' => $attemptId,
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ]);
+    }
+
     public function test_lookup_with_token_owner_works_without_email(): void
     {
         $orderNo = 'ord_lookup_'.Str::lower(Str::random(8));
@@ -280,6 +313,27 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             'payload_json' => json_encode($overrides['payload_json'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'produced_at' => now(),
             'refreshed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertActiveGrant(string $attemptId, string $orderNo, string $userId): void
+    {
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'user_id' => $userId,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'status' => 'active',
+            'expires_at' => null,
+            'benefit_ref' => self::ANON_OWNER,
+            'benefit_type' => 'report_unlock',
+            'source_order_id' => (string) Str::uuid(),
+            'source_event_id' => null,
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -154,6 +154,40 @@ final class CommerceOrderReadFallbackTest extends TestCase
             ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', false);
     }
 
+    public function test_paid_mbti_order_repairs_exact_result_entry_when_result_exists_and_active_grant_is_present(): void
+    {
+        $orderNo = 'ord_fallback_mbti_repair_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'paid');
+        $this->insertResult($attemptId);
+        $this->insertActiveGrant($attemptId, $orderNo);
+
+        $token = $this->issueAnonToken(self::ANON_OWNER);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('grant_state', 'not_started')
+            ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.access_state', 'ready')
+            ->assertJsonPath('exact_result_entry.report_state', 'ready')
+            ->assertJsonPath('exact_result_entry.reason_code', 'projection_repaired_from_entitlement')
+            ->assertJsonPath('exact_result_entry.ready_to_enter', true)
+            ->assertJsonPath('exact_result_entry.actions.page_href', "/result/{$attemptId}")
+            ->assertJsonPath('mbti_access_hub_v1.access_state', 'ready')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true);
+
+        $this->assertDatabaseHas('unified_access_projections', [
+            'attempt_id' => $attemptId,
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ]);
+    }
+
     public function test_valid_payment_recovery_token_reads_pending_order_without_owner_identity(): void
     {
         config([
@@ -357,6 +391,27 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'payload_json' => json_encode($overrides['payload_json'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'produced_at' => now(),
             'refreshed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertActiveGrant(string $attemptId, string $orderNo): void
+    {
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'user_id' => self::ANON_OWNER,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'status' => 'active',
+            'expires_at' => null,
+            'benefit_ref' => self::ANON_OWNER,
+            'benefit_type' => 'report_unlock',
+            'source_order_id' => (string) Str::uuid(),
+            'source_event_id' => null,
             'created_at' => now(),
             'updated_at' => now(),
         ]);


### PR DESCRIPTION
## Summary
- repair missing exact-attempt unified access projections when MBTI results already exist and a valid unlock grant is present
- make entitlement projection refresh skips and failures observable instead of silently swallowing them
- add MBTI exact-result read and order/lookup coverage plus non-regression guards for missing grant, missing result, and non-MBTI attempts

## Verification
- php artisan route:list
- php artisan migrate
- php artisan test tests/Feature/V0_3/AttemptReportAccessReadTest.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/Commerce/EntitlementProjectionRefreshObservabilityTest.php
- bash backend/scripts/ci_verify_mbti.sh

## Notes
- only fap-api changed
- did not touch routes, migrations, or middleware
- did not change fap-web, payment provider integration, content assets, or frontend result gate semantics