### PR TITLE
feat(invite-unlock): add end-to-end diagnostics for unlock progress

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptInviteUnlockController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptInviteUnlockController.php
@@ -10,8 +10,10 @@ use App\Http\Controllers\Controller;
 use App\Models\Attempt;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptInviteUnlockService;
+use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 final class AttemptInviteUnlockController extends Controller
 {
@@ -27,6 +29,7 @@ final class AttemptInviteUnlockController extends Controller
      */
     public function store(Request $request, string $id): JsonResponse
     {
+        $startedAt = hrtime(true);
         $attempt = $this->resolveOwnedAttempt($request, $id);
         $result = $this->inviteUnlocks->createOrReuseInvite(
             $attempt,
@@ -58,7 +61,35 @@ final class AttemptInviteUnlockController extends Controller
             );
         }
 
-        return response()->json(array_merge(['ok' => true], $result));
+        $diagnostics = is_array($result['invite_unlock_diag_v1'] ?? null)
+            ? $result['invite_unlock_diag_v1']
+            : InviteUnlockDiagnostics::build(
+                (int) ($result['completed_invitees'] ?? 0),
+                (int) ($result['required_invitees'] ?? 2),
+                (string) ($result['unlock_stage'] ?? 'locked'),
+                (string) ($result['unlock_source'] ?? 'none'),
+                (string) ($result['status'] ?? 'pending'),
+            );
+        $durationMs = (int) floor((hrtime(true) - $startedAt) / 1_000_000);
+        Log::info('INVITE_UNLOCK_API_DIAGNOSTIC', [
+            'route' => 'attempts.invite_unlocks.store',
+            'source' => __METHOD__,
+            'org_id' => (int) ($attempt->org_id ?? 0),
+            'attempt_id' => (string) ($attempt->id ?? ''),
+            'invite_id' => (string) ($result['invite_id'] ?? ''),
+            'invite_code' => (string) ($result['invite_code'] ?? ''),
+            'created' => (bool) ($result['created'] ?? false),
+            'diagnostic_status' => (string) ($diagnostics['status'] ?? 'locked'),
+            'unlock_stage' => (string) ($diagnostics['unlock_stage'] ?? 'locked'),
+            'unlock_source' => (string) ($diagnostics['unlock_source'] ?? 'none'),
+            'completed_invitees' => (int) ($diagnostics['completed_invitees'] ?? 0),
+            'required_invitees' => (int) ($diagnostics['required_invitees'] ?? 2),
+            'remaining_invitees' => (int) ($diagnostics['remaining_invitees'] ?? 2),
+            'progress_percent' => (int) ($diagnostics['progress_percent'] ?? 0),
+            'duration_ms' => $durationMs,
+        ]);
+
+        return response()->json(array_merge(['ok' => true], $result, ['invite_unlock_diag_v1' => $diagnostics]));
     }
 
     /**
@@ -66,10 +97,38 @@ final class AttemptInviteUnlockController extends Controller
      */
     public function show(Request $request, string $id): JsonResponse
     {
+        $startedAt = hrtime(true);
         $attempt = $this->resolveOwnedAttempt($request, $id);
         $result = $this->inviteUnlocks->getInviteProgress($attempt);
+        $diagnostics = is_array($result['invite_unlock_diag_v1'] ?? null)
+            ? $result['invite_unlock_diag_v1']
+            : InviteUnlockDiagnostics::build(
+                (int) ($result['completed_invitees'] ?? 0),
+                (int) ($result['required_invitees'] ?? 2),
+                (string) ($result['unlock_stage'] ?? 'locked'),
+                (string) ($result['unlock_source'] ?? 'none'),
+                isset($result['status']) ? (string) $result['status'] : null,
+            );
+        $durationMs = (int) floor((hrtime(true) - $startedAt) / 1_000_000);
+        Log::info('INVITE_UNLOCK_API_DIAGNOSTIC', [
+            'route' => 'attempts.invite_unlocks.show',
+            'source' => __METHOD__,
+            'org_id' => (int) ($attempt->org_id ?? 0),
+            'attempt_id' => (string) ($attempt->id ?? ''),
+            'invite_id' => (string) ($result['invite_id'] ?? ''),
+            'invite_code' => (string) ($result['invite_code'] ?? ''),
+            'has_invite' => (bool) ($result['has_invite'] ?? false),
+            'diagnostic_status' => (string) ($diagnostics['status'] ?? 'locked'),
+            'unlock_stage' => (string) ($diagnostics['unlock_stage'] ?? 'locked'),
+            'unlock_source' => (string) ($diagnostics['unlock_source'] ?? 'none'),
+            'completed_invitees' => (int) ($diagnostics['completed_invitees'] ?? 0),
+            'required_invitees' => (int) ($diagnostics['required_invitees'] ?? 2),
+            'remaining_invitees' => (int) ($diagnostics['remaining_invitees'] ?? 2),
+            'progress_percent' => (int) ($diagnostics['progress_percent'] ?? 0),
+            'duration_ms' => $durationMs,
+        ]);
 
-        return response()->json(array_merge(['ok' => true], $result));
+        return response()->json(array_merge(['ok' => true], $result, ['invite_unlock_diag_v1' => $diagnostics]));
     }
 
     private function resolveOwnedAttempt(Request $request, string $id): Attempt

