### PR TITLE
fix(api): make BIG5 start retake gate form-aware and enrich 429 payload

### DIFF
--- a/backend/app/Services/Attempts/AttemptRateLimitService.php
+++ b/backend/app/Services/Attempts/AttemptRateLimitService.php
@@ -16,16 +16,21 @@ final class AttemptRateLimitService
         ?string $userId,
         ?string $anonId,
         int $cooldownHours,
-        int $maxAttemptsPer30Days
+        int $maxAttemptsPer30Days,
+        ?string $formCode = null
     ): void {
         $identity = $this->resolveIdentity($userId, $anonId);
         if ($identity === null) {
             return;
         }
 
+        $normalizedScaleCode = strtoupper(trim($scaleCode));
+        $isBigFive = $normalizedScaleCode === 'BIG5_OCEAN';
+        $normalizedBigFiveFormCode = $isBigFive ? $this->canonicalizeBigFiveFormCode($formCode) : null;
+
         $query = Attempt::query()
             ->where('org_id', $orgId)
-            ->where('scale_code', strtoupper(trim($scaleCode)));
+            ->where('scale_code', $normalizedScaleCode);
 
         if ($identity['type'] === 'user') {
             $query->where('user_id', $identity['value']);
@@ -34,6 +39,99 @@ final class AttemptRateLimitService
         }
 
         $now = CarbonImmutable::now();
+
+        if ($isBigFive) {
+            $attempts = (clone $query)
+                ->orderByDesc('started_at')
+                ->orderByDesc('created_at')
+                ->get([
+                    'id',
+                    'started_at',
+                    'submitted_at',
+                    'created_at',
+                    'dir_version',
+                    'answers_summary_json',
+                ]);
+
+            $formScopedAttempts = $attempts->filter(function (Attempt $attempt) use ($normalizedBigFiveFormCode): bool {
+                return $this->resolveBigFiveAttemptFormCode($attempt) === $normalizedBigFiveFormCode;
+            })->values();
+
+            if ($cooldownHours > 0) {
+                /** @var Attempt|null $latest */
+                $latest = $formScopedAttempts->first();
+                if ($latest !== null) {
+                    $latestAt = $latest->started_at ?? $latest->created_at;
+                    if ($latestAt !== null) {
+                        $latestTs = CarbonImmutable::parse((string) $latestAt);
+                        $cooldownEndsAt = $latestTs->addHours($cooldownHours);
+                        if ($cooldownEndsAt->greaterThan($now)) {
+                            $retryAfterSeconds = $now->diffInSeconds($cooldownEndsAt, false);
+                            if ($retryAfterSeconds < 0) {
+                                $retryAfterSeconds = 0;
+                            }
+
+                            throw new ApiProblemException(
+                                429,
+                                'RETAKE_COOLDOWN',
+                                'retake cooldown active.',
+                                [
+                                    'code' => 'RETAKE_COOLDOWN',
+                                    'reason_code' => 'RETAKE_COOLDOWN',
+                                    'form_code' => $normalizedBigFiveFormCode,
+                                    'retry_after_seconds' => $retryAfterSeconds,
+                                    'cooldown_hours' => $cooldownHours,
+                                    'scope_key' => 'org+scale+identity+form',
+                                ]
+                            );
+                        }
+                    }
+                }
+            }
+
+            if ($maxAttemptsPer30Days > 0) {
+                $windowStart = $now->subDays(30);
+                $attemptsCount = $formScopedAttempts->filter(function (Attempt $attempt) use ($windowStart): bool {
+                    $timestamps = [
+                        $attempt->started_at,
+                        $attempt->submitted_at,
+                        $attempt->created_at,
+                    ];
+                    foreach ($timestamps as $timestamp) {
+                        if ($timestamp === null) {
+                            continue;
+                        }
+
+                        $candidate = CarbonImmutable::parse((string) $timestamp);
+                        if ($candidate->greaterThanOrEqualTo($windowStart)) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                })->count();
+
+                if ($attemptsCount >= $maxAttemptsPer30Days) {
+                    throw new ApiProblemException(
+                        429,
+                        'RETAKE_LIMIT_EXCEEDED',
+                        'retake limit reached in last 30 days.',
+                        [
+                            'code' => 'RETAKE_LIMIT_EXCEEDED',
+                            'reason_code' => 'RETAKE_LIMIT_EXCEEDED',
+                            'form_code' => $normalizedBigFiveFormCode,
+                            'retry_after_seconds' => null,
+                            'max_attempts_per_30_days' => $maxAttemptsPer30Days,
+                            'attempts_in_window' => $attemptsCount,
+                            'limit_window' => '30_days',
+                            'scope_key' => 'org+scale+identity+form',
+                        ]
+                    );
+                }
+            }
+
+            return;
+        }
 
         if ($cooldownHours > 0) {
             $latest = (clone $query)
@@ -105,5 +203,39 @@ final class AttemptRateLimitService
         }
 
         return null;
+    }
+
+    private function canonicalizeBigFiveFormCode(?string $formCode): string
+    {
+        $normalized = strtolower(trim((string) $formCode));
+        if ($normalized === '' || in_array($normalized, ['big5_120', '120', 'big5-120', 'standard_120', 'default'], true)) {
+            return 'big5_120';
+        }
+        if (in_array($normalized, ['big5_90', '90', 'big5-90', 'standard_90', 'short_90'], true)) {
+            return 'big5_90';
+        }
+
+        return 'big5_120';
+    }
+
+    private function resolveBigFiveAttemptFormCode(Attempt $attempt): string
+    {
+        $summary = $attempt->answers_summary_json;
+        if (is_array($summary)) {
+            $meta = is_array($summary['meta'] ?? null) ? $summary['meta'] : [];
+            $fromMeta = $this->canonicalizeBigFiveFormCode(
+                is_scalar($meta['form_code'] ?? null) ? (string) $meta['form_code'] : null
+            );
+            if ($fromMeta === 'big5_90') {
+                return 'big5_90';
+            }
+        }
+
+        $dirVersion = strtolower(trim((string) ($attempt->dir_version ?? '')));
+        if ($dirVersion === 'v1-form-90' || str_contains($dirVersion, 'form-90')) {
+            return 'big5_90';
+        }
+
+        return 'big5_120';
     }
 }

