### PR TITLE
fix(deploy): run release cleanup with sudo

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -52,6 +52,7 @@ set('writable_dirs', [
 set('writable_mode', 'chmod');
 set('writable_chmod_mode', '0775');
 set('writable_use_sudo', false);
+set('cleanup_use_sudo', true);
 
 /**
  * ======================================================


### PR DESCRIPTION
## Summary
- enable `cleanup_use_sudo` in deploy config
- allow `deploy:cleanup` to remove old releases owned by privileged user

## Why
Deploy run `23997171082` failed in `deploy:cleanup` with permission denied removing old release files under `backend/bootstrap/cache`.

## Validation
- `php -l deploy.php`
