### PR TITLE
PR-B1: Build Career UUID-first ontology and immutable snapshot foundation

### DIFF
--- a/backend/app/Domain/Career/IndexStateValue.php
+++ b/backend/app/Domain/Career/IndexStateValue.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career;
+
+final class IndexStateValue
+{
+    public const UNAVAILABLE = 'unavailable';
+
+    public const TRUST_LIMITED = 'trust_limited';
+
+    public const NOINDEX = 'noindex';
+
+    public const INDEXABLE = 'indexable';
+}

--- a/backend/app/Domain/Career/ProjectionLineageReason.php
+++ b/backend/app/Domain/Career/ProjectionLineageReason.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career;
+
+final class ProjectionLineageReason
+{
+    public const INITIAL_CAPTURE = 'initial_capture';
+
+    public const CONTEXT_REFRESH = 'context_refresh';
+
+    public const ASSESSMENT_REFRESH = 'assessment_refresh';
+
+    public const MANUAL_RECOMPUTE = 'manual_recompute';
+}

--- a/backend/app/Domain/Career/ReviewerStatus.php
+++ b/backend/app/Domain/Career/ReviewerStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career;
+
+final class ReviewerStatus
+{
+    public const PENDING = 'pending';
+
+    public const IN_REVIEW = 'in_review';
+
+    public const APPROVED = 'approved';
+
+    public const CHANGES_REQUIRED = 'changes_required';
+}

--- a/backend/app/Models/CareerFoundationModel.php
+++ b/backend/app/Models/CareerFoundationModel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+abstract class CareerFoundationModel extends Model
+{
+    use HasUuids;
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $guarded = [];
+}

--- a/backend/app/Models/CareerImmutableFoundationModel.php
+++ b/backend/app/Models/CareerImmutableFoundationModel.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+abstract class CareerImmutableFoundationModel extends CareerFoundationModel
+{
+    public const UPDATED_AT = null;
+}

--- a/backend/app/Models/ContextSnapshot.php
+++ b/backend/app/Models/ContextSnapshot.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ContextSnapshot extends CareerImmutableFoundationModel
+{
+    protected $table = 'context_snapshots';
+
+    protected $casts = [
+        'captured_at' => 'datetime',
+        'burnout_level' => 'float',
+        'switch_urgency' => 'float',
+        'risk_tolerance' => 'float',
+        'family_constraint_level' => 'float',
+        'manager_track_preference' => 'float',
+        'time_horizon_months' => 'integer',
+        'context_payload' => 'array',
+        'created_at' => 'datetime',
+    ];
+
+    public function currentOccupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'current_occupation_id', 'id');
+    }
+
+    public function profileProjections(): HasMany
+    {
+        return $this->hasMany(ProfileProjection::class, 'context_snapshot_id', 'id');
+    }
+
+    public function recommendationSnapshots(): HasMany
+    {
+        return $this->hasMany(RecommendationSnapshot::class, 'context_snapshot_id', 'id');
+    }
+}

