### PR TITLE
MBTI form-aware public attribution

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -20,6 +20,7 @@ use App\Services\Mbti\MbtiAdaptiveSelectionService;
 use App\Services\Mbti\MbtiIntraTypeProfileService;
 use App\Services\Mbti\MbtiPrivacyConsentContractService;
 use App\Services\Mbti\MbtiPublicProjectionService;
+use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Mbti\MbtiReadModelContractService;
 use App\Services\Mbti\MbtiUserStateOrchestrationService;
@@ -51,6 +52,7 @@ class AttemptReadController extends Controller
         private BigFivePublicProjectionService $bigFivePublicProjectionService,
         private MbtiPrivacyConsentContractService $mbtiPrivacyConsentContractService,
         private MbtiPublicProjectionService $mbtiPublicProjectionService,
+        private MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
         private MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private MbtiUserStateOrchestrationService $mbtiUserStateOrchestrationService,
         private MbtiActionJourneyContractService $mbtiActionJourneyContractService,
@@ -127,6 +129,9 @@ class AttemptReadController extends Controller
         $contentPackageVersion = $this->preferredStringField($result, $attempt, 'content_package_version');
         $scoringSpecVersion = $this->preferredStringField($result, $attempt, 'scoring_spec_version');
         $reportEngineVersion = $this->preferredStringField($result, null, 'report_engine_version', 'v1.2');
+        $mbtiFormSummary = $scaleCode === 'MBTI'
+            ? $this->resolveMbtiFormSummary($request, $attempt, $result)
+            : null;
 
         if ($scaleCode === 'CLINICAL_COMBO_68') {
             $gate = $this->reportGatekeeper->resolve(
@@ -173,9 +178,10 @@ class AttemptReadController extends Controller
                 'type_code' => (string) ($result->type_code ?? ''),
                 'attempt_id' => $attemptId,
                 'locked' => (bool) ($gate['locked'] ?? true),
+                ...$this->mbtiFormEventMeta($mbtiFormSummary),
             ]);
 
-            return response()->json([
+            $responsePayload = [
                 'ok' => true,
                 'attempt_id' => $attemptId,
                 'type_code' => '',
@@ -194,7 +200,12 @@ class AttemptReadController extends Controller
                     'scoring_spec_version' => $scoringSpecVersion,
                     'report_engine_version' => $reportEngineVersion,
                 ],
-            ]);
+            ];
+            if (is_array($mbtiFormSummary)) {
+                $responsePayload['mbti_form_v1'] = $mbtiFormSummary;
+            }
+
+            return response()->json($responsePayload);
         }
 
         $payload = $result->result_json;
@@ -246,6 +257,7 @@ class AttemptReadController extends Controller
             'type_code' => (string) ($result->type_code ?? ''),
             'attempt_id' => $attemptId,
             ...$mbtiEventMeta,
+            ...$this->mbtiFormEventMeta($mbtiFormSummary),
             ...$big5EventMeta,
         ]);
 
@@ -289,6 +301,9 @@ class AttemptReadController extends Controller
                 $responsePayload['comparative_v1'] = $comparative;
             }
         }
+        if (is_array($mbtiFormSummary)) {
+            $responsePayload['mbti_form_v1'] = $mbtiFormSummary;
+        }
 
         return response()->json($responsePayload);
     }
@@ -330,6 +345,9 @@ class AttemptReadController extends Controller
         $responseCodes = $this->resolveResponseScaleCodes($result);
         $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
         $attempt = $this->resolveAttemptForReportRead($request, $id, $scaleCode);
+        $mbtiFormSummary = $scaleCode === 'MBTI'
+            ? $this->resolveMbtiFormSummary($request, $attempt, $result)
+            : null;
 
         $gate = $this->resolveReportGate(
             $orgId,
@@ -401,6 +419,9 @@ class AttemptReadController extends Controller
             $responsePayload[MbtiPreviewContractBuilder::KEY] = $this->mbtiPreviewContractBuilder->buildFromReportEnvelope(
                 $responsePayload
             );
+            if (is_array($mbtiFormSummary)) {
+                $responsePayload['mbti_form_v1'] = $mbtiFormSummary;
+            }
         } elseif ($scaleCode === 'BIG5_OCEAN') {
             $projection = data_get($responsePayload, 'report._meta.big5_public_projection_v1');
             if (! is_array($projection)) {
@@ -489,6 +510,7 @@ class AttemptReadController extends Controller
             'attempt_id' => (string) $attempt->id,
             'locked' => (bool) ($gate['locked'] ?? false),
             ...$mbtiEventMeta,
+            ...$this->mbtiFormEventMeta($mbtiFormSummary),
             ...$big5EventMeta,
         ]);
 
@@ -537,7 +559,10 @@ class AttemptReadController extends Controller
             $refreshedAt = optional($projection?->refreshed_at)->toIso8601String();
         }
 
-        return response()->json([
+        $mbtiFormSummary = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI'
+            ? $this->resolveMbtiFormSummary($request, $attempt)
+            : null;
+        $responsePayload = [
             'ok' => true,
             'attempt_id' => (string) $attempt->id,
             'access_state' => $accessState,
@@ -551,7 +576,12 @@ class AttemptReadController extends Controller
                 'produced_at' => $producedAt,
                 'refreshed_at' => $refreshedAt,
             ],
-        ]);
+        ];
+        if (is_array($mbtiFormSummary)) {
+            $responsePayload['mbti_form_v1'] = $mbtiFormSummary;
+        }
+
+        return response()->json($responsePayload);
     }
 
     private function resolveAttemptForReportRead(
@@ -1692,6 +1722,9 @@ class AttemptReadController extends Controller
         $responseCodes = $this->resolveResponseScaleCodes($result);
         $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
         $attempt = $this->resolveAttemptForReportRead($request, $id, $scaleCode);
+        $mbtiFormSummary = $scaleCode === 'MBTI'
+            ? $this->resolveMbtiFormSummary($request, $attempt, $result)
+            : null;
 
         $gate = $this->reportGatekeeper->resolve(
             $orgId,
@@ -1732,6 +1765,7 @@ class AttemptReadController extends Controller
             'attempt_id' => (string) $attempt->id,
             'locked' => $locked,
             'variant' => $variant,
+            ...$this->mbtiFormEventMeta($mbtiFormSummary),
         ]);
 
         $generated = $this->reportPdfDocumentService->getOrGenerate($attempt, $gate, $result);
