### PR TITLE
Add Alipay return recovery endpoint

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Yansongda\Pay\Pay;
 
 class CommerceController extends Controller
 {
@@ -226,6 +227,78 @@ class CommerceController extends Controller
         }
 
         return response()->json($payload);
+    }
+
+    /**
+     * GET /api/v0.3/orders/{order_no}/recover/alipay-return
+     */
+    public function recoverAlipayReturn(Request $request, string $order_no): JsonResponse
+    {
+        if (! $this->paymentProviders->isEnabled('alipay')) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'PROVIDER_DISABLED',
+                'message' => 'provider not enabled.',
+            ], 404);
+        }
+
+        if (! class_exists(Pay::class)) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'PAYMENT_PROVIDER_NOT_INSTALLED',
+                'message' => 'alipay sdk is not installed.',
+            ], 503);
+        }
+
+        try {
+            Pay::config(config('pay'));
+            $payload = $this->normalizeSdkPayload(Pay::alipay()->callback($request->query()));
+        } catch (\Throwable $e) {
+            Log::warning('ALIPAY_RETURN_RECOVERY_INVALID_SIGNATURE', [
+                'order_no' => $order_no,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'INVALID_SIGNATURE',
+                'message' => 'invalid signature.',
+            ], 400);
+        }
+
+        $normalizedRouteOrderNo = trim($order_no);
+        $normalizedReturnOrderNo = $this->trimNullableString($payload['out_trade_no'] ?? null);
+        if ($normalizedRouteOrderNo === '' || $normalizedReturnOrderNo === null || $normalizedRouteOrderNo !== $normalizedReturnOrderNo) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'ORDER_MISMATCH',
+                'message' => 'returned order does not match the requested order.',
+            ], 422);
+        }
+
+        $order = $this->orders->findOrderByOrderNo($normalizedRouteOrderNo, $this->orgContext->orgId());
+        if ($order === null) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'ORDER_NOT_FOUND',
+                'message' => 'order not found.',
+            ], 404);
+        }
+
+        $paymentRecoveryToken = $this->orders->issuePaymentRecoveryToken($order);
+        $recoveryUrls = $this->orders->presentPaymentRecoveryUrls(
+            $order,
+            $paymentRecoveryToken,
+            $this->resolveRequestedLocale($request)
+        );
+
+        return response()->json([
+            'ok' => true,
+            'order_no' => $normalizedRouteOrderNo,
+            'payment_recovery_token' => $paymentRecoveryToken,
+            'wait_url' => $recoveryUrls['wait_url'],
+            'result_url' => $recoveryUrls['result_url'],
+        ]);
     }
 
     /**
@@ -1485,6 +1558,31 @@ class CommerceController extends Controller
         $normalized = trim((string) $value);
 
         return $normalized !== '' ? $normalized : null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function normalizeSdkPayload(mixed $payload): array
+    {
+        if (is_array($payload)) {
+            return $payload;
+        }
+
+        if ($payload instanceof \JsonSerializable) {
+            $serialized = $payload->jsonSerialize();
+            if (is_array($serialized)) {
+                return $serialized;
+            }
+        }
+
+        if ($payload instanceof PsrResponseInterface) {
+            $decoded = json_decode((string) $payload->getBody(), true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        return [];
     }
 
     /**

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1030,6 +1030,28 @@
                 ]
             }
         },
+        "/api/v0.3/orders/{order_no}/recover/alipay-return": {
+            "get": {
+                "operationId": "api.v0_3.orders.recover_alipay_return",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\CommerceController@recoverAlipayReturn",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ],
+                "x-laravel-name": "api.v0_3.orders.recover_alipay_return"
+            }
+        },
         "/api/v0.3/orders/{order_no}/resend": {
             "post": {
                 "operationId": "post_api_v0_3_orders_order_no_resend",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -216,6 +216,8 @@ Route::prefix('v0.3')->middleware([
         Route::post('/orders/checkout', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@checkout')
             ->middleware(\App\Http\Middleware\FmTokenOptional::class)
             ->name('api.v0_3.orders.checkout');
+        Route::get('/orders/{order_no}/recover/alipay-return', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@recoverAlipayReturn')
+            ->name('api.v0_3.orders.recover_alipay_return');
         Route::post('/orders/lookup', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@lookup')
             ->middleware([\App\Http\Middleware\FmTokenOptional::class, 'throttle:api_order_lookup'])
             ->name('api.v0_3.orders.lookup');

--- a/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
+++ b/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Yansongda\Pay\Pay;
+
+use function Yansongda\Artful\filter_params;
+
+final class AlipayReturnRecoveryEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Pay::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        Pay::clear();
+
+        parent::tearDown();
+    }
+
+    public function test_recover_alipay_return_returns_tokenized_wait_context_for_valid_signed_query(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'app.frontend_url' => 'https://web.example.test',
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_1');
+        $payload = [
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_1',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => 'anon_alipay_return_recovery_1',
+            'X-Locale' => 'en',
+        ])->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('order_no', $orderNo);
+        $response->assertJsonPath('payment_recovery_token', fn ($value) => is_string($value) && $value !== '');
+        $this->assertStringContainsString('/en/pay/wait?order_no='.$orderNo, (string) $response->json('wait_url'));
+    }
+
+    public function test_recover_alipay_return_rejects_invalid_signature(): void
+    {
+        config([
+            'payments.providers.alipay.enabled' => true,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_2');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => 'anon_alipay_return_recovery_2',
+        ])->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?out_trade_no='.$orderNo.'&trade_no=ali_trade_return_recovery_2&trade_status=TRADE_SUCCESS');
+
+        $response->assertStatus(400);
+        $response->assertJsonPath('error_code', 'INVALID_SIGNATURE');
+    }
+
+    public function test_recover_alipay_return_rejects_order_mismatch(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_3');
+        $payload = [
+            'out_trade_no' => 'ord_other_return_recovery',
+            'trade_no' => 'ali_trade_return_recovery_3',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'ORDER_MISMATCH');
+    }
+
+    private function insertOrder(string $anonId): string
+    {
+        $orderNo = 'ord_alipay_recover_'.Str::random(8);
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => null,
+            'amount_cents' => 1990,
+            'currency' => 'CNY',
+            'status' => 'created',
+            'provider' => 'alipay',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 1990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_CREDIT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+
+        return $orderNo;
+    }
+
+    /**
+     * @return array{private: string, public: string}
+     */
+    private function generateRsaKeyPair(): array
+    {
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        if ($resource === false) {
+            self::fail('failed to generate rsa keypair.');
+        }
+
+        $privateKey = '';
+        $exported = openssl_pkey_export($resource, $privateKey);
+        if ($exported !== true || trim($privateKey) === '') {
+            self::fail('failed to export private key.');
+        }
+
+        $details = openssl_pkey_get_details($resource);
+        if (! is_array($details) || trim((string) ($details['key'] ?? '')) === '') {
+            self::fail('failed to get public key.');
+        }
+
+        return [
+            'private' => $privateKey,
+            'public' => (string) $details['key'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function buildAlipaySignature(array $payload, string $privateKey): string
+    {
+        $content = filter_params(
+            $payload,
+            static fn ($key, $value): bool => (string) $value !== '' && $key !== 'sign' && $key !== 'sign_type'
+        )->sortKeys()->toString();
+
+        $signature = '';
+        $ok = openssl_sign($content, $signature, $privateKey, OPENSSL_ALGO_SHA256);
+        if ($ok !== true) {
+            self::fail('failed to sign alipay payload.');
+        }
+
+        return base64_encode($signature);
+    }
+}


### PR DESCRIPTION
## Summary
- add a signed Alipay return recovery endpoint that exchanges provider return params for canonical wait-flow recovery context
- issue an order-bound payment recovery token and wait URL without exposing full order details
- sync the OpenAPI snapshot and add feature coverage for valid, invalid, and mismatched returns

## Verification
- php artisan test tests/Feature/V0_3/AlipayLaunchEndpointTest.php tests/Feature/V0_3/CommerceCheckoutPayActionTest.php tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
- php artisan route:list | rg 'orders/.*/recover/alipay-return|orders/.*/pay/alipay' -n -S
- php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh