### PR TITLE
Codex/invite pr2 staged entitlement

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -604,6 +604,40 @@ class AttemptReadController extends Controller
             $responsePayload['big5_form_v1'] = $big5FormSummary;
         }
 
+        $unlockStage = ReportAccess::normalizeUnlockStage((string) data_get(
+            $payloadJson,
+            'unlock_stage',
+            $accessState === 'ready' ? ReportAccess::UNLOCK_STAGE_FULL : ReportAccess::UNLOCK_STAGE_LOCKED
+        ));
+        $unlockSource = ReportAccess::normalizeUnlockSource((string) data_get(
+            $payloadJson,
+            'unlock_source',
+            ReportAccess::UNLOCK_SOURCE_NONE
+        ));
+        $payloadJson['unlock_stage'] = $unlockStage;
+        $payloadJson['unlock_source'] = $unlockSource;
+        $payloadJson['access_level'] = ReportAccess::normalizeReportAccessLevel((string) data_get(
+            $payloadJson,
+            'access_level',
+            $unlockStage === ReportAccess::UNLOCK_STAGE_PARTIAL
+                ? ReportAccess::REPORT_ACCESS_PARTIAL
+                : ($unlockStage === ReportAccess::UNLOCK_STAGE_FULL
+                    ? ReportAccess::REPORT_ACCESS_FULL
+                    : ReportAccess::REPORT_ACCESS_FREE)
+        ));
+        $payloadJson['variant'] = ReportAccess::normalizeVariant((string) data_get(
+            $payloadJson,
+            'variant',
+            $unlockStage === ReportAccess::UNLOCK_STAGE_PARTIAL
+                ? ReportAccess::VARIANT_PARTIAL
+                : ($unlockStage === ReportAccess::UNLOCK_STAGE_FULL
+                    ? ReportAccess::VARIANT_FULL
+                    : ReportAccess::VARIANT_FREE)
+        ));
+        $responsePayload['unlock_stage'] = $unlockStage;
+        $responsePayload['unlock_source'] = $unlockSource;
+        $responsePayload['payload'] = $payloadJson;
+
         return response()->json($responsePayload);
     }
 

--- a/backend/app/Services/Access/AttemptUnlockProjectionRepairService.php
+++ b/backend/app/Services/Access/AttemptUnlockProjectionRepairService.php
@@ -30,40 +30,48 @@ final class AttemptUnlockProjectionRepairService
             ->where('attempt_id', $attemptId)
             ->first();
 
-        if ($this->isProjectionReady($existing)) {
-            return $existing;
-        }
-
         if (! $this->resultExists($orgId, $attemptId)) {
             return $existing;
         }
 
-        if (! $this->hasActiveUnlockGrant($orgId, $attemptId)) {
+        $unlockState = $this->entitlements->resolveAttemptUnlockState($orgId, $attemptId);
+        $unlockStage = ReportAccess::normalizeUnlockStage((string) ($unlockState['unlock_stage'] ?? ReportAccess::UNLOCK_STAGE_LOCKED));
+        if ($unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED) {
+            return $existing;
+        }
+        if ($this->isProjectionReady($existing) && $this->projectionMatchesUnlockState($existing, $unlockState)) {
             return $existing;
         }
 
-        $modulesAllowed = $this->entitlements->getAllowedModulesForAttempt($orgId, $attemptId);
+        $modulesAllowed = ReportAccess::normalizeModules((array) ($unlockState['modules_allowed'] ?? []));
         $pdfReady = $this->isPdfReady($existing, $attemptId);
+        $accessLevel = ReportAccess::normalizeReportAccessLevel((string) ($unlockState['access_level'] ?? ReportAccess::REPORT_ACCESS_FREE));
+        $variant = ReportAccess::normalizeVariant((string) ($unlockState['variant'] ?? ReportAccess::VARIANT_FREE));
+        $unlockSource = ReportAccess::normalizeUnlockSource((string) ($unlockState['unlock_source'] ?? ReportAccess::UNLOCK_SOURCE_NONE));
+        $existingPayload = is_array($existing?->payload_json) ? $existing->payload_json : [];
+        $existingActions = is_array($existing?->actions_json) ? $existing->actions_json : [];
         $patch = [
             'access_state' => 'ready',
             'report_state' => 'ready',
             'pdf_state' => $pdfReady ? 'ready' : 'missing',
             'reason_code' => 'projection_repaired_from_entitlement',
-            'actions_json' => [
+            'actions_json' => array_merge($existingActions, [
                 'report' => true,
                 'pdf' => $pdfReady,
                 'unlock' => true,
-            ],
-            'payload_json' => [
+            ]),
+            'payload_json' => array_merge($existingPayload, [
                 'attempt_id' => $attemptId,
                 'has_active_grant' => true,
                 'result_exists' => true,
                 'repair_source' => 'attempt_unlock_projection_repair',
-                'access_level' => ReportAccess::REPORT_ACCESS_FULL,
-                'variant' => ReportAccess::VARIANT_FULL,
+                'unlock_stage' => $unlockStage,
+                'unlock_source' => $unlockSource,
+                'access_level' => $accessLevel,
+                'variant' => $variant,
                 'modules_allowed' => $modulesAllowed,
-                'modules_preview' => [],
-            ],
+                'modules_preview' => $modulesAllowed,
+            ]),
         ];
         $meta = [
             'source_system' => 'attempt_unlock_projection_repair',
@@ -90,6 +98,7 @@ final class AttemptUnlockProjectionRepairService
                 'attempt_id' => $attemptId,
                 'existing_reason_code' => $existing?->reason_code,
                 'pdf_ready' => $pdfReady,
+                'unlock_stage' => $unlockStage,
             ]);
 
             return $projection ?? $existing;
@@ -115,28 +124,33 @@ final class AttemptUnlockProjectionRepairService
             && strtolower(trim((string) ($projection->report_state ?? ''))) === 'ready';
     }
 
+    /**
+     * @param  array<string,mixed>  $unlockState
+     */
+    private function projectionMatchesUnlockState(?UnifiedAccessProjection $projection, array $unlockState): bool
+    {
+        if (! $projection instanceof UnifiedAccessProjection) {
+            return false;
+        }
+
+        $payload = is_array($projection->payload_json) ? $projection->payload_json : [];
+        $existingStage = ReportAccess::normalizeUnlockStage((string) ($payload['unlock_stage'] ?? ReportAccess::UNLOCK_STAGE_LOCKED));
+        $targetStage = ReportAccess::normalizeUnlockStage((string) ($unlockState['unlock_stage'] ?? ReportAccess::UNLOCK_STAGE_LOCKED));
+        if ($existingStage !== $targetStage) {
+            return false;
+        }
+
+        $existingSource = ReportAccess::normalizeUnlockSource((string) ($payload['unlock_source'] ?? ReportAccess::UNLOCK_SOURCE_NONE));
+        $targetSource = ReportAccess::normalizeUnlockSource((string) ($unlockState['unlock_source'] ?? ReportAccess::UNLOCK_SOURCE_NONE));
+
+        return $existingSource === $targetSource;
+    }
+
     private function resultExists(int $orgId, string $attemptId): bool
     {
         return DB::table('results')
             ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId)
-            ->exists();
-    }
-
-    private function hasActiveUnlockGrant(int $orgId, string $attemptId): bool
-    {
-        return DB::table('benefit_grants')
-            ->where('org_id', $orgId)
-            ->where('benefit_type', 'report_unlock')
-            ->where('status', 'active')
-            ->where(function ($query) use ($attemptId): void {
-                $query->where('attempt_id', $attemptId)
-                    ->orWhere('scope', 'org');
-            })
-            ->where(function ($query): void {
-                $query->whereNull('expires_at')
-                    ->orWhere('expires_at', '>', now());
-            })
             ->exists();
     }
 