@@ -1747,5 +1781,47 @@ class AttemptReadController extends Controller
             'X-Report-Variant' => $variant,
             'X-Report-Locked' => $locked ? 'true' : 'false',
         ]);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function resolveMbtiFormSummary(Request $request, ?Attempt $attempt, ?Result $result = null): ?array
+    {
+        return $this->mbtiPublicFormSummaryBuilder->summarizeForAttempt(
+            $attempt,
+            $result,
+            $this->resolvePublicReadLocale($request, $attempt?->locale)
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $summary
+     * @return array<string,string>
+     */
+    private function mbtiFormEventMeta(?array $summary): array
+    {
+        $formCode = trim((string) ($summary['form_code'] ?? ''));
+
+        return $formCode !== '' ? ['form_code' => $formCode] : [];
+    }
+
+    private function resolvePublicReadLocale(Request $request, ?string $fallback = null): ?string
+    {
+        foreach ([
+            $request->query('locale'),
+            $request->header('X-Fap-Locale', ''),
+            $request->header('X-Locale', ''),
+            $request->getLocale(),
+            $fallback,
+            config('content_packs.default_locale', 'zh-CN'),
+        ] as $candidate) {
+            $normalized = trim((string) $candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -11,6 +11,7 @@ use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Commerce\OrderManager;
 use App\Services\Commerce\SkuCatalog;
 use App\Services\Email\EmailCaptureService;
+use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Payments\PaymentProviderRegistry;
 use App\Services\Payments\PaymentRouter;
 use App\Services\Report\ReportAccess;
@@ -36,6 +37,7 @@ class CommerceController extends Controller
         private PaymentRouter $paymentRouter,
         private PaymentProviderRegistry $paymentProviders,
         private MbtiAccessHubBuilder $mbtiAccessHubBuilder,
+        private MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
         private LemonSqueezyCheckoutService $lemonSqueezyCheckout,
         private WechatPayCheckoutService $wechatPayCheckout,
         private AlipayCheckoutService $alipayCheckout,
@@ -215,6 +217,7 @@ class CommerceController extends Controller
             'latest_payment_attempt' => $paymentAttemptSummary['latest'],
             'delivery' => $delivery['delivery'],
             'exact_result_entry' => $exactResultEntry,
+            'mbti_form_v1' => $this->mbtiFormSummaryForOrder($order, $request),
         ];
 
         if ($ownershipVerified) {
@@ -683,6 +686,7 @@ class CommerceController extends Controller
             'latest_payment_attempt' => $paymentAttemptSummary['latest'],
             'delivery' => $delivery['delivery'],
             'exact_result_entry' => $exactResultEntry,
+            'mbti_form_v1' => $this->mbtiFormSummaryForOrder($order, $request),
         ];
 
         $mbtiAccessHub = $this->mbtiAccessHubBuilder->buildForLookupHit($order);
@@ -1349,6 +1353,23 @@ class CommerceController extends Controller
         }
 
         return null;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function mbtiFormSummaryForOrder(object $order, Request $request): ?array
+    {
+        $attemptId = $this->trimNullableString($order->target_attempt_id ?? null);
+        if ($attemptId === null) {
+            return null;
+        }
+
+        return $this->mbtiPublicFormSummaryBuilder->summarizeForAttemptId(
+            $attemptId,
+            (int) ($order->org_id ?? $this->orgContext->orgId()),
+            $this->resolveRequestedLocale($request)
+        );
     }
 
     private function resolveIdempotencyKey(Request $request, array $payload): ?string

--- a/backend/app/Http/Controllers/API/V0_3/MeController.php
+++ b/backend/app/Http/Controllers/API/V0_3/MeController.php
@@ -13,7 +13,12 @@ class MeController extends Controller
 
     public function attempts(MeAttemptsIndexRequest $request): JsonResponse
     {
-        $result = $this->me->listAttempts($request->pageSize(), $request->page(), $request->scaleCode());
+        $result = $this->me->listAttempts(
+            $request->pageSize(),
+            $request->page(),
+            $request->scaleCode(),
+            is_string($request->query('locale')) ? $request->query('locale') : null
+        );
 
         return response()->json(array_merge(['ok' => true], $result), 200);
     }

--- a/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
+++ b/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
@@ -261,6 +261,7 @@ final class AttemptSubmitSideEffects
             'scale_uid' => (string) ($postCommitCtx['scale_uid'] ?? ''),
             'pack_id' => (string) ($postCommitCtx['pack_id'] ?? ''),
             'dir_version' => (string) ($postCommitCtx['dir_version'] ?? ''),
+            'form_code' => (string) ($postCommitCtx['form_code'] ?? ''),
             'attempt_id' => $attemptId,
         ], [
             'org_id' => $ctx->orgId(),
@@ -271,6 +272,7 @@ final class AttemptSubmitSideEffects
             'scale_uid' => (string) ($postCommitCtx['scale_uid'] ?? ''),
             'pack_id' => (string) ($postCommitCtx['pack_id'] ?? ''),
             'dir_version' => (string) ($postCommitCtx['dir_version'] ?? ''),
+            'form_code' => (string) ($postCommitCtx['form_code'] ?? ''),
         ]);
     }
 

--- a/backend/app/Services/Attempts/AttemptSubmitTxService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitTxService.php
@@ -120,6 +120,7 @@ class AttemptSubmitTxService
                             'pack_id' => (string) ($locked->pack_id ?? $packId),
                             'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
                             'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
+                            'form_code' => $this->extractStoredFormCode($locked->answers_summary_json, (string) ($locked->dir_version ?? $dirVersion)),
                             'invite_token' => $inviteToken,
                             'share_id' => $shareId,
                             'compare_invite_id' => $compareInviteId,
@@ -152,6 +153,7 @@ class AttemptSubmitTxService
                         'pack_id' => (string) ($locked->pack_id ?? $packId),
                         'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
                         'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
