### PR TITLE
feat(content): execute MBTI PR-1 minimum content loop

### DIFF
--- a/backend/app/Console/Commands/ArticleImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ArticleImportLocalBaseline.php
@@ -1,0 +1,577 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Services\Cms\ArticlePublishService;
+use App\Services\Cms\ArticleService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class ArticleImportLocalBaseline extends Command
+{
+    private const SUPPORTED_LOCALES = ['en', 'zh-CN'];
+
+    protected $signature = 'articles:import-local-baseline
+        {--dry-run : Validate and diff without writing to the database}
+        {--locale=* : Import only specific locale(s)}
+        {--article=* : Import only specific article slug(s)}
+        {--upsert : Update existing records instead of create-missing only}
+        {--status=published : Force imported records to draft or published}
+        {--source-dir= : Override the committed baseline source directory}';
+
+    protected $description = 'Import committed article baseline content into Article CMS tables.';
+
+    public function handle(
+        ArticleService $articleService,
+        ArticlePublishService $articlePublishService,
+    ): int {
+        try {
+            $status = trim((string) $this->option('status'));
+            if (! in_array($status, ['draft', 'published'], true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported --status value: %s',
+                    $status,
+                ));
+            }
+
+            $sourceDir = $this->resolveSourceDir(
+                $this->option('source-dir') !== null
+                    ? (string) $this->option('source-dir')
+                    : null,
+            );
+            $selectedLocales = $this->normalizeSelectedLocales((array) $this->option('locale'));
+            $selectedArticles = $this->normalizeSelectedArticles((array) $this->option('article'));
+
+            $documents = $this->readDocuments($sourceDir, $selectedLocales);
+            $articles = $this->normalizeArticles($documents, $selectedArticles);
+            $summary = $this->importRows(
+                $articles,
+                [
+                    'dry_run' => (bool) $this->option('dry-run'),
+                    'upsert' => (bool) $this->option('upsert'),
+                    'status' => $status,
+                ],
+                $articleService,
+                $articlePublishService,
+            );
+
+            $this->line('baseline_source_dir='.$sourceDir);
+            $this->line('locales_selected='.($selectedLocales === [] ? 'all' : implode(',', $selectedLocales)));
+            $this->line('articles_selected='.($selectedArticles === [] ? 'all' : implode(',', $selectedArticles)));
+            $this->line('dry_run='.((bool) $this->option('dry-run') ? '1' : '0'));
+            $this->line('upsert='.((bool) $this->option('upsert') ? '1' : '0'));
+            $this->line('status_mode='.$status);
+            $this->line('files_found='.(string) count($documents));
+            $this->line('articles_found='.(string) $summary['articles_found']);
+            $this->line('will_create='.(string) $summary['will_create']);
+            $this->line('will_update='.(string) $summary['will_update']);
+            $this->line('will_skip='.(string) $summary['will_skip']);
+            $this->line('errors_count='.(string) $summary['errors_count']);
+
+            $this->info((bool) $this->option('dry-run') ? 'dry-run complete' : 'import complete');
+
+            return self::SUCCESS;
+        } catch (\Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function resolveSourceDir(?string $sourceDir = null): string
+    {
+        $candidate = trim((string) $sourceDir);
+
+        if ($candidate === '') {
+            $candidate = base_path('../content_baselines/articles');
+        } elseif (! str_starts_with($candidate, DIRECTORY_SEPARATOR)) {
+            $candidate = base_path($candidate);
+        }
+
+        $resolved = realpath($candidate);
+
+        if ($resolved === false || ! is_dir($resolved)) {
+            throw new RuntimeException(sprintf(
+                'Article baseline source directory not found: %s',
+                $candidate,
+            ));
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, array{file: string, payload: array<string, mixed>}>
+     */
+    private function readDocuments(string $sourceDir, array $selectedLocales = []): array
+    {
+        $files = $selectedLocales === []
+            ? glob(rtrim($sourceDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'articles.*.json') ?: []
+            : array_map(
+                static fn (string $locale): string => rtrim($sourceDir, DIRECTORY_SEPARATOR)
+                    .DIRECTORY_SEPARATOR
+                    .sprintf('articles.%s.json', $locale),
+                $selectedLocales,
+            );
+
+        if ($files === []) {
+            throw new RuntimeException(sprintf(
+                'No article baseline files found in %s.',
+                $sourceDir,
+            ));
+        }
+
+        sort($files);
+
+        $documents = [];
+        foreach ($files as $file) {
+            if (! is_file($file)) {
+                throw new RuntimeException(sprintf(
+                    'Article baseline file missing: %s',
+                    $file,
+                ));
+            }
+
+            $raw = file_get_contents($file);
+            if (! is_string($raw) || trim($raw) === '') {
+                throw new RuntimeException(sprintf(
+                    'Article baseline file is empty: %s',
+                    $file,
+                ));
+            }
+
+            $decoded = json_decode($raw, true);
+            if (! is_array($decoded)) {
+                throw new RuntimeException(sprintf(
+                    'Article baseline file is not valid JSON: %s',
+                    $file,
+                ));
+            }
+
+            $documents[] = [
+                'file' => $file,
+                'payload' => $decoded,
+            ];
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @param  array<int, array{file: string, payload: array<string, mixed>}>  $documents
+     * @param  array<int, string>  $selectedArticles
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeArticles(array $documents, array $selectedArticles = []): array
+    {
+        $rows = [];
+        $seen = [];
+
+        foreach ($documents as $document) {
+            $file = (string) ($document['file'] ?? 'unknown');
+            $payload = is_array($document['payload'] ?? null) ? $document['payload'] : [];
+            $meta = is_array($payload['meta'] ?? null) ? $payload['meta'] : [];
+            $documentLocale = $this->normalizeLocale($meta['locale'] ?? null, $file);
+            $articles = $payload['articles'] ?? null;
+
+            if (! is_array($articles)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s must contain an articles array.',
+                    $file,
+                ));
+            }
+
+            foreach ($articles as $index => $row) {
+                if (! is_array($row)) {
+                    throw new RuntimeException(sprintf(
+                        'Baseline file %s contains a non-object article row at index %d.',
+                        $file,
+                        $index,
+                    ));
+                }
+
+                $normalized = $this->normalizeArticleRow($row, $documentLocale, $file, (int) $index);
+                if ($selectedArticles !== [] && ! in_array((string) $normalized['slug'], $selectedArticles, true)) {
+                    continue;
+                }
+
+                $unique = (string) $normalized['locale'].'|'.(string) $normalized['slug'];
+                if (isset($seen[$unique])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate article slug %s for locale %s in baseline file %s.',
+                        (string) $normalized['slug'],
+                        (string) $normalized['locale'],
+                        $file,
+                    ));
+                }
+
+                $seen[$unique] = true;
+                $rows[] = $normalized;
+            }
+        }
+
+        usort(
+            $rows,
+            static fn (array $left, array $right): int => [$left['locale'], $left['slug']]
+                <=> [$right['locale'], $right['slug']],
+        );
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function normalizeArticleRow(
+        array $row,
+        string $documentLocale,
+        string $file,
+        int $index,
+    ): array {
+        $slug = strtolower(trim((string) ($row['slug'] ?? '')));
+        if ($slug === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing slug at articles[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        $title = trim((string) ($row['title'] ?? ''));
+        if ($title === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing title for slug=%s.',
+                $file,
+                $slug,
+            ));
+        }
+
+        $excerpt = trim((string) ($row['excerpt'] ?? ''));
+        if ($excerpt === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing excerpt for slug=%s.',
+                $file,
+                $slug,
+            ));
+        }
+
+        $contentMd = trim((string) ($row['content_md'] ?? ''));
+        if ($contentMd === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing content_md for slug=%s.',
+                $file,
+                $slug,
+            ));
+        }
+
+        $locale = array_key_exists('locale', $row)
+            ? $this->normalizeLocale($row['locale'], $file)
+            : $documentLocale;
+        if ($locale !== $documentLocale) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has locale mismatch for slug=%s.',
+                $file,
+                $slug,
+            ));
+        }
+
+        $publishedAt = $this->normalizeNullableDateString($row['published_at'] ?? null, $file, $slug);
+
+        return [
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => $title,
+            'excerpt' => $excerpt,
+            'content_md' => $contentMd,
+            'status' => $this->normalizeStatus($row['status'] ?? 'published', $file, $slug),
+            'is_public' => (bool) ($row['is_public'] ?? true),
+            'is_indexable' => (bool) ($row['is_indexable'] ?? true),
+            'published_at' => $publishedAt,
+        ];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $rows
+     * @param  array{dry_run: bool, upsert: bool, status: string}  $options
+     * @return array<string, int>
+     */
+    private function importRows(
+        array $rows,
+        array $options,
+        ArticleService $articleService,
+        ArticlePublishService $articlePublishService,
+    ): array {
+        $dryRun = (bool) ($options['dry_run'] ?? false);
+        $upsert = (bool) ($options['upsert'] ?? false);
+        $statusMode = (string) ($options['status'] ?? 'published');
+
+        $summary = [
+            'articles_found' => count($rows),
+            'will_create' => 0,
+            'will_update' => 0,
+            'will_skip' => 0,
+            'errors_count' => 0,
+        ];
+
+        $planned = [];
+        foreach ($rows as $row) {
+            $existing = $this->findExistingArticle((string) $row['slug'], (string) $row['locale']);
+            $desired = $this->desiredState($row, $statusMode);
+
+            if (! $existing instanceof Article) {
+                $planned[] = ['action' => 'create', 'row' => $row, 'desired' => $desired, 'existing' => null];
+                $summary['will_create']++;
+
+                continue;
+            }
+
+            if (! $upsert) {
+                $planned[] = ['action' => 'skip', 'row' => $row, 'desired' => $desired, 'existing' => $existing];
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            if ($this->sameState($existing, $desired)) {
+                $planned[] = ['action' => 'skip', 'row' => $row, 'desired' => $desired, 'existing' => $existing];
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            $planned[] = ['action' => 'update', 'row' => $row, 'desired' => $desired, 'existing' => $existing];
+            $summary['will_update']++;
+        }
+
+        if ($dryRun) {
+            return $summary;
+        }
+
+        foreach ($planned as $operation) {
+            if ((string) $operation['action'] === 'skip') {
+                continue;
+            }
+
+            $row = (array) $operation['row'];
+            $desired = (array) $operation['desired'];
+            $existing = $operation['existing'] instanceof Article ? $operation['existing'] : null;
+
+            if (! $existing instanceof Article) {
+                $existing = $articleService->createArticle(
+                    (string) $row['title'],
+                    (string) $row['slug'],
+                    (string) $row['locale'],
+                    (string) $row['content_md'],
+                    null,
+                    [],
+                    0,
+                );
+            }
+
+            $article = $articleService->updateArticle((int) $existing->id, [
+                'title' => (string) $desired['title'],
+                'slug' => (string) $desired['slug'],
+                'locale' => (string) $desired['locale'],
+                'excerpt' => (string) $desired['excerpt'],
+                'content_md' => (string) $desired['content_md'],
+                'content_html' => null,
+                'is_indexable' => (bool) $desired['is_indexable'],
+            ]);
+
+            if ((string) $desired['status'] === 'published') {
+                if ((string) $article->status !== 'published' || ! (bool) $article->is_public) {
+                    $article = $articlePublishService->publishArticle((int) $article->id);
+                }
+
+                if (is_string($desired['published_at']) && $desired['published_at'] !== '') {
+                    $article = $articleService->updateArticle((int) $article->id, [
+                        'status' => 'published',
+                        'is_public' => true,
+                        'published_at' => $desired['published_at'],
+                    ]);
+                }
+            } else {
+                if ((string) $article->status !== 'draft' || (bool) $article->is_public) {
+                    $article = $articlePublishService->unpublishArticle((int) $article->id);
+                }
+
+                $articleService->updateArticle((int) $article->id, [
+                    'status' => 'draft',
+                    'is_public' => false,
+                    'published_at' => null,
+                ]);
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function desiredState(array $row, string $statusMode): array
+    {
+        $status = $statusMode;
+        $isPublic = $statusMode === 'published';
+
+        return [
+            'slug' => (string) $row['slug'],
+            'locale' => (string) $row['locale'],
+            'title' => (string) $row['title'],
+            'excerpt' => (string) $row['excerpt'],
+            'content_md' => (string) $row['content_md'],
+            'status' => $status,
+            'is_public' => $isPublic,
+            'is_indexable' => (bool) $row['is_indexable'],
+            'published_at' => $status === 'published'
+                ? (is_string($row['published_at']) && $row['published_at'] !== '' ? $row['published_at'] : null)
+                : null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $desired
+     */
+    private function sameState(Article $article, array $desired): bool
+    {
+        if ((string) $article->title !== (string) $desired['title']) {
+            return false;
+        }
+        if ((string) ($article->excerpt ?? '') !== (string) $desired['excerpt']) {
+            return false;
+        }
+        if ((string) $article->content_md !== (string) $desired['content_md']) {
+            return false;
+        }
+        if ((bool) $article->is_indexable !== (bool) $desired['is_indexable']) {
+            return false;
+        }
+        if ((string) $article->status !== (string) $desired['status']) {
+            return false;
+        }
+        if ((bool) $article->is_public !== (bool) $desired['is_public']) {
+            return false;
+        }
+
+        $desiredPublishedAt = is_string($desired['published_at']) ? $desired['published_at'] : null;
+        $currentPublishedAt = $article->published_at?->copy()->utc()->toISOString();
+
+        return $desiredPublishedAt === $currentPublishedAt;
+    }
+
+    private function findExistingArticle(string $slug, string $locale): ?Article
+    {
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('slug', $slug)
+            ->where('locale', $locale)
+            ->first();
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, string>
+     */
+    private function normalizeSelectedLocales(array $selectedLocales): array
+    {
+        $normalized = [];
+
+        foreach ($selectedLocales as $locale) {
+            $candidate = trim((string) $locale);
+            if ($candidate === '') {
+                continue;
+            }
+            if ($candidate === 'zh') {
+                $candidate = 'zh-CN';
+            }
+            if (! in_array($candidate, self::SUPPORTED_LOCALES, true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported locale selection: %s',
+                    $candidate,
+                ));
+            }
+            $normalized[$candidate] = $candidate;
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @param  array<int, string>  $selectedArticles
+     * @return array<int, string>
+     */
+    private function normalizeSelectedArticles(array $selectedArticles): array
+    {
+        $normalized = [];
+
+        foreach ($selectedArticles as $slug) {
+            $candidate = strtolower(trim((string) $slug));
+            if ($candidate === '') {
+                continue;
+            }
+
+            $normalized[$candidate] = $candidate;
+        }
+
+        return array_values($normalized);
+    }
+
+    private function normalizeLocale(mixed $locale, string $file): string
+    {
+        $candidate = trim((string) $locale);
+        if ($candidate === 'zh') {
+            $candidate = 'zh-CN';
+        }
+        if (! in_array($candidate, self::SUPPORTED_LOCALES, true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has unsupported locale: %s',
+                $file,
+                $candidate,
+            ));
+        }
+
+        return $candidate;
+    }
+
+    private function normalizeStatus(mixed $status, string $file, string $slug): string
+    {
+        $normalized = strtolower(trim((string) $status));
+        if (! in_array($normalized, ['draft', 'published'], true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid status=%s for slug=%s.',
+                $file,
+                (string) $status,
+                $slug,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeNullableDateString(mixed $value, string $file, string $slug): ?string
+    {
+        $candidate = trim((string) ($value ?? ''));
+        if ($candidate === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($candidate)->utc()->toISOString();
+        } catch (\Throwable) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid published_at=%s for slug=%s.',
+                $file,
+                $candidate,
+                $slug,
+            ));
+        }
+    }
+}

--- a/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+++ b/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CareerCms;
+
+use App\Models\Article;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class ArticleBaselineImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_does_not_write_database(): void
+    {
+        $this->artisan('articles:import-local-baseline', [
+            '--dry-run' => true,
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+        ])
+            ->expectsOutputToContain('files_found=2')
+            ->expectsOutputToContain('articles_found=6')
+            ->expectsOutputToContain('will_create=6')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_import_creates_and_updates_published_public_articles_for_mbti_minimum_set(): void
+    {
+        $this->artisan('articles:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+        ])
+            ->expectsOutputToContain('files_found=2')
+            ->expectsOutputToContain('articles_found=6')
+            ->expectsOutputToContain('will_create=6')
+            ->assertExitCode(0);
+
+        $this->assertSame(6, Article::query()->withoutGlobalScopes()->count());
+        $this->assertSame(
+            6,
+            Article::query()
+                ->withoutGlobalScopes()
+                ->where('status', 'published')
+                ->where('is_public', true)
+                ->count()
+        );
+
+        $enBasics = Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', 'en')
+            ->where('slug', 'mbti-basics')
+            ->firstOrFail();
+        $this->assertSame('MBTI Personality Test (16 Types) | Tool Guide', (string) $enBasics->title);
+
+        $zhGrowth = Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', 'mbti-growth-guide')
+            ->firstOrFail();
+        $this->assertSame('MBTI 性格测试（16型人格）｜成长引导版', (string) $zhGrowth->title);
+
+        $this->artisan('articles:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+        ])
+            ->expectsOutputToContain('articles_found=6')
+            ->expectsOutputToContain('will_skip=6')
+            ->assertExitCode(0);
+
+        $this->assertSame(6, Article::query()->withoutGlobalScopes()->count());
+    }
+}

--- a/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
@@ -426,6 +426,13 @@ final class CareerGuidePublicApiTest extends TestCase
             '--status' => 'published',
         ])->assertExitCode(0);
 
+        $this->artisan('articles:import-local-baseline', [
+            '--locale' => ['en', 'zh-CN'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+        ])->assertExitCode(0);
+
         $this->artisan('career-guides:import-local-baseline', [
             '--locale' => ['en'],
             '--guide' => ['intj-career-playbook'],

--- a/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
@@ -426,6 +426,13 @@ final class CareerRecommendationPublicApiTest extends TestCase
             '--status' => 'published',
         ])->assertExitCode(0);
 
+        $this->artisan('articles:import-local-baseline', [
+            '--locale' => ['en', 'zh-CN'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+        ])->assertExitCode(0);
+
         $this->artisan('career-guides:import-local-baseline', [
             '--locale' => ['en'],
             '--guide' => [

--- a/backend/tests/Feature/V0_5/MbtiPr1MinimumLoopTest.php
+++ b/backend/tests/Feature/V0_5/MbtiPr1MinimumLoopTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class MbtiPr1MinimumLoopTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mbti_pr1_minimum_loop_builds_articles_guides_and_recommendation_linkage(): void
+    {
+        $this->artisan('personality:import-local-baseline', [
+            '--locale' => ['en', 'zh-CN'],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en', 'zh-CN'],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $this->artisan('articles:import-local-baseline', [
+            '--locale' => ['en', 'zh-CN'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/articles',
+        ])->assertExitCode(0);
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--guide' => ['intj-career-playbook', 'enfp-career-playbook'],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['zh-CN'],
+            '--guide' => ['istj-career-playbook', 'esfp-career-playbook'],
+            '--upsert' => true,
+            '--status' => 'published',
+        ])->assertExitCode(0);
+
+        $articlesEn = $this->getJson('/api/v0.5/articles?locale=en&org_id=0&page=1');
+        $articlesEn->assertOk();
+        $this->assertGreaterThan(0, (int) $articlesEn->json('pagination.total'));
+
+        $guidesEn = $this->getJson('/api/v0.5/career-guides?locale=en&org_id=0&page=1');
+        $guidesEn->assertOk();
+        $this->assertGreaterThan(0, (int) $guidesEn->json('pagination.total'));
+
+        $intjGuide = $this->getJson('/api/v0.5/career-guides/intj-career-playbook?locale=en&org_id=0');
+        $intjGuide->assertOk();
+        $this->assertGreaterThanOrEqual(2, count((array) $intjGuide->json('related_articles')));
+
+        $intjA = $this->getJson('/api/v0.5/career-recommendations/mbti/intj-a?locale=en&org_id=0');
+        $intjA->assertOk();
+        $this->assertGreaterThan(0, count((array) $intjA->json('matched_jobs')));
+        $this->assertGreaterThan(0, count((array) $intjA->json('matched_guides')));
+
+        $enfpT = $this->getJson('/api/v0.5/career-recommendations/mbti/enfp-t?locale=en&org_id=0');
+        $enfpT->assertOk();
+        $this->assertGreaterThan(0, count((array) $enfpT->json('matched_jobs')));
+        $this->assertGreaterThan(0, count((array) $enfpT->json('matched_guides')));
+
+        $istjA = $this->getJson('/api/v0.5/career-recommendations/mbti/istj-a?locale=zh-CN&org_id=0');
+        $istjA->assertOk();
+        $this->assertGreaterThan(0, count((array) $istjA->json('matched_jobs')));
+        $this->assertGreaterThan(0, count((array) $istjA->json('matched_guides')));
+
+        $esfpT = $this->getJson('/api/v0.5/career-recommendations/mbti/esfp-t?locale=zh-CN&org_id=0');
+        $esfpT->assertOk();
+        $this->assertGreaterThan(0, count((array) $esfpT->json('matched_jobs')));
+        $this->assertGreaterThan(0, count((array) $esfpT->json('matched_guides')));
+    }
+}

--- a/content_baselines/articles/articles.en.json
+++ b/content_baselines/articles/articles.en.json
@@ -1,0 +1,40 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "en",
+    "source": "mbti_minimum_baseline",
+    "generated_at": "2026-04-06T00:00:00Z"
+  },
+  "articles": [
+    {
+      "slug": "mbti-basics",
+      "title": "MBTI Personality Test (16 Types) | Tool Guide",
+      "excerpt": "A practical, non-mythical guide to MBTI: what it measures, what it does not, and how to use results for better decisions in work, relationships, and self-management.",
+      "content_md": "This is FermatMind's tool-level guide to MBTI. The goal is not to romanticize four letters, but to convert personality signals into reusable decision rules.\n\n## What this assessment does\nMBTI does not answer the lifetime question of who you truly are. It maps default preferences across energy restore, information sampling, decision validation, and structure preference under uncertainty.\n\n## How to use results in real life\nUse MBTI as a working hypothesis, not a label. Track high-energy and high-friction situations for two weeks, then test one behavior change and review outcome quality.",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-02-25T00:00:00Z"
+    },
+    {
+      "slug": "mbti-growth-guide",
+      "title": "MBTI Personality Test (16 Types) | Growth Guide",
+      "excerpt": "A growth-focused playbook for MBTI users: convert preference signals into better communication, energy management, and career decisions.",
+      "content_md": "This article translates assessment output into practical actions for daily decisions.\n\n## Growth loop\nPick one real scenario, choose one behavior change from the report, run it for 2-4 weeks, and review measurable outcomes.\n\n## Practical boundaries\nAssessment output should support reflection and communication, not replace clinical, legal, or high-stakes professional judgment.",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-02-25T00:00:00Z"
+    },
+    {
+      "slug": "mbti-narrative-portrait",
+      "title": "MBTI Personality Test (16 Types) | Narrative Portrait",
+      "excerpt": "A narrative interpretation of MBTI output to help identify recurring life scripts and redesign daily choices with less friction.",
+      "content_md": "Think of daily life as a stream of interruptions, tasks, relationships, and choices. MBTI can be used as a repeatable map for how you sample the world and make decisions.\n\n## Narrative use\nTurn the report into an experiment: choose one scenario, adjust one variable, and run a short retrospective cycle.\n\n## Warning\nDo not treat type as a fixed identity label or as a way to classify others.",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-02-25T00:00:00Z"
+    }
+  ]
+}

--- a/content_baselines/articles/articles.zh-CN.json
+++ b/content_baselines/articles/articles.zh-CN.json
@@ -1,0 +1,40 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "zh-CN",
+    "source": "mbti_minimum_baseline",
+    "generated_at": "2026-04-06T00:00:00Z"
+  },
+  "articles": [
+    {
+      "slug": "mbti-basics",
+      "title": "MBTI 性格测试（16型人格）｜工具说明版",
+      "excerpt": "费马测试对 MBTI 的工具级说明：它测什么、不测什么、如何把结果转化为工作与关系中的可执行决策。",
+      "content_md": "你正在阅读 MBTI 的工具级说明。我们用最少噱头还原其可复用测量框架。\n\n## 这项测评在做什么\n它描述偏好与机制，不评价能力高低。\n\n## 如何使用\n把结果当作假设，记录高能量与高摩擦场景，做小步实验并复盘。",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-02-25T00:00:00Z"
+    },
+    {
+      "slug": "mbti-growth-guide",
+      "title": "MBTI 性格测试（16型人格）｜成长引导版",
+      "excerpt": "将 MBTI 输出转译成成长行动：能量管理、沟通协议、环境适配三条主线。",
+      "content_md": "成长不是被类型定义，而是持续优化你的默认系统。\n\n## 成长回路\n选一个真实场景、改一个行为变量、运行 2-4 周并复盘结果。\n\n## 使用边界\n用于反思与沟通，不替代临床、法律或高风险专业判断。",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-02-25T00:00:00Z"
+    },
+    {
+      "slug": "mbti-narrative-portrait",
+      "title": "MBTI 性格测试（16型人格）｜叙事画像版",
+      "excerpt": "把类型结果变成可复盘的生活叙事：识别重复脚本，重设决策与协作节奏。",
+      "content_md": "把生活当作可复盘的数据流：消息、任务、关系、情绪。\n\n## 叙事用法\n把结果转成实验：选场景、改变量、做短周期复盘。\n\n## 常见误用\n不要把类型当借口，也不要用类型给他人定性。",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-02-25T00:00:00Z"
+    }
+  ]
+}

--- a/content_baselines/career_guides/career_guides.en.json
+++ b/content_baselines/career_guides/career_guides.en.json
@@ -983,7 +983,17 @@
           "job_code": "innovation-consultant"
         }
       ],
-      "related_articles": [],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
       "related_personality_profiles": [
         {
           "type_code": "INTJ"
@@ -1333,7 +1343,17 @@
           "job_code": "brand-manager"
         }
       ],
-      "related_articles": [],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
       "related_personality_profiles": [
         {
           "type_code": "ENFP"
@@ -1383,7 +1403,17 @@
           "job_code": "supply-chain-manager"
         }
       ],
-      "related_articles": [],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
       "related_personality_profiles": [
         {
           "type_code": "ISTJ"
@@ -1733,7 +1763,17 @@
           "job_code": "brand-manager"
         }
       ],
-      "related_articles": [],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
       "related_personality_profiles": [
         {
           "type_code": "ESFP"

--- a/content_baselines/career_guides/career_guides.zh-CN.json
+++ b/content_baselines/career_guides/career_guides.zh-CN.json
@@ -983,7 +983,17 @@
           "job_code": "innovation-consultant"
         }
       ],
-      "related_articles": [],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
       "related_personality_profiles": [
         {
           "type_code": "INTJ"
@@ -1333,7 +1343,17 @@
           "job_code": "brand-manager"
         }
       ],
-      "related_articles": [],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
       "related_personality_profiles": [
         {
           "type_code": "ENFP"
@@ -1383,7 +1403,17 @@
           "job_code": "supply-chain-manager"
         }
       ],
-      "related_articles": [],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
       "related_personality_profiles": [
         {
           "type_code": "ISTJ"
@@ -1733,7 +1763,17 @@
           "job_code": "brand-manager"
         }
       ],
-      "related_articles": [],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
       "related_personality_profiles": [
         {
           "type_code": "ESFP"


### PR DESCRIPTION
## Implementation Summary
This PR executes PR-1 as a minimum viable MBTI content loop in `fap-api`:
- Adds a repeatable article baseline import command for MBTI core content.
- Imports a minimum MBTI article baseline source (3 core article slugs x 2 locales).
- Updates 4 MBTI playbook guides to include related articles so guide import no longer builds empty guide->article linkage for the mainline set.
- Adds focused tests proving:
  - articles API total is non-zero after import,
  - guides API total is non-zero after import,
  - 4 priority recommendation routes expose `matched_guides > 0`.

## Scope Implemented (PR-1)
### 1) Article minimum import chain
- Added `articles:import-local-baseline` command:
  - supports `--dry-run`, `--locale`, `--article`, `--upsert`, `--status`, `--source-dir`
  - validates locale/status/date schema and duplicate `(locale, slug)`
  - uses `ArticleService` + `ArticlePublishService`
  - writes/updates in `org_id=0`
  - ensures `published` + `is_public=true` for published mode

### 2) MBTI minimum article baseline assets
- Added article baseline files under `content_baselines/articles`:
  - `articles.en.json`
  - `articles.zh-CN.json`
- includes core slugs:
  - `mbti-basics`
  - `mbti-growth-guide`
  - `mbti-narrative-portrait`

### 3) MBTI minimum guide/article linkage
- Updated guide baselines for 4 priority playbooks (EN + ZH baseline files):
  - `intj-career-playbook`
  - `enfp-career-playbook`
  - `istj-career-playbook`
  - `esfp-career-playbook`
- each now references the 3 imported MBTI article slugs in `related_articles`.

### 4) Regression + acceptance tests
- Added tests:
  - `ArticleBaselineImportTest`
  - `MbtiPr1MinimumLoopTest`
- Updated existing V0.5 recommendation/guide API tests to import article baseline before guide baseline import.

## Verification Run
- `php artisan route:list` (224 routes)
- `php artisan migrate --force` (nothing to migrate)
- `php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php`
- `php artisan test tests/Feature/V0_5/MbtiPr1MinimumLoopTest.php`
- `php artisan test tests/Feature/V0_5/CareerGuidePublicApiTest.php --filter=imported_local_baseline_publishes_family_guides_with_personality_maps`
- `php artisan test tests/Feature/V0_5/CareerRecommendationPublicApiTest.php --filter=imported_local_baselines_make_representative_32_type_routes_non_empty`
- `bash backend/scripts/ci_verify_mbti.sh` (PASS)

## Deferred (Intentional)
- No full-site article baseline factory or CMS phase-2 governance.
- No Big Five/IQ-EQ full import cleanup.
- No broad recommendation resolver redesign (not needed for PR-1 root cause).

## Risk Notes
- This introduces a minimum article baseline set only; future content expansion still needs additional baseline entries and import coverage.
- Guide import remains strict on unresolved dependencies by design; this PR resolves MBTI mainline dependencies but does not relax global strictness.