--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -13,6 +13,7 @@ use App\Repositories\Report\ReportAccessActor;
 use App\Repositories\Report\ReportSubjectRepository;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
+use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
 use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
 use App\Services\Access\AttemptUnlockProjectionRepairService;
@@ -545,6 +546,7 @@ class AttemptReadController extends Controller
      */
     public function reportAccess(Request $request, string $id): JsonResponse
     {
+        $startedAt = hrtime(true);
         $orgId = $this->currentOrgContext()->orgId();
         $attempt = $this->resolveAttemptForAccessRead($request, $orgId, $id);
         $submissionPayload = $this->latestReadableSubmission($request, (string) $attempt->id);
@@ -716,9 +718,38 @@ class AttemptReadController extends Controller
             (int) ($inviteSnapshot['completed_invitees'] ?? 0),
             (int) ($inviteSnapshot['required_invitees'] ?? 2)
         );
+        $inviteDiagnostics = InviteUnlockDiagnostics::build(
+            (int) ($inviteSnapshot['completed_invitees'] ?? 0),
+            (int) ($inviteSnapshot['required_invitees'] ?? 2),
+            $unlockStage,
+            $unlockSource,
+            null
+        );
         $responsePayload['invite_unlock_v1'] = $inviteSummary;
+        $responsePayload['invite_unlock_diag_v1'] = $inviteDiagnostics;
         $payloadJson['invite_unlock_v1'] = $inviteSummary;
+        $payloadJson['invite_unlock_diag_v1'] = $inviteDiagnostics;
         $responsePayload['payload'] = $payloadJson;
+        $durationMs = (int) floor((hrtime(true) - $startedAt) / 1_000_000);
+        Log::info('REPORT_ACCESS_INVITE_UNLOCK_DIAGNOSTIC', [
+            'org_id' => $orgId,
+            'attempt_id' => (string) ($attempt->id ?? ''),
+            'source' => __METHOD__,
+            'access_state' => $accessState,
+            'report_state' => $reportState,
+            'pdf_state' => $pdfState,
+            'reason_code' => $reasonCode !== '' ? $reasonCode : null,
+            'invite_snapshot_failure_code' => $inviteSnapshotFailureCode,
+            'diagnostic_status' => (string) ($inviteDiagnostics['status'] ?? 'locked'),
+            'diagnostic_status_reason' => (string) ($inviteDiagnostics['status_reason'] ?? 'unlock_stage_locked'),
+            'unlock_stage' => (string) ($inviteDiagnostics['unlock_stage'] ?? 'locked'),
+            'unlock_source' => (string) ($inviteDiagnostics['unlock_source'] ?? 'none'),
+            'completed_invitees' => (int) ($inviteDiagnostics['completed_invitees'] ?? 0),
+            'required_invitees' => (int) ($inviteDiagnostics['required_invitees'] ?? 2),
+            'remaining_invitees' => (int) ($inviteDiagnostics['remaining_invitees'] ?? 2),
+            'progress_percent' => (int) ($inviteDiagnostics['progress_percent'] ?? 0),
+            'duration_ms' => $durationMs,
+        ]);
 
         return response()->json($responsePayload);
     }