+                        'form_code' => $this->extractStoredFormCode($locked->answers_summary_json, (string) ($locked->dir_version ?? $dirVersion)),
                         'invite_token' => $inviteToken,
                         'share_id' => $shareId,
                         'compare_invite_id' => $compareInviteId,
@@ -448,6 +450,7 @@ class AttemptSubmitTxService
                 'pack_id' => $packId,
                 'dir_version' => $dirVersion,
                 'scoring_spec_version' => $scoringSpecVersion,
+                'form_code' => $this->extractStoredFormCode($locked->answers_summary_json, $dirVersion),
                 'invite_token' => $inviteToken,
                 'share_id' => $shareId,
                 'compare_invite_id' => $compareInviteId,
@@ -469,5 +472,30 @@ class AttemptSubmitTxService
             'response_payload' => $responsePayload,
             'post_commit_ctx' => $postCommitCtx,
         ];
+    }
+
+    private function extractStoredFormCode(mixed $answersSummaryJson, string $dirVersion): string
+    {
+        $stored = trim((string) data_get($answersSummaryJson, 'meta.form_code', ''));
+        if ($stored !== '') {
+            return $stored;
+        }
+
+        $forms = config('content_packs.mbti_forms.forms', []);
+        if (! is_array($forms)) {
+            return '';
+        }
+
+        $normalizedDirVersion = trim($dirVersion);
+        foreach ($forms as $formCode => $config) {
+            if (! is_array($config)) {
+                continue;
+            }
+            if ($normalizedDirVersion !== '' && $normalizedDirVersion === trim((string) ($config['dir_version'] ?? ''))) {
+                return trim((string) $formCode);
+            }
+        }
+
+        return '';
     }
 }

--- a/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
+++ b/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
@@ -7,6 +7,7 @@ namespace App\Services\Commerce;
 use App\Models\Attempt;
 use App\Models\UnifiedAccessProjection;
 use App\Services\Access\AttemptUnlockProjectionRepairService;
+use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Report\ReportAccess;
 use Illuminate\Support\Facades\DB;
 
