### PR TITLE
fix(api): stabilize MBTI /report-access when projection repair fails

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -39,6 +39,7 @@ use App\Support\OrgContext;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
 
 class AttemptReadController extends Controller
 {
@@ -549,8 +550,20 @@ class AttemptReadController extends Controller
             ->where('org_id', $orgId)
             ->where('attempt_id', (string) $attempt->id)
             ->exists();
+        $repairFailed = false;
+        $repairFailureCode = null;
         if ($resultExists && strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI') {
-            $this->projectionRepair->repairResultReadyProjectionIfNeeded($orgId, (string) $attempt->id);
+            try {
+                $this->projectionRepair->repairResultReadyProjectionIfNeeded($orgId, (string) $attempt->id);
+            } catch (\Throwable $e) {
+                $repairFailed = true;
+                $repairFailureCode = 'projection_repair_runtime_exception';
+                Log::error('REPORT_ACCESS_PROJECTION_REPAIR_FAILED', [
+                    'org_id' => $orgId,
+                    'attempt_id' => (string) $attempt->id,
+                    'exception' => $e,
+                ]);
+            }
         }
 
         $projection = UnifiedAccessProjection::query()
@@ -577,6 +590,27 @@ class AttemptReadController extends Controller
             $payloadJson = is_array($projection?->payload_json) ? $projection->payload_json : $fallbackStates['payload_json'];
             $producedAt = optional($projection?->produced_at)->toIso8601String();
             $refreshedAt = optional($projection?->refreshed_at)->toIso8601String();
+        }
+
+        if ($repairFailed && $resultExists) {
+            $reasonCode = in_array($reasonCode, ['', 'projection_missing_result_ready'], true)
+                ? 'projection_repair_failed_result_ready_fallback'
+                : $reasonCode;
+            $payloadJson = array_merge($payloadJson, [
+                'fallback' => true,
+                'result_exists' => true,
+                'repair_fallback' => true,
+                'repair_error_code' => $repairFailureCode,
+            ]);
+
+            Log::warning('REPORT_ACCESS_PROJECTION_REPAIR_FALLBACK_APPLIED', [
+                'org_id' => $orgId,
+                'attempt_id' => (string) $attempt->id,
+                'reason_code' => $reasonCode,
+                'access_state' => $accessState,
+                'report_state' => $reportState,
+                'pdf_state' => $pdfState,
+            ]);
         }
 
         $mbtiFormSummary = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI'

--- a/backend/app/Services/Access/AttemptUnlockProjectionRepairService.php
+++ b/backend/app/Services/Access/AttemptUnlockProjectionRepairService.php
@@ -34,7 +34,23 @@ final class AttemptUnlockProjectionRepairService
             return $existing;
         }
 
