### PR TITLE
PR-7: MBTI attribution funnel read model closure (api)

### DIFF
--- a/backend/app/Console/Commands/RefreshMbtiAttributionDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshMbtiAttributionDailyCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Analytics\MbtiAttributionFunnelDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+final class RefreshMbtiAttributionDailyCommand extends Command
+{
+    protected $signature = 'analytics:refresh-mbti-attribution-daily
+        {--from= : Inclusive start date (Y-m-d)}
+        {--to= : Inclusive end date (Y-m-d)}
+        {--org=* : Limit refresh to one or more org ids}
+        {--dry-run : Preview aggregation without writing rows}';
+
+    protected $description = 'Refresh MBTI attribution funnel read model grouped by entry surface/source page type.';
+
+    public function __construct(
+        private readonly MbtiAttributionFunnelDailyBuilder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $from = $this->parseDateOption((string) $this->option('from'), now()->subDays(6)->toDateString());
+        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $orgIds = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            (array) $this->option('org')
+        ), static fn (int $value): bool => $value >= 0));
+
+        $dryRun = (bool) $this->option('dry-run');
+
+        $result = $this->builder->refresh($from, $to, $orgIds, $dryRun);
+
+        $this->line('from='.$result['from']);
+        $this->line('to='.$result['to']);
+        $this->line('org_scope='.(empty($result['org_scope']) ? '*' : implode(',', $result['org_scope'])));
+        $this->line('dry_run='.(($result['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('attempted_rows='.(string) ($result['attempted_rows'] ?? 0));
+        $this->line('deleted_rows='.(string) ($result['deleted_rows'] ?? 0));
+        $this->line('upserted_rows='.(string) ($result['upserted_rows'] ?? 0));
+
+        if (($result['attempted_rows'] ?? 0) === 0) {
+            $this->warn('No MBTI attribution rows were generated for the selected scope.');
+        } else {
+            $this->info($dryRun ? 'dry-run complete' : 'refresh complete');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function parseDateOption(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+}

--- a/backend/app/Console/Commands/ReportMbtiAttributionDailyCommand.php
+++ b/backend/app/Console/Commands/ReportMbtiAttributionDailyCommand.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+final class ReportMbtiAttributionDailyCommand extends Command
+{
+    protected $signature = 'analytics:report-mbti-attribution-daily
+        {--from= : Inclusive start date (Y-m-d)}
+        {--to= : Inclusive end date (Y-m-d)}
+        {--org=* : Limit to one or more org ids}
+        {--entry-surface= : Filter one entry surface}
+        {--json : Output JSON rows}';
+
+    protected $description = 'Read MBTI attribution funnel metrics grouped by entry surface/source page type.';
+
+    public function handle(): int
+    {
+        $from = $this->parseDateOption((string) $this->option('from'), now()->subDays(6)->toDateString());
+        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $orgIds = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            (array) $this->option('org')
+        ), static fn (int $value): bool => $value >= 0));
+
+        $query = DB::table('analytics_mbti_attribution_daily')
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()])
+            ->selectRaw('entry_surface, source_page_type, locale, SUM(entry_views) as entry_views, SUM(start_clicks) as start_clicks, SUM(start_attempts) as start_attempts, SUM(result_views) as result_views, SUM(unlock_clicks) as unlock_clicks, SUM(orders_created) as orders_created, SUM(payments_confirmed) as payments_confirmed, SUM(unlock_successes) as unlock_successes, SUM(payment_unlock_successes) as payment_unlock_successes, SUM(invite_creates) as invite_creates, SUM(invite_shares) as invite_shares, SUM(invite_completions) as invite_completions, SUM(invite_unlock_successes) as invite_unlock_successes')
+            ->groupBy(['entry_surface', 'source_page_type', 'locale'])
+            ->orderByDesc('payments_confirmed');
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        $entrySurface = strtolower(trim((string) $this->option('entry-surface')));
+        if ($entrySurface !== '') {
+            $query->where('entry_surface', $entrySurface);
+        }
+
+        $rows = $query->get()->map(static function (object $row): array {
+            $unlockSuccesses = max(0, (int) ($row->unlock_successes ?? 0));
+            $inviteUnlockSuccesses = max(0, (int) ($row->invite_unlock_successes ?? 0));
+
+            return [
+                'entry_surface' => (string) ($row->entry_surface ?? 'unknown'),
+                'source_page_type' => (string) ($row->source_page_type ?? 'unknown'),
+                'locale' => (string) ($row->locale ?? 'en'),
+                'entry_views' => max(0, (int) ($row->entry_views ?? 0)),
+                'start_clicks' => max(0, (int) ($row->start_clicks ?? 0)),
+                'start_attempts' => max(0, (int) ($row->start_attempts ?? 0)),
+                'result_views' => max(0, (int) ($row->result_views ?? 0)),
+                'unlock_clicks' => max(0, (int) ($row->unlock_clicks ?? 0)),
+                'orders_created' => max(0, (int) ($row->orders_created ?? 0)),
+                'payments_confirmed' => max(0, (int) ($row->payments_confirmed ?? 0)),
+                'unlock_successes' => $unlockSuccesses,
+                'payment_unlock_successes' => max(0, (int) ($row->payment_unlock_successes ?? 0)),
+                'invite_creates' => max(0, (int) ($row->invite_creates ?? 0)),
+                'invite_shares' => max(0, (int) ($row->invite_shares ?? 0)),
+                'invite_completions' => max(0, (int) ($row->invite_completions ?? 0)),
+                'invite_unlock_successes' => $inviteUnlockSuccesses,
+                'invite_unlock_contribution_rate' => $unlockSuccesses > 0
+                    ? round($inviteUnlockSuccesses / $unlockSuccesses, 4)
+                    : 0.0,
+            ];
+        })->values()->all();
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode([
+                'from' => $from->toDateString(),
+                'to' => $to->toDateString(),
+                'rows' => $rows,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        if ($rows === []) {
+            $this->warn('No MBTI attribution rows found for the selected scope.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table([
+            'entry_surface',
+            'source_page_type',
+            'locale',
+            'entry_views',
+            'start_clicks',
+            'start_attempts',
+            'result_views',
+            'unlock_clicks',
+            'orders_created',
+            'payments_confirmed',
+            'unlock_successes',
+            'invite_creates',
+            'invite_shares',
+            'invite_completions',
+            'invite_unlock_rate',
+        ], array_map(static fn (array $row): array => [
+            $row['entry_surface'],
+            $row['source_page_type'],
+            $row['locale'],
+            $row['entry_views'],
+            $row['start_clicks'],
+            $row['start_attempts'],
+            $row['result_views'],
+            $row['unlock_clicks'],
+            $row['orders_created'],
+            $row['payments_confirmed'],
+            $row['unlock_successes'],
+            $row['invite_creates'],
+            $row['invite_shares'],
+            $row['invite_completions'],
+            $row['invite_unlock_contribution_rate'],
+        ], $rows));
+
+        return self::SUCCESS;
+    }
+
+    private function parseDateOption(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php
+++ b/backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_3;
+
+use App\Http\Controllers\Controller;
+use App\Models\Event;
+use App\Support\SchemaBaseline;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+final class MbtiAttributionEventController extends Controller
+{
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_EVENT_NAMES = [
+        'landing_view',
+        'start_click',
+        'start_attempt',
+        'view_result',
+        'click_unlock',
+        'create_order',
+        'payment_confirmed',
+        'purchase_success',
+        'unlock_success',
+        'invite_create_start',
+        'invite_create_success',
+        'invite_create_failed',
+        'invite_share_or_copy',
+        'invite_progress_advanced',
+    ];
+
+    public function store(Request $request): JsonResponse
+    {
+        $this->authorizeIngest($request);
+
+        $data = $request->validate([
+            'eventName' => ['required', 'string', 'max:64'],
+            'payload' => ['nullable', 'array'],
+            'anonymousId' => ['nullable', 'string', 'max:128'],
+            'path' => ['nullable', 'string', 'max:2048'],
+            'timestamp' => ['nullable', 'date'],
+        ]);
+
+        $eventName = strtolower(trim((string) ($data['eventName'] ?? '')));
+        if (! in_array($eventName, self::ALLOWED_EVENT_NAMES, true)) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'INVALID_EVENT_NAME',
+                'message' => 'eventName is not supported by mbti attribution ingest.',
+            ], 422);
+        }
+
+        $payload = is_array($data['payload'] ?? null) ? $data['payload'] : [];
+        $path = $this->normalizeOptionalString($data['path'] ?? null, 2048) ?? '/';
+        $anonymousId = $this->normalizeOptionalString($data['anonymousId'] ?? null, 128);
+        $occurredAt = Carbon::parse((string) ($data['timestamp'] ?? now()->toISOString()));
+
+        $attemptId = $this->normalizeOptionalString(
+            $payload['attempt_id']
+                ?? $payload['target_attempt_id']
+                ?? null,
+            64
+        );
+
+        $meta = [
+            'entry_surface' => $this->normalizeOptionalString($payload['entry_surface'] ?? null, 128) ?? 'unknown',
+            'source_page_type' => $this->normalizeOptionalString($payload['source_page_type'] ?? null, 64) ?? 'unknown',
+            'target_action' => $this->normalizeOptionalString($payload['target_action'] ?? null, 128),
+            'test_slug' => $this->normalizeOptionalString($payload['test_slug'] ?? null, 128),
+            'form_code' => $this->normalizeOptionalString($payload['form_code'] ?? null, 64),
+            'landing_path' => $this->normalizeOptionalString($payload['landing_path'] ?? null, 2048) ?? $path,
+            'path' => $path,
+            'anonymous_id' => $anonymousId,
+            'target_attempt_id' => $this->normalizeOptionalString($payload['target_attempt_id'] ?? null, 64),
+            'attempt_id' => $attemptId,
+            'raw_payload' => $payload,
+        ];
+
+        $locale = $this->normalizeOptionalString($payload['locale'] ?? null, 16)
+            ?? ($path !== '' && str_starts_with($path, '/zh') ? 'zh' : 'en');
+
+        $orgId = $this->resolveOrgId($request);
+
+        $attributes = [
+            'id' => (string) Str::uuid(),
+            'event_code' => $eventName,
+            'event_name' => $eventName,
+            'org_id' => $orgId,
+            'anon_id' => $anonymousId,
+            'attempt_id' => $attemptId,
+            'meta_json' => $meta,
+            'occurred_at' => $occurredAt,
+            'scale_code' => 'MBTI',
+            'channel' => 'web',
+            'locale' => $locale,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        if (SchemaBaseline::hasColumn('events', 'scale_code_v2')) {
+            $attributes['scale_code_v2'] = 'MBTI';
+        }
+
+        Event::query()->create($attributes);
+
+        return response()->json([
+            'ok' => true,
+            'event_code' => $eventName,
+            'org_id' => $orgId,
+        ], 202);
+    }
+
+    private function authorizeIngest(Request $request): void
+    {
+        $configuredToken = trim((string) config('fap.events.ingest_token', ''));
+        if ($configuredToken === '') {
+            return;
+        }
+
+        $provided = trim((string) ($request->bearerToken() ?? ''));
+        if ($provided === '') {
+            $provided = trim((string) $request->header('X-Track-Ingest-Token', ''));
+        }
+
+        if ($provided === '' || ! hash_equals($configuredToken, $provided)) {
+            abort(response()->json([
+                'ok' => false,
+                'error_code' => 'unauthorized',
+                'message' => 'Invalid ingest token.',
+            ], 401));
+        }
+    }
+
+    private function resolveOrgId(Request $request): int
+    {
+        $attr = $request->attributes->get('org_id');
+        if (is_numeric($attr)) {
+            return max(0, (int) $attr);
+        }
+
+        $header = trim((string) ($request->header('X-Org-Id') ?? ''));
+        if ($header !== '' && preg_match('/^\d+$/', $header) === 1) {
+            return (int) $header;
+        }
+
+        return 0;
+    }
+
+    private function normalizeOptionalString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Http/Requests/V0_3/StartAttemptRequest.php
+++ b/backend/app/Http/Requests/V0_3/StartAttemptRequest.php
@@ -33,6 +33,10 @@ class StartAttemptRequest extends FormRequest
             'invite_unlock_code' => 64,
             'share_click_id' => 128,
             'entrypoint' => 128,
+            'entry_surface' => 128,
+            'source_page_type' => 64,
+            'target_action' => 128,
+            'test_slug' => 128,
             'landing_path' => 2048,
         ] as $field => $maxLength) {
             $value = $this->normalizeString($this->input($field), $maxLength);
@@ -77,6 +81,10 @@ class StartAttemptRequest extends FormRequest
             'invite_unlock_code' => ['nullable', 'string', 'max:64'],
             'share_click_id' => ['nullable', 'string', 'max:128'],
             'entrypoint' => ['nullable', 'string', 'max:128'],
+            'entry_surface' => ['nullable', 'string', 'max:128'],
+            'source_page_type' => ['nullable', 'string', 'max:64'],
+            'target_action' => ['nullable', 'string', 'max:128'],
+            'test_slug' => ['nullable', 'string', 'max:128'],
             'landing_path' => ['nullable', 'string', 'max:2048'],
             'utm' => ['nullable'],
             'utm_source' => ['nullable', 'string', 'max:512'],

--- a/backend/app/Services/Analytics/MbtiAttributionFunnelDailyBuilder.php
+++ b/backend/app/Services/Analytics/MbtiAttributionFunnelDailyBuilder.php
@@ -1,0 +1,661 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Models\Order;
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+
+final class MbtiAttributionFunnelDailyBuilder
+{
+    /**
+     * @var array<string, string>
+     */
+    private const ENTRY_EVENT_METRIC_MAP = [
+        'landing_view' => 'entry_views',
+        'start_click' => 'start_clicks',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const ATTEMPT_EVENT_METRIC_MAP = [
+        'view_result' => 'result_views',
+        'click_unlock' => 'unlock_clicks',
+        'invite_create_success' => 'invite_creates',
+        'invite_share_or_copy' => 'invite_shares',
+        'invite_unlock_completion_qualified' => 'invite_completions',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const EVENT_CODES = [
+        'landing_view',
+        'start_click',
+        'view_result',
+        'click_unlock',
+        'invite_create_success',
+        'invite_share_or_copy',
+        'invite_unlock_completion_qualified',
+        'invite_unlock_partial_granted',
+        'invite_unlock_full_granted',
+    ];
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array{rows:list<array<string,mixed>>,attempted_rows:int,org_scope:list<int>,from:string,to:string}
+     */
+    public function build(\DateTimeInterface $from, \DateTimeInterface $to, array $orgIds = []): array
+    {
+        $fromAt = CarbonImmutable::parse($from)->startOfDay();
+        $toAt = CarbonImmutable::parse($to)->endOfDay();
+        $normalizedOrgIds = $this->normalizeOrgIds($orgIds);
+
+        $startAttemptRows = $this->loadMbtiAttemptsStartedInRange($fromAt, $toAt, $normalizedOrgIds);
+        $eventRows = $this->loadMbtiEventsInRange($fromAt, $toAt, $normalizedOrgIds);
+        $orderRows = $this->loadOrderRowsInRange($fromAt, $toAt, $normalizedOrgIds);
+
+        $candidateAttemptIds = [];
+        foreach ($startAttemptRows as $row) {
+            $attemptId = trim((string) ($row->id ?? ''));
+            if ($attemptId !== '') {
+                $candidateAttemptIds[$attemptId] = true;
+            }
+        }
+        foreach ($eventRows as $row) {
+            $meta = $this->decodeJson($row->meta_json ?? null);
+            $attemptId = $this->resolveAttemptId($row->attempt_id ?? null, $meta);
+            if ($attemptId !== null) {
+                $candidateAttemptIds[$attemptId] = true;
+            }
+        }
+        foreach ($orderRows as $row) {
+            $attemptId = trim((string) ($row->target_attempt_id ?? ''));
+            if ($attemptId !== '') {
+                $candidateAttemptIds[$attemptId] = true;
+            }
+        }
+
+        $attemptDimensions = $this->loadAttemptDimensions(array_keys($candidateAttemptIds), $normalizedOrgIds);
+        $rows = [];
+
+        foreach ($startAttemptRows as $row) {
+            $attemptId = trim((string) ($row->id ?? ''));
+            if ($attemptId === '') {
+                continue;
+            }
+
+            $dimensions = $attemptDimensions[$attemptId] ?? null;
+            if ($dimensions === null) {
+                continue;
+            }
+
+            $day = $this->normalizeDay($row->created_at ?? null);
+            if ($day === null) {
+                continue;
+            }
+
+            $this->incrementMetric($rows, $day, $dimensions, 'start_attempts', 1);
+        }
+
+        foreach ($eventRows as $row) {
+            $eventCode = strtolower(trim((string) ($row->event_code ?? '')));
+            if ($eventCode === '') {
+                continue;
+            }
+
+            $day = $this->normalizeDay($row->occurred_at ?? null);
+            if ($day === null) {
+                continue;
+            }
+
+            $meta = $this->decodeJson($row->meta_json ?? null);
+            $orgId = max(0, (int) ($row->org_id ?? 0));
+            $eventLocale = $this->normalizeLocale($row->locale ?? null);
+
+            if (array_key_exists($eventCode, self::ENTRY_EVENT_METRIC_MAP)) {
+                $dimensions = $this->resolveEntryDimensionsFromMeta($meta, $orgId, $eventLocale);
+                if (! $this->isMbtiSurface($dimensions['entry_surface'])) {
+                    continue;
+                }
+
+                $this->incrementMetric($rows, $day, $dimensions, self::ENTRY_EVENT_METRIC_MAP[$eventCode], 1);
+                continue;
+            }
+
+            $attemptId = $this->resolveAttemptId($row->attempt_id ?? null, $meta);
+            if ($attemptId === null) {
+                continue;
+            }
+
+            $dimensions = $attemptDimensions[$attemptId] ?? null;
+            if ($dimensions === null) {
+                continue;
+            }
+
+            if (array_key_exists($eventCode, self::ATTEMPT_EVENT_METRIC_MAP)) {
+                $this->incrementMetric($rows, $day, $dimensions, self::ATTEMPT_EVENT_METRIC_MAP[$eventCode], 1);
+            }
+
+            if (in_array($eventCode, ['invite_unlock_partial_granted', 'invite_unlock_full_granted'], true)) {
+                $this->incrementMetric($rows, $day, $dimensions, 'invite_unlock_successes', 1);
+                $this->incrementMetric($rows, $day, $dimensions, 'unlock_successes', 1);
+            }
+        }
+
+        foreach ($orderRows as $row) {
+            $attemptId = trim((string) ($row->target_attempt_id ?? ''));
+            if ($attemptId === '') {
+                continue;
+            }
+
+            $dimensions = $attemptDimensions[$attemptId] ?? null;
+            if ($dimensions === null) {
+                continue;
+            }
+
+            $createdDay = $this->normalizeDay($row->created_at ?? null);
+            if ($createdDay !== null) {
+                $this->incrementMetric($rows, $createdDay, $dimensions, 'orders_created', 1);
+            }
+
+            $paidDay = $this->normalizeDay($row->paid_at ?? null);
+            if ($paidDay !== null && $this->isPaidOrder($row)) {
+                $this->incrementMetric($rows, $paidDay, $dimensions, 'payments_confirmed', 1);
+            }
+
+            $unlockDay = $this->resolveOrderUnlockDay($row);
+            if ($unlockDay !== null) {
+                $this->incrementMetric($rows, $unlockDay, $dimensions, 'payment_unlock_successes', 1);
+                $this->incrementMetric($rows, $unlockDay, $dimensions, 'unlock_successes', 1);
+            }
+        }
+
+        $finalRows = array_values(array_map(function (array $row): array {
+            $row['updated_at'] = now();
+            $row['last_refreshed_at'] = now();
+
+            return $row;
+        }, $rows));
+
+        return [
+            'rows' => $finalRows,
+            'attempted_rows' => count($finalRows),
+            'org_scope' => $normalizedOrgIds,
+            'from' => $fromAt->toDateString(),
+            'to' => $toAt->toDateString(),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array{rows:list<array<string,mixed>>,attempted_rows:int,deleted_rows:int,upserted_rows:int,org_scope:list<int>,from:string,to:string,dry_run:bool}
+     */
+    public function refresh(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        bool $dryRun = false,
+    ): array {
+        $payload = $this->build($from, $to, $orgIds);
+        $rows = $payload['rows'];
+        $deletedRows = 0;
+        $upsertedRows = 0;
+
+        if (! $dryRun) {
+            DB::transaction(function () use ($payload, $rows, &$deletedRows, &$upsertedRows): void {
+                $deletedRows = $this->deleteScope($payload['from'], $payload['to'], $payload['org_scope']);
+
+                if ($rows === []) {
+                    return;
+                }
+
+                DB::table('analytics_mbti_attribution_daily')->upsert(
+                    $rows,
+                    ['day', 'org_id', 'locale', 'entry_surface', 'source_page_type', 'test_slug', 'form_code'],
+                    [
+                        'entry_views',
+                        'start_clicks',
+                        'start_attempts',
+                        'result_views',
+                        'unlock_clicks',
+                        'orders_created',
+                        'payments_confirmed',
+                        'unlock_successes',
+                        'payment_unlock_successes',
+                        'invite_creates',
+                        'invite_shares',
+                        'invite_completions',
+                        'invite_unlock_successes',
+                        'last_refreshed_at',
+                        'updated_at',
+                    ]
+                );
+
+                $upsertedRows = count($rows);
+            });
+        }
+
+        return $payload + [
+            'deleted_rows' => $deletedRows,
+            'upserted_rows' => $upsertedRows,
+            'dry_run' => $dryRun,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<object>
+     */
+    private function loadMbtiAttemptsStartedInRange(
+        CarbonImmutable $from,
+        CarbonImmutable $to,
+        array $orgIds,
+    ): array {
+        if (! SchemaBaseline::hasTable('attempts')) {
+            return [];
+        }
+
+        $query = DB::table('attempts')
+            ->whereBetween('created_at', [$from, $to])
+            ->select(['id', 'org_id', 'locale', 'answers_summary_json', 'created_at', 'scale_code']);
+
+        if (SchemaBaseline::hasColumn('attempts', 'scale_code_v2')) {
+            $query->addSelect('scale_code_v2');
+        }
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        $this->applyMbtiAttemptFilter($query);
+
+        return $query->get()->all();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<object>
+     */
+    private function loadMbtiEventsInRange(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('events')) {
+            return [];
+        }
+
+        [$sql, $bindings] = $this->lowerInSql('event_code', self::EVENT_CODES);
+
+        $query = DB::table('events')
+            ->whereBetween('occurred_at', [$from, $to])
+            ->whereRaw($sql, $bindings)
+            ->select(['id', 'org_id', 'event_code', 'attempt_id', 'meta_json', 'occurred_at', 'locale']);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        return $query->get()->all();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<object>
+     */
+    private function loadOrderRowsInRange(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('orders')) {
+            return [];
+        }
+
+        $query = DB::table('orders')
+            ->whereNotNull('target_attempt_id')
+            ->where(function ($nested) use ($from, $to): void {
+                $nested->whereBetween('created_at', [$from, $to])
+                    ->orWhereBetween('paid_at', [$from, $to]);
+
+                if (SchemaBaseline::hasColumn('orders', 'fulfilled_at')) {
+                    $nested->orWhereBetween('fulfilled_at', [$from, $to]);
+                }
+            });
+
+        $columns = [
+            'target_attempt_id',
+            'org_id',
+            'status',
+            'created_at',
+            'paid_at',
+        ];
+        if (SchemaBaseline::hasColumn('orders', 'payment_state')) {
+            $columns[] = 'payment_state';
+        }
+        if (SchemaBaseline::hasColumn('orders', 'grant_state')) {
+            $columns[] = 'grant_state';
+        }
+        if (SchemaBaseline::hasColumn('orders', 'fulfilled_at')) {
+            $columns[] = 'fulfilled_at';
+        }
+
+        $query->select($columns);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        return $query->get()->all();
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     * @param  list<int>  $orgIds
+     * @return array<string,array{org_id:int,locale:string,entry_surface:string,source_page_type:string,test_slug:string,form_code:string}>
+     */
+    private function loadAttemptDimensions(array $attemptIds, array $orgIds): array
+    {
+        if ($attemptIds === [] || ! SchemaBaseline::hasTable('attempts')) {
+            return [];
+        }
+
+        $dimensions = [];
+
+        foreach (array_chunk($attemptIds, 500) as $chunk) {
+            $query = DB::table('attempts')
+                ->whereIn('id', $chunk)
+                ->select(['id', 'org_id', 'locale', 'answers_summary_json', 'scale_code']);
+
+            if (SchemaBaseline::hasColumn('attempts', 'scale_code_v2')) {
+                $query->addSelect('scale_code_v2');
+            }
+
+            if ($orgIds !== []) {
+                $query->whereIn('org_id', $orgIds);
+            }
+
+            $this->applyMbtiAttemptFilter($query);
+
+            foreach ($query->get() as $row) {
+                $attemptId = trim((string) ($row->id ?? ''));
+                if ($attemptId === '') {
+                    continue;
+                }
+
+                $summary = $this->decodeJson($row->answers_summary_json ?? null);
+                $meta = is_array($summary['meta'] ?? null) ? $summary['meta'] : [];
+
+                $entrySurface = $this->normalizeDimension($meta['entry_surface'] ?? $meta['entrypoint'] ?? null, 'unknown');
+                $sourcePageType = $this->normalizeDimension($meta['source_page_type'] ?? null, $this->guessSourcePageType($entrySurface));
+                $testSlug = $this->normalizeDimension($meta['test_slug'] ?? null, '');
+                $formCode = $this->normalizeDimension($meta['form_code'] ?? null, '');
+
+                if (! $this->isMbtiSurface($entrySurface)) {
+                    $entrySurface = 'mbti_unknown';
+                    if ($sourcePageType === 'unknown') {
+                        $sourcePageType = 'unknown';
+                    }
+                }
+
+                $dimensions[$attemptId] = [
+                    'org_id' => max(0, (int) ($row->org_id ?? 0)),
+                    'locale' => $this->normalizeLocale($row->locale ?? null),
+                    'entry_surface' => $entrySurface,
+                    'source_page_type' => $sourcePageType,
+                    'test_slug' => $testSlug,
+                    'form_code' => $formCode,
+                ];
+            }
+        }
+
+        return $dimensions;
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array{org_id:int,locale:string,entry_surface:string,source_page_type:string,test_slug:string,form_code:string}
+     */
+    private function resolveEntryDimensionsFromMeta(array $meta, int $orgId, string $locale): array
+    {
+        $entrySurface = $this->normalizeDimension($meta['entry_surface'] ?? null, 'unknown');
+        $sourcePageType = $this->normalizeDimension($meta['source_page_type'] ?? null, $this->guessSourcePageType($entrySurface));
+
+        return [
+            'org_id' => max(0, $orgId),
+            'locale' => $locale,
+            'entry_surface' => $entrySurface,
+            'source_page_type' => $sourcePageType,
+            'test_slug' => $this->normalizeDimension($meta['test_slug'] ?? null, ''),
+            'form_code' => $this->normalizeDimension($meta['form_code'] ?? null, ''),
+        ];
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $rows
+     * @param  array{org_id:int,locale:string,entry_surface:string,source_page_type:string,test_slug:string,form_code:string}  $dimensions
+     */
+    private function incrementMetric(array &$rows, string $day, array $dimensions, string $metric, int $delta): void
+    {
+        $key = implode('|', [
+            $day,
+            (string) $dimensions['org_id'],
+            $dimensions['locale'],
+            $dimensions['entry_surface'],
+            $dimensions['source_page_type'],
+            $dimensions['test_slug'],
+            $dimensions['form_code'],
+        ]);
+
+        if (! isset($rows[$key])) {
+            $rows[$key] = [
+                'day' => $day,
+                'org_id' => $dimensions['org_id'],
+                'locale' => $dimensions['locale'],
+                'entry_surface' => $dimensions['entry_surface'],
+                'source_page_type' => $dimensions['source_page_type'],
+                'test_slug' => $dimensions['test_slug'],
+                'form_code' => $dimensions['form_code'],
+                'entry_views' => 0,
+                'start_clicks' => 0,
+                'start_attempts' => 0,
+                'result_views' => 0,
+                'unlock_clicks' => 0,
+                'orders_created' => 0,
+                'payments_confirmed' => 0,
+                'unlock_successes' => 0,
+                'payment_unlock_successes' => 0,
+                'invite_creates' => 0,
+                'invite_shares' => 0,
+                'invite_completions' => 0,
+                'invite_unlock_successes' => 0,
+                'created_at' => now(),
+            ];
+        }
+
+        $rows[$key][$metric] = max(0, (int) ($rows[$key][$metric] ?? 0) + $delta);
+    }
+
+    private function normalizeDay(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($value)->toDateString();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function isPaidOrder(object $row): bool
+    {
+        $paymentState = strtolower(trim((string) ($row->payment_state ?? '')));
+        $status = strtolower(trim((string) ($row->status ?? '')));
+
+        return in_array($paymentState, [Order::PAYMENT_STATE_PAID], true)
+            || in_array($status, [Order::STATUS_PAID, Order::STATUS_FULFILLED], true);
+    }
+
+    private function resolveOrderUnlockDay(object $row): ?string
+    {
+        $grantState = strtolower(trim((string) ($row->grant_state ?? '')));
+        $status = strtolower(trim((string) ($row->status ?? '')));
+
+        if ($grantState === Order::GRANT_STATE_GRANTED || $status === Order::STATUS_FULFILLED) {
+            $fulfilledDay = $this->normalizeDay($row->fulfilled_at ?? null);
+            if ($fulfilledDay !== null) {
+                return $fulfilledDay;
+            }
+
+            return $this->normalizeDay($row->paid_at ?? null);
+        }
+
+        return null;
+    }
+
+    private function resolveAttemptId(mixed $rowAttemptId, array $meta): ?string
+    {
+        $direct = $this->normalizeOptionalString($rowAttemptId, 64);
+        if ($direct !== null) {
+            return $direct;
+        }
+
+        return $this->normalizeOptionalString(
+            $meta['target_attempt_id'] ?? $meta['attempt_id'] ?? null,
+            64
+        );
+    }
+
+    private function normalizeLocale(mixed $value): string
+    {
+        $locale = strtolower(trim((string) ($value ?? '')));
+
+        if ($locale === '') {
+            return 'en';
+        }
+
+        return $locale;
+    }
+
+    private function normalizeDimension(mixed $value, string $fallback): string
+    {
+        $normalized = strtolower(trim((string) ($value ?? '')));
+        if ($normalized === '') {
+            return $fallback;
+        }
+
+        return mb_substr($normalized, 0, 128, 'UTF-8');
+    }
+
+    private function normalizeOptionalString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJson(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     */
+    private function deleteScope(string $from, string $to, array $orgIds): int
+    {
+        $query = DB::table('analytics_mbti_attribution_daily')
+            ->whereBetween('day', [$from, $to]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        return (int) $query->delete();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<int>
+     */
+    private function normalizeOrgIds(array $orgIds): array
+    {
+        $normalized = array_values(array_unique(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            $orgIds
+        ), static fn (int $value): bool => $value >= 0)));
+
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    private function isMbtiSurface(string $entrySurface): bool
+    {
+        return str_starts_with($entrySurface, 'mbti_');
+    }
+
+    private function guessSourcePageType(string $entrySurface): string
+    {
+        if (str_starts_with($entrySurface, 'mbti_')) {
+            $guess = str_replace('mbti_', '', $entrySurface);
+
+            return $guess !== '' ? $guess : 'unknown';
+        }
+
+        return 'unknown';
+    }
+
+    /**
+     * @param  \Illuminate\Database\Query\Builder  $query
+     */
+    private function applyMbtiAttemptFilter($query): void
+    {
+        $query->where(function ($nested): void {
+            $nested->whereRaw("LOWER(COALESCE(scale_code, '')) = ?", ['mbti']);
+
+            if (SchemaBaseline::hasColumn('attempts', 'scale_code_v2')) {
+                $nested->orWhereRaw("LOWER(COALESCE(scale_code_v2, '')) = ?", ['mbti']);
+            }
+        });
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return array{0:string,1:list<string>}
+     */
+    private function lowerInSql(string $column, array $values): array
+    {
+        $placeholders = implode(', ', array_fill(0, count($values), '?'));
+
+        return [
+            "LOWER(COALESCE({$column}, '')) IN ({$placeholders})",
+            array_map(static fn (string $value): string => strtolower(trim($value)), $values),
+        ];
+    }
+}

--- a/backend/database/migrations/2026_04_06_120000_create_analytics_mbti_attribution_daily_table.php
+++ b/backend/database/migrations/2026_04_06_120000_create_analytics_mbti_attribution_daily_table.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('analytics_mbti_attribution_daily')) {
+            Schema::create('analytics_mbti_attribution_daily', function (Blueprint $table): void {
+                $table->id();
+                $table->date('day');
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('locale', 16)->default('en');
+                $table->string('entry_surface', 128)->default('unknown');
+                $table->string('source_page_type', 64)->default('unknown');
+                $table->string('test_slug', 128)->default('');
+                $table->string('form_code', 64)->default('');
+
+                $table->unsignedInteger('entry_views')->default(0);
+                $table->unsignedInteger('start_clicks')->default(0);
+                $table->unsignedInteger('start_attempts')->default(0);
+                $table->unsignedInteger('result_views')->default(0);
+                $table->unsignedInteger('unlock_clicks')->default(0);
+                $table->unsignedInteger('orders_created')->default(0);
+                $table->unsignedInteger('payments_confirmed')->default(0);
+                $table->unsignedInteger('unlock_successes')->default(0);
+                $table->unsignedInteger('payment_unlock_successes')->default(0);
+                $table->unsignedInteger('invite_creates')->default(0);
+                $table->unsignedInteger('invite_shares')->default(0);
+                $table->unsignedInteger('invite_completions')->default(0);
+                $table->unsignedInteger('invite_unlock_successes')->default(0);
+
+                $table->timestamp('last_refreshed_at')->nullable();
+                $table->timestamps();
+
+                $table->unique(
+                    ['day', 'org_id', 'locale', 'entry_surface', 'source_page_type', 'test_slug', 'form_code'],
+                    'analytics_mbti_attr_daily_unique'
+                );
+                $table->index(['day', 'org_id'], 'analytics_mbti_attr_daily_day_org_idx');
+                $table->index(['entry_surface', 'source_page_type'], 'analytics_mbti_attr_daily_surface_idx');
+            });
+
+            return;
+        }
+
+        Schema::table('analytics_mbti_attribution_daily', function (Blueprint $table): void {
+            if (! Schema::hasColumn('analytics_mbti_attribution_daily', 'payment_unlock_successes')) {
+                $table->unsignedInteger('payment_unlock_successes')->default(0)->after('unlock_successes');
+            }
+            if (! Schema::hasColumn('analytics_mbti_attribution_daily', 'invite_unlock_successes')) {
+                $table->unsignedInteger('invite_unlock_successes')->default(0)->after('invite_completions');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -147,6 +147,30 @@
                 ]
             }
         },
+        "/api/v0.3/analytics/mbti-attribution-events": {
+            "post": {
+                "operationId": "api.v0_3.analytics.mbti_attribution_events.store",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\MbtiAttributionEventController@store",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\LimitApiPublicPayloadSize",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_track"
+                ],
+                "x-laravel-name": "api.v0_3.analytics.mbti_attribution_events.store"
+            }
+        },
         "/api/v0.3/attempts/start": {
             "post": {
                 "operationId": "api.v0_3.attempts.start",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\API\V0_3\ComplianceDsarController;
 use App\Http\Controllers\API\V0_3\EmailCaptureController;
 use App\Http\Controllers\API\V0_3\EmailPreferenceController;
 use App\Http\Controllers\API\V0_3\MbtiCompareInviteController;
+use App\Http\Controllers\API\V0_3\MbtiAttributionEventController;
 use App\Http\Controllers\API\V0_3\MeController as MeV03Controller;
 use App\Http\Controllers\API\V0_3\OrgInvitesController;
 use App\Http\Controllers\API\V0_3\OrgsController;
@@ -280,6 +281,12 @@ Route::prefix('v0.3')->middleware([
                 'throttle:api_track',
             ])
             ->where('shareId', '[A-Za-z0-9_-]{6,128}');
+        Route::post('/analytics/mbti-attribution-events', [MbtiAttributionEventController::class, 'store'])
+            ->middleware([
+                \App\Http\Middleware\LimitApiPublicPayloadSize::class,
+                'throttle:api_track',
+            ])
+            ->name('api.v0_3.analytics.mbti_attribution_events.store');
         Route::get('/compare/mbti/{inviteId}', [MbtiCompareInviteController::class, 'show'])
             ->middleware([
                 \App\Http\Middleware\FmTokenOptional::class,

--- a/backend/tests/Feature/Analytics/MbtiAttributionEventIngestTest.php
+++ b/backend/tests/Feature/Analytics/MbtiAttributionEventIngestTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class MbtiAttributionEventIngestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ingest_endpoint_persists_mbti_attribution_event_with_envelope_payload(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.3/analytics/mbti-attribution-events', [
+            'eventName' => 'landing_view',
+            'anonymousId' => 'anon_pr7_001',
+            'path' => '/zh/topics/mbti',
+            'timestamp' => '2026-04-06T10:00:00+08:00',
+            'payload' => [
+                'entry_surface' => 'mbti_topic_detail',
+                'source_page_type' => 'topic_detail',
+                'target_action' => 'start_mbti_test_primary',
+                'test_slug' => 'mbti-personality-test-16-personality-types',
+                'form_code' => 'mbti_144',
+                'landing_path' => '/zh/topics/mbti',
+                'locale' => 'zh',
+            ],
+        ]);
+
+        $response->assertStatus(202);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('event_code', 'landing_view');
+
+        $row = DB::table('events')
+            ->where('event_code', 'landing_view')
+            ->where('anon_id', 'anon_pr7_001')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame(0, (int) ($row->org_id ?? 0));
+
+        $meta = is_array($row->meta_json ?? null)
+            ? $row->meta_json
+            : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
+
+        $this->assertSame('mbti_topic_detail', $meta['entry_surface'] ?? null);
+        $this->assertSame('/zh/topics/mbti', $meta['landing_path'] ?? null);
+    }
+
+    public function test_ingest_endpoint_rejects_missing_or_invalid_ingest_token(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $response = $this->postJson('/api/v0.3/analytics/mbti-attribution-events', [
+            'eventName' => 'landing_view',
+            'payload' => [
+                'entry_surface' => 'mbti_topic_detail',
+            ],
+        ]);
+
+        $response->assertStatus(401);
+        $response->assertJsonPath('ok', false);
+        $response->assertJsonPath('error_code', 'UNAUTHORIZED');
+    }
+}

--- a/backend/tests/Feature/Analytics/MbtiAttributionFunnelDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/MbtiAttributionFunnelDailyBuilderTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\MbtiAttributionFunnelDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiAttributionFunnelDailyBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_refresh_builds_mbti_rows_grouped_by_entry_surface_and_source_page_type(): void
+    {
+        $orgId = 11;
+        $day = CarbonImmutable::parse('2026-04-06 09:00:00');
+
+        $attemptTopic = (string) Str::uuid();
+        $attemptPersonality = (string) Str::uuid();
+
+        $this->insertMbtiAttempt(
+            attemptId: $attemptTopic,
+            orgId: $orgId,
+            locale: 'zh',
+            createdAt: $day,
+            entrySurface: 'mbti_topic_detail',
+            sourcePageType: 'topic_detail',
+            testSlug: 'mbti-personality-test-16-personality-types',
+            formCode: 'mbti_144',
+        );
+        $this->insertMbtiAttempt(
+            attemptId: $attemptPersonality,
+            orgId: $orgId,
+            locale: 'zh',
+            createdAt: $day->addMinutes(5),
+            entrySurface: 'mbti_personality_detail',
+            sourcePageType: 'personality_detail',
+            testSlug: 'mbti-personality-test-16-personality-types',
+            formCode: 'mbti_144',
+        );
+
+        $this->insertEvent($orgId, 'landing_view', null, $day, [
+            'entry_surface' => 'mbti_topic_detail',
+            'source_page_type' => 'topic_detail',
+            'test_slug' => 'mbti-personality-test-16-personality-types',
+            'form_code' => 'mbti_144',
+            'locale' => 'zh',
+        ]);
+        $this->insertEvent($orgId, 'start_click', null, $day->addMinute(), [
+            'entry_surface' => 'mbti_topic_detail',
+            'source_page_type' => 'topic_detail',
+            'test_slug' => 'mbti-personality-test-16-personality-types',
+            'form_code' => 'mbti_144',
+            'locale' => 'zh',
+        ]);
+        $this->insertEvent($orgId, 'view_result', $attemptTopic, $day->addMinutes(10));
+        $this->insertEvent($orgId, 'click_unlock', $attemptTopic, $day->addMinutes(12));
+        $this->insertEvent($orgId, 'invite_create_success', $attemptTopic, $day->addMinutes(15));
+        $this->insertEvent($orgId, 'invite_share_or_copy', $attemptTopic, $day->addMinutes(16));
+        $this->insertEvent($orgId, 'invite_unlock_completion_qualified', $attemptTopic, $day->addMinutes(40), [
+            'target_attempt_id' => $attemptTopic,
+            'completion_id' => (string) Str::uuid(),
+        ]);
+        $this->insertEvent($orgId, 'invite_unlock_full_granted', $attemptTopic, $day->addMinutes(41), [
+            'target_attempt_id' => $attemptTopic,
+        ]);
+
+        $this->insertOrder(
+            orderNo: 'ord_pr7_mbti_001',
+            attemptId: $attemptTopic,
+            orgId: $orgId,
+            createdAt: $day->addMinutes(20),
+            paidAt: $day->addMinutes(24),
+            fulfilledAt: $day->addMinutes(28),
+        );
+
+        $result = app(MbtiAttributionFunnelDailyBuilder::class)->refresh(
+            $day,
+            $day,
+            [$orgId],
+            false,
+        );
+
+        $this->assertSame(2, (int) ($result['upserted_rows'] ?? 0));
+
+        $topicRow = DB::table('analytics_mbti_attribution_daily')
+            ->where('day', $day->toDateString())
+            ->where('org_id', $orgId)
+            ->where('locale', 'zh')
+            ->where('entry_surface', 'mbti_topic_detail')
+            ->where('source_page_type', 'topic_detail')
+            ->first();
+
+        $this->assertNotNull($topicRow);
+        $this->assertSame(1, (int) ($topicRow->entry_views ?? 0));
+        $this->assertSame(1, (int) ($topicRow->start_clicks ?? 0));
+        $this->assertSame(1, (int) ($topicRow->start_attempts ?? 0));
+        $this->assertSame(1, (int) ($topicRow->result_views ?? 0));
+        $this->assertSame(1, (int) ($topicRow->unlock_clicks ?? 0));
+        $this->assertSame(1, (int) ($topicRow->orders_created ?? 0));
+        $this->assertSame(1, (int) ($topicRow->payments_confirmed ?? 0));
+        $this->assertSame(1, (int) ($topicRow->invite_creates ?? 0));
+        $this->assertSame(1, (int) ($topicRow->invite_shares ?? 0));
+        $this->assertSame(1, (int) ($topicRow->invite_completions ?? 0));
+        $this->assertSame(1, (int) ($topicRow->payment_unlock_successes ?? 0));
+        $this->assertSame(1, (int) ($topicRow->invite_unlock_successes ?? 0));
+        $this->assertSame(2, (int) ($topicRow->unlock_successes ?? 0));
+
+        $personalityRow = DB::table('analytics_mbti_attribution_daily')
+            ->where('day', $day->toDateString())
+            ->where('org_id', $orgId)
+            ->where('locale', 'zh')
+            ->where('entry_surface', 'mbti_personality_detail')
+            ->where('source_page_type', 'personality_detail')
+            ->first();
+
+        $this->assertNotNull($personalityRow);
+        $this->assertSame(1, (int) ($personalityRow->start_attempts ?? 0));
+        $this->assertSame(0, (int) ($personalityRow->entry_views ?? 0));
+        $this->assertSame(0, (int) ($personalityRow->payments_confirmed ?? 0));
+    }
+
+    private function insertMbtiAttempt(
+        string $attemptId,
+        int $orgId,
+        string $locale,
+        CarbonImmutable $createdAt,
+        string $entrySurface,
+        string $sourcePageType,
+        string $testSlug,
+        string $formCode,
+    ): void {
+        $answersSummary = [
+            'stage' => 'start',
+            'meta' => [
+                'entry_surface' => $entrySurface,
+                'source_page_type' => $sourcePageType,
+                'test_slug' => $testSlug,
+                'form_code' => $formCode,
+                'landing_path' => '/zh/tests/mbti-personality-test-16-personality-types',
+            ],
+        ];
+
+        $row = [
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'anon_id' => 'anon_'.substr(str_replace('-', '', $attemptId), 0, 10),
+            'user_id' => null,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'question_count' => 93,
+            'answers_summary_json' => json_encode($answersSummary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'channel' => 'web',
+            'referrer' => '/tests/mbti-personality-test-16-personality-types',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'started_at' => $createdAt,
+            'submitted_at' => null,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_04',
+            'content_package_version' => 'content_2026_04',
+            'scoring_spec_version' => 'scoring_2026_04',
+            'norm_version' => 'norm_2026_04',
+            'result_json' => json_encode(['type_code' => 'INTJ'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ];
+
+        if (Schema::hasColumn('attempts', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('attempts', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        DB::table('attempts')->insert($row);
+    }
+
+    private function insertEvent(
+        int $orgId,
+        string $eventCode,
+        ?string $attemptId,
+        CarbonImmutable $occurredAt,
+        array $meta = [],
+    ): void {
+        $metaPayload = array_merge([
+            'attempt_id' => $attemptId,
+            'target_attempt_id' => $attemptId,
+        ], $meta);
+
+        $row = [
+            'id' => (string) Str::uuid(),
+            'event_code' => $eventCode,
+            'event_name' => $eventCode,
+            'org_id' => $orgId,
+            'user_id' => null,
+            'anon_id' => $attemptId ? 'anon_'.$attemptId : null,
+            'session_id' => 'session_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 8),
+            'request_id' => 'req_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 12),
+            'attempt_id' => $attemptId,
+            'meta_json' => json_encode($metaPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $occurredAt,
+            'share_id' => null,
+            'created_at' => $occurredAt,
+            'updated_at' => $occurredAt,
+            'scale_code' => 'MBTI',
+            'channel' => 'web',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh',
+        ];
+
+        if (Schema::hasColumn('events', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('events', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        DB::table('events')->insert($row);
+    }
+
+    private function insertOrder(
+        string $orderNo,
+        string $attemptId,
+        int $orgId,
+        CarbonImmutable $createdAt,
+        CarbonImmutable $paidAt,
+        CarbonImmutable $fulfilledAt,
+    ): void {
+        $row = [
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'provider' => 'stripe',
+            'status' => 'fulfilled',
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'amount_cents' => 199,
+            'currency' => 'CNY',
+            'sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'user_id' => null,
+            'anon_id' => 'anon_'.$attemptId,
+            'org_id' => $orgId,
+            'target_attempt_id' => $attemptId,
+            'paid_at' => $paidAt,
+            'fulfilled_at' => $fulfilledAt,
+            'created_at' => $createdAt,
+            'updated_at' => $fulfilledAt,
+        ];
+
+        if (Schema::hasColumn('orders', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('orders', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $row['amount_total'] = 199;
+        }
+
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $row['item_sku'] = 'MBTI_REPORT_FULL';
+        }
+
+        DB::table('orders')->insert($row);
+    }
+}

--- a/backend/tests/Feature/Analytics/ReportMbtiAttributionDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/ReportMbtiAttributionDailyCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class ReportMbtiAttributionDailyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_report_command_outputs_grouped_rows_and_invite_unlock_contribution_rate(): void
+    {
+        DB::table('analytics_mbti_attribution_daily')->insert([
+            'day' => '2026-04-06',
+            'org_id' => 7,
+            'locale' => 'zh',
+            'entry_surface' => 'mbti_topic_detail',
+            'source_page_type' => 'topic_detail',
+            'test_slug' => 'mbti-personality-test-16-personality-types',
+            'form_code' => 'mbti_144',
+            'entry_views' => 10,
+            'start_clicks' => 5,
+            'start_attempts' => 4,
+            'result_views' => 3,
+            'unlock_clicks' => 2,
+            'orders_created' => 2,
+            'payments_confirmed' => 1,
+            'unlock_successes' => 2,
+            'payment_unlock_successes' => 1,
+            'invite_creates' => 2,
+            'invite_shares' => 1,
+            'invite_completions' => 1,
+            'invite_unlock_successes' => 1,
+            'last_refreshed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('analytics:report-mbti-attribution-daily', [
+            '--from' => '2026-04-06',
+            '--to' => '2026-04-06',
+            '--org' => [7],
+            '--json' => true,
+        ])->expectsOutputToContain('"entry_surface":"mbti_topic_detail"')
+            ->assertSuccessful();
+    }
+}

--- a/backend/tests/Feature/AttemptStartPersistenceTest.php
+++ b/backend/tests/Feature/AttemptStartPersistenceTest.php
@@ -50,4 +50,43 @@ final class AttemptStartPersistenceTest extends TestCase
         $this->assertGreaterThan(0, (int) ($attempt->question_count ?? 0));
         $this->assertNotNull($attempt->started_at);
     }
+
+    public function test_attempt_start_persists_mbti_entry_attribution_fields_into_meta(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'test_anon_mbti_attr';
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'anon_id' => $anonId,
+            'form_code' => 'mbti_144',
+            'entrypoint' => 'mbti_topic_detail',
+            'entry_surface' => 'mbti_topic_detail',
+            'source_page_type' => 'topic_detail',
+            'target_action' => 'start_mbti_test_primary',
+            'test_slug' => 'mbti-personality-test-16-personality-types',
+            'landing_path' => '/zh/topics/mbti',
+        ]);
+
+        $response->assertStatus(200);
+        $attemptId = (string) $response->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $attempt = DB::table('attempts')->where('id', $attemptId)->first();
+        $this->assertNotNull($attempt);
+
+        $summary = is_array($attempt->answers_summary_json ?? null)
+            ? $attempt->answers_summary_json
+            : (json_decode((string) ($attempt->answers_summary_json ?? '{}'), true) ?: []);
+        $meta = is_array($summary['meta'] ?? null) ? $summary['meta'] : [];
+
+        $this->assertSame('mbti_topic_detail', $meta['entrypoint'] ?? null);
+        $this->assertSame('mbti_topic_detail', $meta['entry_surface'] ?? null);
+        $this->assertSame('topic_detail', $meta['source_page_type'] ?? null);
+        $this->assertSame('start_mbti_test_primary', $meta['target_action'] ?? null);
+        $this->assertSame('mbti-personality-test-16-personality-types', $meta['test_slug'] ?? null);
+        $this->assertSame('/zh/topics/mbti', $meta['landing_path'] ?? null);
+    }
 }


### PR DESCRIPTION
## Summary
- add MBTI attribution ingest endpoint for web `/api/track` envelope events
- add MBTI attribution daily read model (`analytics_mbti_attribution_daily`) grouped by `entry_surface/source_page_type`
- add builder + refresh command + report command for operations use
- persist MBTI start-attempt entry attribution fields (`entry_surface/source_page_type/target_action/test_slug/landing_path`) into attempt meta
- add feature tests for ingest, builder, command output, and attempt attribution persistence

## Why
MBTI already has conversion capability, but post-launch operations still cannot stably answer funnel contribution by entry surface through payment and invite completion. This PR adds the minimal backend authority read model for PR-7.

## New capabilities
- POST `/api/v0.3/analytics/mbti-attribution-events`
- `analytics:refresh-mbti-attribution-daily`
- `analytics:report-mbti-attribution-daily`

## Validation
- `php artisan test --filter='(MbtiAttributionEventIngestTest|MbtiAttributionFunnelDailyBuilderTest|ReportMbtiAttributionDailyCommandTest|AttemptStartPersistenceTest)'`
- `php artisan test --filter='(AnalyticsFunnelDailyBuilderTest|RefreshAnalyticsFunnelDailyCommandTest|MbtiAttributionEventIngestTest|MbtiAttributionFunnelDailyBuilderTest|ReportMbtiAttributionDailyCommandTest)'`