@@ -15,6 +16,7 @@ final class MbtiAccessHubBuilder
     public function __construct(
         private OrderManager $orders,
         private AttemptUnlockProjectionRepairService $projectionRepair,
+        private MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
     ) {}
 
     /**
@@ -44,6 +46,7 @@ final class MbtiAccessHubBuilder
             'access_state' => $locked
                 ? ReportAccess::ACCESS_HUB_STATE_LOCKED
                 : ReportAccess::ACCESS_HUB_STATE_READY,
+            'mbti_form_v1' => $this->mbtiPublicFormSummaryBuilder->summarizeForAttempt($attempt),
             'report_access' => [
                 'can_view_report' => $reportUrl !== null,
                 'attempt_id' => $attemptId,
@@ -110,6 +113,10 @@ final class MbtiAccessHubBuilder
         return [
             'access_state' => $this->stringOrNull($exactResultEntry['access_state'] ?? null)
                 ?? $this->resolveDeliveryAccessState($order, $canViewReport, $canRequestClaimEmail, $canResend),
+            'mbti_form_v1' => $this->mbtiPublicFormSummaryBuilder->summarizeForAttemptId(
+                $attemptId,
+                (int) ($order->org_id ?? 0)
+            ),
             'report_access' => [
                 'can_view_report' => $canViewReport,
                 'attempt_id' => $attemptId,
@@ -291,6 +298,7 @@ final class MbtiAccessHubBuilder
 
         return [
             'attempt_id' => $attemptId,
+            'mbti_form_v1' => $this->mbtiPublicFormSummaryBuilder->summarizeForAttemptId($attemptId, $orgId),
             'access_state' => $accessState,
             'report_state' => $reportState,
             'pdf_state' => $pdfState,

--- a/backend/app/Services/Mbti/MbtiPublicFormSummaryBuilder.php
+++ b/backend/app/Services/Mbti/MbtiPublicFormSummaryBuilder.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Illuminate\Support\Facades\DB;
+
+final class MbtiPublicFormSummaryBuilder
+{
+    public function __construct(
+        private readonly MbtiFormCatalog $catalog,
+    ) {}
+
+    /**
+     * @return array{
+     *   form_code:string,
+     *   label:string,
+     *   short_label:string,
+     *   question_count:int,
+     *   estimated_minutes:int,
+     *   scale_code:string
+     * }|null
+     */
+    public function summarizeForAttempt(?Attempt $attempt, ?Result $result = null, ?string $locale = null): ?array
+    {
+        if (! $this->isMbtiRecord($attempt, $result)) {
+            return null;
+        }
+
+        $formCode = $this->resolveStoredFormCode($attempt, $result);
+        if ($formCode === null) {
+            return null;
+        }
+
+        return $this->buildSummary($formCode, $locale, $this->preferredPackId($attempt, $result));
+    }
+
+    /**
+     * @return array{
+     *   form_code:string,
+     *   label:string,
+     *   short_label:string,
+     *   question_count:int,
+     *   estimated_minutes:int,
+     *   scale_code:string
+     * }|null
+     */
+    public function summarizeForAttemptId(?string $attemptId, int $orgId, ?string $locale = null): ?array
+    {
+        $normalizedAttemptId = trim((string) $attemptId);
+        if ($normalizedAttemptId === '') {
+            return null;
+        }
+
+        $attempt = Attempt::query()
+            ->where('org_id', $orgId)
+            ->where('id', $normalizedAttemptId)
+            ->first();
+
+        return $attempt instanceof Attempt
+            ? $this->summarizeForAttempt($attempt, null, $locale)
+            : null;
+    }
+
+    private function isMbtiRecord(?Attempt $attempt, ?Result $result): bool
+    {
+        return strtoupper(trim((string) ($attempt?->scale_code ?? $result?->scale_code ?? ''))) === 'MBTI';
+    }
+
+    private function preferredPackId(?Attempt $attempt, ?Result $result): ?string
+    {
+        $packId = trim((string) ($attempt?->pack_id ?? $result?->pack_id ?? ''));
+
+        return $packId !== '' ? $packId : null;
+    }
+
+    private function resolveStoredFormCode(?Attempt $attempt, ?Result $result): ?string
+    {
+        $candidates = [
+            $this->extractFormCode($attempt?->answers_summary_json ?? null),
+            $this->extractFormCode($result?->result_json ?? null),
+            $this->matchFormCodeByDirVersion((string) ($attempt?->dir_version ?? '')),
+            $this->matchFormCodeByDirVersion((string) ($result?->dir_version ?? '')),
+        ];
+
+        foreach ($candidates as $candidate) {
+            $normalized = trim((string) $candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private function extractFormCode(mixed $payload): ?string
+    {
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        $metaFormCode = trim((string) data_get($payload, 'meta.form_code', ''));
+        if ($metaFormCode !== '') {
+            try {
+                return (string) $this->catalog->resolve($metaFormCode)['form_code'];
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private function matchFormCodeByDirVersion(string $dirVersion): ?string
+    {
+        $normalizedDirVersion = trim($dirVersion);
+        if ($normalizedDirVersion === '') {
+            return null;
+        }
+
+        $forms = config('content_packs.mbti_forms.forms', []);
+        if (! is_array($forms)) {
+            return null;
+        }
+
+        foreach ($forms as $formCode => $config) {
+            if (! is_array($config)) {
+                continue;
+            }
+
+            if ($normalizedDirVersion === trim((string) ($config['dir_version'] ?? ''))) {
+                return (string) $formCode;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{
+     *   form_code:string,
+     *   label:string,
+     *   short_label:string,
+     *   question_count:int,
+     *   estimated_minutes:int,
+     *   scale_code:string
+     * }|null
+     */
+    private function buildSummary(string $formCode, ?string $locale, ?string $packId): ?array
+    {
+        try {
+            $resolved = $this->catalog->resolve($formCode, $packId);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $forms = config('content_packs.mbti_forms.forms', []);
+        $formConfig = is_array($forms) ? ($forms[$resolved['form_code']] ?? null) : null;
+        if (! is_array($formConfig)) {
+            return null;
+        }
+
+        $public = is_array($formConfig['public'] ?? null) ? $formConfig['public'] : [];
+        $language = $this->normalizeLanguage($locale);
+        $labels = is_array($public['label'] ?? null) ? $public['label'] : [];
+        $shortLabels = is_array($public['short_label'] ?? null) ? $public['short_label'] : [];
+
+        $label = trim((string) ($labels[$language] ?? $labels['zh'] ?? ''));
+        $shortLabel = trim((string) ($shortLabels[$language] ?? $shortLabels['zh'] ?? ''));
+        if ($label === '' || $shortLabel === '') {
+            return null;
+        }
+
+        return [
+            'form_code' => (string) $resolved['form_code'],
+            'label' => $label,
+            'short_label' => $shortLabel,
+            'question_count' => (int) ($resolved['question_count'] ?? 0),
+            'estimated_minutes' => (int) ($public['estimated_minutes'] ?? 0),
+            'scale_code' => 'MBTI',
+        ];
+    }
+
+    private function normalizeLanguage(?string $locale): string
+    {
+        $normalized = strtolower(trim((string) $locale));
+
+        return str_starts_with($normalized, 'en') ? 'en' : 'zh';
+    }
+}

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -6,6 +6,7 @@ use App\Exceptions\Api\ApiProblemException;
 use App\Models\Attempt;
 use App\Models\Result;
 use App\Models\UnifiedAccessProjection;
+use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Report\Resolvers\OfferResolver;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
@@ -57,6 +58,7 @@ class MeAttemptsService
     public function __construct(
         private readonly ScaleRegistry $scaleRegistry,
         private readonly OfferResolver $offerResolver,
+        private readonly MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
     ) {}
 
     public function list(
@@ -65,7 +67,8 @@ class MeAttemptsService
         ?string $anonId,
         int $pageSize,
         int $page,
-        ?string $scaleCode = null
+        ?string $scaleCode = null,
+        ?string $locale = null
     ): array {
         if ($userId === null && $anonId === null) {
             throw new ApiProblemException(401, 'UNAUTHORIZED', 'Missing or invalid fm_token.');
@@ -142,7 +145,11 @@ class MeAttemptsService
         foreach ($attemptModels as $attempt) {
             $attemptId = (string) ($attempt->id ?? '');
             $result = $resultByAttemptId[$attemptId] ?? null;
-            $items[] = $this->presentAttempt($attempt, $result, $projectionByAttemptId[$attemptId] ?? null);
+            $presented = $this->presentAttempt($attempt, $result, $projectionByAttemptId[$attemptId] ?? null);
+            if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI') {
+                $presented['mbti_form_v1'] = $this->mbtiPublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
+            }
+            $items[] = $presented;
         }
 
         $paginator->setCollection(collect($items));

--- a/backend/app/Services/V0_3/MeFacadeService.php
+++ b/backend/app/Services/V0_3/MeFacadeService.php
@@ -30,7 +30,7 @@ class MeFacadeService
         private readonly PiiCipher $piiCipher,
     ) {}
 
-    public function listAttempts(int $pageSize, int $page = 1, ?string $scaleCode = null): array
+    public function listAttempts(int $pageSize, int $page = 1, ?string $scaleCode = null, ?string $locale = null): array
     {
         $userId = $this->orgContext->userId();
 
@@ -40,7 +40,8 @@ class MeFacadeService
             $this->orgContext->anonId(),
             $this->normalizePageSize($pageSize),
             max(1, $page),
-            $scaleCode
+            $scaleCode,
+            $locale
         );
     }
 

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -60,12 +60,34 @@ return [
                     'standard_144',
                     'pro_144',
                 ],
+                'public' => [
+                    'label' => [
+                        'zh' => '144题完整版',
+                        'en' => '144-question full version',
+                    ],
+                    'short_label' => [
+                        'zh' => '144题',
+                        'en' => '144 questions',
+                    ],
+                    'estimated_minutes' => 15,
+                ],
             ],
             'mbti_93' => [
                 'dir_version' => 'MBTI-CN-v0.3-form-93',
                 'aliases' => [
                     '93',
                     'standard_93',
+                ],
+                'public' => [
+                    'label' => [
+                        'zh' => '93题标准版',
+                        'en' => '93-question standard version',
+                    ],
+                    'short_label' => [
+                        'zh' => '93题',
+                        'en' => '93 questions',
+                    ],
+                    'estimated_minutes' => 10,
                 ],
             ],
         ],

--- a/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
@@ -40,9 +40,10 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
         return $token;
     }
 
-    private function createAttempt(string $attemptId, string $scaleCode, string $anonId): void
+    private function createAttempt(string $attemptId, string $scaleCode, string $anonId, string $formCode = 'mbti_144'): void
     {
         $isMbti = $scaleCode === 'MBTI';
+        $isMbti93 = $isMbti && $formCode === 'mbti_93';
 
         Attempt::create([
             'id' => $attemptId,
@@ -52,21 +53,22 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
-            'question_count' => $isMbti ? 144 : 20,
+            'question_count' => $isMbti ? ($isMbti93 ? 93 : 144) : 20,
             'client_platform' => 'test',
-            'answers_summary_json' => ['stage' => 'seed'],
+            'answers_summary_json' => $isMbti ? ['stage' => 'seed', 'meta' => ['form_code' => $formCode]] : ['stage' => 'seed'],
             'started_at' => now(),
             'submitted_at' => now(),
             'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id') : "{$scaleCode}.pack",
-            'dir_version' => $isMbti ? 'MBTI-CN-v0.3' : "{$scaleCode}.dir",
-            'content_package_version' => 'attempt-v1',
-            'scoring_spec_version' => 'attempt-score-v1',
+            'dir_version' => $isMbti ? ($isMbti93 ? 'MBTI-CN-v0.3-form-93' : 'MBTI-CN-v0.3') : "{$scaleCode}.dir",
+            'content_package_version' => $isMbti ? ($isMbti93 ? 'v0.3-form-93' : 'v0.3') : 'attempt-v1',
+            'scoring_spec_version' => $isMbti ? ($isMbti93 ? '2026.01.mbti_93' : '2026.01.mbti_144') : 'attempt-score-v1',
         ]);
     }
 
-    private function createResult(string $attemptId, string $scaleCode): void
+    private function createResult(string $attemptId, string $scaleCode, string $formCode = 'mbti_144'): void
     {
         $isMbti = $scaleCode === 'MBTI';
+        $isMbti93 = $isMbti && $formCode === 'mbti_93';
 
         Result::create([
             'id' => (string) Str::uuid(),
@@ -102,7 +104,7 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
                     'AT' => 'clear',
                 ]
                 : [],
-            'content_package_version' => 'result-v1',
+            'content_package_version' => $isMbti ? ($isMbti93 ? 'v0.3-form-93' : 'v0.3') : 'result-v1',
             'result_json' => $isMbti
                 ? [
                     'raw_score' => 0,
@@ -125,6 +127,7 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
                             'AT' => 'clear',
                         ],
                     ],
+                    'meta' => ['form_code' => $formCode],
                 ]
                 : [
                     'scale_code' => 'SDS_20',
@@ -134,8 +137,8 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
                     'sections' => [],
                 ],
             'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id') : "{$scaleCode}.pack",
-            'dir_version' => $isMbti ? 'MBTI-CN-v0.3' : "{$scaleCode}.dir",
-            'scoring_spec_version' => 'result-score-v1',
+            'dir_version' => $isMbti ? ($isMbti93 ? 'MBTI-CN-v0.3-form-93' : 'MBTI-CN-v0.3') : "{$scaleCode}.dir",
+            'scoring_spec_version' => $isMbti ? ($isMbti93 ? '2026.01.mbti_93' : '2026.01.mbti_144') : 'result-score-v1',
             'report_engine_version' => 'v1.2',
             'is_valid' => true,
             'computed_at' => now(),
@@ -218,6 +221,9 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
         $response->assertJsonPath('ok', true);
         $response->assertJsonPath('scale_code', 'MBTI');
         $response->assertJsonPath('meta.scale_code', 'MBTI');
+        $response->assertJsonPath('mbti_form_v1.form_code', 'mbti_144');
+        $response->assertJsonPath('mbti_form_v1.question_count', 144);
+        $response->assertJsonPath('mbti_form_v1.scale_code', 'MBTI');
         $this->assertStringNotContainsString('ATTEMPT_NOT_FOUND', (string) $response->getContent());
     }
 

--- a/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+++ b/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
@@ -40,8 +40,10 @@ final class AttemptReportAccessReadTest extends TestCase
         return $token;
     }
 
-    private function createAttempt(string $attemptId, string $anonId): void
+    private function createAttempt(string $attemptId, string $anonId, string $formCode = 'mbti_144'): void
     {
+        $isMbti93 = $formCode === 'mbti_93';
+
         Attempt::create([
             'id' => $attemptId,
             'org_id' => 0,
@@ -50,20 +52,22 @@ final class AttemptReportAccessReadTest extends TestCase
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
-            'question_count' => 144,
+            'question_count' => $isMbti93 ? 93 : 144,
             'client_platform' => 'test',
-            'answers_summary_json' => ['stage' => 'seed'],
+            'answers_summary_json' => ['stage' => 'seed', 'meta' => ['form_code' => $formCode]],
             'started_at' => now(),
             'submitted_at' => now(),
             'pack_id' => (string) config('content_packs.default_pack_id'),
-            'dir_version' => 'MBTI-CN-v0.3',
-            'content_package_version' => 'attempt-v1',
-            'scoring_spec_version' => 'attempt-score-v1',
+            'dir_version' => $isMbti93 ? 'MBTI-CN-v0.3-form-93' : 'MBTI-CN-v0.3',
+            'content_package_version' => $isMbti93 ? 'v0.3-form-93' : 'v0.3',
+            'scoring_spec_version' => $isMbti93 ? '2026.01.mbti_93' : '2026.01.mbti_144',
         ]);
     }
 
-    private function createResult(string $attemptId): void
+    private function createResult(string $attemptId, string $formCode = 'mbti_144'): void
     {
+        $isMbti93 = $formCode === 'mbti_93';
+
         Result::create([
             'id' => (string) Str::uuid(),
             'org_id' => 0,
@@ -74,11 +78,11 @@ final class AttemptReportAccessReadTest extends TestCase
             'scores_json' => [],
             'scores_pct' => [],
             'axis_states' => [],
-            'content_package_version' => 'result-v1',
-            'result_json' => ['type_code' => 'INTJ-A'],
+            'content_package_version' => $isMbti93 ? 'v0.3-form-93' : 'v0.3',
+            'result_json' => ['type_code' => 'INTJ-A', 'meta' => ['form_code' => $formCode]],
             'pack_id' => (string) config('content_packs.default_pack_id'),
-            'dir_version' => 'MBTI-CN-v0.3',
-            'scoring_spec_version' => 'result-score-v1',
+            'dir_version' => $isMbti93 ? 'MBTI-CN-v0.3-form-93' : 'MBTI-CN-v0.3',
+            'scoring_spec_version' => $isMbti93 ? '2026.01.mbti_93' : '2026.01.mbti_144',
             'report_engine_version' => 'v1.2',
             'is_valid' => true,
             'computed_at' => now(),
@@ -113,8 +117,8 @@ final class AttemptReportAccessReadTest extends TestCase
         $attemptId = (string) Str::uuid();
         $anonId = 'anon_access_reader';
         $token = $this->issueAnonToken($anonId);
-        $this->createAttempt($attemptId, $anonId);
-        $this->createResult($attemptId);
+        $this->createAttempt($attemptId, $anonId, 'mbti_93');
+        $this->createResult($attemptId, 'mbti_93');
 
         DB::table('unified_access_projections')->insert([
             'attempt_id' => $attemptId,
@@ -149,6 +153,9 @@ final class AttemptReportAccessReadTest extends TestCase
         $response->assertJsonPath('actions.history_href', '/history/mbti');
         $response->assertJsonPath('actions.lookup_href', '/orders/lookup');
         $response->assertJsonPath('payload.has_active_grant', true);
+        $response->assertJsonPath('mbti_form_v1.form_code', 'mbti_93');
+        $response->assertJsonPath('mbti_form_v1.question_count', 93);
+        $response->assertJsonPath('mbti_form_v1.scale_code', 'MBTI');
     }
 
     public function test_it_repairs_missing_ready_projection_from_active_entitlement_when_result_exists(): void

--- a/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
@@ -82,6 +82,13 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ],
         ]);
         $this->insertResult($attemptId);
+        DB::table('attempts')->where('id', $attemptId)->update([
+            'question_count' => 93,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'dir_version' => 'MBTI-CN-v0.3-form-93',
+            'content_package_version' => 'v0.3-form-93',
+            'scoring_spec_version' => '2026.01.mbti_93',
+        ]);
         $this->insertProjection($attemptId, [
             'access_state' => 'ready',
             'report_state' => 'ready',
@@ -101,7 +108,10 @@ final class CommerceOrderLookupSecurityTest extends TestCase
         ]);
 
         $response->assertStatus(200)
+            ->assertJsonPath('mbti_form_v1.form_code', 'mbti_93')
+            ->assertJsonPath('mbti_form_v1.question_count', 93)
             ->assertJsonPath('mbti_access_hub_v1.access_state', 'ready')
+            ->assertJsonPath('mbti_access_hub_v1.mbti_form_v1.form_code', 'mbti_93')
             ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
             ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
             ->assertJsonPath('mbti_access_hub_v1.report_access.order_no', $orderNo)
@@ -118,6 +128,7 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ->assertJsonPath('mbti_access_hub_v1.workspace_lite.entry_kind', 'mbti_history')
             ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId)
             ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.mbti_form_v1.form_code', 'mbti_93')
             ->assertJsonPath('exact_result_entry.ready_to_enter', true)
             ->assertJsonPath('exact_result_entry.actions.page_href', "/result/{$attemptId}");
     }