-        $unlockState = $this->entitlements->resolveAttemptUnlockState($orgId, $attemptId);
+        try {
+            $unlockState = $this->entitlements->resolveAttemptUnlockState($orgId, $attemptId);
+        } catch (\Throwable $e) {
+            Log::error('ATTEMPT_UNLOCK_PROJECTION_REPAIR_UNLOCK_STATE_FAILED', [
+                'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'existing_reason_code' => $existing?->reason_code,
+                'exception' => $e,
+            ]);
+
+            if ($existing instanceof UnifiedAccessProjection) {
+                return $existing;
+            }
+
+            return $this->persistConservativeFallbackProjection($attemptId, $existing);
+        }
+
         $unlockStage = ReportAccess::normalizeUnlockStage((string) ($unlockState['unlock_stage'] ?? ReportAccess::UNLOCK_STAGE_LOCKED));
         if ($unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED) {
             return $existing;
@@ -105,6 +121,76 @@ final class AttemptUnlockProjectionRepairService
         } catch (\Throwable $e) {
             Log::error('ATTEMPT_UNLOCK_PROJECTION_REPAIR_FAILED', [
                 'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'existing_reason_code' => $existing?->reason_code,
+                'exception' => $e,
+            ]);
+
+            return $existing;
+        }
+    }
+
+    private function persistConservativeFallbackProjection(
+        string $attemptId,
+        ?UnifiedAccessProjection $existing
+    ): ?UnifiedAccessProjection {
+        $existingPayload = is_array($existing?->payload_json) ? $existing->payload_json : [];
+        $existingActions = is_array($existing?->actions_json) ? $existing->actions_json : [];
+        $pdfReady = strtolower(trim((string) ($existing?->pdf_state ?? ''))) === 'ready';
+        $reasonCode = 'projection_repair_failed_fallback_locked';
+        $patch = [
+            'access_state' => 'locked',
+            'report_state' => 'ready',
+            'pdf_state' => $pdfReady ? 'ready' : 'missing',
+            'reason_code' => $reasonCode,
+            'actions_json' => array_merge($existingActions, [
+                'report' => true,
+                'pdf' => $pdfReady,
+                'unlock' => false,
+            ]),
+            'payload_json' => array_merge($existingPayload, [
+                'attempt_id' => $attemptId,
+                'fallback' => true,
+                'result_exists' => true,
+                'repair_fallback' => true,
+                'repair_source' => 'attempt_unlock_projection_repair',
+                'repair_error_code' => 'unlock_state_resolution_failed',
+                'unlock_stage' => ReportAccess::UNLOCK_STAGE_LOCKED,
+                'unlock_source' => ReportAccess::UNLOCK_SOURCE_NONE,
+                'access_level' => ReportAccess::REPORT_ACCESS_FREE,
+                'variant' => ReportAccess::VARIANT_FREE,
+                'modules_allowed' => ReportAccess::defaultModulesAllowedForLocked(ReportAccess::SCALE_MBTI),
+                'modules_preview' => ReportAccess::allDefaultModulesOffered(ReportAccess::SCALE_MBTI),
+            ]),
+        ];
+        $meta = [
+            'source_system' => 'attempt_unlock_projection_repair',
+            'source_ref' => 'result#'.$attemptId,
+            'actor_type' => 'system',
+            'actor_id' => 'attempt_unlock_projection_repair',
+            'reason_code' => $reasonCode,
+        ];
+
+        try {
+            $projection = $this->projectionWriter->refreshAttemptProjection($attemptId, $patch, $meta);
+
+            if (! $projection instanceof UnifiedAccessProjection) {
+                $projection = $this->persistProjectionPatch($attemptId, $patch, $existing);
+                Log::warning('ATTEMPT_UNLOCK_PROJECTION_REPAIR_FALLBACK_WRITER_UNAVAILABLE', [
+                    'attempt_id' => $attemptId,
+                    'existing_reason_code' => $existing?->reason_code,
+                ]);
+            }
+
+            Log::warning('ATTEMPT_UNLOCK_PROJECTION_REPAIR_FALLBACK_APPLIED', [
+                'attempt_id' => $attemptId,
+                'reason_code' => $reasonCode,
+                'pdf_ready' => $pdfReady,
+            ]);
+
+            return $projection;
+        } catch (\Throwable $e) {
+            Log::error('ATTEMPT_UNLOCK_PROJECTION_REPAIR_FALLBACK_FAILED', [
                 'attempt_id' => $attemptId,
                 'existing_reason_code' => $existing?->reason_code,
                 'exception' => $e,

--- a/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+++ b/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
@@ -6,10 +6,13 @@ namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\Commerce\EntitlementManager;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Mockery\MockInterface;
 use Tests\TestCase;
 
 final class AttemptReportAccessReadTest extends TestCase
@@ -383,5 +386,98 @@ final class AttemptReportAccessReadTest extends TestCase
         $modulesAllowed = (array) $response->json('payload.modules_allowed');
         $this->assertContains('core_free', $modulesAllowed);
         $this->assertContains('career', $modulesAllowed);
+    }
+
+    public function test_it_keeps_result_ready_report_access_available_for_mbti_144_when_projection_is_missing(): void
+    {
+        $this->assertReportAccessAvailableForMbtiForm('mbti_144');
+    }
+
+    public function test_it_keeps_result_ready_report_access_available_for_mbti_93_when_projection_is_missing(): void
+    {
+        $this->assertReportAccessAvailableForMbtiForm('mbti_93');
+    }
+
+    private function assertReportAccessAvailableForMbtiForm(string $formCode): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_form_'.$formCode;
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId, $formCode);
+        $this->createResult($attemptId, $formCode);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'locked');
+        $response->assertJsonPath('report_state', 'ready');
+        $response->assertJsonPath('reason_code', 'projection_missing_result_ready');
+        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+        $response->assertJsonPath('payload.fallback', true);
+        $response->assertJsonPath('payload.result_exists', true);
+        $response->assertJsonPath('mbti_form_v1.form_code', $formCode);
+    }
+
+    public function test_it_returns_conservative_report_access_fallback_when_unlock_state_resolution_fails(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_repair_fallback';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId, 'mbti_144');
+        $this->createResult($attemptId, 'mbti_144');
+        $this->createActiveGrant($attemptId, $anonId);
+
+        Log::spy();
+        $this->mock(EntitlementManager::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('resolveAttemptUnlockState')
+                ->once()
+                ->andThrow(new \RuntimeException('simulated unlock-state failure'));
+        });
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'locked');
+        $response->assertJsonPath('report_state', 'ready');
+        $response->assertJsonPath('reason_code', 'projection_repair_failed_fallback_locked');
+        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+        $response->assertJsonPath('payload.fallback', true);
+        $response->assertJsonPath('payload.result_exists', true);
+        $response->assertJsonPath('payload.repair_fallback', true);
+        $response->assertJsonPath('payload.repair_error_code', 'unlock_state_resolution_failed');
+        $response->assertJsonPath('unlock_stage', 'locked');
+        $response->assertJsonPath('unlock_source', 'none');
+        $response->assertJsonPath('payload.access_level', 'free');
+        $response->assertJsonPath('payload.variant', 'free');
+        $response->assertJsonPath('mbti_form_v1.form_code', 'mbti_144');
+        $this->assertDatabaseHas('unified_access_projections', [
+            'attempt_id' => $attemptId,
+            'reason_code' => 'projection_repair_failed_fallback_locked',
+        ]);
+
+        Log::shouldHaveReceived('error')
+            ->once()
+            ->withArgs(function (string $message, array $context) use ($attemptId): bool {
+                return $message === 'ATTEMPT_UNLOCK_PROJECTION_REPAIR_UNLOCK_STATE_FAILED'
+                    && (string) ($context['attempt_id'] ?? '') === $attemptId;
+            });
+        Log::shouldHaveReceived('warning')
+            ->atLeast()->once()
+            ->withArgs(function (string $message, array $context) use ($attemptId): bool {
+                return $message === 'ATTEMPT_UNLOCK_PROJECTION_REPAIR_FALLBACK_APPLIED'
+                    && (string) ($context['attempt_id'] ?? '') === $attemptId;
+            });
     }
 }


### PR DESCRIPTION
## Summary
- prevent MBTI `/api/v0.3/attempts/{id}/report-access` from returning 500 when projection repair throws
- add conservative fallback handling in projection repair service (locked + report_state=ready) with explicit reason/payload markers
- keep observability via structured error/warning logs
- add regression coverage for MBTI 144/93 and repair-failure fallback

## Scope
- backend only (`fap-api`)
- no route changes
- no migration changes
- no frontend changes
- no `FmTokenAuth.php` changes

## Why
Frontend rich result path depends on `/report-access`. When this endpoint 500s, the client falls back to simple result rendering even if `/report` is available. This change keeps `/report-access` consumable under repair failures while preserving conservative staged truth semantics.

## Validation
- `php artisan route:list`
- `php artisan migrate` (Nothing to migrate)
- `php artisan test tests/Feature/V0_3/AttemptReportAccessReadTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`
