### PR TITLE
fix(deploy): unblock sitemap-authority guard by setting backend env

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -122,7 +122,10 @@ $productionHost = host('production')
     ->set('healthcheck_host', getenv('HEALTHCHECK_HOST_PROD') ?: 'fermatmind.com')
     ->set('ops_entry_host', getenv('OPS_ENTRY_HOST_PROD') ?: 'ops.fermatmind.com')
     ->set('nginx_site', '/etc/nginx/sites-enabled/fap-api')
-    ->set('php_fpm_service', getenv('PHP_FPM_SERVICE_PROD') ?: 'php8.4-fpm');
+    ->set('php_fpm_service', getenv('PHP_FPM_SERVICE_PROD') ?: 'php8.4-fpm')
+    ->set('env', [
+        'SEO_PUBLIC_SITEMAP_AUTHORITY' => getenv('SEO_PUBLIC_SITEMAP_AUTHORITY_PROD') ?: 'backend',
+    ]);
 
 if ($productionIdentityFile !== null) {
     $productionHost->setIdentityFile($productionIdentityFile);
@@ -137,7 +140,10 @@ $stagingHost = host('staging')
     ->set('healthcheck_host', getenv('HEALTHCHECK_HOST_STG') ?: 'staging.fermatmind.com')
     ->set('ops_entry_host', getenv('OPS_ENTRY_HOST_STG') ?: '')
     ->set('nginx_site', '/etc/nginx/sites-enabled/fap-api-staging')
-    ->set('php_fpm_service', getenv('PHP_FPM_SERVICE_STG') ?: 'php8.4-fpm');
+    ->set('php_fpm_service', getenv('PHP_FPM_SERVICE_STG') ?: 'php8.4-fpm')
+    ->set('env', [
+        'SEO_PUBLIC_SITEMAP_AUTHORITY' => getenv('SEO_PUBLIC_SITEMAP_AUTHORITY_STG') ?: 'backend',
+    ]);
 
 if ($stagingIdentityFile !== null) {
     $stagingHost->setIdentityFile($stagingIdentityFile);


### PR DESCRIPTION
## Summary
- fix deploy failure at `guard:sitemap-authority`
- set host-level deploy env so Laravel config resolves `services.seo.public_sitemap_authority=backend` during deploy tasks
- keep existing guard strict (no downgrade)

## Root Cause
Deploy run `23996260462` failed because runtime config resolved `SEO_PUBLIC_SITEMAP_AUTHORITY=frontend` on staging, while deploy guard requires `backend`.

## Change
- `deploy.php`
  - for `production` host, set:
    - `SEO_PUBLIC_SITEMAP_AUTHORITY=${SEO_PUBLIC_SITEMAP_AUTHORITY_PROD:-backend}`
  - for `staging` host, set:
    - `SEO_PUBLIC_SITEMAP_AUTHORITY=${SEO_PUBLIC_SITEMAP_AUTHORITY_STG:-backend}`

## Validation
- `php -l deploy.php`