@@ -240,6 +251,8 @@ final class CommerceOrderLookupSecurityTest extends TestCase
         ?string $userId = null,
         string $scaleCode = 'BIG5_OCEAN'
     ): void {
+        $isMbti = strtoupper($scaleCode) === 'MBTI';
+
         DB::table('attempts')->insert([
             'id' => $attemptId,
             'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
@@ -250,17 +263,17 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
-            'question_count' => 120,
+            'question_count' => $isMbti ? 144 : 120,
             'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'client_platform' => 'test',
             'client_version' => '1.0.0',
             'channel' => 'test',
             'started_at' => now()->subMinute(),
             'submitted_at' => now(),
-            'pack_id' => 'BIG5_OCEAN',
-            'dir_version' => 'v1',
-            'content_package_version' => 'v1',
-            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id') : 'BIG5_OCEAN',
+            'dir_version' => $isMbti ? 'MBTI-CN-v0.3' : 'v1',
+            'content_package_version' => $isMbti ? 'v0.3' : 'v1',
+            'scoring_spec_version' => $isMbti ? '2026.01.mbti_144' : 'big5_spec_2026Q1_v1',
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -84,6 +84,13 @@ final class CommerceOrderReadFallbackTest extends TestCase
         $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI');
         $this->insertOrderForOwner($orderNo, $attemptId, 'paid');
         $this->insertResult($attemptId);
+        DB::table('attempts')->where('id', $attemptId)->update([
+            'question_count' => 93,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'dir_version' => 'MBTI-CN-v0.3-form-93',
+            'content_package_version' => 'v0.3-form-93',
+            'scoring_spec_version' => '2026.01.mbti_93',
+        ]);
         $this->insertProjection($attemptId, [
             'access_state' => 'ready',
             'report_state' => 'ready',
@@ -103,7 +110,10 @@ final class CommerceOrderReadFallbackTest extends TestCase
         ])->getJson('/api/v0.3/orders/'.$orderNo);
 
         $response->assertStatus(200)
+            ->assertJsonPath('mbti_form_v1.form_code', 'mbti_93')
+            ->assertJsonPath('mbti_form_v1.question_count', 93)
             ->assertJsonPath('mbti_access_hub_v1.access_state', 'ready')
+            ->assertJsonPath('mbti_access_hub_v1.mbti_form_v1.form_code', 'mbti_93')
             ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
             ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
             ->assertJsonPath('mbti_access_hub_v1.report_access.order_no', $orderNo)
@@ -124,7 +134,9 @@ final class CommerceOrderReadFallbackTest extends TestCase
             ->assertJsonPath('mbti_access_hub_v1.exact_result_entry.report_state', 'ready')
             ->assertJsonPath('mbti_access_hub_v1.exact_result_entry.ready_to_enter', true)
             ->assertJsonPath('mbti_access_hub_v1.exact_result_entry.actions.page_href', "/result/{$attemptId}")
+            ->assertJsonPath('mbti_access_hub_v1.exact_result_entry.mbti_form_v1.form_code', 'mbti_93')
             ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.mbti_form_v1.form_code', 'mbti_93')
             ->assertJsonPath('exact_result_entry.ready_to_enter', true)
             ->assertJsonPath('exact_result_entry.actions.page_href', "/result/{$attemptId}");
     }
@@ -318,6 +330,8 @@ final class CommerceOrderReadFallbackTest extends TestCase
         string $scaleCode = 'BIG5_OCEAN',
         string $locale = 'zh-CN'
     ): void {
+        $isMbti = strtoupper($scaleCode) === 'MBTI';
+
         DB::table('attempts')->insert([
             'id' => $attemptId,
             'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
@@ -328,17 +342,17 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => $locale,
-            'question_count' => 120,
+            'question_count' => $isMbti ? 144 : 120,
             'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'client_platform' => 'test',
             'client_version' => '1.0.0',
             'channel' => 'test',
             'started_at' => now()->subMinute(),
             'submitted_at' => now(),
-            'pack_id' => 'BIG5_OCEAN',
-            'dir_version' => 'v1',
-            'content_package_version' => 'v1',
-            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id') : 'BIG5_OCEAN',
+            'dir_version' => $isMbti ? 'MBTI-CN-v0.3' : 'v1',
+            'content_package_version' => $isMbti ? 'v0.3' : 'v1',
+            'scoring_spec_version' => $isMbti ? '2026.01.mbti_144' : 'big5_spec_2026Q1_v1',
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/backend/tests/Feature/V0_3/MbtiFormVersionFlowTest.php
+++ b/backend/tests/Feature/V0_3/MbtiFormVersionFlowTest.php
@@ -106,6 +106,14 @@ final class MbtiFormVersionFlowTest extends TestCase
         $this->assertSame('mbti.cn-mainland.zh-CN.2026.form93.provisional', (string) $attempt->norm_version);
         $this->assertSame(93, (int) $attempt->question_count);
         $this->assertSame('mbti_93', data_get($attempt->answers_summary_json, 'meta.form_code'));
+
+        $startEvent = DB::table('events')
+            ->where('event_code', 'test_start')
+            ->where('attempt_id', $attemptId)
+            ->latest('created_at')
+            ->first();
+        $this->assertNotNull($startEvent);
+        $this->assertSame('mbti_93', (string) data_get(json_decode((string) ($startEvent->meta_json ?? '{}'), true), 'form_code'));
     }
 
     public function test_mbti_submit_scores_against_93_source(): void
@@ -171,5 +179,13 @@ final class MbtiFormVersionFlowTest extends TestCase
         $this->assertSame('MBTI-CN-v0.3-form-93', (string) ($result->dir_version ?? ''));
         $this->assertSame('v0.3-form-93', (string) ($result->content_package_version ?? ''));
         $this->assertSame('2026.01.mbti_93', (string) ($result->scoring_spec_version ?? ''));
+
+        $submitEvent = DB::table('events')
+            ->where('event_code', 'test_submit')
+            ->where('attempt_id', $attemptId)
+            ->latest('created_at')
+            ->first();
+        $this->assertNotNull($submitEvent);
+        $this->assertSame('mbti_93', (string) data_get(json_decode((string) ($submitEvent->meta_json ?? '{}'), true), 'form_code'));
     }
 }

--- a/backend/tests/Feature/V0_3/MbtiHistoryAccessSummaryTest.php
+++ b/backend/tests/Feature/V0_3/MbtiHistoryAccessSummaryTest.php
@@ -28,14 +28,14 @@ final class MbtiHistoryAccessSummaryTest extends TestCase
         $this->seedUser($userId);
         $token = $this->seedFmToken($anonId, $userId);
 
-        $previewAttemptId = $this->seedMbtiAttempt($anonId, (string) $userId, 'ENFP-T', now()->subDay());
-        $fullAttemptId = $this->seedMbtiAttempt($anonId, (string) $userId, 'INTJ-A', now());
+        $previewAttemptId = $this->seedMbtiAttempt($anonId, (string) $userId, 'ENFP-T', now()->subDay(), 'mbti_93');
+        $fullAttemptId = $this->seedMbtiAttempt($anonId, (string) $userId, 'INTJ-A', now(), 'mbti_144');
         $processingAttemptId = $this->seedMbtiAttempt($anonId, (string) $userId, 'ISTP-A', now()->subDays(2));
         $restoringAttemptId = $this->seedMbtiAttempt($anonId, (string) $userId, 'INFJ-T', now()->subDays(3));
         $unavailableAttemptId = $this->seedMbtiAttempt($anonId, (string) $userId, 'INFP-T', now()->subDays(4));
 
-        $this->seedMbtiResult($previewAttemptId, 'ENFP-T');
-        $this->seedMbtiResult($fullAttemptId, 'INTJ-A');
+        $this->seedMbtiResult($previewAttemptId, 'ENFP-T', 'mbti_93');
+        $this->seedMbtiResult($fullAttemptId, 'INTJ-A', 'mbti_144');
         $this->seedMbtiResult($processingAttemptId, 'ISTP-A');
         $this->seedMbtiResult($restoringAttemptId, 'INFJ-T');
         $this->seedMbtiResult($unavailableAttemptId, 'INFP-T');
@@ -124,6 +124,8 @@ final class MbtiHistoryAccessSummaryTest extends TestCase
         $response->assertJsonPath('items.0.access_summary.actions.wait_href', null);
         $response->assertJsonPath('items.0.access_summary.actions.history_href', '/history/mbti');
         $response->assertJsonPath('items.0.access_summary.actions.lookup_href', '/orders/lookup');
+        $response->assertJsonPath('items.0.mbti_form_v1.form_code', 'mbti_144');
+        $response->assertJsonPath('items.0.mbti_form_v1.short_label', '144题');
 
         $response->assertJsonPath('items.1.attempt_id', $previewAttemptId);
         $response->assertJsonPath('items.1.type_code', 'ENFP-T');
@@ -141,6 +143,8 @@ final class MbtiHistoryAccessSummaryTest extends TestCase
         $response->assertJsonPath('items.1.access_summary.actions.wait_href', null);
         $response->assertJsonPath('items.1.access_summary.actions.history_href', '/history/mbti');
         $response->assertJsonPath('items.1.access_summary.actions.lookup_href', '/orders/lookup');
+        $response->assertJsonPath('items.1.mbti_form_v1.form_code', 'mbti_93');
+        $response->assertJsonPath('items.1.mbti_form_v1.short_label', '93题');
 
         $response->assertJsonPath('items.2.attempt_id', $processingAttemptId);
         $response->assertJsonPath('items.2.type_code', 'ISTP-A');
@@ -179,9 +183,16 @@ final class MbtiHistoryAccessSummaryTest extends TestCase
         $response->assertJsonPath('items.4.access_summary.actions.lookup_href', '/orders/lookup');
     }
 