--- a/backend/app/Services/Attempts/AttemptInviteUnlockCompletionService.php
+++ b/backend/app/Services/Attempts/AttemptInviteUnlockCompletionService.php
@@ -10,10 +10,12 @@ use App\Models\AttemptInviteUnlockCompletion;
 use App\Models\Result;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Commerce\EntitlementManager;
+use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
 use App\Services\Attempts\InviteUnlock\InviteUnlockCompletionStatus;
 use App\Services\Attempts\InviteUnlock\InviteUnlockStatus;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 final class AttemptInviteUnlockCompletionService
@@ -37,17 +39,27 @@ final class AttemptInviteUnlockCompletionService
         ?string $inviteeUserId,
         ?string $inviteeAnonId,
     ): array {
+        $startedAt = hrtime(true);
         $normalizedInviteCode = trim($inviteCode);
         $normalizedAttemptId = trim($inviteeAttemptId);
         if ($normalizedInviteCode === '' || $normalizedAttemptId === '') {
-            return [
+            $invalidInputPayload = [
                 'ok' => false,
                 'error_code' => 'INVITE_UNLOCK_COMPLETION_INVALID_INPUT',
                 'message' => 'invite_code and invitee_attempt_id are required.',
             ];
+
+            $this->logCompletionDiagnostic(
+                $normalizedInviteCode,
+                $normalizedAttemptId,
+                $invalidInputPayload,
+                $startedAt
+            );
+
+            return $invalidInputPayload;
         }
 
-        return DB::transaction(function () use (
+        $result = DB::transaction(function () use (
             $normalizedInviteCode,
             $normalizedAttemptId,
             $inviteeUserId,
@@ -353,6 +365,15 @@ final class AttemptInviteUnlockCompletionService
 
             return $this->buildCompletionPayload($completion, $refreshedInvite, false);
         });
+
+        $this->logCompletionDiagnostic(
+            $normalizedInviteCode,
+            $normalizedAttemptId,
+            $result,
+            $startedAt
+        );
+
+        return $result;
     }
 
     /**
@@ -593,6 +614,61 @@ final class AttemptInviteUnlockCompletionService
                 $this->eventRecorder->record('invite_unlock_mixed_confirmed', $inviterUserIdInt, $baseMeta, $context);
             }
         }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function logCompletionDiagnostic(
+        string $inviteCode,
+        string $inviteeAttemptId,
+        array $payload,
+        int $startedAt
+    ): void {
+        $progress = is_array($payload['progress'] ?? null) ? $payload['progress'] : [];
+        $diagnostics = is_array($progress['invite_unlock_diag_v1'] ?? null)
+            ? $progress['invite_unlock_diag_v1']
+            : InviteUnlockDiagnostics::build(
+                (int) ($progress['completed_invitees'] ?? 0),
+                (int) ($progress['required_invitees'] ?? 2),
+                (string) ($payload['unlock_stage'] ?? ($progress['unlock_stage'] ?? 'locked')),
+                (string) ($payload['unlock_source'] ?? ($progress['unlock_source'] ?? 'none')),
+                isset($progress['status']) ? (string) $progress['status'] : null
+            );
+        $durationMs = (int) floor((hrtime(true) - $startedAt) / 1_000_000);
+        $logPayload = [
+            'source' => __METHOD__,
+            'invite_code' => $inviteCode,
+            'invitee_attempt_id' => $inviteeAttemptId,
+            'ok' => (bool) ($payload['ok'] ?? false),
+            'idempotent' => (bool) ($payload['idempotent'] ?? false),
+            'invite_id' => (string) ($payload['invite_id'] ?? ''),
+            'completion_id' => (string) ($payload['completion_id'] ?? ''),
+            'qualification_status' => (string) ($payload['qualification_status'] ?? ''),
+            'qualified_reason' => (string) ($payload['qualified_reason'] ?? ''),
+            'qualified' => (bool) ($payload['qualified'] ?? false),
+            'counted' => (bool) ($payload['counted'] ?? false),
+            'diagnostic_status' => (string) ($diagnostics['status'] ?? 'locked'),
+            'diagnostic_status_reason' => (string) ($diagnostics['status_reason'] ?? 'unlock_stage_locked'),
+            'unlock_stage' => (string) ($diagnostics['unlock_stage'] ?? 'locked'),
+            'unlock_source' => (string) ($diagnostics['unlock_source'] ?? 'none'),
+            'completed_invitees' => (int) ($diagnostics['completed_invitees'] ?? 0),
+            'required_invitees' => (int) ($diagnostics['required_invitees'] ?? 2),
+            'remaining_invitees' => (int) ($diagnostics['remaining_invitees'] ?? 2),
+            'progress_percent' => (int) ($diagnostics['progress_percent'] ?? 0),
+            'duration_ms' => $durationMs,
+        ];
+
+        if ((bool) ($payload['ok'] ?? false) === true) {
+            Log::info('INVITE_UNLOCK_COMPLETION_DIAGNOSTIC', $logPayload);
+
+            return;
+        }
+
+        Log::warning('INVITE_UNLOCK_COMPLETION_DIAGNOSTIC', array_merge($logPayload, [
+            'error_code' => (string) ($payload['error_code'] ?? 'INVITE_UNLOCK_COMPLETION_REJECTED'),
+            'message' => (string) ($payload['message'] ?? 'invite unlock completion rejected'),
+        ]));
     }
 
     /**

--- a/backend/app/Services/Attempts/AttemptInviteUnlockService.php
+++ b/backend/app/Services/Attempts/AttemptInviteUnlockService.php
@@ -10,6 +10,7 @@ use App\Models\AttemptInviteUnlock;
 use App\Models\AttemptInviteUnlockCompletion;
 use App\Models\Result;
 use App\Services\Commerce\EntitlementManager;
+use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
 use App\Services\Attempts\InviteUnlock\InviteUnlockStatus;
 use App\Services\Report\InviteUnlockSummaryBuilder;
 use App\Services\Report\ReportAccess;
@@ -139,6 +140,14 @@ final class AttemptInviteUnlockService
             ->first();
 
         if (! $existing instanceof AttemptInviteUnlock) {
+            $diagnostics = InviteUnlockDiagnostics::build(
+                0,
+                self::DEFAULT_REQUIRED_INVITEES,
+                ReportAccess::UNLOCK_STAGE_LOCKED,
+                ReportAccess::UNLOCK_SOURCE_NONE,
+                null
+            );
+
             return [
                 'has_invite' => false,
                 'created' => false,
@@ -161,6 +170,7 @@ final class AttemptInviteUnlockService
                     0,
                     self::DEFAULT_REQUIRED_INVITEES
                 ),
+                'invite_unlock_diag_v1' => $diagnostics,
             ];
         }
 
@@ -227,6 +237,14 @@ final class AttemptInviteUnlockService
         );
         $unlockStage = ReportAccess::normalizeUnlockStage((string) ($unlockState['unlock_stage'] ?? ReportAccess::UNLOCK_STAGE_LOCKED));
         $unlockSource = ReportAccess::normalizeUnlockSource((string) ($unlockState['unlock_source'] ?? ReportAccess::UNLOCK_SOURCE_NONE));
+        $inviteStatus = (string) ($invite->status ?? InviteUnlockStatus::PENDING);
+        $diagnostics = InviteUnlockDiagnostics::build(
+            $completedInvitees,
+            $requiredInvitees,
+            $unlockStage,
+            $unlockSource,
+            $inviteStatus
+        );
 
         return [
             'has_invite' => true,
@@ -236,7 +254,7 @@ final class AttemptInviteUnlockService
             'target_org_id' => (int) ($invite->target_org_id ?? 0),
             'target_attempt_id' => (string) ($invite->target_attempt_id ?? ''),
             'target_scale_code' => (string) ($invite->target_scale_code ?? ''),
-            'status' => (string) ($invite->status ?? InviteUnlockStatus::PENDING),
+            'status' => $inviteStatus,
             'required_invitees' => $requiredInvitees,
             'completed_invitees' => $completedInvitees,
             'qualification_rule_version' => (string) ($invite->qualification_rule_version ?? self::RULE_VERSION),
@@ -250,6 +268,7 @@ final class AttemptInviteUnlockService
                 $completedInvitees,
                 $requiredInvitees
             ),
+            'invite_unlock_diag_v1' => $diagnostics,
         ];
     }
 

--- a/backend/app/Services/Attempts/InviteUnlock/InviteUnlockDiagnostics.php
+++ b/backend/app/Services/Attempts/InviteUnlock/InviteUnlockDiagnostics.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Attempts\InviteUnlock;
+
+use App\Services\Report\ReportAccess;
+
+final class InviteUnlockDiagnostics
+{
+    /**
+     * @return array{
+     *   status:string,
+     *   status_reason:string,
+     *   completed_invitees:int,
+     *   required_invitees:int,
+     *   remaining_invitees:int,
+     *   progress_ratio:float,
+     *   progress_percent:int,
+     *   unlock_stage:string,
+     *   unlock_source:string,
+     *   invite_status:?string,
+     *   snapshot_at:string
+     * }
+     */
+    public static function build(
+        int $completedInvitees,
+        int $requiredInvitees,
+        string $unlockStage,
+        string $unlockSource,
+        ?string $inviteStatus = null
+    ): array {
+        $required = max(1, $requiredInvitees);
+        $completed = max(0, min($required, $completedInvitees));
+        $stage = ReportAccess::normalizeUnlockStage($unlockStage);
+        $source = ReportAccess::normalizeUnlockSource($unlockSource);
+        $remaining = max(0, $required - $completed);
+        $ratio = round($completed / $required, 4);
+        $percent = (int) round($ratio * 100);
+        $status = self::resolveStatus($stage, $source);
+        $statusReason = self::resolveStatusReason($stage, $source, $completed);
+        $normalizedInviteStatus = self::normalizeInviteStatus($inviteStatus);
+
+        return [
+            'status' => $status,
+            'status_reason' => $statusReason,
+            'completed_invitees' => $completed,
+            'required_invitees' => $required,
+            'remaining_invitees' => $remaining,
+            'progress_ratio' => $ratio,
+            'progress_percent' => $percent,
+            'unlock_stage' => $stage,
+            'unlock_source' => $source,
+            'invite_status' => $normalizedInviteStatus,
+            'snapshot_at' => now()->toIso8601String(),
+        ];
+    }
+
+    private static function resolveStatus(string $stage, string $source): string
+    {
+        if ($stage === ReportAccess::UNLOCK_STAGE_FULL && $source === ReportAccess::UNLOCK_SOURCE_MIXED) {
+            return 'mixed_unlock';
+        }
+
+        if ($stage === ReportAccess::UNLOCK_STAGE_FULL) {
+            return 'full_unlock';
+        }
+
+        if ($stage === ReportAccess::UNLOCK_STAGE_PARTIAL) {
+            return 'partial_unlock';
+        }
+
+        return 'locked';
+    }
+
+    private static function resolveStatusReason(string $stage, string $source, int $completedInvitees): string
+    {
+        if ($stage === ReportAccess::UNLOCK_STAGE_FULL && $source === ReportAccess::UNLOCK_SOURCE_MIXED) {
+            return 'unlock_stage_full_source_mixed';
+        }
+
+        if ($stage === ReportAccess::UNLOCK_STAGE_FULL) {
+            return 'unlock_stage_full';
+        }
+
+        if ($stage === ReportAccess::UNLOCK_STAGE_PARTIAL) {
+            return 'unlock_stage_partial';
+        }
+
+        if ($completedInvitees > 0) {
+            return 'unlock_stage_locked_with_progress';
+        }
+
+        return 'unlock_stage_locked';
+    }
+
+    private static function normalizeInviteStatus(?string $inviteStatus): ?string
+    {
+        if ($inviteStatus === null) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($inviteStatus));
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/tests/Feature/V0_3/AttemptInviteUnlockFoundationTest.php
+++ b/backend/tests/Feature/V0_3/AttemptInviteUnlockFoundationTest.php
@@ -39,7 +39,9 @@ final class AttemptInviteUnlockFoundationTest extends TestCase
             ->assertJsonPath('required_invitees', 2)
             ->assertJsonPath('completed_invitees', 0)
             ->assertJsonPath('unlock_stage', 'locked')
-            ->assertJsonPath('unlock_source', 'none');
+            ->assertJsonPath('unlock_source', 'none')
+            ->assertJsonPath('invite_unlock_diag_v1.status', 'locked')
+            ->assertJsonPath('invite_unlock_diag_v1.progress_percent', 0);
 
         $inviteCode = (string) $post->json('invite_code');
         $this->assertNotSame('', $inviteCode);
@@ -50,7 +52,8 @@ final class AttemptInviteUnlockFoundationTest extends TestCase
             ->assertJsonPath('has_invite', true)
             ->assertJsonPath('created', false)
             ->assertJsonPath('invite_code', $inviteCode)
-            ->assertJsonPath('completed_invitees', 0);
+            ->assertJsonPath('completed_invitees', 0)
+            ->assertJsonPath('invite_unlock_diag_v1.status', 'locked');
 
         $this->assertSame(1, AttemptInviteUnlock::query()->count());
         $this->assertDatabaseHas('events', [
@@ -97,6 +100,7 @@ final class AttemptInviteUnlockFoundationTest extends TestCase
         $this->assertSame(1, (int) data_get($qualifiedOne, 'progress.completed_invitees'));
         $this->assertSame(InviteUnlockStatus::IN_PROGRESS, (string) data_get($qualifiedOne, 'progress.status'));
         $this->assertSame('partial', (string) ($qualifiedOne['unlock_stage'] ?? ''));
+        $this->assertSame('partial_unlock', (string) data_get($qualifiedOne, 'progress.invite_unlock_diag_v1.status'));
         $this->assertDatabaseHas('benefit_grants', [
             'org_id' => 0,
             'attempt_id' => $targetAttemptId,
@@ -161,6 +165,7 @@ final class AttemptInviteUnlockFoundationTest extends TestCase
         $this->assertSame(2, (int) data_get($qualifiedTwo, 'progress.completed_invitees'));
         $this->assertSame(InviteUnlockStatus::COMPLETED, (string) data_get($qualifiedTwo, 'progress.status'));
         $this->assertSame('full', (string) ($qualifiedTwo['unlock_stage'] ?? ''));
+        $this->assertSame('full_unlock', (string) data_get($qualifiedTwo, 'progress.invite_unlock_diag_v1.status'));
         $this->assertDatabaseHas('benefit_grants', [
             'org_id' => 0,
             'attempt_id' => $targetAttemptId,

--- a/backend/tests/Feature/V0_3/AttemptInviteUnlockStagedEntitlementTest.php
+++ b/backend/tests/Feature/V0_3/AttemptInviteUnlockStagedEntitlementTest.php
@@ -34,7 +34,8 @@ final class AttemptInviteUnlockStagedEntitlementTest extends TestCase
             ->getJson("/api/v0.3/attempts/{$targetAttemptId}/report-access")
             ->assertOk()
             ->assertJsonPath('unlock_stage', 'locked')
-            ->assertJsonPath('unlock_source', 'none');
+            ->assertJsonPath('unlock_source', 'none')
+            ->assertJsonPath('invite_unlock_diag_v1.status', 'locked');
 
         $inviteeAttemptOne = $this->createAttemptWithResult('anon_stage_invitee_one');
         $completionService->recordCompletionForInvite($inviteCode, $inviteeAttemptOne, null, 'anon_stage_invitee_one');
@@ -45,7 +46,8 @@ final class AttemptInviteUnlockStagedEntitlementTest extends TestCase
             ->assertJsonPath('unlock_stage', 'partial')
             ->assertJsonPath('unlock_source', 'invite')
             ->assertJsonPath('payload.access_level', 'partial')
-            ->assertJsonPath('payload.variant', 'partial');
+            ->assertJsonPath('payload.variant', 'partial')
+            ->assertJsonPath('invite_unlock_diag_v1.status', 'partial_unlock');
 
         $inviteeAttemptTwo = $this->createAttemptWithResult('anon_stage_invitee_two');
         $completionService->recordCompletionForInvite($inviteCode, $inviteeAttemptTwo, null, 'anon_stage_invitee_two');
@@ -56,7 +58,8 @@ final class AttemptInviteUnlockStagedEntitlementTest extends TestCase
             ->assertJsonPath('unlock_stage', 'full')
             ->assertJsonPath('unlock_source', 'invite')
             ->assertJsonPath('payload.access_level', 'full')
-            ->assertJsonPath('payload.variant', 'full');
+            ->assertJsonPath('payload.variant', 'full')
+            ->assertJsonPath('invite_unlock_diag_v1.status', 'full_unlock');
 
         $this->assertSame(1, DB::table('benefit_grants')
             ->where('attempt_id', $targetAttemptId)
@@ -101,7 +104,8 @@ final class AttemptInviteUnlockStagedEntitlementTest extends TestCase
             ->getJson("/api/v0.3/attempts/{$paymentFirstAttemptId}/report-access")
             ->assertOk()
             ->assertJsonPath('unlock_stage', 'full')
-            ->assertJsonPath('unlock_source', 'payment');
+            ->assertJsonPath('unlock_source', 'payment')
+            ->assertJsonPath('invite_unlock_diag_v1.status', 'full_unlock');
 
         // invite partial first, then payment full should converge to full and source=mixed
         $partialFirstAnon = 'anon_stage_partial_first';
@@ -128,7 +132,8 @@ final class AttemptInviteUnlockStagedEntitlementTest extends TestCase
             ->getJson("/api/v0.3/attempts/{$partialFirstAttemptId}/report-access")
             ->assertOk()
             ->assertJsonPath('unlock_stage', 'full')
-            ->assertJsonPath('unlock_source', 'mixed');
+            ->assertJsonPath('unlock_source', 'mixed')
+            ->assertJsonPath('invite_unlock_diag_v1.status', 'mixed_unlock');
     }
 
     /**


### PR DESCRIPTION
## Summary
- add normalized `invite_unlock_diag_v1` payload for invite unlock state/progress
- add structured diagnostics logging in invite-unlocks and report-access endpoints
- add completion-path diagnostics logging for qualified/rejected/idempotent cases
- extend invite unlock feature tests to assert locked/partial/full/mixed diagnostic statuses

## Verification
- php artisan route:list
- php artisan migrate --no-interaction
- php artisan test --filter='AttemptInviteUnlock(Foundation|StagedEntitlement)Test'
- php artisan test --filter=AttemptReportAccessReadTest
- bash backend/scripts/ci_verify_mbti.sh
