### PR TITLE
fix(deploy): tolerate missing supervisorctl path in queue reload

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -338,15 +338,37 @@ task('queue:reload-workers', function () {
             run('{{bin/php}} artisan queue:restart --ansi');
         });
 
-        run("sudo -n {$supervisorctl} reread");
-        run("sudo -n {$supervisorctl} update");
+        $supervisorctlAvailable = test('[ -x ' . escapeshellarg($supervisorctl) . ' ] || command -v supervisorctl >/dev/null 2>&1');
+        if (! $supervisorctlAvailable) {
+            if ($legacySystemdService !== '') {
+                $quotedService = escapeshellarg($legacySystemdService);
+                writeln('<comment>supervisorctl not found; fallback to legacy systemd queue service</comment>');
+                run("if sudo -n /usr/bin/systemctl list-unit-files {$quotedService} >/dev/null 2>&1; then sudo -n /usr/bin/systemctl restart {$quotedService}; else echo 'legacy queue systemd service not found: {$legacySystemdService}' >&2; fi");
+                return;
+            }
+
+            writeln('<comment>supervisorctl not found and no legacy systemd service configured; skip manager-specific queue reload</comment>');
+            return;
+        }
+
+        $resolvedSupervisorctl = trim((string) run(
+            'if [ -x ' . escapeshellarg($supervisorctl) . ' ]; then echo ' . escapeshellarg($supervisorctl) . '; else command -v supervisorctl; fi'
+        ));
+        $quotedSupervisorctl = escapeshellarg($resolvedSupervisorctl);
+
+        run("sudo -n {$quotedSupervisorctl} reread");
+        run("sudo -n {$quotedSupervisorctl} update");
 
         foreach ($requiredPrograms as $program) {
-            run("sudo -n {$supervisorctl} restart {$program}:* >/dev/null 2>&1 || sudo -n {$supervisorctl} restart {$program}");
+            $quotedProgramAll = escapeshellarg($program . ':*');
+            $quotedProgram = escapeshellarg($program);
+            run("sudo -n {$quotedSupervisorctl} restart {$quotedProgramAll} >/dev/null 2>&1 || sudo -n {$quotedSupervisorctl} restart {$quotedProgram}");
         }
 
         foreach ($optionalPrograms as $program) {
-            run("sudo -n {$supervisorctl} restart {$program}:* >/dev/null 2>&1 || sudo -n {$supervisorctl} restart {$program} >/dev/null 2>&1 || true");
+            $quotedProgramAll = escapeshellarg($program . ':*');
+            $quotedProgram = escapeshellarg($program);
+            run("sudo -n {$quotedSupervisorctl} restart {$quotedProgramAll} >/dev/null 2>&1 || sudo -n {$quotedSupervisorctl} restart {$quotedProgram} >/dev/null 2>&1 || true");
         }
 
         if ($legacySystemdService !== '') {


### PR DESCRIPTION
## Summary
- keep sitemap authority guard fix intact
- avoid deploy failure when `queue_supervisorctl` path is invalid on host
- resolve supervisorctl path dynamically and fallback to legacy systemd queue service when supervisorctl is unavailable

## Why
Deploy run `23996855697` no longer failed at `guard:sitemap-authority`, but then failed in `queue:reload-workers` with `/usr/bin/supervisorctl: command not found`, preventing rollout of backend fixes.

## Validation
- `php -l deploy.php`