-    private function seedMbtiAttempt(string $anonId, string $userId, string $typeCode, \DateTimeInterface $submittedAt): string
+    private function seedMbtiAttempt(
+        string $anonId,
+        string $userId,
+        string $typeCode,
+        \DateTimeInterface $submittedAt,
+        string $formCode = 'mbti_144'
+    ): string
     {
         $attemptId = (string) Str::uuid();
+        $is93 = $formCode === 'mbti_93';
 
         Attempt::create([
             'id' => $attemptId,
@@ -194,25 +205,27 @@ final class MbtiHistoryAccessSummaryTest extends TestCase
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
-            'question_count' => 144,
-            'answers_summary_json' => ['seed' => true],
+            'question_count' => $is93 ? 93 : 144,
+            'answers_summary_json' => ['seed' => true, 'meta' => ['form_code' => $formCode]],
             'client_platform' => 'test',
             'client_version' => '1.0.0',
             'channel' => 'test',
             'started_at' => (clone $submittedAt)->modify('-10 minutes'),
             'submitted_at' => $submittedAt,
             'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
-            'dir_version' => 'MBTI-CN-v0.3',
-            'content_package_version' => 'v0.3',
-            'scoring_spec_version' => '2026.01',
+            'dir_version' => $is93 ? 'MBTI-CN-v0.3-form-93' : 'MBTI-CN-v0.3',
+            'content_package_version' => $is93 ? 'v0.3-form-93' : 'v0.3',
+            'scoring_spec_version' => $is93 ? '2026.01.mbti_93' : '2026.01.mbti_144',
             'type_code' => $typeCode,
         ]);
 
         return $attemptId;
     }
 