--- a/backend/app/Services/Attempts/AttemptInviteUnlockCompletionService.php
+++ b/backend/app/Services/Attempts/AttemptInviteUnlockCompletionService.php
@@ -8,6 +8,7 @@ use App\Models\Attempt;
 use App\Models\AttemptInviteUnlock;
 use App\Models\AttemptInviteUnlockCompletion;
 use App\Models\Result;
+use App\Services\Commerce\EntitlementManager;
 use App\Services\Attempts\InviteUnlock\InviteUnlockCompletionStatus;
 use App\Services\Attempts\InviteUnlock\InviteUnlockStatus;
 use Illuminate\Database\QueryException;
@@ -16,8 +17,13 @@ use Illuminate\Support\Str;
 
 final class AttemptInviteUnlockCompletionService
 {
+    private const MBTI_PARTIAL_BENEFIT_CODE = 'MBTI_CAREER';
+
+    private const MBTI_FULL_BENEFIT_CODE = 'MBTI_REPORT_FULL';
+
     public function __construct(
         private readonly AttemptInviteUnlockService $inviteService,
+        private readonly EntitlementManager $entitlements,
     ) {}
 
     /**
@@ -501,6 +507,8 @@ final class AttemptInviteUnlockCompletionService
         AttemptInviteUnlock $invite,
         bool $idempotent
     ): array {
+        $entitlementState = $this->syncStagedEntitlementsForInvite($invite);
+
         return [
             'ok' => true,
             'idempotent' => $idempotent,
@@ -512,6 +520,94 @@ final class AttemptInviteUnlockCompletionService
             'qualified' => (bool) ($completion->qualified ?? false),
             'counted' => (bool) ($completion->counted ?? false),
             'progress' => $this->inviteService->buildInvitePayload($invite),
+            'unlock_stage' => (string) ($entitlementState['unlock_stage'] ?? 'locked'),
+            'unlock_source' => (string) ($entitlementState['unlock_source'] ?? 'none'),
+        ];
+    }
+
+    /**
+     * @return array{unlock_stage:string,unlock_source:string}
+     */
+    private function syncStagedEntitlementsForInvite(AttemptInviteUnlock $invite): array
+    {
+        $orgId = (int) ($invite->target_org_id ?? 0);
+        $attemptId = trim((string) ($invite->target_attempt_id ?? ''));
+        $scaleCode = strtoupper(trim((string) ($invite->target_scale_code ?? '')));
+        if ($orgId < 0 || $attemptId === '' || $scaleCode !== 'MBTI') {
+            return [
+                'unlock_stage' => 'locked',
+                'unlock_source' => 'none',
+            ];
+        }
+
+        $inviterUserId = $this->normalizeUserId((string) ($invite->inviter_user_id ?? ''));
+        $inviterAnonId = $this->normalizeString((string) ($invite->inviter_anon_id ?? ''));
+
+        $completedInvitees = max(0, (int) ($invite->completed_invitees ?? 0));
+        $fullAlready = $this->entitlements->hasActiveGrantForAttemptBenefitCode(
+            $orgId,
+            $attemptId,
+            self::MBTI_FULL_BENEFIT_CODE
+        );
+        $partialAlready = $this->entitlements->hasActiveGrantForAttemptBenefitCode(
+            $orgId,
+            $attemptId,
+            self::MBTI_PARTIAL_BENEFIT_CODE
+        );
+
+        if ($completedInvitees >= 2 && ! $fullAlready) {
+            $this->entitlements->grantAttemptUnlock(
+                $orgId,
+                $inviterUserId,
+                $inviterAnonId,
+                self::MBTI_FULL_BENEFIT_CODE,
+                $attemptId,
+                null,
+                'attempt',
+                null,
+                null,
+                [
+                    'granted_via' => 'invite_unlock',
+                    'invite_unlock_code' => (string) ($invite->invite_code ?? ''),
+                    'invite_unlock_id' => (string) ($invite->id ?? ''),
+                    'invite_unlock_stage' => 'full',
+                ]
+            );
+        } elseif ($completedInvitees >= 1 && ! $fullAlready && ! $partialAlready) {
+            $this->entitlements->grantAttemptUnlock(
+                $orgId,
+                $inviterUserId,
+                $inviterAnonId,
+                self::MBTI_PARTIAL_BENEFIT_CODE,
+                $attemptId,
+                null,
+                'attempt',
+                null,
+                null,
+                [
+                    'granted_via' => 'invite_unlock',
+                    'invite_unlock_code' => (string) ($invite->invite_code ?? ''),
+                    'invite_unlock_id' => (string) ($invite->id ?? ''),
+                    'invite_unlock_stage' => 'partial',
+                ]
+            );
+        }
+
+        $state = $this->entitlements->syncAttemptProjectionFromEntitlements(
+            $orgId,
+            $attemptId,
+            [
+                'source_system' => 'invite_unlock_completion',
+                'source_ref' => (string) ($invite->invite_code ?? $attemptId),
+                'actor_type' => $inviterUserId !== null ? 'user' : 'anon',
+                'actor_id' => $inviterUserId ?? $inviterAnonId,
+                'reason_code' => 'invite_unlock_stage_synced',
+            ]
+        );
+
+        return [
+            'unlock_stage' => (string) ($state['unlock_stage'] ?? 'locked'),
+            'unlock_source' => (string) ($state['unlock_source'] ?? 'none'),
         ];
     }
 

--- a/backend/app/Services/Commerce/EntitlementManager.php
+++ b/backend/app/Services/Commerce/EntitlementManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Commerce;
 
+use App\Models\UnifiedAccessProjection;
 use App\Services\Report\ReportAccess;
 use App\Services\Storage\UnifiedAccessProjectionWriter;
 use Illuminate\Support\Facades\DB;
@@ -10,6 +11,10 @@ use Illuminate\Support\Str;
 
 class EntitlementManager
 {
+    private const MBTI_FULL_BENEFIT_CODE = 'MBTI_REPORT_FULL';
+
+    private const MBTI_PARTIAL_BENEFIT_CODE = 'MBTI_CAREER';
+
     public function __construct(
         private readonly UnifiedAccessProjectionWriter $accessProjections,
         private readonly OrderManager $orders,
@@ -73,7 +78,8 @@ class EntitlementManager
         ?string $orderNo,
         ?string $scopeOverride = null,
         ?string $expiresAt = null,
-        ?array $modules = null
+        ?array $modules = null,
+        ?array $metaPatch = null
     ): array {
         $benefitCode = strtoupper(trim($benefitCode));
         $attemptId = trim($attemptId);
@@ -111,13 +117,23 @@ class EntitlementManager
         }
 
         if ($existing) {
+            $meta = $this->decodeMeta($existing->meta_json ?? null);
+            $metaChanged = false;
             if ($grantedModules !== []) {
-                $meta = $this->decodeMeta($existing->meta_json ?? null);
                 $mergedModules = ReportAccess::normalizeModules(array_merge(
                     is_array($meta['modules'] ?? null) ? $meta['modules'] : [],
                     $grantedModules
                 ));
                 $meta['modules'] = $mergedModules;
+                $metaChanged = true;
+            }
+
+            if (is_array($metaPatch) && $metaPatch !== []) {
+                $meta = array_merge($meta, $metaPatch);
+                $metaChanged = true;
+            }
+
+            if ($metaChanged) {
 
                 DB::table('benefit_grants')
                     ->where('id', (string) ($existing->id ?? ''))
@@ -134,12 +150,13 @@ class EntitlementManager
                 $this->orders->syncGrantState($normalizedExistingOrderNo, $orgId, 'granted');
             }
 
-            $this->refreshAccessProjection($attemptId, [
+            $this->refreshAccessProjection($orgId, $attemptId, [
                 'source_system' => 'entitlement_manager',
                 'source_ref' => $normalizedExistingOrderNo !== '' ? $normalizedExistingOrderNo : $benefitCode,
                 'actor_type' => $userId !== '' ? 'user' : 'anon',
                 'actor_id' => $userId !== '' ? $userId : $anonId,
                 'reason_code' => 'entitlement_granted',
+                'org_id' => $orgId,
             ]);
 
             return [
@@ -180,11 +197,21 @@ class EntitlementManager
             'updated_at' => $now,
         ];
 
+        $rowMeta = [];
         if ($grantedModules !== []) {
-            $row['meta_json'] = json_encode([
-                'modules' => $grantedModules,
-                'granted_via' => 'entitlement_manager',
-            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $rowMeta['modules'] = $grantedModules;
+        }
+
+        if (is_array($metaPatch) && $metaPatch !== []) {
+            $rowMeta = array_merge($rowMeta, $metaPatch);
+        }
+
+        if (! array_key_exists('granted_via', $rowMeta)) {
+            $rowMeta['granted_via'] = 'entitlement_manager';
+        }
+
+        if ($rowMeta !== []) {
+            $row['meta_json'] = json_encode($rowMeta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
         }
 
         if ($expiresAt !== null) {
@@ -200,12 +227,13 @@ class EntitlementManager
         if ($normalizedOrderNo !== '') {
             $this->orders->syncGrantState($normalizedOrderNo, $orgId, 'granted');
         }
-        $this->refreshAccessProjection($attemptId, [
+        $this->refreshAccessProjection($orgId, $attemptId, [
             'source_system' => 'entitlement_manager',
             'source_ref' => $normalizedOrderNo !== '' ? $normalizedOrderNo : $benefitCode,
             'actor_type' => $userId !== '' ? 'user' : 'anon',
             'actor_id' => $userId !== '' ? $userId : $anonId,
             'reason_code' => 'entitlement_granted',
+            'org_id' => $orgId,
         ]);
 
         return [
@@ -225,19 +253,7 @@ class EntitlementManager
             return ReportAccess::defaultModulesAllowedForLocked();
         }
 
-        $rows = DB::table('benefit_grants')
-            ->select(['benefit_code', 'meta_json', 'scope', 'attempt_id'])
-            ->where('org_id', $orgId)
-            ->where('status', 'active')
-            ->where(function ($q) use ($attemptId) {
-                $q->where('attempt_id', $attemptId)
-                    ->orWhere('scope', 'org');
-            })
-            ->where(function ($q) {
-                $q->whereNull('expires_at')
-                    ->orWhere('expires_at', '>', now());
-            })
-            ->get();
+        $rows = $this->activeGrantRowsForAttempt($orgId, $attemptId);
 
         $modules = ReportAccess::defaultModulesAllowedForLocked();
         foreach ($rows as $row) {
@@ -256,6 +272,168 @@ class EntitlementManager
         }
 
         return ReportAccess::normalizeModules($modules);
+    }
+
+    public function hasActiveGrantForAttemptBenefitCode(int $orgId, string $attemptId, string $benefitCode): bool
+    {
+        $attemptId = trim($attemptId);
+        $benefitCode = strtoupper(trim($benefitCode));
+        if ($attemptId === '' || $benefitCode === '') {
+            return false;
+        }
+
+        return DB::table('benefit_grants')
+            ->where('org_id', $orgId)
+            ->where('benefit_code', $benefitCode)
+            ->where('status', 'active')
+            ->where(function ($q) use ($attemptId) {
+                $q->where('attempt_id', $attemptId)
+                    ->orWhere('scope', 'org');
+            })
+            ->where(function ($q) {
+                $q->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            })
+            ->exists();
+    }
+
+    /**
+     * @return array{unlock_stage:string,unlock_source:string,modules_allowed:list<string>,access_level:string,variant:string,has_active_grant:bool,has_full_grant:bool,has_partial_grant:bool}
+     */
+    public function resolveAttemptUnlockState(int $orgId, string $attemptId): array
+    {
+        $attemptId = trim($attemptId);
+        if ($attemptId === '') {
+            return [
+                'unlock_stage' => ReportAccess::UNLOCK_STAGE_LOCKED,
+                'unlock_source' => ReportAccess::UNLOCK_SOURCE_NONE,
+                'modules_allowed' => ReportAccess::defaultModulesAllowedForLocked(),
+                'access_level' => ReportAccess::REPORT_ACCESS_FREE,
+                'variant' => ReportAccess::VARIANT_FREE,
+                'has_active_grant' => false,
+                'has_full_grant' => false,
+                'has_partial_grant' => false,
+            ];
+        }
+
+        $scaleCode = $this->resolveScaleCodeForAttempt($orgId, $attemptId);
+        $rows = $this->activeGrantRowsForAttempt($orgId, $attemptId);
+        $benefitCodes = [];
+        foreach ($rows as $row) {
+            $code = strtoupper(trim((string) ($row->benefit_code ?? '')));
+            if ($code !== '') {
+                $benefitCodes[$code] = true;
+            }
+        }
+
+        $modulesAllowed = $this->getAllowedModulesForAttempt($orgId, $attemptId);
+        $freeModule = ReportAccess::freeModuleForScale($scaleCode);
+        $fullModule = ReportAccess::fullModuleForScale($scaleCode);
+        $hasPaidModuleAccess = count(array_diff($modulesAllowed, [$freeModule])) > 0;
+
+        $hasFullGrant = in_array($fullModule, $modulesAllowed, true);
+        $hasPartialGrant = false;
+        if ($scaleCode === ReportAccess::SCALE_MBTI) {
+            $hasFullGrant = $hasFullGrant || isset($benefitCodes[self::MBTI_FULL_BENEFIT_CODE]);
+            $hasPartialGrant = isset($benefitCodes[self::MBTI_PARTIAL_BENEFIT_CODE]);
+        } elseif ($scaleCode !== '') {
+            $hasFullGrant = $hasFullGrant || $hasPaidModuleAccess;
+        }
+
+        $unlockStage = ReportAccess::UNLOCK_STAGE_LOCKED;
+        if ($hasFullGrant) {
+            $unlockStage = ReportAccess::UNLOCK_STAGE_FULL;
+        } elseif ($hasPaidModuleAccess || $hasPartialGrant) {
+            $unlockStage = ReportAccess::UNLOCK_STAGE_PARTIAL;
+        }
+
+        $unlockSource = $this->resolveUnlockSource($rows, $unlockStage);
+        $accessLevel = match ($unlockStage) {
+            ReportAccess::UNLOCK_STAGE_PARTIAL => ReportAccess::REPORT_ACCESS_PARTIAL,
+            ReportAccess::UNLOCK_STAGE_FULL => ReportAccess::REPORT_ACCESS_FULL,
+            default => ReportAccess::REPORT_ACCESS_FREE,
+        };
+        $variant = match ($unlockStage) {
+            ReportAccess::UNLOCK_STAGE_PARTIAL => ReportAccess::VARIANT_PARTIAL,
+            ReportAccess::UNLOCK_STAGE_FULL => ReportAccess::VARIANT_FULL,
+            default => ReportAccess::VARIANT_FREE,
+        };
+
+        return [
+            'unlock_stage' => $unlockStage,
+            'unlock_source' => $unlockSource,
+            'modules_allowed' => $modulesAllowed,
+            'access_level' => $accessLevel,
+            'variant' => $variant,
+            'has_active_grant' => $rows->count() > 0,
+            'has_full_grant' => $hasFullGrant,
+            'has_partial_grant' => $hasPartialGrant || ($unlockStage === ReportAccess::UNLOCK_STAGE_PARTIAL),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array{unlock_stage:string,unlock_source:string,modules_allowed:list<string>,access_level:string,variant:string,has_active_grant:bool,has_full_grant:bool,has_partial_grant:bool}
+     */
+    public function syncAttemptProjectionFromEntitlements(int $orgId, string $attemptId, array $meta = []): array
+    {
+        $attemptId = trim($attemptId);
+        $state = $this->resolveAttemptUnlockState($orgId, $attemptId);
+        if ($attemptId === '') {
+            return $state;
+        }
+
+        $unlockStage = ReportAccess::normalizeUnlockStage((string) ($state['unlock_stage'] ?? ReportAccess::UNLOCK_STAGE_LOCKED));
+        $resultExists = DB::table('results')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->exists();
+        $existingProjection = UnifiedAccessProjection::query()
+            ->where('attempt_id', $attemptId)
+            ->first();
+        $existingPayload = is_array($existingProjection?->payload_json) ? $existingProjection->payload_json : [];
+        $existingActions = is_array($existingProjection?->actions_json) ? $existingProjection->actions_json : [];
+
+        $payload = array_merge($existingPayload, [
+            'attempt_id' => $attemptId,
+            'result_exists' => $resultExists,
+            'has_active_grant' => (bool) ($state['has_active_grant'] ?? false),
+            'unlock_stage' => $unlockStage,
+            'unlock_source' => ReportAccess::normalizeUnlockSource((string) ($state['unlock_source'] ?? ReportAccess::UNLOCK_SOURCE_NONE)),
+            'modules_allowed' => ReportAccess::normalizeModules((array) ($state['modules_allowed'] ?? [])),
+            'access_level' => ReportAccess::normalizeReportAccessLevel((string) ($state['access_level'] ?? ReportAccess::REPORT_ACCESS_FREE)),
+            'variant' => ReportAccess::normalizeVariant((string) ($state['variant'] ?? ReportAccess::VARIANT_FREE)),
+            'modules_preview' => ReportAccess::normalizeModules((array) ($state['modules_allowed'] ?? [])),
+        ]);
+
+        $patch = [
+            'access_state' => $resultExists
+                ? ($unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED ? 'locked' : 'ready')
+                : 'pending',
+            'report_state' => $resultExists ? 'ready' : 'pending',
+            'pdf_state' => $unlockStage === ReportAccess::UNLOCK_STAGE_FULL
+                ? (string) ($existingProjection?->pdf_state ?? 'missing')
+                : 'missing',
+            'reason_code' => trim((string) ($meta['reason_code'] ?? '')) !== ''
+                ? (string) $meta['reason_code']
+                : ($unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED ? 'projection_locked_from_entitlement' : 'entitlement_granted'),
+            'actions_json' => array_merge($existingActions, [
+                'report' => true,
+                'pdf' => $unlockStage === ReportAccess::UNLOCK_STAGE_FULL,
+                'unlock' => $unlockStage !== ReportAccess::UNLOCK_STAGE_LOCKED,
+            ]),
+            'payload_json' => $payload,
+        ];
+
+        $this->accessProjections->refreshAttemptProjection($attemptId, $patch, [
+            'source_system' => trim((string) ($meta['source_system'] ?? 'entitlement_manager')),
+            'source_ref' => trim((string) ($meta['source_ref'] ?? $attemptId)),
+            'actor_type' => isset($meta['actor_type']) ? (string) $meta['actor_type'] : null,
+            'actor_id' => isset($meta['actor_id']) ? (string) $meta['actor_id'] : null,
+            'reason_code' => (string) $patch['reason_code'],
+        ]);
+
+        return $state;
     }
 
     public function revokeByOrderNo(int $orgId, string $orderNo): array
@@ -345,6 +523,68 @@ class EntitlementManager
         ];
     }
 
+    private function activeGrantRowsForAttempt(int $orgId, string $attemptId): \Illuminate\Support\Collection
+    {
+        return DB::table('benefit_grants')
+            ->select(['benefit_code', 'meta_json', 'scope', 'attempt_id', 'order_no'])
+            ->where('org_id', $orgId)
+            ->where('status', 'active')
+            ->where(function ($q) use ($attemptId) {
+                $q->where('attempt_id', $attemptId)
+                    ->orWhere('scope', 'org');
+            })
+            ->where(function ($q) {
+                $q->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            })
+            ->get();
+    }
+
+    private function resolveScaleCodeForAttempt(int $orgId, string $attemptId): string
+    {
+        $attemptScale = DB::table('attempts')
+            ->where('org_id', $orgId)
+            ->where('id', $attemptId)
+            ->value('scale_code');
+
+        return strtoupper(trim((string) $attemptScale));
+    }
+
+    private function resolveUnlockSource(\Illuminate\Support\Collection $rows, string $unlockStage): string
+    {
+        $unlockStage = ReportAccess::normalizeUnlockStage($unlockStage);
+        if ($unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED) {
+            return ReportAccess::UNLOCK_SOURCE_NONE;
+        }
+
+        $hasPaymentSource = false;
+        $hasInviteSource = false;
+        foreach ($rows as $row) {
+            if (trim((string) ($row->order_no ?? '')) !== '') {
+                $hasPaymentSource = true;
+            }
+
+            $benefitCode = strtoupper(trim((string) ($row->benefit_code ?? '')));
+            $meta = $this->decodeMeta($row->meta_json ?? null);
+            $grantedVia = strtolower(trim((string) ($meta['granted_via'] ?? '')));
+            if ($grantedVia === 'invite_unlock' || $benefitCode === self::MBTI_PARTIAL_BENEFIT_CODE) {
+                $hasInviteSource = true;
+            }
+        }
+
+        if ($hasInviteSource && $hasPaymentSource) {
+            return ReportAccess::UNLOCK_SOURCE_MIXED;
+        }
+        if ($hasInviteSource) {
+            return ReportAccess::UNLOCK_SOURCE_INVITE;
+        }
+        if ($hasPaymentSource) {
+            return ReportAccess::UNLOCK_SOURCE_PAYMENT;
+        }
+
+        return ReportAccess::UNLOCK_SOURCE_MIXED;
+    }
+
     private function badRequest(string $code, string $message): array
     {
         return [
@@ -385,31 +625,10 @@ class EntitlementManager
     /**
      * @param  array<string,mixed>  $meta
      */
-    private function refreshAccessProjection(string $attemptId, array $meta): void
+    private function refreshAccessProjection(int $orgId, string $attemptId, array $meta): void
     {
         try {
-            $projection = $this->accessProjections->refreshAttemptProjection(
-                $attemptId,
-                [
-                    'access_state' => 'ready',
-                    'reason_code' => 'entitlement_granted',
-                    'actions_json' => [
-                        'report' => true,
-                        'pdf' => true,
-                    ],
-                ],
-                $meta
-            );
-
-            if ($projection === null) {
-                Log::warning('ENTITLEMENT_ACCESS_PROJECTION_REFRESH_SKIPPED', [
-                    'attempt_id' => $attemptId,
-                    'source_ref' => $meta['source_ref'] ?? null,
-                    'source_system' => $meta['source_system'] ?? 'entitlement_manager',
-                    'actor_type' => $meta['actor_type'] ?? null,
-                    'actor_id' => $meta['actor_id'] ?? null,
-                ]);
-            }
+            $this->syncAttemptProjectionFromEntitlements($orgId, $attemptId, $meta);
         } catch (\Throwable $e) {
             Log::error('ENTITLEMENT_ACCESS_PROJECTION_REFRESH_FAILED', [
                 'attempt_id' => $attemptId,

--- a/backend/app/Services/Commerce/EntitlementManager.php
+++ b/backend/app/Services/Commerce/EntitlementManager.php
@@ -425,13 +425,22 @@ class EntitlementManager
             'payload_json' => $payload,
         ];
 
-        $this->accessProjections->refreshAttemptProjection($attemptId, $patch, [
+        $projection = $this->accessProjections->refreshAttemptProjection($attemptId, $patch, [
             'source_system' => trim((string) ($meta['source_system'] ?? 'entitlement_manager')),
             'source_ref' => trim((string) ($meta['source_ref'] ?? $attemptId)),
             'actor_type' => isset($meta['actor_type']) ? (string) $meta['actor_type'] : null,
             'actor_id' => isset($meta['actor_id']) ? (string) $meta['actor_id'] : null,
             'reason_code' => (string) $patch['reason_code'],
         ]);
+        if ($projection === null) {
+            Log::warning('ENTITLEMENT_ACCESS_PROJECTION_REFRESH_SKIPPED', [
+                'attempt_id' => $attemptId,
+                'source_ref' => $meta['source_ref'] ?? $attemptId,
+                'source_system' => $meta['source_system'] ?? 'entitlement_manager',
+                'actor_type' => $meta['actor_type'] ?? null,
+                'actor_id' => $meta['actor_id'] ?? null,
+            ]);
+        }
 
         return $state;
     }

--- a/backend/app/Services/Report/ReportAccess.php
+++ b/backend/app/Services/Report/ReportAccess.php
@@ -38,11 +38,29 @@ final class ReportAccess
 
     public const VARIANT_FREE = 'free';
 
+    public const VARIANT_PARTIAL = 'partial';
+
     public const VARIANT_FULL = 'full';
 
     public const REPORT_ACCESS_FREE = 'free';
 
+    public const REPORT_ACCESS_PARTIAL = 'partial';
+
     public const REPORT_ACCESS_FULL = 'full';
+
+    public const UNLOCK_STAGE_LOCKED = 'locked';
+
+    public const UNLOCK_STAGE_PARTIAL = 'partial';
+
+    public const UNLOCK_STAGE_FULL = 'full';
+
+    public const UNLOCK_SOURCE_NONE = 'none';
+
+    public const UNLOCK_SOURCE_INVITE = 'invite';
+
+    public const UNLOCK_SOURCE_PAYMENT = 'payment';
+
+    public const UNLOCK_SOURCE_MIXED = 'mixed';
 
     public const CARD_ACCESS_FREE = 'free';
 
@@ -212,18 +230,53 @@ final class ReportAccess
     {
         $variant = strtolower(trim((string) $variant));
 
-        return $variant === self::VARIANT_FREE
-            ? self::VARIANT_FREE
-            : self::VARIANT_FULL;
+        if ($variant === self::VARIANT_FREE) {
+            return self::VARIANT_FREE;
+        }
+
+        if ($variant === self::VARIANT_PARTIAL) {
+            return self::VARIANT_PARTIAL;
+        }
+
+        return self::VARIANT_FULL;
     }
 
     public static function normalizeReportAccessLevel(?string $level): string
     {
         $level = strtolower(trim((string) $level));
 
-        return $level === self::REPORT_ACCESS_FREE
-            ? self::REPORT_ACCESS_FREE
-            : self::REPORT_ACCESS_FULL;
+        if ($level === self::REPORT_ACCESS_FREE) {
+            return self::REPORT_ACCESS_FREE;
+        }
+
+        if ($level === self::REPORT_ACCESS_PARTIAL) {
+            return self::REPORT_ACCESS_PARTIAL;
+        }
+
+        return self::REPORT_ACCESS_FULL;
+    }
+
+    public static function normalizeUnlockStage(?string $stage): string
+    {
+        $stage = strtolower(trim((string) $stage));
+
+        return match ($stage) {
+            self::UNLOCK_STAGE_PARTIAL => self::UNLOCK_STAGE_PARTIAL,
+            self::UNLOCK_STAGE_FULL => self::UNLOCK_STAGE_FULL,
+            default => self::UNLOCK_STAGE_LOCKED,
+        };
+    }
+
+    public static function normalizeUnlockSource(?string $source): string
+    {
+        $source = strtolower(trim((string) $source));
+
+        return match ($source) {
+            self::UNLOCK_SOURCE_INVITE => self::UNLOCK_SOURCE_INVITE,
+            self::UNLOCK_SOURCE_PAYMENT => self::UNLOCK_SOURCE_PAYMENT,
+            self::UNLOCK_SOURCE_MIXED => self::UNLOCK_SOURCE_MIXED,
+            default => self::UNLOCK_SOURCE_NONE,
+        };
     }
 
     public static function normalizeCardAccessLevel(?string $level): string

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -182,12 +182,23 @@ class ReportGatekeeper
         $modulesPreview = (array) ($crisisState['modules_preview'] ?? $modulesPreview);
         $hasFullAccess = (bool) ($crisisState['has_full_access'] ?? $hasFullAccess);
         $hasPaidModuleAccess = (bool) ($crisisState['has_paid_module_access'] ?? $hasPaidModuleAccess);
-
-        $variant = $hasPaidModuleAccess ? ReportAccess::VARIANT_FULL : ReportAccess::VARIANT_FREE;
-        $reportAccessLevel = $variant === ReportAccess::VARIANT_FREE
-            ? ReportAccess::REPORT_ACCESS_FREE
-            : ReportAccess::REPORT_ACCESS_FULL;
-        $locked = $variant === ReportAccess::VARIANT_FREE;
+        $unlockStage = $hasFullAccess
+            ? ReportAccess::UNLOCK_STAGE_FULL
+            : ($hasPaidModuleAccess ? ReportAccess::UNLOCK_STAGE_PARTIAL : ReportAccess::UNLOCK_STAGE_LOCKED);
+        $renderVariant = $unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED
+            ? ReportAccess::VARIANT_FREE
+            : ReportAccess::VARIANT_FULL;
+        $variant = match ($unlockStage) {
+            ReportAccess::UNLOCK_STAGE_PARTIAL => ReportAccess::VARIANT_PARTIAL,
+            ReportAccess::UNLOCK_STAGE_FULL => ReportAccess::VARIANT_FULL,
+            default => ReportAccess::VARIANT_FREE,
+        };
+        $reportAccessLevel = match ($unlockStage) {
+            ReportAccess::UNLOCK_STAGE_PARTIAL => ReportAccess::REPORT_ACCESS_PARTIAL,
+            ReportAccess::UNLOCK_STAGE_FULL => ReportAccess::REPORT_ACCESS_FULL,
+            default => ReportAccess::REPORT_ACCESS_FREE,
+        };
+        $locked = $unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED;
 
         $shouldUseSnapshot = $hasFullAccess && $this->offerResolver->modulesCoverOffered($modulesAllowed, $modulesOffered);
         $snapshotStrictMode = $this->strictSnapshotModeEnabled();
@@ -301,7 +312,7 @@ class ReportGatekeeper
                     );
                 }
 
-                $report = $this->snapshotReportForVariant($snapshotRow, $variant);
+                $report = $this->snapshotReportForVariant($snapshotRow, $renderVariant);
                 if ($report !== []) {
                     return $this->responsePayload(
                         $locked,
@@ -372,7 +383,7 @@ class ReportGatekeeper
             $scaleCode,
             $attempt,
             $result,
-            $variant,
+            $renderVariant,
             $modulesAllowed,
             $modulesPreview
         );
@@ -391,7 +402,7 @@ class ReportGatekeeper
             $report = $this->applyTeaser($report, $viewPolicy);
         }
 
-        if ($shouldUseSnapshot && $variant === ReportAccess::VARIANT_FULL) {
+        if ($shouldUseSnapshot && $renderVariant === ReportAccess::VARIANT_FULL) {
             $reportFreeBuilt = $this->buildReportVariant(
                 $scaleCode,
                 $attempt,
@@ -671,7 +682,9 @@ class ReportGatekeeper
         array $modulesPreview = [],
         array $norms = [],
         array $quality = [],
-        bool $isMbtiContract = false
+        bool $isMbtiContract = false,
+        ?string $unlockStage = null,
+        ?string $unlockSource = null
     ): array {
         $generating = (bool) ($meta['generating'] ?? false);
         $snapshotError = (bool) ($meta['snapshot_error'] ?? false);
@@ -690,14 +703,25 @@ class ReportGatekeeper
             }
         }
 
+        $normalizedAccessLevel = ReportAccess::normalizeReportAccessLevel($accessLevel);
+        $normalizedUnlockStage = ReportAccess::normalizeUnlockStage(
+            $unlockStage
+                ?? match ($normalizedAccessLevel) {
+                    ReportAccess::REPORT_ACCESS_PARTIAL => ReportAccess::UNLOCK_STAGE_PARTIAL,
+                    ReportAccess::REPORT_ACCESS_FULL => ReportAccess::UNLOCK_STAGE_FULL,
+                    default => ReportAccess::UNLOCK_STAGE_LOCKED,
+                }
+        );
         $payload = [
             'ok' => true,
             'generating' => $generating,
             'snapshot_error' => $snapshotError,
             'retry_after_seconds' => $retryAfterSeconds,
             'locked' => $locked,
-            'access_level' => ReportAccess::normalizeReportAccessLevel($accessLevel),
+            'access_level' => $normalizedAccessLevel,
             'variant' => ReportAccess::normalizeVariant($variant),
+            'unlock_stage' => $normalizedUnlockStage,
+            'unlock_source' => ReportAccess::normalizeUnlockSource($unlockSource ?? ReportAccess::UNLOCK_SOURCE_NONE),
             'upgrade_sku' => $paywall['upgrade_sku'] ?? ($viewPolicy['upgrade_sku'] ?? null),
             'upgrade_sku_effective' => $paywall['upgrade_sku_effective'] ?? ($viewPolicy['upgrade_sku'] ?? null),
             'offers' => $paywall['offers'] ?? [],

--- a/backend/app/Services/Report/Resolvers/AccessResolver.php
+++ b/backend/app/Services/Report/Resolvers/AccessResolver.php
@@ -37,7 +37,7 @@ class AccessResolver
 
     /**
      * @param  list<string>  $modulesOffered
-     * @return array{modules_allowed:list<string>,modules_preview:list<string>,has_paid_module_access:bool}
+     * @return array{modules_allowed:list<string>,modules_preview:list<string>,has_paid_module_access:bool,unlock_stage:string}
      */
     public function resolveModules(
         string $scaleCode,
@@ -74,11 +74,15 @@ class AccessResolver
 
         $modulesPreview = ReportAccess::normalizeModules($modulesOffered);
         $hasPaidModuleAccess = count(array_diff($modulesAllowed, [$freeModule])) > 0;
+        $unlockStage = $hasFullAccess
+            ? ReportAccess::UNLOCK_STAGE_FULL
+            : ($hasPaidModuleAccess ? ReportAccess::UNLOCK_STAGE_PARTIAL : ReportAccess::UNLOCK_STAGE_LOCKED);
 
         return [
             'modules_allowed' => $modulesAllowed,
             'modules_preview' => $modulesPreview,
             'has_paid_module_access' => $hasPaidModuleAccess,
+            'unlock_stage' => $unlockStage,
         ];
     }
 

--- a/backend/tests/Feature/Report/ModulesGateReportTest.php
+++ b/backend/tests/Feature/Report/ModulesGateReportTest.php
@@ -138,8 +138,9 @@ final class ModulesGateReportTest extends TestCase
 
         $after->assertStatus(200);
         $after->assertJson([
-            'variant' => 'full',
-            'access_level' => 'full',
+            'variant' => 'partial',
+            'access_level' => 'partial',
+            'unlock_stage' => 'partial',
         ]);
 
         $sections = $after->json('report.sections');

--- a/backend/tests/Feature/V0_3/AttemptInviteUnlockFoundationTest.php
+++ b/backend/tests/Feature/V0_3/AttemptInviteUnlockFoundationTest.php
@@ -88,6 +88,19 @@ final class AttemptInviteUnlockFoundationTest extends TestCase
         );
         $this->assertSame(1, (int) data_get($qualifiedOne, 'progress.completed_invitees'));
         $this->assertSame(InviteUnlockStatus::IN_PROGRESS, (string) data_get($qualifiedOne, 'progress.status'));
+        $this->assertSame('partial', (string) ($qualifiedOne['unlock_stage'] ?? ''));
+        $this->assertDatabaseHas('benefit_grants', [
+            'org_id' => 0,
+            'attempt_id' => $targetAttemptId,
+            'benefit_code' => 'MBTI_CAREER',
+            'status' => 'active',
+        ]);
+        $this->assertDatabaseMissing('benefit_grants', [
+            'org_id' => 0,
+            'attempt_id' => $targetAttemptId,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'status' => 'active',
+        ]);
 
         $selfReferralAttempt = $this->createAttemptWithOptionalResult($inviterAnonId, 'MBTI', true, true);
         $selfReferral = $completionService->recordCompletionForInvite($inviteCode, $selfReferralAttempt, null, $inviterAnonId);
@@ -139,6 +152,13 @@ final class AttemptInviteUnlockFoundationTest extends TestCase
         );
         $this->assertSame(2, (int) data_get($qualifiedTwo, 'progress.completed_invitees'));
         $this->assertSame(InviteUnlockStatus::COMPLETED, (string) data_get($qualifiedTwo, 'progress.status'));
+        $this->assertSame('full', (string) ($qualifiedTwo['unlock_stage'] ?? ''));
+        $this->assertDatabaseHas('benefit_grants', [
+            'org_id' => 0,
+            'attempt_id' => $targetAttemptId,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'status' => 'active',
+        ]);
 
         $lateSelfAttempt = $this->createAttemptWithOptionalResult($inviterAnonId, 'MBTI', true, true);
         $lateSelfReferral = $completionService->recordCompletionForInvite($inviteCode, $lateSelfAttempt, null, $inviterAnonId);
@@ -166,6 +186,18 @@ final class AttemptInviteUnlockFoundationTest extends TestCase
             (string) ($overflow['qualification_status'] ?? '')
         );
         $this->assertSame(2, (int) data_get($overflow, 'progress.completed_invitees'));
+        $this->assertSame(1, DB::table('benefit_grants')
+            ->where('org_id', 0)
+            ->where('attempt_id', $targetAttemptId)
+            ->where('benefit_code', 'MBTI_CAREER')
+            ->where('status', 'active')
+            ->count());
+        $this->assertSame(1, DB::table('benefit_grants')
+            ->where('org_id', 0)
+            ->where('attempt_id', $targetAttemptId)
+            ->where('benefit_code', 'MBTI_REPORT_FULL')
+            ->where('status', 'active')
+            ->count());
 
         $inviteRow = AttemptInviteUnlock::query()->where('invite_code', $inviteCode)->firstOrFail();
         $this->assertSame(2, (int) $inviteRow->completed_invitees);
@@ -179,7 +211,7 @@ final class AttemptInviteUnlockFoundationTest extends TestCase
         );
     }
 
-    public function test_submit_side_effect_records_completion_without_grants(): void
+    public function test_submit_side_effect_records_completion_and_syncs_partial_stage_entitlement(): void
     {
         $inviteService = app(AttemptInviteUnlockService::class);
         $sideEffects = app(AttemptSubmitSideEffects::class);
@@ -222,7 +254,18 @@ final class AttemptInviteUnlockFoundationTest extends TestCase
             InviteUnlockCompletionStatus::QUALIFIED_COUNTED,
             (string) ($completion->qualification_status ?? '')
         );
-        $this->assertSame(0, DB::table('benefit_grants')->count());
+        $this->assertDatabaseHas('benefit_grants', [
+            'org_id' => 0,
+            'attempt_id' => $targetAttemptId,
+            'benefit_code' => 'MBTI_CAREER',
+            'status' => 'active',
+        ]);
+        $this->assertDatabaseMissing('benefit_grants', [
+            'org_id' => 0,
+            'attempt_id' => $targetAttemptId,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'status' => 'active',
+        ]);
     }
 
     /**

--- a/backend/tests/Feature/V0_3/AttemptInviteUnlockStagedEntitlementTest.php
+++ b/backend/tests/Feature/V0_3/AttemptInviteUnlockStagedEntitlementTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Attempts\AttemptInviteUnlockCompletionService;
+use App\Services\Attempts\AttemptInviteUnlockService;
+use App\Services\Commerce\EntitlementManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptInviteUnlockStagedEntitlementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_invite_progress_transitions_report_access_unlock_stage_from_locked_to_partial_to_full(): void
+    {
+        $inviteService = app(AttemptInviteUnlockService::class);
+        $completionService = app(AttemptInviteUnlockCompletionService::class);
+
+        $inviterAnonId = 'anon_stage_inviter';
+        $targetAttemptId = $this->createAttemptWithResult($inviterAnonId);
+        $targetAttempt = Attempt::query()->where('id', $targetAttemptId)->firstOrFail();
+        $invite = $inviteService->createOrReuseInvite($targetAttempt, null, $inviterAnonId);
+        $inviteCode = (string) ($invite['invite_code'] ?? '');
+
+        $headers = $this->authHeaders($inviterAnonId);
+        $this->withHeaders($headers)
+            ->getJson("/api/v0.3/attempts/{$targetAttemptId}/report-access")
+            ->assertOk()
+            ->assertJsonPath('unlock_stage', 'locked')
+            ->assertJsonPath('unlock_source', 'none');
+
+        $inviteeAttemptOne = $this->createAttemptWithResult('anon_stage_invitee_one');
+        $completionService->recordCompletionForInvite($inviteCode, $inviteeAttemptOne, null, 'anon_stage_invitee_one');
+
+        $this->withHeaders($headers)
+            ->getJson("/api/v0.3/attempts/{$targetAttemptId}/report-access")
+            ->assertOk()
+            ->assertJsonPath('unlock_stage', 'partial')
+            ->assertJsonPath('unlock_source', 'invite')
+            ->assertJsonPath('payload.access_level', 'partial')
+            ->assertJsonPath('payload.variant', 'partial');
+
+        $inviteeAttemptTwo = $this->createAttemptWithResult('anon_stage_invitee_two');
+        $completionService->recordCompletionForInvite($inviteCode, $inviteeAttemptTwo, null, 'anon_stage_invitee_two');
+
+        $this->withHeaders($headers)
+            ->getJson("/api/v0.3/attempts/{$targetAttemptId}/report-access")
+            ->assertOk()
+            ->assertJsonPath('unlock_stage', 'full')
+            ->assertJsonPath('unlock_source', 'invite')
+            ->assertJsonPath('payload.access_level', 'full')
+            ->assertJsonPath('payload.variant', 'full');
+
+        $this->assertSame(1, DB::table('benefit_grants')
+            ->where('attempt_id', $targetAttemptId)
+            ->where('benefit_code', 'MBTI_CAREER')
+            ->where('status', 'active')
+            ->count());
+        $this->assertSame(1, DB::table('benefit_grants')
+            ->where('attempt_id', $targetAttemptId)
+            ->where('benefit_code', 'MBTI_REPORT_FULL')
+            ->where('status', 'active')
+            ->count());
+    }
+
+    public function test_payment_and_invite_stages_coexist_without_downgrading_full_access(): void
+    {
+        /** @var EntitlementManager $entitlements */
+        $entitlements = app(EntitlementManager::class);
+        $inviteService = app(AttemptInviteUnlockService::class);
+        $completionService = app(AttemptInviteUnlockCompletionService::class);
+
+        // payment full first, then invite completion should stay full and source=payment
+        $paymentFirstAnon = 'anon_stage_payment_first';
+        $paymentFirstAttemptId = $this->createAttemptWithResult($paymentFirstAnon);
+        $entitlements->grantAttemptUnlock(
+            0,
+            null,
+            $paymentFirstAnon,
+            'MBTI_REPORT_FULL',
+            $paymentFirstAttemptId,
+            'ORDER-PAY-FIRST'
+        );
+        $paymentFirstAttempt = Attempt::query()->where('id', $paymentFirstAttemptId)->firstOrFail();
+        $paymentFirstInvite = $inviteService->createOrReuseInvite($paymentFirstAttempt, null, $paymentFirstAnon);
+        $completionService->recordCompletionForInvite(
+            (string) $paymentFirstInvite['invite_code'],
+            $this->createAttemptWithResult('anon_stage_payment_first_invitee'),
+            null,
+            'anon_stage_payment_first_invitee'
+        );
+
+        $this->withHeaders($this->authHeaders($paymentFirstAnon))
+            ->getJson("/api/v0.3/attempts/{$paymentFirstAttemptId}/report-access")
+            ->assertOk()
+            ->assertJsonPath('unlock_stage', 'full')
+            ->assertJsonPath('unlock_source', 'payment');
+
+        // invite partial first, then payment full should converge to full and source=mixed
+        $partialFirstAnon = 'anon_stage_partial_first';
+        $partialFirstAttemptId = $this->createAttemptWithResult($partialFirstAnon);
+        $partialFirstAttempt = Attempt::query()->where('id', $partialFirstAttemptId)->firstOrFail();
+        $partialFirstInvite = $inviteService->createOrReuseInvite($partialFirstAttempt, null, $partialFirstAnon);
+        $completionService->recordCompletionForInvite(
+            (string) $partialFirstInvite['invite_code'],
+            $this->createAttemptWithResult('anon_stage_partial_first_invitee'),
+            null,
+            'anon_stage_partial_first_invitee'
+        );
+
+        $entitlements->grantAttemptUnlock(
+            0,
+            null,
+            $partialFirstAnon,
+            'MBTI_REPORT_FULL',
+            $partialFirstAttemptId,
+            'ORDER-PARTIAL-THEN-PAY'
+        );
+
+        $this->withHeaders($this->authHeaders($partialFirstAnon))
+            ->getJson("/api/v0.3/attempts/{$partialFirstAttemptId}/report-access")
+            ->assertOk()
+            ->assertJsonPath('unlock_stage', 'full')
+            ->assertJsonPath('unlock_source', 'mixed');
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function authHeaders(string $anonId): array
+    {
+        return [
+            'Authorization' => 'Bearer '.$this->issueAnonToken($anonId),
+            'X-Anon-Id' => $anonId,
+        ];
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'submit'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => ['total' => 100],
+            'scores_pct' => ['axis_a' => 50],
+            'axis_states' => ['axis_a' => 'clear'],
+            'content_package_version' => 'v0.3',
+            'result_json' => ['type_code' => 'INTJ-A', 'summary' => 'stage test'],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+}

--- a/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+++ b/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
@@ -89,22 +89,29 @@ final class AttemptReportAccessReadTest extends TestCase
         ]);
     }
 
-    private function createActiveGrant(string $attemptId, string $anonId): void
+    private function createActiveGrant(
+        string $attemptId,
+        string $anonId,
+        string $benefitCode = 'MBTI_REPORT_FULL',
+        ?string $orderNo = null,
+        ?array $meta = null,
+    ): void
     {
         DB::table('benefit_grants')->insert([
             'id' => (string) Str::uuid(),
             'org_id' => 0,
             'user_id' => $anonId,
-            'benefit_code' => 'MBTI_REPORT_FULL',
+            'benefit_code' => $benefitCode,
             'scope' => 'attempt',
             'attempt_id' => $attemptId,
-            'order_no' => 'ORDER-'.$attemptId,
+            'order_no' => $orderNo ?? 'ORDER-'.$attemptId,
             'status' => 'active',
             'expires_at' => null,
             'benefit_ref' => $anonId,
             'benefit_type' => 'report_unlock',
             'source_order_id' => (string) Str::uuid(),
             'source_event_id' => null,
+            'meta_json' => $meta !== null ? json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : null,
             'created_at' => now(),
             'updated_at' => now(),
         ]);
@@ -182,6 +189,10 @@ final class AttemptReportAccessReadTest extends TestCase
         $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
         $response->assertJsonPath('payload.has_active_grant', true);
         $response->assertJsonPath('payload.result_exists', true);
+        $response->assertJsonPath('unlock_stage', 'full');
+        $response->assertJsonPath('unlock_source', 'payment');
+        $response->assertJsonPath('payload.unlock_stage', 'full');
+        $response->assertJsonPath('payload.unlock_source', 'payment');
         $response->assertJsonPath('payload.access_level', 'full');
         $response->assertJsonPath('payload.variant', 'full');
         $this->assertDatabaseHas('unified_access_projections', [
@@ -213,6 +224,10 @@ final class AttemptReportAccessReadTest extends TestCase
         $response->assertJsonPath('report_state', 'ready');
         $response->assertJsonPath('reason_code', 'projection_missing_result_ready');
         $response->assertJsonPath('payload.result_exists', true);
+        $response->assertJsonPath('unlock_stage', 'locked');
+        $response->assertJsonPath('unlock_source', 'none');
+        $response->assertJsonPath('payload.unlock_stage', 'locked');
+        $response->assertJsonPath('payload.unlock_source', 'none');
         $response->assertJsonPath('payload.has_active_grant', null);
         $this->assertDatabaseMissing('unified_access_projections', [
             'attempt_id' => $attemptId,
@@ -326,5 +341,47 @@ final class AttemptReportAccessReadTest extends TestCase
             'attempt_id' => $attemptId,
             'reason_code' => 'projection_repaired_from_entitlement',
         ]);
+    }
+
+    public function test_it_repairs_partial_projection_from_invite_partial_grant_without_escalating_to_full(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_partial_repair';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createResult($attemptId);
+        $this->createActiveGrant(
+            $attemptId,
+            $anonId,
+            'MBTI_CAREER',
+            '',
+            [
+                'granted_via' => 'invite_unlock',
+                'invite_unlock_stage' => 'partial',
+            ]
+        );
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'ready');
+        $response->assertJsonPath('report_state', 'ready');
+        $response->assertJsonPath('reason_code', 'projection_repaired_from_entitlement');
+        $response->assertJsonPath('unlock_stage', 'partial');
+        $response->assertJsonPath('unlock_source', 'invite');
+        $response->assertJsonPath('payload.unlock_stage', 'partial');
+        $response->assertJsonPath('payload.unlock_source', 'invite');
+        $response->assertJsonPath('payload.access_level', 'partial');
+        $response->assertJsonPath('payload.variant', 'partial');
+        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+        $modulesAllowed = (array) $response->json('payload.modules_allowed');
+        $this->assertContains('core_free', $modulesAllowed);
+        $this->assertContains('career', $modulesAllowed);
     }
 }


### PR DESCRIPTION
## Title
feat(invite-unlock): PR2 MBTI staged unlock via entitlement + projection + report-access

## Summary
在 PR1（invite foundation）基础上，把邀请进度正式接入现有 backend unlock 主链，形成 staged truth：

- 0 个有效 invitee -> `locked`
- 1 个有效 invitee -> `partial`（仅 Career 章节）
- 2 个有效 invitee -> `full`（等同现有 full unlock）

主链保持不变：

`benefit_grants -> entitlement resolution -> unified_access_projections -> /attempts/{id}/report-access`

本 PR 仅改 `fap-api`，不改前端 UI。

## Scope
1. 继续复用 `benefit_grants`，使用两种 benefit_code 表达阶段：
- partial: `MBTI_CAREER`
- full: `MBTI_REPORT_FULL`

2. completion side-effect 中同步 staged entitlement（幂等）：
- `completed_invitees >= 1` 且无 full -> 发 partial grant
- `completed_invitees >= 2` -> 发 full grant

3. projection 改为 stage-aware（无 migration）：
- 在 `payload_json` 写入 `unlock_stage`, `unlock_source`, `access_level`, `variant`, `modules_allowed`

4. repair 改为 stage-aware（P0）：
- 修复 `benefit_type=report_unlock` 宽匹配导致 partial 被修成 full 的风险
- partial only 时 repair 结果保持 partial
- full 存在才是 full

5. `/report-access` 返回 staged truth（保持兼容）：
- 新增顶层 `unlock_stage`, `unlock_source`
- 与 `payload.unlock_stage`, `payload.unlock_source` 保持一致
- partial 下仍返回 `actions.page_href`

6. payment 与 invite 并存规则：
- payment full 不降级
- partial + payment full 收敛到 full
- source 可为 `payment` / `invite` / `mixed`

## Non-Goals
- 不改 `fap-web`
- 不新增 route
- 不新增 migration
- 不改 `FmTokenAuth.php`
- 不改 payment/order/wait 主逻辑
- 不扩到 Big Five staged unlock
- 不做 analytics/ops/history 二级面

## Files Changed
- `backend/app/Services/Commerce/EntitlementManager.php`
- `backend/app/Services/Attempts/AttemptInviteUnlockCompletionService.php`
- `backend/app/Services/Access/AttemptUnlockProjectionRepairService.php`
- `backend/app/Services/Report/ReportAccess.php`
- `backend/app/Services/Report/ReportGatekeeper.php`
- `backend/app/Services/Report/Resolvers/AccessResolver.php`
- `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `backend/tests/Feature/V0_3/AttemptInviteUnlockFoundationTest.php`
- `backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php`
- `backend/tests/Feature/Report/ModulesGateReportTest.php`
- `backend/tests/Feature/V0_3/AttemptInviteUnlockStagedEntitlementTest.php` (new)

## Validation
已执行并通过：

1. `php artisan route:list`
2. `php artisan migrate`（Nothing to migrate）
3. `php artisan test tests/Feature/V0_3/AttemptInviteUnlockFoundationTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php tests/Feature/Report/ModulesGateReportTest.php tests/Feature/V0_3/AttemptInviteUnlockStagedEntitlementTest.php`
4. `php artisan test tests/Feature/Commerce/EntitlementProjectionRefreshObservabilityTest.php`
5. `bash backend/scripts/ci_verify_mbti.sh`

## Follow-up Fix Included
追加修复了 observability 回归：
- 恢复 projection refresh skipped 时的 warning 日志 `ENTITLEMENT_ACCESS_PROJECTION_REFRESH_SKIPPED`
- 确保老测试 `EntitlementProjectionRefreshObservabilityTest` 继续通过

## Commits
- `475e7fa8` feat(invite-unlock): add staged entitlement and projection truth for MBTI
- `75b969c0` fix(entitlement): restore projection refresh skipped warning