--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -83,18 +83,6 @@ class AttemptStartService
 
         ScaleRolloutGate::assertEnabled($scaleCode, $row, $region, $anonId);
 
-        if (strtoupper($scaleCode) === 'BIG5_OCEAN') {
-            $retakePolicy = $this->resolveBigFiveRetakePolicy((string) ($row['default_dir_version'] ?? 'v1'));
-            $this->attemptRateLimitService->assertRetakeAllowed(
-                $orgId,
-                $scaleCode,
-                $ctx->userId(),
-                $anonId,
-                (int) ($retakePolicy['cooldown_hours'] ?? 24),
-                (int) ($retakePolicy['max_attempts_per_30_days'] ?? 3)
-            );
-        }
-
         $packId = (string) ($row['default_pack_id'] ?? '');
         $dirVersion = (string) ($row['default_dir_version'] ?? '');
         $registryPackId = $packId;
@@ -144,6 +132,19 @@ class AttemptStartService
 
         if ($packId === '' || $dirVersion === '') {
             throw new ApiProblemException(500, 'CONTENT_PACK_ERROR', 'scale pack not configured.');
+        }
+
+        if (strtoupper($scaleCode) === 'BIG5_OCEAN') {
+            $retakePolicy = $this->resolveBigFiveRetakePolicy($dirVersion !== '' ? $dirVersion : 'v1');
+            $this->attemptRateLimitService->assertRetakeAllowed(
+                $orgId,
+                $scaleCode,
+                $ctx->userId(),
+                $anonId,
+                (int) ($retakePolicy['cooldown_hours'] ?? 24),
+                (int) ($retakePolicy['max_attempts_per_30_days'] ?? 3),
+                $resolvedFormCode
+            );
         }
 
         $questionCount = $this->resolveQuestionCount(

--- a/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
+++ b/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
@@ -38,7 +38,7 @@ final class Big5RetakeCooldownTest extends TestCase
         (new ScaleRegistrySeeder)->run();
 
         $anonId = 'anon_big5_cooldown';
-        $this->createAttempt($anonId, now()->subHours(1));
+        $this->createAttempt($anonId, now()->subHours(1), 'big5_120');
 
         $response = $this->postJson('/api/v0.3/attempts/start', [
             'scale_code' => 'BIG5_OCEAN',
@@ -49,6 +49,11 @@ final class Big5RetakeCooldownTest extends TestCase
 
         $response->assertStatus(429);
         $response->assertJsonPath('error_code', 'RETAKE_COOLDOWN');
+        $response->assertJsonPath('details.code', 'RETAKE_COOLDOWN');
+        $response->assertJsonPath('details.reason_code', 'RETAKE_COOLDOWN');
+        $response->assertJsonPath('details.form_code', 'big5_120');
+        $response->assertJsonPath('details.scope_key', 'org+scale+identity+form');
+        $this->assertGreaterThan(0, (int) $response->json('details.retry_after_seconds'));
     }
 
     public function test_big5_retake_limit_blocks_when_max_attempts_reached_in_30_days(): void
@@ -56,9 +61,9 @@ final class Big5RetakeCooldownTest extends TestCase
         (new ScaleRegistrySeeder)->run();
 
         $anonId = 'anon_big5_retake_limit';
-        $this->createAttempt($anonId, now()->subDays(2));
-        $this->createAttempt($anonId, now()->subDays(10));
-        $this->createAttempt($anonId, now()->subDays(20));
+        $this->createAttempt($anonId, now()->subDays(2), 'big5_120');
+        $this->createAttempt($anonId, now()->subDays(10), 'big5_120');
+        $this->createAttempt($anonId, now()->subDays(20), 'big5_120');
 
         $response = $this->postJson('/api/v0.3/attempts/start', [
             'scale_code' => 'BIG5_OCEAN',
@@ -69,6 +74,91 @@ final class Big5RetakeCooldownTest extends TestCase
 
         $response->assertStatus(429);
         $response->assertJsonPath('error_code', 'RETAKE_LIMIT_EXCEEDED');
+        $response->assertJsonPath('details.code', 'RETAKE_LIMIT_EXCEEDED');
+        $response->assertJsonPath('details.reason_code', 'RETAKE_LIMIT_EXCEEDED');
+        $response->assertJsonPath('details.form_code', 'big5_120');
+        $response->assertJsonPath('details.scope_key', 'org+scale+identity+form');
+        $response->assertJsonPath('details.limit_window', '30_days');
+        $response->assertJsonPath('details.retry_after_seconds', null);
+    }
+
+    public function test_big5_retake_cooldown_is_form_aware_from_120_to_90(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_big5_form_aware_120_to_90';
+
+        $start120 = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'BIG5_OCEAN',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'anon_id' => $anonId,
+            'form_code' => 'big5_120',
+        ]);
+        $start120->assertStatus(200);
+        $start120->assertJsonPath('form_code', 'big5_120');
+
+        $start90 = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'BIG5_OCEAN',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'anon_id' => $anonId,
+            'form_code' => 'big5_90',
+        ]);
+        $start90->assertStatus(200);
+        $start90->assertJsonPath('form_code', 'big5_90');
+    }
+
+    public function test_big5_retake_cooldown_is_form_aware_from_90_to_120(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_big5_form_aware_90_to_120';
+
+        $start90 = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'BIG5_OCEAN',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'anon_id' => $anonId,
+            'form_code' => 'big5_90',
+        ]);
+        $start90->assertStatus(200);
+        $start90->assertJsonPath('form_code', 'big5_90');
+
+        $start120 = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'BIG5_OCEAN',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'anon_id' => $anonId,
+            'form_code' => 'big5_120',
+        ]);
+        $start120->assertStatus(200);
+        $start120->assertJsonPath('form_code', 'big5_120');
+    }
+
+    public function test_non_big5_scales_keep_start_behavior_unchanged(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_mbti_retake_control';
+
+        $first = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'anon_id' => $anonId,
+        ]);
+        $first->assertStatus(200);
+        $first->assertJsonPath('ok', true);
+
+        $second = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'anon_id' => $anonId,
+        ]);
+        $second->assertStatus(200);
+        $second->assertJsonPath('ok', true);
     }
 
     public function test_big5_retake_policy_reads_mapped_raw_policy_when_content_path_mode_is_v2(): void