-    private function seedMbtiResult(string $attemptId, string $typeCode): void
+    private function seedMbtiResult(string $attemptId, string $typeCode, string $formCode = 'mbti_144'): void
     {
+        $is93 = $formCode === 'mbti_93';
+
         Result::create([
             'id' => (string) Str::uuid(),
             'org_id' => 0,
@@ -230,11 +243,11 @@ final class MbtiHistoryAccessSummaryTest extends TestCase
             ],
             'scores_pct' => ['EI' => 50, 'SN' => 50, 'TF' => 50, 'JP' => 50, 'AT' => 50],
             'axis_states' => ['EI' => 'clear', 'SN' => 'clear', 'TF' => 'clear', 'JP' => 'clear', 'AT' => 'clear'],
-            'content_package_version' => 'v0.3',
-            'result_json' => ['type_code' => $typeCode],
+            'content_package_version' => $is93 ? 'v0.3-form-93' : 'v0.3',
+            'result_json' => ['type_code' => $typeCode, 'meta' => ['form_code' => $formCode]],
             'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
-            'dir_version' => 'MBTI-CN-v0.3',
-            'scoring_spec_version' => '2026.01',
+            'dir_version' => $is93 ? 'MBTI-CN-v0.3-form-93' : 'MBTI-CN-v0.3',
+            'scoring_spec_version' => $is93 ? '2026.01.mbti_93' : '2026.01.mbti_144',
             'report_engine_version' => 'v1.2',
             'is_valid' => true,
             'computed_at' => now(),

--- a/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResultTelemetryContractTest.php
@@ -41,6 +41,7 @@ class MbtiResultTelemetryContractTest extends TestCase
 
             $meta = json_decode((string) ($event->meta_json ?? '{}'), true) ?: [];
             $eventMeta[$eventCode] = $meta;
+            $this->assertSame('mbti_144', (string) ($meta['form_code'] ?? ''));
             $this->assertSame('INTJ-A', (string) ($meta['type_code'] ?? ''));
             $this->assertSame('A', (string) ($meta['identity'] ?? ''));
             $this->assertSame('report_phase4a_contract', (string) ($meta['engine_version'] ?? ''));


### PR DESCRIPTION
## Summary
- add backend-owned `mbti_form_v1` public summaries for MBTI attempt/result/order/history reads
- propagate authoritative form attribution into result/report/order/history/access-hub payloads and MBTI telemetry
- cover new and fallback attribution paths with MBTI-focused feature tests

## Testing
- php artisan route:list
- php artisan migrate
- php artisan test tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php tests/Feature/V0_3/MbtiHistoryAccessSummaryTest.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/V0_3/MbtiResultTelemetryContractTest.php tests/Feature/V0_3/MbtiFormVersionFlowTest.php
- bash backend/scripts/ci_verify_mbti.sh
- php artisan test (repo baseline still has unrelated failures outside MBTI attribution scope)