### PR TITLE
PR-6(API): MBTI scene summary blocks for topic/type/recommendation surfaces

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerRecommendationController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerRecommendationController.php
@@ -214,6 +214,7 @@ final class CareerRecommendationController extends Controller
             is_array($landingSurface['cta_bundle'] ?? null) ? $landingSurface['cta_bundle'] : [],
             3
         );
+        $sceneSummaryBlocks = $this->buildMbtiSceneSummaryBlocks($locale, trim((string) data_get($payload, 'public_route_slug', '')));
 
         if ($nextStepBlocks === [] && $preferredRoles !== []) {
             foreach ($preferredRoles as $index => $group) {
@@ -254,6 +255,7 @@ final class CareerRecommendationController extends Controller
             ],
             'faq_blocks' => $faqBlocks,
             'compare_blocks' => $compareBlocks,
+            'scene_summary_blocks' => $sceneSummaryBlocks,
             'next_step_blocks' => $nextStepBlocks,
             'evidence_refs' => array_values(array_filter([
                 (string) ($seoSurface['metadata_fingerprint'] ?? ''),
@@ -261,6 +263,7 @@ final class CareerRecommendationController extends Controller
                 'career.summary',
                 $matchedJobs !== [] ? 'matched_jobs' : '',
                 $matchedGuides !== [] ? 'matched_guides' : '',
+                $sceneSummaryBlocks !== [] ? 'scene_summary_blocks' : '',
             ])),
             'public_safety_state' => 'public_indexable',
             'indexability_state' => 'indexable',
@@ -275,6 +278,66 @@ final class CareerRecommendationController extends Controller
                 'locale' => $locale,
             ],
         ]);
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function buildMbtiSceneSummaryBlocks(string $locale, string $publicRouteSlug): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $startTestPath = '/'.$segment.'/tests/mbti-personality-test-16-personality-types';
+        $recommendationPath = $publicRouteSlug !== ''
+            ? '/'.$segment.'/career/recommendations/mbti/'.rawurlencode($publicRouteSlug)
+            : '/'.$segment.'/career/recommendations';
+
+        return [
+            [
+                'key' => 'career_direction',
+                'title' => $locale === 'zh-CN' ? '职业方向' : 'Career direction',
+                'body' => $locale === 'zh-CN'
+                    ? '保留当前职业推荐页，继续对照高匹配岗位。'
+                    : 'Keep this recommendation page open while comparing highest-fit roles.',
+                'href' => $recommendationPath,
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'major_selection',
+                'title' => $locale === 'zh-CN' ? '专业选择' : 'Major selection',
+                'body' => $locale === 'zh-CN'
+                    ? '先回 MBTI 主题页搭建判断框架，再看职业路径。'
+                    : 'Use the MBTI topic hub to frame major decisions before role-level choices.',
+                'href' => '/'.$segment.'/topics/mbti',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'team_collaboration',
+                'title' => $locale === 'zh-CN' ? '团队协作' : 'Team collaboration',
+                'body' => $locale === 'zh-CN'
+                    ? '结合人格类型页，补齐协作偏好线索。'
+                    : 'Pair this with personality type detail to validate collaboration preferences.',
+                'href' => '/'.$segment.'/personality',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'relationship_patterns',
+                'title' => $locale === 'zh-CN' ? '关系相处' : 'Relationship patterns',
+                'body' => $locale === 'zh-CN'
+                    ? '从主题页继续阅读关系与沟通场景。'
+                    : 'Continue from topic-level guidance for relationship and communication scenarios.',
+                'href' => '/'.$segment.'/topics/mbti',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'growth_planning',
+                'title' => $locale === 'zh-CN' ? '成长建议' : 'Growth planning',
+                'body' => $locale === 'zh-CN'
+                    ? '开始测试，拿到完整个性化成长建议。'
+                    : 'Start the test to unlock complete personalized growth guidance.',
+                'href' => $startTestPath,
+                'kind' => 'scene_entry',
+            ],
+        ];
     }
 
     /**

--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -269,6 +269,9 @@ class PersonalityController extends Controller
             is_array($projection['dimensions'] ?? null) ? $projection['dimensions'] : [],
             2
         );
+        $routeSlug = $this->resolveRouteSlug($profile, $variant);
+        $isMbtiScale = strtoupper((string) ($profile->scale_code ?? '')) === 'MBTI';
+        $sceneSummaryBlocks = $isMbtiScale ? $this->buildMbtiSceneSummaryBlocks($locale, $routeSlug) : [];
 
         return $this->answerSurfaceContractService->build([
             'answer_scope' => ($profile->is_indexable ?? false) ? 'public_indexable_detail' : 'public_noindex_detail',
@@ -291,6 +294,7 @@ class PersonalityController extends Controller
             ])),
             'faq_blocks' => $this->answerSurfaceContractService->extractFaqBlocksFromSectionPayloads($sections),
             'compare_blocks' => $compareBlocks,
+            'scene_summary_blocks' => $sceneSummaryBlocks,
             'next_step_blocks' => $this->answerSurfaceContractService->buildNextStepBlocksFromCtas(
                 is_array($landingSurface['cta_bundle'] ?? null) ? $landingSurface['cta_bundle'] : [],
                 3
@@ -305,6 +309,7 @@ class PersonalityController extends Controller
                 'mbti_public_projection_v1',
                 count($compareBlocks) > 0 ? 'projection_dimensions' : '',
                 count($sections) > 0 ? 'personality_sections' : '',
+                $sceneSummaryBlocks !== [] ? 'scene_summary_blocks' : '',
             ])),
             'public_safety_state' => 'public_indexable',
             'indexability_state' => ($profile->is_indexable ?? false) ? 'indexable' : 'noindex',
@@ -368,6 +373,64 @@ class PersonalityController extends Controller
             'related_surface_keys' => ['personality_detail', 'topic_cluster'],
             'fingerprint_seed' => ['locale' => $locale],
         ]);
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function buildMbtiSceneSummaryBlocks(string $locale, string $routeSlug): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $startTestPath = '/'.$segment.'/tests/mbti-personality-test-16-personality-types';
+        $profilePath = '/'.$segment.'/personality/'.rawurlencode($routeSlug);
+
+        return [
+            [
+                'key' => 'career_direction',
+                'title' => $locale === 'zh-CN' ? '职业方向' : 'Career direction',
+                'body' => $locale === 'zh-CN'
+                    ? '先看职业推荐入口，再回到类型页做验证。'
+                    : 'Review career recommendations first, then validate from the type page.',
+                'href' => '/'.$segment.'/career/recommendations',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'major_selection',
+                'title' => $locale === 'zh-CN' ? '专业选择' : 'Major selection',
+                'body' => $locale === 'zh-CN'
+                    ? '先回 MBTI 主题页整理判断框架，再做路径选择。'
+                    : 'Use the MBTI topic hub as the decision frame before choosing a major path.',
+                'href' => '/'.$segment.'/topics/mbti',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'team_collaboration',
+                'title' => $locale === 'zh-CN' ? '团队协作' : 'Team collaboration',
+                'body' => $locale === 'zh-CN'
+                    ? '保留当前类型页，继续对照团队协作特征。'
+                    : 'Keep this type page as reference when comparing collaboration patterns.',
+                'href' => $profilePath,
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'relationship_patterns',
+                'title' => $locale === 'zh-CN' ? '关系相处' : 'Relationship patterns',
+                'body' => $locale === 'zh-CN'
+                    ? '从类型页回到主题页，补齐关系场景解释。'
+                    : 'Jump from type detail back to topic context for relationship cues.',
+                'href' => '/'.$segment.'/topics/mbti',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'growth_planning',
+                'title' => $locale === 'zh-CN' ? '成长建议' : 'Growth planning',
+                'body' => $locale === 'zh-CN'
+                    ? '直接开始测试，拿到结构化成长建议。'
+                    : 'Start the test directly to generate structured growth suggestions.',
+                'href' => $startTestPath,
+                'kind' => 'scene_entry',
+            ],
+        ];
     }
 
     private function resolveRouteSlug(PersonalityProfile $profile, ?PersonalityProfileVariant $variant): string

--- a/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
@@ -284,18 +284,23 @@ final class TopicController extends Controller
             ];
         }
 
+        $isMbtiTopic = strtolower((string) ($profile->topic_code ?? $profile->slug ?? '')) === 'mbti';
+        $sceneSummaryBlocks = $isMbtiTopic ? $this->buildMbtiSceneSummaryBlocks($locale) : [];
+
         return $this->answerSurfaceContractService->build([
             'answer_scope' => $profile->is_indexable ? 'public_indexable_detail' : 'public_noindex_detail',
             'surface_type' => 'topic_public_detail',
             'summary_blocks' => $summaryBlocks,
             'faq_blocks' => $this->answerSurfaceContractService->extractFaqBlocksFromSectionPayloads($sections),
             'compare_blocks' => $compareBlocks,
+            'scene_summary_blocks' => $sceneSummaryBlocks,
             'next_step_blocks' => array_slice($nextStepBlocks, 0, 4),
             'evidence_refs' => array_values(array_filter([
                 (string) ($seoSurface['metadata_fingerprint'] ?? ''),
                 (string) ($landingSurface['landing_fingerprint'] ?? ''),
                 count($entryGroups) > 0 ? 'topic_entry_groups' : '',
                 count($sections) > 0 ? 'topic_sections' : '',
+                $sceneSummaryBlocks !== [] ? 'scene_summary_blocks' : '',
             ])),
             'public_safety_state' => 'public_indexable',
             'indexability_state' => $profile->is_indexable ? 'indexable' : 'noindex',
@@ -310,6 +315,63 @@ final class TopicController extends Controller
                 'entry_group_count' => count($entryGroups),
             ],
         ]);
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function buildMbtiSceneSummaryBlocks(string $locale): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $startTestPath = '/'.$segment.'/tests/mbti-personality-test-16-personality-types';
+
+        return [
+            [
+                'key' => 'career_direction',
+                'title' => $locale === 'zh-CN' ? '职业方向' : 'Career direction',
+                'body' => $locale === 'zh-CN'
+                    ? '先看职业推荐入口，快速判断高匹配岗位。'
+                    : 'Start from career recommendations to identify higher-fit roles quickly.',
+                'href' => '/'.$segment.'/career/recommendations',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'major_selection',
+                'title' => $locale === 'zh-CN' ? '专业选择' : 'Major selection',
+                'body' => $locale === 'zh-CN'
+                    ? '先建立 MBTI 框架，再把专业方向放进同一判断路径。'
+                    : 'Build an MBTI frame first, then evaluate majors against the same path.',
+                'href' => '/'.$segment.'/topics/mbti',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'team_collaboration',
+                'title' => $locale === 'zh-CN' ? '团队协作' : 'Team collaboration',
+                'body' => $locale === 'zh-CN'
+                    ? '回到人格类型索引，比较协作风格差异。'
+                    : 'Return to personality types to compare collaboration styles.',
+                'href' => '/'.$segment.'/personality',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'relationship_patterns',
+                'title' => $locale === 'zh-CN' ? '关系相处' : 'Relationship patterns',
+                'body' => $locale === 'zh-CN'
+                    ? '从 MBTI 主题页继续阅读关系线索。'
+                    : 'Continue from the MBTI topic hub for relationship pattern cues.',
+                'href' => '/'.$segment.'/topics/mbti',
+                'kind' => 'scene_entry',
+            ],
+            [
+                'key' => 'growth_planning',
+                'title' => $locale === 'zh-CN' ? '成长建议' : 'Growth planning',
+                'body' => $locale === 'zh-CN'
+                    ? '直接开始测试，获取个性化成长线索。'
+                    : 'Start the test directly to unlock personalized growth cues.',
+                'href' => $startTestPath,
+                'kind' => 'scene_entry',
+            ],
+        ];
     }
 
     /**

--- a/backend/app/Services/PublicSurface/AnswerSurfaceContractService.php
+++ b/backend/app/Services/PublicSurface/AnswerSurfaceContractService.php
@@ -241,16 +241,18 @@ final class AnswerSurfaceContractService
             $key = $this->normalizeString($block['key'] ?? null);
             $title = $this->normalizeString($block['title'] ?? null);
             $body = $this->normalizeString($block['body'] ?? null);
+            $href = $this->normalizeString($block['href'] ?? null);
             $kind = $this->normalizeString($block['kind'] ?? null);
 
-            if ($key === null && $title === null && $body === null) {
+            if ($key === null && $title === null && $body === null && $href === null) {
                 continue;
             }
 
             $normalized[] = [
-                'key' => $key ?? $title ?? $body,
+                'key' => $key ?? $title ?? $href ?? $body,
                 'title' => $title,
                 'body' => $body,
+                'href' => $href,
                 'kind' => $kind,
             ];
         }

--- a/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
@@ -310,6 +310,8 @@ final class CareerRecommendationPublicApiTest extends TestCase
             ->assertJsonPath('answer_surface_v1.surface_type', 'career_recommendation_public_detail')
             ->assertJsonPath('answer_surface_v1.summary_blocks.0.key', 'answer_first')
             ->assertJsonPath('answer_surface_v1.compare_blocks.0.key', 'authority_route')
+            ->assertJsonPath('answer_surface_v1.scene_summary_blocks.0.key', 'career_direction')
+            ->assertJsonPath('answer_surface_v1.scene_summary_blocks.0.href', '/en/career/recommendations/mbti/intj-a')
             ->assertJsonPath('answer_surface_v1.next_step_blocks.0.key', 'start_test')
             ->assertJsonPath('canonical_type_code', 'INTJ')
             ->assertJsonPath('public_route_slug', 'intj-a')

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -206,6 +206,8 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('answer_surface_v1.answer_scope', 'public_indexable_detail')
             ->assertJsonPath('answer_surface_v1.surface_type', 'personality_public_detail')
             ->assertJsonPath('answer_surface_v1.summary_blocks.0.key', 'type_summary')
+            ->assertJsonPath('answer_surface_v1.scene_summary_blocks.0.key', 'career_direction')
+            ->assertJsonPath('answer_surface_v1.scene_summary_blocks.0.href', '/en/career/recommendations')
             ->assertJsonPath('answer_surface_v1.next_step_blocks.0.key', 'start_test')
             ->assertJsonPath('mbti_public_projection_v1.display_type', 'INTJ')
             ->assertJsonPath('mbti_public_projection_v1.canonical_type_code', 'INTJ')

--- a/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
@@ -335,6 +335,37 @@ final class TopicsPublicApiTest extends TestCase
             ->assertJsonMissingPath('entry_groups.tests');
     }
 
+    public function test_non_mbti_topic_does_not_emit_mbti_scene_summary_blocks(): void
+    {
+        $topic = $this->createTopicProfile([
+            'topic_code' => 'big-five',
+            'slug' => 'big-five',
+            'title' => 'Big Five',
+            'excerpt' => 'Big Five topic detail.',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        TopicProfileSection::query()->create([
+            'profile_id' => (int) $topic->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Big Five overview body.',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+
+        $response = $this->getJson('/api/v0.5/topics/big-five?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('profile.topic_code', 'big-five')
+            ->assertJsonPath('answer_surface_v1.surface_type', 'topic_public_detail')
+            ->assertJsonPath('answer_surface_v1.scene_summary_blocks', []);
+    }
+
     public function test_seo_endpoint_returns_locale_aware_meta_and_jsonld(): void
     {
         config(['app.frontend_url' => 'https://staging.fermatmind.com']);

--- a/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
@@ -242,6 +242,8 @@ final class TopicsPublicApiTest extends TestCase
             ->assertJsonPath('answer_surface_v1.answer_scope', 'public_indexable_detail')
             ->assertJsonPath('answer_surface_v1.surface_type', 'topic_public_detail')
             ->assertJsonPath('answer_surface_v1.summary_blocks.0.key', 'topic_summary')
+            ->assertJsonPath('answer_surface_v1.scene_summary_blocks.0.key', 'career_direction')
+            ->assertJsonPath('answer_surface_v1.scene_summary_blocks.0.href', '/en/career/recommendations')
             ->assertJsonPath('answer_surface_v1.next_step_blocks.0.key', 'featured')
             ->assertJsonPath('entry_groups.featured.0.entry_type', 'personality_profile')
             ->assertJsonPath('entry_groups.featured.0.title', (string) $personality->title)

--- a/backend/tests/Unit/Services/PublicSurface/AnswerSurfaceContractServiceTest.php
+++ b/backend/tests/Unit/Services/PublicSurface/AnswerSurfaceContractServiceTest.php
@@ -37,6 +37,14 @@ final class AnswerSurfaceContractServiceTest extends TestCase
                     'body' => 'This profile leans inward before acting.',
                 ],
             ],
+            'scene_summary_blocks' => [
+                [
+                    'key' => 'career_direction',
+                    'title' => 'Career direction',
+                    'body' => 'Use role-fit content to anchor your next decision.',
+                    'href' => '/en/career/recommendations',
+                ],
+            ],
             'next_step_blocks' => [
                 [
                     'key' => 'start_test',
@@ -65,6 +73,8 @@ final class AnswerSurfaceContractServiceTest extends TestCase
         $this->assertCount(1, $contract['summary_blocks']);
         $this->assertCount(1, $contract['faq_blocks']);
         $this->assertCount(1, $contract['compare_blocks']);
+        $this->assertCount(1, $contract['scene_summary_blocks']);
+        $this->assertSame('/en/career/recommendations', $contract['scene_summary_blocks'][0]['href']);
         $this->assertCount(1, $contract['next_step_blocks']);
         $this->assertSame(['mbti_public_projection_v1', 'landing_surface_v1'], $contract['evidence_refs']);
         $this->assertIsString($contract['answer_fingerprint']);


### PR DESCRIPTION
## Summary
- add MBTI `scene_summary_blocks` output on public v0.5 topic/personality/career-recommendation detail surfaces
- keep MBTI-only scope guard for scene blocks (no spillover to non-MBTI topic/personality data)
- expose `href` in answer-surface content block normalization so web can render executable scene entry links
- extend API tests/contracts to assert scene block keys and links are present

## Verification
- `php artisan test tests/Unit/Services/PublicSurface/AnswerSurfaceContractServiceTest.php tests/Feature/V0_5/TopicsPublicApiTest.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/V0_5/CareerRecommendationPublicApiTest.php`