@@ -108,8 +198,15 @@ final class Big5RetakeCooldownTest extends TestCase
         $this->assertSame(1, (int) ($policy['max_attempts_per_30_days'] ?? -1));
     }
 
-    private function createAttempt(string $anonId, \DateTimeInterface $startedAt): void
+    private function createAttempt(string $anonId, \DateTimeInterface $startedAt, string $formCode = 'big5_120'): void
     {
+        $normalizedFormCode = strtolower(trim($formCode)) === 'big5_90' ? 'big5_90' : 'big5_120';
+        $dirVersion = $normalizedFormCode === 'big5_90' ? 'v1-form-90' : 'v1';
+        $questionCount = $normalizedFormCode === 'big5_90' ? 90 : 120;
+        $scoringSpecVersion = $normalizedFormCode === 'big5_90'
+            ? 'big5_spec_2026Q2_form90_v1'
+            : 'big5_spec_2026Q1_v1';
+
         Attempt::query()->create([
             'id' => (string) Str::uuid(),
             'org_id' => 0,
@@ -118,15 +215,20 @@ final class Big5RetakeCooldownTest extends TestCase
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
-            'question_count' => 120,
+            'question_count' => $questionCount,
             'client_platform' => 'test',
             'started_at' => $startedAt,
             'submitted_at' => $startedAt,
             'pack_id' => 'BIG5_OCEAN',
-            'dir_version' => 'v1',
-            'content_package_version' => 'v1',
-            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
-            'answers_summary_json' => ['stage' => 'seed'],
+            'dir_version' => $dirVersion,
+            'content_package_version' => $dirVersion,
+            'scoring_spec_version' => $scoringSpecVersion,
+            'answers_summary_json' => [
+                'stage' => 'seed',
+                'meta' => [
+                    'form_code' => $normalizedFormCode,
+                ],
+            ],
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- make BIG5 start retake gate form-aware by scoping to `org + scale + identity + form`
- isolate `big5_120` and `big5_90` cooldown/retake limit so they no longer cross-block
- enrich BIG5 business 429 payload with `code`, `reason_code`, `form_code`, `retry_after_seconds`, and `scope_key`
- keep non-BIG5 behavior unchanged

## Scope
- backend only (`fap-api`)
- no route changes
- no migration changes
- no middleware changes (`FmTokenAuth.php` unchanged)

## Changed files
- `backend/app/Services/Attempts/AttemptRateLimitService.php`
- `backend/app/Services/Attempts/AttemptStartService.php`
- `backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php`

## Verification
- `php artisan route:list --path=api/v0.3/attempts/start -v`
- `php artisan migrate --no-interaction` (Nothing to migrate)
- `php artisan test --filter=Big5RetakeCooldownTest`
- `php artisan test --filter=BigFiveFormVersionFlowTest`
- `bash backend/scripts/ci_verify_mbti.sh` (pass)
- sample curl checks for:
  - 120 -> 90 cross-form start success (same identity)
  - 90 -> 120 cross-form start success (same identity)
  - same-form repeat still blocked with `RETAKE_COOLDOWN` and `details.form_code`

## Notes
- this PR intentionally does not change frontend error mapping; backend contract is now available for frontend follow-up mapping PR.
