### PR TITLE
Enrich Alipay return URLs with recovery context

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -655,13 +655,14 @@ class CommerceController extends Controller
         $orgId = $this->orgContext->orgId();
         $userId = $this->orgContext->userId();
         $anonId = $this->resolveAnonId($request);
+        $requestedPaymentRecoveryToken = $this->resolvePaymentRecoveryToken($request);
         $found = $this->orders->getOrder(
             $orgId,
             $userId !== null ? (string) $userId : null,
             $anonId,
             $order_no,
             false,
-            $this->resolvePaymentRecoveryToken($request)
+            $requestedPaymentRecoveryToken
         );
         if (! ($found['ok'] ?? false)) {
             $errorCode = (string) data_get($found, 'error_code', data_get($found, 'error', ''));
@@ -682,9 +683,27 @@ class CommerceController extends Controller
         if (! in_array($scene, ['desktop', 'mobile'], true)) {
             $scene = 'desktop';
         }
+        $paymentRecoveryVerified = (bool) ($found['payment_recovery_verified'] ?? false);
+        $paymentRecoveryToken = $paymentRecoveryVerified && $requestedPaymentRecoveryToken !== null
+            ? $requestedPaymentRecoveryToken
+            : $this->orders->issuePaymentRecoveryToken($order);
+        $recoveryUrls = $this->orders->presentPaymentRecoveryUrls(
+            $order,
+            $paymentRecoveryToken,
+            $this->resolveRequestedLocale($request)
+        );
+        $launchOrder = (array) $order;
+        $enrichedReturnUrl = $this->buildAlipayReturnUrl(
+            $order,
+            $paymentRecoveryToken,
+            $recoveryUrls
+        );
+        if ($enrichedReturnUrl !== null) {
+            $launchOrder['return_url'] = $enrichedReturnUrl;
+        }
 
         try {
-            $launch = $this->alipayCheckout->launch((array) $order, $scene);
+            $launch = $this->alipayCheckout->launch($launchOrder, $scene);
             $response = $this->toHttpResponse($launch);
             if ($response instanceof Response) {
                 return $response;
@@ -1466,6 +1485,90 @@ class CommerceController extends Controller
         $normalized = trim((string) $value);
 
         return $normalized !== '' ? $normalized : null;
+    }
+
+    /**
+     * @param  array{wait_url:?string,result_url:?string}  $recoveryUrls
+     */
+    private function buildAlipayReturnUrl(object $order, ?string $paymentRecoveryToken, array $recoveryUrls): ?string
+    {
+        $baseReturnUrl = $this->trimNullableString(data_get(config('pay.alipay.default', []), 'return_url', ''))
+            ?? $this->deriveDefaultAlipayReturnUrl($recoveryUrls);
+        $orderNo = $this->trimNullableString($order->order_no ?? null);
+
+        if ($baseReturnUrl === null || $orderNo === null) {
+            return $baseReturnUrl;
+        }
+
+        $waitUrl = $this->trimNullableString($recoveryUrls['wait_url'] ?? null);
+        $resultUrl = $this->trimNullableString($recoveryUrls['result_url'] ?? null);
+        $fragment = parse_url($baseReturnUrl, PHP_URL_FRAGMENT);
+        $query = [];
+        $existingQuery = parse_url($baseReturnUrl, PHP_URL_QUERY);
+        if (is_string($existingQuery) && $existingQuery !== '') {
+            parse_str($existingQuery, $query);
+        }
+
+        $query['order_no'] = $orderNo;
+        if ($paymentRecoveryToken !== null) {
+            $query['payment_recovery_token'] = $paymentRecoveryToken;
+        }
+        if ($waitUrl !== null) {
+            $query['wait_url'] = $waitUrl;
+        }
+        if ($resultUrl !== null) {
+            $query['result_url'] = $resultUrl;
+        }
+
+        $baseWithoutQuery = preg_replace('/[?#].*$/', '', $baseReturnUrl) ?: $baseReturnUrl;
+        $built = $baseWithoutQuery;
+        if ($query !== []) {
+            $built .= '?'.http_build_query($query);
+        }
+        if (is_string($fragment) && $fragment !== '') {
+            $built .= '#'.$fragment;
+        }
+
+        return $built;
+    }
+
+    /**
+     * @param  array{wait_url:?string,result_url:?string}  $recoveryUrls
+     */
+    private function deriveDefaultAlipayReturnUrl(array $recoveryUrls): ?string
+    {
+        foreach ([
+            $this->trimNullableString($recoveryUrls['wait_url'] ?? null),
+            $this->trimNullableString($recoveryUrls['result_url'] ?? null),
+        ] as $candidateUrl) {
+            if ($candidateUrl === null) {
+                continue;
+            }
+
+            $scheme = parse_url($candidateUrl, PHP_URL_SCHEME);
+            $host = parse_url($candidateUrl, PHP_URL_HOST);
+            $port = parse_url($candidateUrl, PHP_URL_PORT);
+            $path = trim((string) parse_url($candidateUrl, PHP_URL_PATH));
+
+            if (! is_string($scheme) || $scheme === '' || ! is_string($host) || $host === '' || $path === '') {
+                continue;
+            }
+
+            $segments = explode('/', ltrim($path, '/'));
+            $locale = in_array($segments[0] ?? '', ['en', 'zh'], true) ? $segments[0] : null;
+            if ($locale === null) {
+                continue;
+            }
+
+            $base = $scheme.'://'.$host;
+            if (is_int($port)) {
+                $base .= ':'.$port;
+            }
+
+            return $base.'/'.$locale.'/pay/return/alipay';
+        }
+
+        return null;
     }
 
     /**

--- a/backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php
+++ b/backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php
@@ -38,7 +38,7 @@ class AlipayCheckoutService
         if ($notifyUrl === '') {
             $notifyUrl = url('/api/v0.3/webhooks/payment/alipay');
         }
-        $returnUrl = trim((string) data_get(config('pay.alipay.default', []), 'return_url', ''));
+        $returnUrl = trim((string) ($order['return_url'] ?? data_get(config('pay.alipay.default', []), 'return_url', '')));
 
         $amountCents = max(0, (int) ($order['amount_cents'] ?? 0));
         $totalAmount = number_format($amountCents / 100, 2, '.', '');

--- a/backend/tests/Feature/V0_3/AlipayLaunchEndpointTest.php
+++ b/backend/tests/Feature/V0_3/AlipayLaunchEndpointTest.php
@@ -52,6 +52,94 @@ final class AlipayLaunchEndpointTest extends TestCase
         $response->assertSee('pay');
     }
 
+    public function test_launch_endpoint_enriches_return_url_with_wait_recovery_context(): void
+    {
+        config([
+            'app.frontend_url' => 'https://web.example.test',
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.return_url' => 'https://web.example.test/en/pay/return/alipay',
+        ]);
+
+        $orderNo = $this->insertOrder('anon_owner_3');
+
+        $service = Mockery::mock(AlipayCheckoutService::class);
+        $service->shouldReceive('launch')
+            ->once()
+            ->withArgs(function (array $order, string $scene) use ($orderNo): bool {
+                $this->assertSame('desktop', $scene);
+                $this->assertArrayHasKey('return_url', $order);
+
+                $returnUrl = (string) ($order['return_url'] ?? '');
+                $this->assertStringStartsWith('https://web.example.test/en/pay/return/alipay?', $returnUrl);
+
+                $parsedQuery = [];
+                parse_str((string) parse_url($returnUrl, PHP_URL_QUERY), $parsedQuery);
+
+                $this->assertSame($orderNo, (string) ($parsedQuery['order_no'] ?? ''));
+                $this->assertNotSame('', (string) ($parsedQuery['payment_recovery_token'] ?? ''));
+                $this->assertStringContainsString(
+                    '/en/pay/wait?order_no='.$orderNo,
+                    (string) ($parsedQuery['wait_url'] ?? '')
+                );
+
+                return true;
+            })
+            ->andReturn(new Response('<html>pay</html>', 200));
+        $this->app->instance(AlipayCheckoutService::class, $service);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => 'anon_owner_3',
+            'X-Locale' => 'en',
+        ])->get('/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop');
+
+        $response->assertStatus(200);
+        $response->assertSee('pay');
+    }
+
+    public function test_launch_endpoint_derives_return_url_from_recovery_urls_when_static_config_is_missing(): void
+    {
+        config([
+            'app.frontend_url' => 'https://web.example.test',
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.return_url' => null,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_owner_4');
+
+        $service = Mockery::mock(AlipayCheckoutService::class);
+        $service->shouldReceive('launch')
+            ->once()
+            ->withArgs(function (array $order, string $scene) use ($orderNo): bool {
+                $this->assertSame('desktop', $scene);
+                $this->assertArrayHasKey('return_url', $order);
+
+                $returnUrl = (string) ($order['return_url'] ?? '');
+                $this->assertStringStartsWith('https://web.example.test/en/pay/return/alipay?', $returnUrl);
+
+                $parsedQuery = [];
+                parse_str((string) parse_url($returnUrl, PHP_URL_QUERY), $parsedQuery);
+
+                $this->assertSame($orderNo, (string) ($parsedQuery['order_no'] ?? ''));
+                $this->assertNotSame('', (string) ($parsedQuery['payment_recovery_token'] ?? ''));
+                $this->assertStringContainsString(
+                    '/en/pay/wait?order_no='.$orderNo,
+                    (string) ($parsedQuery['wait_url'] ?? '')
+                );
+
+                return true;
+            })
+            ->andReturn(new Response('<html>pay</html>', 200));
+        $this->app->instance(AlipayCheckoutService::class, $service);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => 'anon_owner_4',
+            'X-Locale' => 'en',
+        ])->get('/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop');
+
+        $response->assertStatus(200);
+        $response->assertSee('pay');
+    }
+
     private function insertOrder(string $anonId): string
     {
         $orderNo = 'ord_alipay_'.Str::random(8);

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -594,15 +594,30 @@ final class CommerceCheckoutPayActionTest extends TestCase
 
         $orderNo = 'ord_alipay_recovery_checkout_1';
         $this->insertPendingOrder($orderNo, 'alipay', 'anon_alipay_recovery_checkout_1');
+        $token = app(PaymentRecoveryToken::class)->issue($orderNo);
 
         $service = Mockery::mock(\App\Services\Commerce\Checkout\AlipayCheckoutService::class);
         $service->shouldReceive('launch')
             ->once()
-            ->with(Mockery::type('array'), 'desktop')
+            ->withArgs(function (array $order, string $scene) use ($orderNo, $token): bool {
+                $this->assertSame('desktop', $scene);
+                $this->assertArrayHasKey('return_url', $order);
+
+                $returnUrl = (string) ($order['return_url'] ?? '');
+                $parsedQuery = [];
+                parse_str((string) parse_url($returnUrl, PHP_URL_QUERY), $parsedQuery);
+
+                $this->assertSame($orderNo, (string) ($parsedQuery['order_no'] ?? ''));
+                $this->assertSame($token, (string) ($parsedQuery['payment_recovery_token'] ?? ''));
+                $this->assertStringContainsString(
+                    '/pay/wait?order_no='.$orderNo.'&payment_recovery_token='.$token,
+                    (string) ($parsedQuery['wait_url'] ?? '')
+                );
+
+                return true;
+            })
             ->andReturn('<html>pay</html>');
         $this->app->instance(\App\Services\Commerce\Checkout\AlipayCheckoutService::class, $service);
-
-        $token = app(PaymentRecoveryToken::class)->issue($orderNo);
 
         $response = $this->get('/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop&paymentRecoveryToken='.urlencode($token));
 


### PR DESCRIPTION
## Summary
- enrich Alipay return URLs with order-bound recovery context
- preserve /pay/wait as the canonical recovery and exact-result entry hub
- keep provider webhook and unlock truth ownership unchanged

## Verification
- php artisan route:list
- php artisan migrate
- php artisan test tests/Feature/V0_3/AlipayLaunchEndpointTest.php tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
- bash backend/scripts/ci_verify_mbti.sh