--- a/backend/app/Models/EditorialPatch.php
+++ b/backend/app/Models/EditorialPatch.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EditorialPatch extends CareerFoundationModel
+{
+    protected $table = 'editorial_patches';
+
+    protected $casts = [
+        'required' => 'boolean',
+        'notes' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/app/Models/IndexState.php
+++ b/backend/app/Models/IndexState.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class IndexState extends CareerFoundationModel
+{
+    protected $table = 'index_states';
+
+    protected $casts = [
+        'index_eligible' => 'boolean',
+        'reason_codes' => 'array',
+        'changed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/app/Models/Occupation.php
+++ b/backend/app/Models/Occupation.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Occupation extends CareerFoundationModel
+{
+    protected $table = 'occupations';
+
+    protected $casts = [
+        'structural_stability' => 'float',
+        'task_prototype_signature' => 'array',
+        'market_semantics_gap' => 'float',
+        'regulatory_divergence' => 'float',
+        'toolchain_divergence' => 'float',
+        'skill_gap_threshold' => 'float',
+        'trust_inheritance_scope' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function family(): BelongsTo
+    {
+        return $this->belongsTo(OccupationFamily::class, 'family_id', 'id');
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id', 'id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id', 'id');
+    }
+
+    public function aliases(): HasMany
+    {
+        return $this->hasMany(OccupationAlias::class, 'occupation_id', 'id');
+    }
+
+    public function crosswalks(): HasMany
+    {
+        return $this->hasMany(OccupationCrosswalk::class, 'occupation_id', 'id');
+    }
+
+    public function truthMetrics(): HasMany
+    {
+        return $this->hasMany(OccupationTruthMetric::class, 'occupation_id', 'id');
+    }
+
+    public function skillGraphs(): HasMany
+    {
+        return $this->hasMany(OccupationSkillGraph::class, 'occupation_id', 'id');
+    }
+
+    public function trustManifests(): HasMany
+    {
+        return $this->hasMany(TrustManifest::class, 'occupation_id', 'id');
+    }
+
+    public function editorialPatches(): HasMany
+    {
+        return $this->hasMany(EditorialPatch::class, 'occupation_id', 'id');
+    }
+
+    public function indexStates(): HasMany
+    {
+        return $this->hasMany(IndexState::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/app/Models/OccupationAlias.php
+++ b/backend/app/Models/OccupationAlias.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OccupationAlias extends CareerFoundationModel
+{
+    protected $table = 'occupation_aliases';
+
+    protected $casts = [
+        'precision_score' => 'float',
+        'confidence_score' => 'float',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+
+    public function family(): BelongsTo
+    {
+        return $this->belongsTo(OccupationFamily::class, 'family_id', 'id');
+    }
+}

--- a/backend/app/Models/OccupationCrosswalk.php
+++ b/backend/app/Models/OccupationCrosswalk.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OccupationCrosswalk extends CareerFoundationModel
+{
+    protected $table = 'occupation_crosswalks';
+
+    protected $casts = [
+        'confidence_score' => 'float',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/app/Models/OccupationFamily.php
+++ b/backend/app/Models/OccupationFamily.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class OccupationFamily extends CareerFoundationModel
+{
+    protected $table = 'occupation_families';
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupations(): HasMany
+    {
+        return $this->hasMany(Occupation::class, 'family_id', 'id');
+    }
+
+    public function aliases(): HasMany
+    {
+        return $this->hasMany(OccupationAlias::class, 'family_id', 'id');
+    }
+}

--- a/backend/app/Models/OccupationSkillGraph.php
+++ b/backend/app/Models/OccupationSkillGraph.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OccupationSkillGraph extends CareerFoundationModel
+{
+    protected $table = 'occupation_skill_graphs';
+
+    protected $casts = [
+        'skill_overlap_graph' => 'array',
+        'task_overlap_graph' => 'array',
+        'tool_overlap_graph' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/app/Models/OccupationTruthMetric.php
+++ b/backend/app/Models/OccupationTruthMetric.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OccupationTruthMetric extends CareerFoundationModel
+{
+    protected $table = 'occupation_truth_metrics';
+
+    protected $casts = [
+        'median_pay_usd_annual' => 'integer',
+        'jobs_2024' => 'integer',
+        'projected_jobs_2034' => 'integer',
+        'employment_change' => 'integer',
+        'outlook_pct_2024_2034' => 'float',
+        'ai_exposure' => 'float',
+        'effective_at' => 'datetime',
+        'reviewed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+
+    public function sourceTrace(): BelongsTo
+    {
+        return $this->belongsTo(SourceTrace::class, 'source_trace_id', 'id');
+    }
+}

--- a/backend/app/Models/ProfileProjection.php
+++ b/backend/app/Models/ProfileProjection.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class ProfileProjection extends CareerImmutableFoundationModel
+{
+    protected $table = 'profile_projections';
+
+    protected $casts = [
+        'psychometric_axis_coverage' => 'float',
+        'projection_payload' => 'array',
+        'created_at' => 'datetime',
+    ];
+
+    public function contextSnapshot(): BelongsTo
+    {
+        return $this->belongsTo(ContextSnapshot::class, 'context_snapshot_id', 'id');
+    }
+
+    public function parentLineages(): HasMany
+    {
+        return $this->hasMany(ProjectionLineage::class, 'parent_projection_id', 'id');
+    }
+
+    public function childLineage(): HasOne
+    {
+        return $this->hasOne(ProjectionLineage::class, 'child_projection_id', 'id');
+    }
+
+    public function recommendationSnapshots(): HasMany
+    {
+        return $this->hasMany(RecommendationSnapshot::class, 'profile_projection_id', 'id');
+    }
+}

--- a/backend/app/Models/ProjectionLineage.php
+++ b/backend/app/Models/ProjectionLineage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProjectionLineage extends CareerImmutableFoundationModel
+{
+    protected $table = 'projection_lineages';
+
+    protected $casts = [
+        'diff_summary' => 'array',
+        'created_at' => 'datetime',
+    ];
+
+    public function parentProjection(): BelongsTo
+    {
+        return $this->belongsTo(ProfileProjection::class, 'parent_projection_id', 'id');
+    }
+
+    public function childProjection(): BelongsTo
+    {
+        return $this->belongsTo(ProfileProjection::class, 'child_projection_id', 'id');
+    }
+
+    public function triggerContextSnapshot(): BelongsTo
+    {
+        return $this->belongsTo(ContextSnapshot::class, 'trigger_context_snapshot_id', 'id');
+    }
+}

--- a/backend/app/Models/RecommendationSnapshot.php
+++ b/backend/app/Models/RecommendationSnapshot.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class RecommendationSnapshot extends CareerImmutableFoundationModel
+{
+    protected $table = 'recommendation_snapshots';
+
+    protected $casts = [
+        'snapshot_payload' => 'array',
+        'created_at' => 'datetime',
+    ];
+
+    public function profileProjection(): BelongsTo
+    {
+        return $this->belongsTo(ProfileProjection::class, 'profile_projection_id', 'id');
+    }
+
+    public function contextSnapshot(): BelongsTo
+    {
+        return $this->belongsTo(ContextSnapshot::class, 'context_snapshot_id', 'id');
+    }
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+
+    public function transitionPaths(): HasMany
+    {
+        return $this->hasMany(TransitionPath::class, 'recommendation_snapshot_id', 'id');
+    }
+}

--- a/backend/app/Models/SourceTrace.php
+++ b/backend/app/Models/SourceTrace.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class SourceTrace extends CareerFoundationModel
+{
+    protected $table = 'source_traces';
+
+    protected $casts = [
+        'fields_used' => 'array',
+        'retrieved_at' => 'datetime',
+        'evidence_strength' => 'float',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function truthMetrics(): HasMany
+    {
+        return $this->hasMany(OccupationTruthMetric::class, 'source_trace_id', 'id');
+    }
+}

--- a/backend/app/Models/TransitionPath.php
+++ b/backend/app/Models/TransitionPath.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TransitionPath extends CareerImmutableFoundationModel
+{
+    protected $table = 'transition_paths';
+
+    protected $casts = [
+        'path_payload' => 'array',
+        'created_at' => 'datetime',
+    ];
+
+    public function recommendationSnapshot(): BelongsTo
+    {
+        return $this->belongsTo(RecommendationSnapshot::class, 'recommendation_snapshot_id', 'id');
+    }
+
+    public function fromOccupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'from_occupation_id', 'id');
+    }
+
+    public function toOccupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'to_occupation_id', 'id');
+    }
+}

--- a/backend/app/Models/TrustManifest.php
+++ b/backend/app/Models/TrustManifest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TrustManifest extends CareerImmutableFoundationModel
+{
+    protected $table = 'trust_manifests';
+
+    protected $casts = [
+        'locale_context' => 'array',
+        'methodology' => 'array',
+        'reviewed_at' => 'datetime',
+        'ai_assistance' => 'array',
+        'quality' => 'array',
+        'last_substantive_update_at' => 'datetime',
+        'next_review_due_at' => 'datetime',
+        'created_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/database/migrations/2026_04_07_000100_create_occupation_families_table.php
+++ b/backend/database/migrations/2026_04_07_000100_create_occupation_families_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('occupation_families')) {
+            return;
+        }
+
+        Schema::create('occupation_families', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('canonical_slug', 160)->unique();
+            $table->string('title_en', 255);
+            $table->string('title_zh', 255);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_000200_create_occupations_table.php
+++ b/backend/database/migrations/2026_04_07_000200_create_occupations_table.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('occupations')) {
+            return;
+        }
+
+        Schema::create('occupations', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('family_id');
+            $table->uuid('parent_id')->nullable();
+            $table->string('canonical_slug', 160)->unique();
+            $table->string('entity_level', 64);
+            $table->string('truth_market', 32);
+            $table->string('display_market', 32);
+            $table->string('crosswalk_mode', 64);
+            $table->string('canonical_title_en', 255);
+            $table->string('canonical_title_zh', 255);
+            $table->string('search_h1_zh', 255);
+            $table->decimal('structural_stability', 5, 4)->nullable();
+            $table->json('task_prototype_signature')->nullable();
+            $table->decimal('market_semantics_gap', 5, 4)->nullable();
+            $table->decimal('regulatory_divergence', 5, 4)->nullable();
+            $table->decimal('toolchain_divergence', 5, 4)->nullable();
+            $table->decimal('skill_gap_threshold', 5, 4)->nullable();
+            $table->json('trust_inheritance_scope')->nullable();
+            $table->timestamps();
+
+            $table->index(['family_id', 'entity_level'], 'occupations_family_level_idx');
+            $table->index(['truth_market', 'display_market'], 'occupations_market_idx');
+
+            $table->foreign('family_id')
+                ->references('id')
+                ->on('occupation_families')
+                ->restrictOnDelete();
+            $table->foreign('parent_id')
+                ->references('id')
+                ->on('occupations')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_000300_create_occupation_aliases_table.php
+++ b/backend/database/migrations/2026_04_07_000300_create_occupation_aliases_table.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('occupation_aliases')) {
+            return;
+        }
+
+        Schema::create('occupation_aliases', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id')->nullable();
+            $table->foreignUuid('family_id')->nullable();
+            $table->string('alias', 255);
+            $table->string('normalized', 255);
+            $table->string('lang', 16);
+            $table->string('register', 64);
+            $table->string('intent_scope', 64);
+            $table->string('target_kind', 64);
+            $table->decimal('precision_score', 5, 4)->nullable();
+            $table->decimal('confidence_score', 5, 4)->nullable();
+            $table->string('seniority_hint', 64)->nullable();
+            $table->string('function_hint', 128)->nullable();
+            $table->timestamps();
+
+            $table->index(['normalized', 'lang'], 'occupation_aliases_lookup_idx');
+            $table->index(['occupation_id', 'family_id'], 'occupation_aliases_target_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+            $table->foreign('family_id')
+                ->references('id')
+                ->on('occupation_families')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_000400_create_occupation_crosswalks_table.php
+++ b/backend/database/migrations/2026_04_07_000400_create_occupation_crosswalks_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('occupation_crosswalks')) {
+            return;
+        }
+
+        Schema::create('occupation_crosswalks', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->string('source_system', 64);
+            $table->string('source_code', 128)->nullable();
+            $table->string('source_title', 255);
+            $table->string('mapping_type', 64);
+            $table->decimal('confidence_score', 5, 4)->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->index(['occupation_id', 'source_system'], 'occupation_crosswalks_occ_system_idx');
+            $table->index(['source_system', 'source_code'], 'occupation_crosswalks_source_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_000500_create_source_traces_table.php
+++ b/backend/database/migrations/2026_04_07_000500_create_source_traces_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('source_traces')) {
+            return;
+        }
+
+        Schema::create('source_traces', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('source_id', 128);
+            $table->string('source_type', 64);
+            $table->string('title', 255);
+            $table->string('url', 2048)->nullable();
+            $table->json('fields_used');
+            $table->timestamp('retrieved_at');
+            $table->decimal('evidence_strength', 5, 4)->nullable();
+            $table->timestamps();
+
+            $table->index(['source_type', 'source_id'], 'source_traces_type_source_idx');
+            $table->index('retrieved_at', 'source_traces_retrieved_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_000600_create_occupation_truth_metrics_table.php
+++ b/backend/database/migrations/2026_04_07_000600_create_occupation_truth_metrics_table.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('occupation_truth_metrics')) {
+            return;
+        }
+
+        Schema::create('occupation_truth_metrics', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->foreignUuid('source_trace_id')->nullable();
+            $table->unsignedBigInteger('median_pay_usd_annual')->nullable();
+            $table->unsignedBigInteger('jobs_2024')->nullable();
+            $table->unsignedBigInteger('projected_jobs_2034')->nullable();
+            $table->bigInteger('employment_change')->nullable();
+            $table->decimal('outlook_pct_2024_2034', 6, 2)->nullable();
+            $table->string('outlook_description', 255)->nullable();
+            $table->string('entry_education', 255)->nullable();
+            $table->string('work_experience', 255)->nullable();
+            $table->string('on_the_job_training', 255)->nullable();
+            $table->decimal('ai_exposure', 6, 2)->nullable();
+            $table->longText('ai_rationale')->nullable();
+            $table->string('truth_market', 32);
+            $table->timestamp('effective_at');
+            $table->timestamp('reviewed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['occupation_id', 'effective_at'], 'occupation_truth_metrics_occ_effective_idx');
+            $table->index(['truth_market', 'effective_at'], 'occupation_truth_metrics_market_effective_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+            $table->foreign('source_trace_id')
+                ->references('id')
+                ->on('source_traces')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_000700_create_occupation_skill_graphs_table.php
+++ b/backend/database/migrations/2026_04_07_000700_create_occupation_skill_graphs_table.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('occupation_skill_graphs')) {
+            return;
+        }
+
+        Schema::create('occupation_skill_graphs', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->string('stack_key', 128);
+            $table->json('skill_overlap_graph');
+            $table->json('task_overlap_graph')->nullable();
+            $table->json('tool_overlap_graph')->nullable();
+            $table->timestamps();
+
+            $table->index(['occupation_id', 'stack_key'], 'occupation_skill_graphs_occ_stack_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_000800_create_trust_manifests_table.php
+++ b/backend/database/migrations/2026_04_07_000800_create_trust_manifests_table.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('trust_manifests')) {
+            return;
+        }
+
+        Schema::create('trust_manifests', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->string('content_version', 64);
+            $table->string('data_version', 64);
+            $table->string('logic_version', 64);
+            $table->json('locale_context');
+            $table->json('methodology');
+            $table->string('reviewer_status', 64);
+            $table->string('reviewer_id', 128)->nullable();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->json('ai_assistance')->nullable();
+            $table->json('quality')->nullable();
+            $table->timestamp('last_substantive_update_at');
+            $table->timestamp('next_review_due_at')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['occupation_id', 'created_at'], 'trust_manifests_occ_created_idx');
+            $table->index(['reviewer_status', 'next_review_due_at'], 'trust_manifests_review_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_000900_create_editorial_patches_table.php
+++ b/backend/database/migrations/2026_04_07_000900_create_editorial_patches_table.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('editorial_patches')) {
+            return;
+        }
+
+        Schema::create('editorial_patches', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->boolean('required')->default(false);
+            $table->string('status', 64);
+            $table->string('patch_version', 64)->nullable();
+            $table->json('notes')->nullable();
+            $table->timestamps();
+
+            $table->index(['occupation_id', 'status'], 'editorial_patches_occ_status_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_001000_create_index_states_table.php
+++ b/backend/database/migrations/2026_04_07_001000_create_index_states_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('index_states')) {
+            return;
+        }
+
+        Schema::create('index_states', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->string('index_state', 64);
+            $table->boolean('index_eligible')->default(false);
+            $table->string('canonical_path', 255);
+            $table->string('canonical_target', 255)->nullable();
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('changed_at');
+            $table->timestamps();
+
+            $table->index(['occupation_id', 'changed_at'], 'index_states_occ_changed_idx');
+            $table->index(['index_state', 'index_eligible'], 'index_states_state_eligible_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_001100_create_context_snapshots_table.php
+++ b/backend/database/migrations/2026_04_07_001100_create_context_snapshots_table.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('context_snapshots')) {
+            return;
+        }
+
+        Schema::create('context_snapshots', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('identity_id', 64)->nullable();
+            $table->string('visitor_id', 64)->nullable();
+            $table->timestamp('captured_at');
+            $table->foreignUuid('current_occupation_id')->nullable();
+            $table->string('employment_status', 64)->nullable();
+            $table->string('monthly_comp_band', 64)->nullable();
+            $table->decimal('burnout_level', 6, 2)->nullable();
+            $table->decimal('switch_urgency', 6, 2)->nullable();
+            $table->decimal('risk_tolerance', 6, 2)->nullable();
+            $table->string('geo_region', 64)->nullable();
+            $table->decimal('family_constraint_level', 6, 2)->nullable();
+            $table->decimal('manager_track_preference', 6, 2)->nullable();
+            $table->unsignedInteger('time_horizon_months')->nullable();
+            $table->json('context_payload');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['identity_id', 'captured_at'], 'context_snapshots_identity_idx');
+            $table->index(['visitor_id', 'captured_at'], 'context_snapshots_visitor_idx');
+            $table->index('current_occupation_id', 'context_snapshots_current_occ_idx');
+
+            $table->foreign('current_occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_001200_create_profile_projections_table.php
+++ b/backend/database/migrations/2026_04_07_001200_create_profile_projections_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('profile_projections')) {
+            return;
+        }
+
+        Schema::create('profile_projections', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('identity_id', 64)->nullable();
+            $table->string('visitor_id', 64)->nullable();
+            $table->foreignUuid('context_snapshot_id');
+            $table->string('projection_version', 64);
+            $table->decimal('psychometric_axis_coverage', 6, 2)->nullable();
+            $table->json('projection_payload');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['context_snapshot_id', 'created_at'], 'profile_projections_context_idx');
+            $table->index(['identity_id', 'created_at'], 'profile_projections_identity_idx');
+            $table->index(['visitor_id', 'created_at'], 'profile_projections_visitor_idx');
+
+            $table->foreign('context_snapshot_id')
+                ->references('id')
+                ->on('context_snapshots')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_001300_create_projection_lineages_table.php
+++ b/backend/database/migrations/2026_04_07_001300_create_projection_lineages_table.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('projection_lineages')) {
+            return;
+        }
+
+        Schema::create('projection_lineages', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('parent_projection_id')->nullable();
+            $table->foreignUuid('child_projection_id');
+            $table->foreignUuid('trigger_context_snapshot_id')->nullable();
+            $table->string('trigger_assessment_id', 64)->nullable();
+            $table->string('lineage_reason', 64);
+            $table->json('diff_summary')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->unique('child_projection_id');
+            $table->index('parent_projection_id', 'projection_lineages_parent_idx');
+            $table->index('trigger_context_snapshot_id', 'projection_lineages_trigger_context_idx');
+
+            $table->foreign('parent_projection_id')
+                ->references('id')
+                ->on('profile_projections')
+                ->restrictOnDelete();
+            $table->foreign('child_projection_id')
+                ->references('id')
+                ->on('profile_projections')
+                ->restrictOnDelete();
+            $table->foreign('trigger_context_snapshot_id')
+                ->references('id')
+                ->on('context_snapshots')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_001400_create_recommendation_snapshots_table.php
+++ b/backend/database/migrations/2026_04_07_001400_create_recommendation_snapshots_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('recommendation_snapshots')) {
+            return;
+        }
+
+        Schema::create('recommendation_snapshots', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('profile_projection_id');
+            $table->foreignUuid('context_snapshot_id');
+            $table->foreignUuid('occupation_id');
+            $table->json('snapshot_payload');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['profile_projection_id', 'created_at'], 'recommendation_snapshots_projection_idx');
+            $table->index(['context_snapshot_id', 'occupation_id'], 'recommendation_snapshots_context_occ_idx');
+
+            $table->foreign('profile_projection_id')
+                ->references('id')
+                ->on('profile_projections')
+                ->restrictOnDelete();
+            $table->foreign('context_snapshot_id')
+                ->references('id')
+                ->on('context_snapshots')
+                ->restrictOnDelete();
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_04_07_001500_create_transition_paths_table.php
+++ b/backend/database/migrations/2026_04_07_001500_create_transition_paths_table.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('transition_paths')) {
+            return;
+        }
+
+        Schema::create('transition_paths', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('recommendation_snapshot_id');
+            $table->foreignUuid('from_occupation_id');
+            $table->foreignUuid('to_occupation_id');
+            $table->string('path_type', 64);
+            $table->json('path_payload');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['recommendation_snapshot_id', 'path_type'], 'transition_paths_snapshot_type_idx');
+            $table->index(['from_occupation_id', 'to_occupation_id'], 'transition_paths_occ_pair_idx');
+
+            $table->foreign('recommendation_snapshot_id')
+                ->references('id')
+                ->on('recommendation_snapshots')
+                ->restrictOnDelete();
+            $table->foreign('from_occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+            $table->foreign('to_occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Career/CareerFoundationLineageTest.php
+++ b/backend/tests/Feature/Career/CareerFoundationLineageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\RecommendationSnapshot;
+use App\Models\TransitionPath;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerFoundationLineageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function lineage_chain_can_link_projection_context_recommendation_and_transition_rows(): void
+    {
+        $chain = CareerFoundationFixture::seedMinimalChain();
+
+        $recommendation = RecommendationSnapshot::query()->findOrFail($chain['recommendationSnapshot']->id);
+        $transitionPath = TransitionPath::query()->findOrFail($chain['transitionPath']->id);
+
+        $this->assertSame($chain['childProjection']->id, $recommendation->profileProjection?->id);
+        $this->assertSame($chain['contextSnapshot']->id, $recommendation->contextSnapshot?->id);
+        $this->assertSame($chain['occupation']->id, $recommendation->occupation?->id);
+        $this->assertSame($recommendation->id, $transitionPath->recommendationSnapshot?->id);
+        $this->assertSame($chain['occupation']->id, $transitionPath->fromOccupation?->id);
+        $this->assertSame($chain['occupation']->id, $transitionPath->toOccupation?->id);
+    }
+}

--- a/backend/tests/Feature/Career/CareerFoundationSchemaTest.php
+++ b/backend/tests/Feature/Career/CareerFoundationSchemaTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\ContextSnapshot;
+use App\Models\EditorialPatch;
+use App\Models\ProfileProjection;
+use App\Models\ProjectionLineage;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerFoundationSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function career_foundation_tables_exist_and_immutable_tables_have_no_updated_at_column(): void
+    {
+        $tables = [
+            'occupation_families',
+            'occupations',
+            'occupation_aliases',
+            'occupation_crosswalks',
+            'occupation_truth_metrics',
+            'occupation_skill_graphs',
+            'source_traces',
+            'trust_manifests',
+            'editorial_patches',
+            'index_states',
+            'context_snapshots',
+            'profile_projections',
+            'projection_lineages',
+            'recommendation_snapshots',
+            'transition_paths',
+        ];
+
+        foreach ($tables as $table) {
+            $this->assertTrue(Schema::hasTable($table), "Expected table {$table} to exist");
+        }
+
+        foreach (['context_snapshots', 'profile_projections', 'projection_lineages', 'recommendation_snapshots', 'transition_paths', 'trust_manifests'] as $table) {
+            $this->assertFalse(Schema::hasColumn($table, 'updated_at'), "Immutable table {$table} must not have updated_at");
+        }
+    }
+
+    #[Test]
+    public function immutable_chain_foreign_keys_do_not_use_cascade_delete(): void
+    {
+        foreach (['context_snapshots', 'profile_projections', 'projection_lineages', 'recommendation_snapshots', 'transition_paths'] as $table) {
+            $foreignKeys = DB::select("PRAGMA foreign_key_list('{$table}')");
+
+            foreach ($foreignKeys as $foreignKey) {
+                $this->assertNotSame('CASCADE', strtoupper((string) $foreignKey->on_delete), "Immutable table {$table} must not cascade delete");
+            }
+        }
+    }
+
+    #[Test]
+    public function append_friendly_snapshots_allow_multiple_rows_for_the_same_identity(): void
+    {
+        $chain = CareerFoundationFixture::seedMinimalChain();
+
+        $secondContext = ContextSnapshot::query()->create([
+            'identity_id' => 'identity-1',
+            'visitor_id' => 'visitor-1',
+            'captured_at' => now(),
+            'current_occupation_id' => $chain['occupation']->id,
+            'employment_status' => 'employed',
+            'context_payload' => ['trigger' => 'manual_refresh'],
+        ]);
+
+        $secondProjection = ProfileProjection::query()->create([
+            'identity_id' => 'identity-1',
+            'visitor_id' => 'visitor-1',
+            'context_snapshot_id' => $chain['contextSnapshot']->id,
+            'projection_version' => 'career_projection_v1',
+            'projection_payload' => ['fit_axes' => ['autonomy' => 0.77]],
+        ]);
+
+        $this->assertSame(2, ContextSnapshot::query()->where('identity_id', 'identity-1')->count());
+        $this->assertNotNull($secondContext->created_at);
+        $this->assertSame(3, ProfileProjection::query()->where('identity_id', 'identity-1')->count());
+        $this->assertNotNull($secondProjection->created_at);
+    }
+
+    #[Test]
+    public function projection_lineage_allows_one_direct_parent_per_child(): void
+    {
+        $chain = CareerFoundationFixture::seedMinimalChain();
+
+        $this->expectException(QueryException::class);
+
+        ProjectionLineage::query()->create([
+            'parent_projection_id' => $chain['parentProjection']->id,
+            'child_projection_id' => $chain['childProjection']->id,
+            'lineage_reason' => 'manual_recompute',
+            'diff_summary' => ['note' => 'duplicate direct parent should fail'],
+        ]);
+    }
+
+    #[Test]
+    public function immutable_history_rows_survive_editorial_changes(): void
+    {
+        $chain = CareerFoundationFixture::seedMinimalChain();
+
+        $chain['occupation']->update([
+            'canonical_title_en' => 'Backend Systems Architect',
+        ]);
+
+        $patch = EditorialPatch::query()->findOrFail($chain['editorialPatch']->id);
+        $patch->update([
+            'required' => true,
+            'status' => 'queued',
+        ]);
+
+        $this->assertDatabaseHas('context_snapshots', ['id' => $chain['contextSnapshot']->id]);
+        $this->assertDatabaseHas('profile_projections', ['id' => $chain['parentProjection']->id]);
+        $this->assertDatabaseHas('profile_projections', ['id' => $chain['childProjection']->id]);
+        $this->assertDatabaseHas('projection_lineages', ['id' => $chain['lineage']->id]);
+        $this->assertDatabaseHas('recommendation_snapshots', ['id' => $chain['recommendationSnapshot']->id]);
+        $this->assertDatabaseHas('transition_paths', ['id' => $chain['transitionPath']->id]);
+    }
+}

--- a/backend/tests/Fixtures/Career/CareerFoundationFixture.php
+++ b/backend/tests/Fixtures/Career/CareerFoundationFixture.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Career;
+
+use App\Domain\Career\IndexStateValue;
+use App\Domain\Career\ProjectionLineageReason;
+use App\Domain\Career\ReviewerStatus;
+use App\Models\ContextSnapshot;
+use App\Models\EditorialPatch;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationAlias;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use App\Models\OccupationSkillGraph;
+use App\Models\OccupationTruthMetric;
+use App\Models\ProfileProjection;
+use App\Models\ProjectionLineage;
+use App\Models\RecommendationSnapshot;
+use App\Models\SourceTrace;
+use App\Models\TransitionPath;
+use App\Models\TrustManifest;
+
+final class CareerFoundationFixture
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function seedMinimalChain(): array
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'software-engineering',
+            'title_en' => 'Software Engineering',
+            'title_zh' => '软件工程',
+        ]);
+
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => 'backend-architect',
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'trust_inheritance',
+            'canonical_title_en' => 'Backend Architect',
+            'canonical_title_zh' => '后端架构师',
+            'search_h1_zh' => '后端架构师职业诊断',
+            'structural_stability' => 0.84,
+            'task_prototype_signature' => [
+                'analysis' => 0.86,
+                'build' => 0.74,
+                'coordination' => 0.58,
+            ],
+            'market_semantics_gap' => 0.22,
+            'regulatory_divergence' => 0.14,
+            'toolchain_divergence' => 0.19,
+            'skill_gap_threshold' => 0.40,
+            'trust_inheritance_scope' => [
+                'allow_task_truth' => true,
+                'allow_pay_direct_inheritance' => false,
+            ],
+        ]);
+
+        $alias = OccupationAlias::query()->create([
+            'occupation_id' => $occupation->id,
+            'alias' => '后端架构师',
+            'normalized' => '后端架构师',
+            'lang' => 'zh-CN',
+            'register' => 'market_title',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.97,
+            'confidence_score' => 0.98,
+            'seniority_hint' => 'senior',
+            'function_hint' => 'backend_architecture',
+        ]);
+
+        $crosswalk = OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'us_soc',
+            'source_code' => '15-1252',
+            'source_title' => 'Software Developers',
+            'mapping_type' => 'trust_inheritance',
+            'confidence_score' => 0.84,
+            'notes' => 'BLS proxy for specialized market title.',
+        ]);
+
+        $sourceTrace = SourceTrace::query()->create([
+            'source_id' => 'bls_ooh_15_1252',
+            'source_type' => 'bls_ooh',
+            'title' => 'BLS Occupational Outlook Handbook',
+            'url' => 'https://www.bls.gov/ooh/computer-and-information-technology/software-developers.htm',
+            'fields_used' => ['median_pay_usd_annual', 'outlook_pct_2024_2034'],
+            'retrieved_at' => now()->subDay(),
+            'evidence_strength' => 0.92,
+        ]);
+
+        $truthMetric = OccupationTruthMetric::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_trace_id' => $sourceTrace->id,
+            'median_pay_usd_annual' => 133080,
+            'jobs_2024' => 1693800,
+            'projected_jobs_2034' => 1961400,
+            'employment_change' => 267700,
+            'outlook_pct_2024_2034' => 16,
+            'outlook_description' => 'Much faster than average',
+            'entry_education' => "Bachelor's degree",
+            'work_experience' => 'None',
+            'on_the_job_training' => 'None',
+            'ai_exposure' => 9,
+            'ai_rationale' => 'Routine coding work is being restructured by LLMs.',
+            'truth_market' => 'US',
+            'effective_at' => now()->subDays(7),
+            'reviewed_at' => now()->subDay(),
+        ]);
+
+        $skillGraph = OccupationSkillGraph::query()->create([
+            'occupation_id' => $occupation->id,
+            'stack_key' => 'core',
+            'skill_overlap_graph' => ['distributed_systems' => 0.82],
+            'task_overlap_graph' => ['api_contracts' => 0.91],
+            'tool_overlap_graph' => ['kubernetes' => 0.71],
+        ]);
+
+        $trustManifest = TrustManifest::query()->create([
+            'occupation_id' => $occupation->id,
+            'content_version' => 'v4.1',
+            'data_version' => '2026.04',
+            'logic_version' => 'foundation_only',
+            'locale_context' => ['truth_market' => 'US', 'display_market' => 'CN'],
+            'methodology' => ['source_program' => 'BLS OOH'],
+            'reviewer_status' => ReviewerStatus::APPROVED,
+            'reviewer_id' => 'editor-1',
+            'reviewed_at' => now()->subHours(4),
+            'ai_assistance' => ['used' => true, 'mode' => 'summary'],
+            'quality' => ['confidence' => 0.88],
+            'last_substantive_update_at' => now()->subDay(),
+            'next_review_due_at' => now()->addMonths(3),
+        ]);
+
+        $editorialPatch = EditorialPatch::query()->create([
+            'occupation_id' => $occupation->id,
+            'required' => false,
+            'status' => 'not_required',
+            'patch_version' => null,
+            'notes' => ['reason' => 'trust inheritance sufficient'],
+        ]);
+
+        $indexState = IndexState::query()->create([
+            'occupation_id' => $occupation->id,
+            'index_state' => IndexStateValue::TRUST_LIMITED,
+            'index_eligible' => false,
+            'canonical_path' => '/career/jobs/backend-architect',
+            'canonical_target' => null,
+            'reason_codes' => ['trust_limited'],
+            'changed_at' => now()->subHour(),
+        ]);
+
+        $contextSnapshot = ContextSnapshot::query()->create([
+            'identity_id' => 'identity-1',
+            'visitor_id' => 'visitor-1',
+            'captured_at' => now()->subMinutes(30),
+            'current_occupation_id' => $occupation->id,
+            'employment_status' => 'employed',
+            'monthly_comp_band' => '25k_40k',
+            'burnout_level' => 0.62,
+            'switch_urgency' => 0.71,
+            'risk_tolerance' => 0.45,
+            'geo_region' => 'cn-east',
+            'family_constraint_level' => 0.40,
+            'manager_track_preference' => 0.32,
+            'time_horizon_months' => 12,
+            'context_payload' => [
+                'trigger' => 'career_refresh',
+                'notes' => ['wants higher autonomy'],
+            ],
+        ]);
+
+        $parentProjection = ProfileProjection::query()->create([
+            'identity_id' => 'identity-1',
+            'visitor_id' => 'visitor-1',
+            'context_snapshot_id' => $contextSnapshot->id,
+            'projection_version' => 'career_projection_v1',
+            'psychometric_axis_coverage' => 0.76,
+            'projection_payload' => ['fit_axes' => ['abstraction' => 0.88]],
+        ]);
+
+        $childProjection = ProfileProjection::query()->create([
+            'identity_id' => 'identity-1',
+            'visitor_id' => 'visitor-1',
+            'context_snapshot_id' => $contextSnapshot->id,
+            'projection_version' => 'career_projection_v1',
+            'psychometric_axis_coverage' => 0.81,
+            'projection_payload' => ['fit_axes' => ['abstraction' => 0.92]],
+        ]);
+
+        $lineage = ProjectionLineage::query()->create([
+            'parent_projection_id' => $parentProjection->id,
+            'child_projection_id' => $childProjection->id,
+            'trigger_context_snapshot_id' => $contextSnapshot->id,
+            'trigger_assessment_id' => 'assessment-1',
+            'lineage_reason' => ProjectionLineageReason::CONTEXT_REFRESH,
+            'diff_summary' => ['abstraction' => ['from' => 0.88, 'to' => 0.92]],
+        ]);
+
+        $recommendationSnapshot = RecommendationSnapshot::query()->create([
+            'profile_projection_id' => $childProjection->id,
+            'context_snapshot_id' => $contextSnapshot->id,
+            'occupation_id' => $occupation->id,
+            'snapshot_payload' => ['fit_score' => 0.84, 'claim_permissions' => ['allow_strong_claim' => false]],
+        ]);
+
+        $transitionPath = TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $recommendationSnapshot->id,
+            'from_occupation_id' => $occupation->id,
+            'to_occupation_id' => $occupation->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => ['steps' => ['deepen system design', 'lead more cross-team decisions']],
+        ]);
+
+        return [
+            'family' => $family,
+            'occupation' => $occupation,
+            'alias' => $alias,
+            'crosswalk' => $crosswalk,
+            'sourceTrace' => $sourceTrace,
+            'truthMetric' => $truthMetric,
+            'skillGraph' => $skillGraph,
+            'trustManifest' => $trustManifest,
+            'editorialPatch' => $editorialPatch,
+            'indexState' => $indexState,
+            'contextSnapshot' => $contextSnapshot,
+            'parentProjection' => $parentProjection,
+            'childProjection' => $childProjection,
+            'lineage' => $lineage,
+            'recommendationSnapshot' => $recommendationSnapshot,
+            'transitionPath' => $transitionPath,
+        ];
+    }
+}

--- a/backend/tests/Unit/Migrations/CareerFoundationMigrationDefinitionTest.php
+++ b/backend/tests/Unit/Migrations/CareerFoundationMigrationDefinitionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerFoundationMigrationDefinitionTest extends TestCase
+{
+    /**
+     * @return array<string, string>
+     */
+    private function migrationFiles(): array
+    {
+        return [
+            'occupation_families' => base_path('database/migrations/2026_04_07_000100_create_occupation_families_table.php'),
+            'occupations' => base_path('database/migrations/2026_04_07_000200_create_occupations_table.php'),
+            'occupation_aliases' => base_path('database/migrations/2026_04_07_000300_create_occupation_aliases_table.php'),
+            'occupation_crosswalks' => base_path('database/migrations/2026_04_07_000400_create_occupation_crosswalks_table.php'),
+            'source_traces' => base_path('database/migrations/2026_04_07_000500_create_source_traces_table.php'),
+            'occupation_truth_metrics' => base_path('database/migrations/2026_04_07_000600_create_occupation_truth_metrics_table.php'),
+            'occupation_skill_graphs' => base_path('database/migrations/2026_04_07_000700_create_occupation_skill_graphs_table.php'),
+            'trust_manifests' => base_path('database/migrations/2026_04_07_000800_create_trust_manifests_table.php'),
+            'editorial_patches' => base_path('database/migrations/2026_04_07_000900_create_editorial_patches_table.php'),
+            'index_states' => base_path('database/migrations/2026_04_07_001000_create_index_states_table.php'),
+            'context_snapshots' => base_path('database/migrations/2026_04_07_001100_create_context_snapshots_table.php'),
+            'profile_projections' => base_path('database/migrations/2026_04_07_001200_create_profile_projections_table.php'),
+            'projection_lineages' => base_path('database/migrations/2026_04_07_001300_create_projection_lineages_table.php'),
+            'recommendation_snapshots' => base_path('database/migrations/2026_04_07_001400_create_recommendation_snapshots_table.php'),
+            'transition_paths' => base_path('database/migrations/2026_04_07_001500_create_transition_paths_table.php'),
+        ];
+    }
+
+    #[Test]
+    public function career_foundation_create_migrations_are_present(): void
+    {
+        foreach ($this->migrationFiles() as $table => $path) {
+            $this->assertFileExists($path, "Missing migration for {$table}");
+        }
+    }
+
+    #[Test]
+    public function every_career_foundation_table_uses_a_uuid_primary_key(): void
+    {
+        foreach ($this->migrationFiles() as $table => $path) {
+            $source = (string) file_get_contents($path);
+
+            $this->assertMatchesRegularExpression(
+                "/\\\$table->uuid\\('id'\\)->primary\\(\\);/",
+                $source,
+                "Expected UUID primary key in {$table}"
+            );
+        }
+    }
+
+    #[Test]
+    public function immutable_chain_migrations_use_uuid_foreign_keys_and_no_cascade_delete(): void
+    {
+        $immutableSources = [
+            'context_snapshots' => (string) file_get_contents($this->migrationFiles()['context_snapshots']),
+            'profile_projections' => (string) file_get_contents($this->migrationFiles()['profile_projections']),
+            'projection_lineages' => (string) file_get_contents($this->migrationFiles()['projection_lineages']),
+            'recommendation_snapshots' => (string) file_get_contents($this->migrationFiles()['recommendation_snapshots']),
+            'transition_paths' => (string) file_get_contents($this->migrationFiles()['transition_paths']),
+        ];
+
+        $this->assertStringContainsString("foreignUuid('current_occupation_id')", $immutableSources['context_snapshots']);
+        $this->assertStringContainsString("foreignUuid('context_snapshot_id')", $immutableSources['profile_projections']);
+        $this->assertStringContainsString("foreignUuid('child_projection_id')", $immutableSources['projection_lineages']);
+        $this->assertStringContainsString("foreignUuid('profile_projection_id')", $immutableSources['recommendation_snapshots']);
+        $this->assertStringContainsString("foreignUuid('recommendation_snapshot_id')", $immutableSources['transition_paths']);
+
+        foreach ($immutableSources as $table => $source) {
+            $this->assertStringNotContainsString('cascadeOnDelete()', $source, "Immutable table {$table} must not cascade delete");
+            $this->assertStringNotContainsString('$table->timestamps()', $source, "Immutable table {$table} must not define updated_at");
+        }
+    }
+
+    #[Test]
+    public function projection_lineages_enforces_one_direct_parent_per_child_in_schema_definition(): void
+    {
+        $source = (string) file_get_contents($this->migrationFiles()['projection_lineages']);
+
+        $this->assertStringContainsString("\$table->unique('child_projection_id');", $source);
+    }
+
+    #[Test]
+    public function immutable_snapshot_tables_do_not_define_forbidden_subject_unique_constraints(): void
+    {
+        $sources = [
+            'context_snapshots' => (string) file_get_contents($this->migrationFiles()['context_snapshots']),
+            'profile_projections' => (string) file_get_contents($this->migrationFiles()['profile_projections']),
+            'recommendation_snapshots' => (string) file_get_contents($this->migrationFiles()['recommendation_snapshots']),
+        ];
+
+        foreach ($sources as $table => $source) {
+            $this->assertDoesNotMatchRegularExpression('/\\$table->unique\\(\\[[^\\]]*(identity_id|visitor_id|context_snapshot_id|profile_projection_id)[^\\]]*\\]/', $source, "Immutable table {$table} must remain append-friendly");
+            $this->assertStringNotContainsString("unique(['attempt_id']", $source, "Immutable table {$table} must not copy attempt-style overwrite semantics");
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- add a brand-new Career foundation schema with 15 UUID-first tables for ontology, truth, trust, index state, and immutable lineage snapshots
- keep the new foundation fully separate from legacy CMS Career tables and existing mutable snapshot/projection tables
- standardize new Career foundation models on a shared UUID base model, plus an immutable base model for created-at-only history tables
- add a minimal `App\Domain\Career` landing with explicit constants for lineage reasons, reviewer status, and index-state semantics
- add backend fixtures and tests that lock UUID PK/FK usage, immutable delete behavior, append-friendly snapshot semantics, and projection lineage integrity

## Why
PR-A already froze the frontend Career contracts. PR-B1 needs the first backend authority layer that can safely back those contracts later without inheriting the mutable CMS architecture or the overwrite-style snapshot patterns already present elsewhere in the repo.

This PR therefore builds a fresh UUID-first Career foundation for:
- occupation ontology
- alias / crosswalk / truth metrics
- trust manifests
- editorial patch and index-state history
- immutable context / projection / recommendation / transition lineage

## Schema scope
### Ontology / truth / trust
- `occupation_families`
- `occupations`
- `occupation_aliases`
- `occupation_crosswalks`
- `occupation_truth_metrics`
- `occupation_skill_graphs`
- `source_traces`
- `trust_manifests`
- `editorial_patches`
- `index_states`

### Immutable lineage chain
- `context_snapshots`
- `profile_projections`
- `projection_lineages`
- `recommendation_snapshots`
- `transition_paths`

## Guardrails in this PR
- all new core tables use UUID primary keys
- all new foundation FKs are UUID-based
- slug / alias / source code remain secondary indexed fields only
- immutable lineage tables do not use `updated_at`
- immutable lineage tables do not use `cascadeOnDelete()`
- `projection_lineages.child_projection_id` is unique so one child can only have one direct parent edge
- append-friendly snapshot semantics are preserved; there is no `is_current`, `latest`, or subject-unique overwrite design

## Explicitly not touched
- legacy CMS authority-unfit systems like `career_jobs`, `career_job_revisions`, `CareerJobService`, and `CareerRecommendationService`
- existing mutable tables like `report_snapshots` and `unified_access_projections`
- controllers, resources, scoring formulas, transition formulas, or frontend wiring

## Validation
- `vendor/bin/pint --test app/Models/CareerFoundationModel.php app/Models/CareerImmutableFoundationModel.php app/Models/OccupationFamily.php app/Models/Occupation.php app/Models/OccupationAlias.php app/Models/OccupationCrosswalk.php app/Models/OccupationTruthMetric.php app/Models/OccupationSkillGraph.php app/Models/SourceTrace.php app/Models/TrustManifest.php app/Models/EditorialPatch.php app/Models/IndexState.php app/Models/ContextSnapshot.php app/Models/ProfileProjection.php app/Models/ProjectionLineage.php app/Models/RecommendationSnapshot.php app/Models/TransitionPath.php app/Domain/Career/ProjectionLineageReason.php app/Domain/Career/IndexStateValue.php app/Domain/Career/ReviewerStatus.php tests/Fixtures/Career/CareerFoundationFixture.php tests/Unit/Migrations/CareerFoundationMigrationDefinitionTest.php tests/Feature/Career/CareerFoundationSchemaTest.php tests/Feature/Career/CareerFoundationLineageTest.php database/migrations/2026_04_07_000100_create_occupation_families_table.php database/migrations/2026_04_07_000200_create_occupations_table.php database/migrations/2026_04_07_000300_create_occupation_aliases_table.php database/migrations/2026_04_07_000400_create_occupation_crosswalks_table.php database/migrations/2026_04_07_000500_create_source_traces_table.php database/migrations/2026_04_07_000600_create_occupation_truth_metrics_table.php database/migrations/2026_04_07_000700_create_occupation_skill_graphs_table.php database/migrations/2026_04_07_000800_create_trust_manifests_table.php database/migrations/2026_04_07_000900_create_editorial_patches_table.php database/migrations/2026_04_07_001000_create_index_states_table.php database/migrations/2026_04_07_001100_create_context_snapshots_table.php database/migrations/2026_04_07_001200_create_profile_projections_table.php database/migrations/2026_04_07_001300_create_projection_lineages_table.php database/migrations/2026_04_07_001400_create_recommendation_snapshots_table.php database/migrations/2026_04_07_001500_create_transition_paths_table.php`
- `php artisan test tests/Unit/Migrations/MigrationSafetyTest.php tests/Unit/Migrations/CareerFoundationMigrationDefinitionTest.php tests/Feature/Career/CareerFoundationSchemaTest.php tests/Feature/Career/CareerFoundationLineageTest.php`
- `php artisan test tests/Feature/CareerCms/CareerJobSchemaSmokeTest.php tests/Feature/CareerCms/CareerGuideSchemaModelTest.php tests/Feature/V0_5/CareerJobPublicApiTest.php tests/Feature/V0_5/CareerRecommendationPublicApiTest.php`

## Deferred to PR-B2 or later
- trigger-level hard immutability enforcement
- scoring engine formulas
- transition engine formulas
- import/compile jobs
- API controllers/resources for protocol bundle output
- frontend wiring to the new Career foundation tables
