### PR TITLE
PR-B4: Build Career protocol bundle output and thin API contract layer

### DIFF
--- a/backend/app/DTO/Career/CareerJobDetailBundle.php
+++ b/backend/app/DTO/Career/CareerJobDetailBundle.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerJobDetailBundle
+{
+    /**
+     * @param  array<string, mixed>  $identity
+     * @param  array<string, mixed>  $localePolicy
+     * @param  array<string, mixed>  $titles
+     * @param  list<array<string, mixed>>  $aliasIndex
+     * @param  array<string, mixed>  $ontology
+     * @param  array<string, mixed>  $truthLayer
+     * @param  array<string, mixed>  $trustManifest
+     * @param  array<string, mixed>  $scoreBundle
+     * @param  array<string, mixed>  $warnings
+     * @param  array<string, mixed>  $claimPermissions
+     * @param  array<string, mixed>  $integritySummary
+     * @param  array<string, mixed>  $seoContract
+     * @param  array<string, mixed>  $provenanceMeta
+     */
+    public function __construct(
+        public readonly array $identity,
+        public readonly array $localePolicy,
+        public readonly array $titles,
+        public readonly array $aliasIndex,
+        public readonly array $ontology,
+        public readonly array $truthLayer,
+        public readonly array $trustManifest,
+        public readonly array $scoreBundle,
+        public readonly array $warnings,
+        public readonly array $claimPermissions,
+        public readonly array $integritySummary,
+        public readonly array $seoContract,
+        public readonly array $provenanceMeta,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'bundle_kind' => 'career_job_detail',
+            'bundle_version' => 'career.protocol.job_detail.v1',
+            'identity' => $this->identity,
+            'locale_policy' => $this->localePolicy,
+            'titles' => $this->titles,
+            'alias_index' => $this->aliasIndex,
+            'ontology' => $this->ontology,
+            'truth_layer' => $this->truthLayer,
+            'trust_manifest' => $this->trustManifest,
+            'score_bundle' => $this->scoreBundle,
+            'warnings' => $this->warnings,
+            'claim_permissions' => $this->claimPermissions,
+            'integrity_summary' => $this->integritySummary,
+            'seo_contract' => $this->seoContract,
+            'provenance_meta' => $this->provenanceMeta,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
+++ b/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerRecommendationDetailBundle
+{
+    /**
+     * @param  array<string, mixed>  $identity
+     * @param  array<string, mixed>  $recommendationSubjectMeta
+     * @param  array<string, mixed>  $supportingTruthSummary
+     * @param  array<string, mixed>  $scoreBundle
+     * @param  array<string, mixed>  $warnings
+     * @param  array<string, mixed>  $claimPermissions
+     * @param  array<string, mixed>  $integritySummary
+     * @param  array<string, mixed>  $trustManifest
+     * @param  array<string, mixed>  $seoContract
+     * @param  array<string, mixed>  $provenanceMeta
+     */
+    public function __construct(
+        public readonly array $identity,
+        public readonly array $recommendationSubjectMeta,
+        public readonly array $supportingTruthSummary,
+        public readonly array $scoreBundle,
+        public readonly array $warnings,
+        public readonly array $claimPermissions,
+        public readonly array $integritySummary,
+        public readonly array $trustManifest,
+        public readonly array $seoContract,
+        public readonly array $provenanceMeta,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'bundle_kind' => 'career_recommendation_detail',
+            'bundle_version' => 'career.protocol.recommendation_detail.v1',
+            'identity' => $this->identity,
+            'recommendation_subject_meta' => $this->recommendationSubjectMeta,
+            'supporting_truth_summary' => $this->supportingTruthSummary,
+            'score_bundle' => $this->scoreBundle,
+            'warnings' => $this->warnings,
+            'claim_permissions' => $this->claimPermissions,
+            'integrity_summary' => $this->integritySummary,
+            'trust_manifest' => $this->trustManifest,
+            'seo_contract' => $this->seoContract,
+            'provenance_meta' => $this->provenanceMeta,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerJobDetailResource;
+use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
+use Illuminate\Http\JsonResponse;
+
+final class CareerJobDetailController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerJobDetailBundleBuilder $bundleBuilder,
+    ) {}
+
+    public function show(string $slug): JsonResponse|CareerJobDetailResource
+    {
+        $bundle = $this->bundleBuilder->buildBySlug($slug);
+
+        if ($bundle === null) {
+            return $this->notFoundResponse('career job detail bundle unavailable.');
+        }
+
+        return new CareerJobDetailResource($bundle);
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerRecommendationDetailController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerRecommendationDetailController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerRecommendationDetailResource;
+use App\Services\Career\Bundles\CareerRecommendationDetailBundleBuilder;
+use Illuminate\Http\JsonResponse;
+
+final class CareerRecommendationDetailController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerRecommendationDetailBundleBuilder $bundleBuilder,
+    ) {}
+
+    public function show(string $type): JsonResponse|CareerRecommendationDetailResource
+    {
+        $bundle = $this->bundleBuilder->buildByType($type);
+
+        if ($bundle === null) {
+            return $this->notFoundResponse('career recommendation detail bundle unavailable.');
+        }
+
+        return new CareerRecommendationDetailResource($bundle);
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerJobDetailResource.php
+++ b/backend/app/Http/Resources/Career/CareerJobDetailResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerJobDetailBundle;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerJobDetailBundle
+ */
+final class CareerJobDetailResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerJobDetailBundle $bundle */
+        $bundle = $this->resource;
+
+        return $bundle->toArray();
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerRecommendationDetailResource.php
+++ b/backend/app/Http/Resources/Career/CareerRecommendationDetailResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerRecommendationDetailBundle;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerRecommendationDetailBundle
+ */
+final class CareerRecommendationDetailResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerRecommendationDetailBundle $bundle */
+        $bundle = $this->resource;
+
+        return $bundle->toArray();
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -47,6 +47,13 @@ final class CareerJobDetailBundleBuilder
             ])
             ->where('occupation_id', $occupation->id)
             ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
             ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
             ->first();

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\DTO\Career\CareerJobDetailBundle;
+use App\Models\Occupation;
+use App\Models\RecommendationSnapshot;
+use App\Services\PublicSurface\SeoSurfaceContractService;
+
+final class CareerJobDetailBundleBuilder
+{
+    public function __construct(
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
+    ) {}
+
+    public function buildBySlug(string $slug): ?CareerJobDetailBundle
+    {
+        $normalizedSlug = trim($slug);
+        if ($normalizedSlug === '') {
+            return null;
+        }
+
+        $occupation = Occupation::query()
+            ->with([
+                'family',
+                'aliases',
+                'crosswalks',
+                'editorialPatches' => fn ($query) => $query->orderByDesc('updated_at')->orderByDesc('created_at'),
+            ])
+            ->where('canonical_slug', $normalizedSlug)
+            ->first();
+
+        if (! $occupation instanceof Occupation) {
+            return null;
+        }
+
+        $snapshot = RecommendationSnapshot::query()
+            ->with([
+                'profileProjection',
+                'contextSnapshot',
+                'truthMetric.sourceTrace',
+                'trustManifest',
+                'indexState',
+                'compileRun',
+            ])
+            ->where('occupation_id', $occupation->id)
+            ->whereNotNull('compiled_at')
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        if (! $snapshot instanceof RecommendationSnapshot) {
+            return null;
+        }
+
+        $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
+        $truthMetric = $snapshot->truthMetric;
+        $sourceTrace = $truthMetric?->sourceTrace;
+        $trustManifest = $snapshot->trustManifest;
+        $indexState = $snapshot->indexState;
+        $editorialPatch = $occupation->editorialPatches->first();
+        $importRunId = $truthMetric?->import_run_id
+            ?? $trustManifest?->import_run_id
+            ?? $indexState?->import_run_id;
+
+        return new CareerJobDetailBundle(
+            identity: [
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $occupation->canonical_slug,
+                'entity_level' => $occupation->entity_level,
+                'family_uuid' => $occupation->family_id,
+                'parent_uuid' => $occupation->parent_id,
+            ],
+            localePolicy: [
+                'truth_market' => $occupation->truth_market,
+                'display_market' => $occupation->display_market,
+                'crosswalk_mode' => $occupation->crosswalk_mode,
+                'locale_warning' => $occupation->truth_market !== $occupation->display_market
+                    ? 'cross_market_display'
+                    : null,
+                'truth_notice_required' => $occupation->truth_market !== $occupation->display_market,
+            ],
+            titles: [
+                'canonical_en' => $occupation->canonical_title_en,
+                'canonical_zh' => $occupation->canonical_title_zh,
+                'search_h1_zh' => $occupation->search_h1_zh,
+                'short_title_en' => $occupation->canonical_title_en,
+                'short_title_zh' => $occupation->canonical_title_zh,
+            ],
+            aliasIndex: $occupation->aliases
+                ->sortBy([
+                    ['lang', 'asc'],
+                    ['register', 'asc'],
+                    ['alias', 'asc'],
+                ])
+                ->values()
+                ->map(static fn ($alias): array => [
+                    'alias' => $alias->alias,
+                    'normalized' => $alias->normalized,
+                    'lang' => $alias->lang,
+                    'register' => $alias->register,
+                    'intent_scope' => $alias->intent_scope,
+                    'target_kind' => $alias->target_kind,
+                    'target_uuid' => $alias->occupation_id ?? $alias->family_id,
+                    'precision' => $alias->precision_score,
+                    'confidence' => $alias->confidence_score,
+                ])
+                ->all(),
+            ontology: [
+                'task_prototype_signature' => is_array($occupation->task_prototype_signature) ? $occupation->task_prototype_signature : [],
+                'structural_stability' => $occupation->structural_stability,
+                'market_semantics_gap' => $occupation->market_semantics_gap,
+                'regulatory_divergence' => $occupation->regulatory_divergence,
+                'toolchain_divergence' => $occupation->toolchain_divergence,
+                'skill_gap_threshold' => $occupation->skill_gap_threshold,
+                'trust_inheritance_scope' => is_array($occupation->trust_inheritance_scope) ? $occupation->trust_inheritance_scope : [],
+                'crosswalks' => $occupation->crosswalks
+                    ->map(static fn ($crosswalk): array => [
+                        'source_system' => $crosswalk->source_system,
+                        'source_code' => $crosswalk->source_code,
+                        'source_title' => $crosswalk->source_title,
+                        'mapping_type' => $crosswalk->mapping_type,
+                        'confidence_score' => $crosswalk->confidence_score,
+                    ])
+                    ->all(),
+            ],
+            truthLayer: [
+                'source_refs' => array_values(array_filter([
+                    is_string($sourceTrace?->id) ? [
+                        'source_trace_id' => $sourceTrace->id,
+                        'source_id' => $sourceTrace->source_id,
+                        'source_type' => $sourceTrace->source_type,
+                        'title' => $sourceTrace->title,
+                        'url' => $sourceTrace->url,
+                        'fields_used' => is_array($sourceTrace->fields_used) ? $sourceTrace->fields_used : [],
+                        'retrieved_at' => optional($sourceTrace->retrieved_at)?->toISOString(),
+                        'evidence_strength' => $sourceTrace->evidence_strength,
+                    ] : null,
+                ])),
+                'median_pay_usd_annual' => $truthMetric?->median_pay_usd_annual,
+                'jobs_2024' => $truthMetric?->jobs_2024,
+                'projected_jobs_2034' => $truthMetric?->projected_jobs_2034,
+                'employment_change' => $truthMetric?->employment_change,
+                'outlook_pct_2024_2034' => $truthMetric?->outlook_pct_2024_2034,
+                'outlook_description' => $truthMetric?->outlook_description,
+                'entry_education' => $truthMetric?->entry_education,
+                'work_experience' => $truthMetric?->work_experience,
+                'on_the_job_training' => $truthMetric?->on_the_job_training,
+                'ai_exposure' => $truthMetric?->ai_exposure,
+                'ai_rationale' => $truthMetric?->ai_rationale,
+                'truth_market' => $truthMetric?->truth_market,
+                'truth_last_reviewed_at' => optional($truthMetric?->reviewed_at)->toISOString(),
+            ],
+            trustManifest: [
+                'content_version' => $trustManifest?->content_version,
+                'data_version' => $trustManifest?->data_version,
+                'logic_version' => $trustManifest?->logic_version,
+                'locale_context' => is_array($trustManifest?->locale_context) ? $trustManifest->locale_context : [],
+                'methodology' => is_array($trustManifest?->methodology) ? $trustManifest->methodology : [],
+                'reviewer_status' => $trustManifest?->reviewer_status,
+                'reviewed_at' => optional($trustManifest?->reviewed_at)->toISOString(),
+                'ai_assistance' => is_array($trustManifest?->ai_assistance) ? $trustManifest->ai_assistance : [],
+                'quality' => is_array($trustManifest?->quality) ? $trustManifest->quality : [],
+                'last_substantive_update_at' => optional($trustManifest?->last_substantive_update_at)->toISOString(),
+                'next_review_due_at' => optional($trustManifest?->next_review_due_at)->toISOString(),
+                'editorial_patch' => [
+                    'required' => (bool) ($editorialPatch?->required ?? false),
+                    'status' => $editorialPatch?->status,
+                    'notes' => is_array($editorialPatch?->notes) ? $editorialPatch->notes : [],
+                ],
+            ],
+            scoreBundle: $this->normalizeArray($payload['score_bundle'] ?? []),
+            warnings: $this->normalizeArray($payload['warnings'] ?? []),
+            claimPermissions: $this->normalizeArray($payload['claim_permissions'] ?? []),
+            integritySummary: $this->normalizeArray($payload['integrity_summary'] ?? []),
+            seoContract: $this->buildSeoContract($occupation, $snapshot),
+            provenanceMeta: [
+                'content_version' => $trustManifest?->content_version,
+                'data_version' => $trustManifest?->data_version,
+                'logic_version' => $trustManifest?->logic_version,
+                'compiler_version' => $snapshot->compiler_version,
+                'compiled_at' => optional($snapshot->compiled_at)->toISOString(),
+                'truth_metric_id' => $snapshot->truth_metric_id,
+                'trust_manifest_id' => $snapshot->trust_manifest_id,
+                'index_state_id' => $snapshot->index_state_id,
+                'compile_run_id' => $snapshot->compile_run_id,
+                'import_run_id' => $importRunId,
+                'source_trace_id' => $truthMetric?->source_trace_id,
+                'compile_refs' => $this->normalizeArray($payload['compile_refs'] ?? []),
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildSeoContract(Occupation $occupation, RecommendationSnapshot $snapshot): array
+    {
+        $indexState = $snapshot->indexState;
+        $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
+        $canonicalTarget = $indexState?->canonical_target;
+        $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_job_detail_bundle',
+            'canonical_url' => $canonicalTarget ?: $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $canonicalTarget,
+            'index_state' => $indexState?->index_state,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeArray(mixed $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -16,7 +16,8 @@ final class CareerRecommendationDetailBundleBuilder
 
     public function buildByType(string $type): ?CareerRecommendationDetailBundle
     {
-        $normalizedType = strtoupper(trim($type));
+        $requestedType = trim($type);
+        $normalizedType = strtoupper($requestedType);
         if ($normalizedType === '') {
             return null;
         }
@@ -34,6 +35,13 @@ final class CareerRecommendationDetailBundleBuilder
                 'compileRun',
             ])
             ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
             ->whereHas('profileProjection', function ($query) use ($normalizedType, $canonicalType): void {
                 $query->where(function ($inner) use ($normalizedType, $canonicalType): void {
                     $inner->where('projection_payload->recommendation_subject_meta->type_code', $normalizedType)
@@ -103,7 +111,7 @@ final class CareerRecommendationDetailBundleBuilder
                 'locale_context' => is_array($trustManifest?->locale_context) ? $trustManifest->locale_context : [],
                 'methodology' => is_array($trustManifest?->methodology) ? $trustManifest->methodology : [],
             ],
-            seoContract: $this->buildSeoContract($snapshot, $subjectMeta),
+            seoContract: $this->buildSeoContract($snapshot, $subjectMeta, $requestedType),
             provenanceMeta: [
                 'content_version' => $trustManifest?->content_version,
                 'data_version' => $trustManifest?->data_version,
@@ -126,13 +134,11 @@ final class CareerRecommendationDetailBundleBuilder
      * @param  array<string, mixed>  $subjectMeta
      * @return array<string, mixed>
      */
-    private function buildSeoContract(RecommendationSnapshot $snapshot, array $subjectMeta): array
+    private function buildSeoContract(RecommendationSnapshot $snapshot, array $subjectMeta, string $requestedType): array
     {
         $indexState = $snapshot->indexState;
-        $typeCode = strtolower((string) ($subjectMeta['type_code'] ?? $subjectMeta['canonical_type_code'] ?? ''));
-        $canonicalPath = is_string($indexState?->canonical_path) && $typeCode !== ''
-            ? '/career/recommendations/mbti/'.$typeCode
-            : '/career/recommendations/mbti/'.$typeCode;
+        $routeSubject = $this->routeSubject($subjectMeta, $requestedType);
+        $canonicalPath = '/career/recommendations/mbti/'.$routeSubject;
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
@@ -165,5 +171,32 @@ final class CareerRecommendationDetailBundleBuilder
     private function normalizeArray(mixed $value): array
     {
         return is_array($value) ? $value : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $subjectMeta
+     */
+    private function routeSubject(array $subjectMeta, string $requestedType): string
+    {
+        $candidates = [
+            $requestedType,
+            is_scalar($subjectMeta['public_route_slug'] ?? null) ? (string) $subjectMeta['public_route_slug'] : null,
+            is_scalar($subjectMeta['route_type'] ?? null) ? (string) $subjectMeta['route_type'] : null,
+            is_scalar($subjectMeta['canonical_type_code'] ?? null) ? (string) $subjectMeta['canonical_type_code'] : null,
+            is_scalar($subjectMeta['type_code'] ?? null) ? (string) $subjectMeta['type_code'] : null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_string($candidate)) {
+                continue;
+            }
+
+            $normalized = strtolower(trim($candidate));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return 'unknown';
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\DTO\Career\CareerRecommendationDetailBundle;
+use App\Models\RecommendationSnapshot;
+use App\Services\PublicSurface\SeoSurfaceContractService;
+
+final class CareerRecommendationDetailBundleBuilder
+{
+    public function __construct(
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
+    ) {}
+
+    public function buildByType(string $type): ?CareerRecommendationDetailBundle
+    {
+        $normalizedType = strtoupper(trim($type));
+        if ($normalizedType === '') {
+            return null;
+        }
+
+        $canonicalType = strtoupper(strtok($normalizedType, '-') ?: $normalizedType);
+
+        $snapshot = RecommendationSnapshot::query()
+            ->with([
+                'occupation.family',
+                'truthMetric.sourceTrace',
+                'trustManifest',
+                'indexState',
+                'profileProjection',
+                'contextSnapshot',
+                'compileRun',
+            ])
+            ->whereNotNull('compiled_at')
+            ->whereHas('profileProjection', function ($query) use ($normalizedType, $canonicalType): void {
+                $query->where(function ($inner) use ($normalizedType, $canonicalType): void {
+                    $inner->where('projection_payload->recommendation_subject_meta->type_code', $normalizedType)
+                        ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $normalizedType)
+                        ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $canonicalType);
+                });
+            })
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        if (! $snapshot instanceof RecommendationSnapshot || ! $snapshot->occupation) {
+            return null;
+        }
+
+        $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
+        $projectionPayload = is_array($snapshot->profileProjection?->projection_payload) ? $snapshot->profileProjection->projection_payload : [];
+        $subjectMeta = $this->normalizeArray($projectionPayload['recommendation_subject_meta'] ?? []);
+        if ($subjectMeta === []) {
+            return null;
+        }
+
+        $truthMetric = $snapshot->truthMetric;
+        $sourceTrace = $truthMetric?->sourceTrace;
+        $trustManifest = $snapshot->trustManifest;
+        $indexState = $snapshot->indexState;
+        $importRunId = $truthMetric?->import_run_id
+            ?? $trustManifest?->import_run_id
+            ?? $indexState?->import_run_id;
+
+        return new CareerRecommendationDetailBundle(
+            identity: [
+                'occupation_uuid' => $snapshot->occupation->id,
+                'canonical_slug' => $snapshot->occupation->canonical_slug,
+                'entity_level' => $snapshot->occupation->entity_level,
+                'family_uuid' => $snapshot->occupation->family_id,
+                'canonical_title_en' => $snapshot->occupation->canonical_title_en,
+                'canonical_title_zh' => $snapshot->occupation->canonical_title_zh,
+            ],
+            recommendationSubjectMeta: $subjectMeta,
+            supportingTruthSummary: [
+                'truth_market' => $truthMetric?->truth_market ?? $snapshot->occupation->truth_market,
+                'display_market' => $snapshot->occupation->display_market,
+                'median_pay_usd_annual' => $truthMetric?->median_pay_usd_annual,
+                'outlook_pct_2024_2034' => $truthMetric?->outlook_pct_2024_2034,
+                'outlook_description' => $truthMetric?->outlook_description,
+                'ai_exposure' => $truthMetric?->ai_exposure,
+                'source_trace' => is_string($sourceTrace?->id) ? [
+                    'source_trace_id' => $sourceTrace->id,
+                    'source_id' => $sourceTrace->source_id,
+                    'title' => $sourceTrace->title,
+                    'url' => $sourceTrace->url,
+                    'evidence_strength' => $sourceTrace->evidence_strength,
+                ] : null,
+            ],
+            scoreBundle: $this->normalizeArray($payload['score_bundle'] ?? []),
+            warnings: $this->normalizeArray($payload['warnings'] ?? []),
+            claimPermissions: $this->normalizeArray($payload['claim_permissions'] ?? []),
+            integritySummary: $this->normalizeArray($payload['integrity_summary'] ?? []),
+            trustManifest: [
+                'content_version' => $trustManifest?->content_version,
+                'data_version' => $trustManifest?->data_version,
+                'logic_version' => $trustManifest?->logic_version,
+                'reviewer_status' => $trustManifest?->reviewer_status,
+                'reviewed_at' => optional($trustManifest?->reviewed_at)->toISOString(),
+                'quality' => is_array($trustManifest?->quality) ? $trustManifest->quality : [],
+                'locale_context' => is_array($trustManifest?->locale_context) ? $trustManifest->locale_context : [],
+                'methodology' => is_array($trustManifest?->methodology) ? $trustManifest->methodology : [],
+            ],
+            seoContract: $this->buildSeoContract($snapshot, $subjectMeta),
+            provenanceMeta: [
+                'content_version' => $trustManifest?->content_version,
+                'data_version' => $trustManifest?->data_version,
+                'logic_version' => $trustManifest?->logic_version,
+                'compiler_version' => $snapshot->compiler_version,
+                'compiled_at' => optional($snapshot->compiled_at)->toISOString(),
+                'truth_metric_id' => $snapshot->truth_metric_id,
+                'trust_manifest_id' => $snapshot->trust_manifest_id,
+                'index_state_id' => $snapshot->index_state_id,
+                'compile_run_id' => $snapshot->compile_run_id,
+                'import_run_id' => $importRunId,
+                'profile_projection_id' => $snapshot->profile_projection_id,
+                'context_snapshot_id' => $snapshot->context_snapshot_id,
+                'compile_refs' => $this->normalizeArray($payload['compile_refs'] ?? []),
+            ],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $subjectMeta
+     * @return array<string, mixed>
+     */
+    private function buildSeoContract(RecommendationSnapshot $snapshot, array $subjectMeta): array
+    {
+        $indexState = $snapshot->indexState;
+        $typeCode = strtolower((string) ($subjectMeta['type_code'] ?? $subjectMeta['canonical_type_code'] ?? ''));
+        $canonicalPath = is_string($indexState?->canonical_path) && $typeCode !== ''
+            ? '/career/recommendations/mbti/'.$typeCode
+            : '/career/recommendations/mbti/'.$typeCode;
+        $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_recommendation_detail_bundle',
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => (string) ($subjectMeta['display_title'] ?? $subjectMeta['type_code'] ?? $snapshot->occupation?->canonical_title_en ?? ''),
+            'description' => (string) ($snapshot->occupation?->canonical_title_en ?? ''),
+            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $indexState?->canonical_target,
+            'index_state' => $indexState?->index_state,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeArray(mixed $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2345,6 +2345,40 @@
                 ]
             }
         },
+        "/api/v0.5/career/jobs/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_career_jobs_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerJobDetailController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/career/recommendations/mbti/{type}": {
+            "get": {
+                "operationId": "get_api_v0_5_career_recommendations_mbti_type_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerRecommendationDetailController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/cms/articles": {
             "post": {
                 "operationId": "post_api_v0_5_cms_articles",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -13,8 +13,8 @@ use App\Http\Controllers\API\V0_3\ClaimController as ClaimV03Controller;
 use App\Http\Controllers\API\V0_3\ComplianceDsarController;
 use App\Http\Controllers\API\V0_3\EmailCaptureController;
 use App\Http\Controllers\API\V0_3\EmailPreferenceController;
-use App\Http\Controllers\API\V0_3\MbtiCompareInviteController;
 use App\Http\Controllers\API\V0_3\MbtiAttributionEventController;
+use App\Http\Controllers\API\V0_3\MbtiCompareInviteController;
 use App\Http\Controllers\API\V0_3\MeController as MeV03Controller;
 use App\Http\Controllers\API\V0_3\OrgInvitesController;
 use App\Http\Controllers\API\V0_3\OrgsController;
@@ -29,6 +29,8 @@ use App\Http\Controllers\API\V0_4\BootController;
 use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
+use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
+use App\Http\Controllers\API\V0_5\Career\CareerRecommendationDetailController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
 use App\Http\Controllers\API\V0_5\Cms\CareerGuideController;
 use App\Http\Controllers\API\V0_5\Cms\CareerJobController;
@@ -393,6 +395,8 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
 });
 
 Route::prefix('v0.5')->group(function () {
+    Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);
+    Route::get('/career/recommendations/mbti/{type}', [CareerRecommendationDetailController::class, 'show']);
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\CareerJob;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerJobDetailApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_a_resource_backed_job_detail_bundle_with_explicit_sections(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+
+        $this->getJson('/api/v0.5/career/jobs/backend-architect')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_job_detail')
+            ->assertJsonPath('identity.canonical_slug', 'backend-architect')
+            ->assertJsonPath('trust_manifest.content_version', 'v4.1')
+            ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/backend-architect')
+            ->assertJsonStructure([
+                'identity',
+                'locale_policy',
+                'titles',
+                'alias_index',
+                'ontology',
+                'truth_layer',
+                'trust_manifest',
+                'score_bundle' => ['fit_score'],
+                'warnings',
+                'claim_permissions',
+                'integrity_summary',
+                'seo_contract',
+                'provenance_meta' => ['compiler_version', 'compile_refs'],
+            ]);
+    }
+
+    public function test_it_remains_conservative_and_does_not_fall_back_to_legacy_cms_jobs(): void
+    {
+        CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'authority-only']);
+
+        CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'legacy-backend-architect',
+            'slug' => 'legacy-backend-architect',
+            'locale' => 'en',
+            'title' => 'Legacy Backend Architect',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/legacy-backend-architect')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+}

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
 use App\Models\CareerJob;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -17,7 +19,40 @@ final class CareerJobDetailApiTest extends TestCase
     public function test_it_returns_a_resource_backed_job_detail_bundle_with_explicit_sections(): void
     {
         $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
-        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-job-api',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
 
         $this->getJson('/api/v0.5/career/jobs/backend-architect')
             ->assertOk()

--- a/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerRecommendationDetailApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_a_resource_backed_recommendation_detail_bundle_with_provenance_and_claims(): void
+    {
+        $chain = CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+        $chain['childProjection']->update([
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'recommendation_subject_meta' => [
+                        'type_code' => 'INTJ-A',
+                        'canonical_type_code' => 'INTJ',
+                        'display_title' => 'INTJ-A Career Match',
+                    ],
+                ],
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+
+        $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_recommendation_detail')
+            ->assertJsonPath('recommendation_subject_meta.type_code', 'INTJ-A')
+            ->assertJsonPath('claim_permissions.allow_salary_comparison', false)
+            ->assertJsonPath('seo_contract.index_eligible', false)
+            ->assertJsonStructure([
+                'identity',
+                'recommendation_subject_meta',
+                'supporting_truth_summary',
+                'score_bundle' => ['fit_score'],
+                'warnings',
+                'claim_permissions',
+                'integrity_summary',
+                'trust_manifest',
+                'seo_contract',
+                'provenance_meta' => ['compiler_version', 'compile_refs'],
+            ]);
+    }
+
+    public function test_it_returns_conservative_not_found_when_subject_meta_bundle_is_unavailable(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+
+        $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+}

--- a/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
@@ -16,10 +18,35 @@ final class CareerRecommendationDetailApiTest extends TestCase
     public function test_it_returns_a_resource_backed_recommendation_detail_bundle_with_provenance_and_claims(): void
     {
         $chain = CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-rec-api',
+            'scope_mode' => 'first_wave_trust_inheritance',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_trust_inheritance',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
         $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
             'projection_payload' => array_merge(
                 is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
                 [
+                    'materialization' => 'career_first_wave',
                     'recommendation_subject_meta' => [
                         'type_code' => 'INTJ-A',
                         'canonical_type_code' => 'INTJ',
@@ -29,13 +56,17 @@ final class CareerRecommendationDetailApiTest extends TestCase
             ),
         ]);
 
-        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
 
         $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
             ->assertOk()
             ->assertJsonPath('bundle_kind', 'career_recommendation_detail')
             ->assertJsonPath('recommendation_subject_meta.type_code', 'INTJ-A')
             ->assertJsonPath('claim_permissions.allow_salary_comparison', false)
+            ->assertJsonPath('seo_contract.canonical_path', '/career/recommendations/mbti/intj')
             ->assertJsonPath('seo_contract.index_eligible', false)
             ->assertJsonStructure([
                 'identity',

--- a/backend/tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerJobDetailBundleBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_an_explicit_job_detail_bundle_from_authority_rows(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+
+        $bundle = app(CareerJobDetailBundleBuilder::class)->buildBySlug('backend-architect');
+
+        $this->assertNotNull($bundle);
+        $payload = $bundle?->toArray() ?? [];
+
+        $this->assertSame('career.protocol.job_detail.v1', $payload['bundle_version']);
+        $this->assertSame($chain['occupation']->id, data_get($payload, 'identity.occupation_uuid'));
+        $this->assertSame($chain['occupation']->canonical_title_en, data_get($payload, 'titles.canonical_en'));
+        $this->assertSame($chain['trustManifest']->content_version, data_get($payload, 'trust_manifest.content_version'));
+        $this->assertArrayHasKey('fit_score', (array) data_get($payload, 'score_bundle'));
+        $this->assertArrayHasKey('allow_strong_claim', (array) data_get($payload, 'claim_permissions'));
+        $this->assertArrayHasKey('metadata_contract_version', (array) data_get($payload, 'seo_contract'));
+        $this->assertArrayHasKey('compiler_version', (array) data_get($payload, 'provenance_meta'));
+    }
+
+    public function test_it_returns_null_when_only_mutable_occupation_exists_without_compiled_authority_snapshot(): void
+    {
+        CareerFoundationFixture::seedHighTrustCompleteChain();
+
+        $bundle = app(CareerJobDetailBundleBuilder::class)->buildBySlug('backend-architect');
+
+        $this->assertNull($bundle);
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career;
 
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
 use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -17,7 +19,40 @@ final class CareerJobDetailBundleBuilderTest extends TestCase
     public function test_it_builds_an_explicit_job_detail_bundle_from_authority_rows(): void
     {
         $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
-        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-build-job',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
 
         $bundle = app(CareerJobDetailBundleBuilder::class)->buildBySlug('backend-architect');
 
@@ -41,5 +76,75 @@ final class CareerJobDetailBundleBuilderTest extends TestCase
         $bundle = app(CareerJobDetailBundleBuilder::class)->buildBySlug('backend-architect');
 
         $this->assertNull($bundle);
+    }
+
+    public function test_it_prefers_first_wave_materialized_compile_snapshots_over_later_non_public_compiles(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-wave']);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-wave',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile(
+            $chain['childProjection'],
+            $chain['occupation'],
+            [
+                'compile_run_id' => $compileRun->id,
+                'trust_manifest_id' => $chain['trustManifest']->id,
+                'index_state_id' => $chain['indexState']->id,
+                'truth_metric_id' => $chain['truthMetric']->id,
+                'import_run_id' => $importRun->id,
+            ],
+        );
+
+        $personalContext = $chain['contextSnapshot']->replicate();
+        $personalContext->compile_run_id = null;
+        $personalContext->captured_at = now()->subMinute();
+        $personalContext->context_payload = ['materialization' => 'user_personalized'];
+        $personalContext->save();
+
+        $personalProjection = $chain['childProjection']->replicate();
+        $personalProjection->compile_run_id = null;
+        $personalProjection->context_snapshot_id = $personalContext->id;
+        $personalProjection->projection_payload = ['materialization' => 'user_personalized'];
+        $personalProjection->save();
+
+        app(CareerRecommendationCompiler::class)->compile($personalProjection, $chain['occupation']);
+
+        $bundle = app(CareerJobDetailBundleBuilder::class)->buildBySlug('backend-architect-wave');
+
+        $this->assertNotNull($bundle);
+        $this->assertSame(
+            $compileRun->id,
+            data_get($bundle?->toArray(), 'provenance_meta.compile_run_id')
+        );
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career;
 
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
 use App\Services\Career\Bundles\CareerRecommendationDetailBundleBuilder;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -17,10 +19,35 @@ final class CareerRecommendationDetailBundleBuilderTest extends TestCase
     public function test_it_builds_a_recommendation_bundle_from_compiled_snapshot_and_subject_meta(): void
     {
         $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-build-rec',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
         $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
             'projection_payload' => array_merge(
                 is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
                 [
+                    'materialization' => 'career_first_wave',
                     'recommendation_subject_meta' => [
                         'type_code' => 'INTJ-A',
                         'canonical_type_code' => 'INTJ',
@@ -30,7 +57,10 @@ final class CareerRecommendationDetailBundleBuilderTest extends TestCase
             ),
         ]);
 
-        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
 
         $bundle = app(CareerRecommendationDetailBundleBuilder::class)->buildByType('intj');
 
@@ -42,6 +72,7 @@ final class CareerRecommendationDetailBundleBuilderTest extends TestCase
         $this->assertArrayHasKey('fit_score', (array) data_get($payload, 'score_bundle'));
         $this->assertArrayHasKey('allow_strong_claim', (array) data_get($payload, 'claim_permissions'));
         $this->assertSame('career_recommendation_detail_bundle', data_get($payload, 'seo_contract.surface_type'));
+        $this->assertSame('/career/recommendations/mbti/intj', data_get($payload, 'seo_contract.canonical_path'));
         $this->assertArrayHasKey('compile_refs', (array) data_get($payload, 'provenance_meta'));
     }
 
@@ -53,5 +84,92 @@ final class CareerRecommendationDetailBundleBuilderTest extends TestCase
         $bundle = app(CareerRecommendationDetailBundleBuilder::class)->buildByType('INTJ');
 
         $this->assertNull($bundle);
+    }
+
+    public function test_it_prefers_first_wave_materialized_subject_snapshots_over_later_non_public_compiles(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-rec-wave']);
+        $chain['childProjection']->update([
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'recommendation_subject_meta' => [
+                        'type_code' => 'INTJ-A',
+                        'canonical_type_code' => 'INTJ',
+                    ],
+                    'materialization' => 'career_first_wave',
+                ],
+            ),
+        ]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-rec-wave',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile(
+            $chain['childProjection'],
+            $chain['occupation'],
+            [
+                'compile_run_id' => $compileRun->id,
+                'trust_manifest_id' => $chain['trustManifest']->id,
+                'index_state_id' => $chain['indexState']->id,
+                'truth_metric_id' => $chain['truthMetric']->id,
+                'import_run_id' => $importRun->id,
+            ],
+        );
+
+        $personalContext = $chain['contextSnapshot']->replicate();
+        $personalContext->compile_run_id = null;
+        $personalContext->captured_at = now()->subMinute();
+        $personalContext->context_payload = ['materialization' => 'user_personalized'];
+        $personalContext->save();
+
+        $personalProjection = $chain['childProjection']->replicate();
+        $personalProjection->compile_run_id = null;
+        $personalProjection->context_snapshot_id = $personalContext->id;
+        $personalProjection->projection_payload = [
+            'materialization' => 'user_personalized',
+            'recommendation_subject_meta' => [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+            ],
+        ];
+        $personalProjection->save();
+
+        app(CareerRecommendationCompiler::class)->compile($personalProjection, $chain['occupation']);
+
+        $bundle = app(CareerRecommendationDetailBundleBuilder::class)->buildByType('intj');
+
+        $this->assertNotNull($bundle);
+        $this->assertSame(
+            $compileRun->id,
+            data_get($bundle?->toArray(), 'provenance_meta.compile_run_id')
+        );
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Bundles\CareerRecommendationDetailBundleBuilder;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerRecommendationDetailBundleBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_recommendation_bundle_from_compiled_snapshot_and_subject_meta(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
+        $chain['childProjection']->update([
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'recommendation_subject_meta' => [
+                        'type_code' => 'INTJ-A',
+                        'canonical_type_code' => 'INTJ',
+                        'display_title' => 'INTJ-A Career Match',
+                    ],
+                ],
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+
+        $bundle = app(CareerRecommendationDetailBundleBuilder::class)->buildByType('intj');
+
+        $this->assertNotNull($bundle);
+        $payload = $bundle?->toArray() ?? [];
+
+        $this->assertSame('career.protocol.recommendation_detail.v1', $payload['bundle_version']);
+        $this->assertSame('INTJ-A', data_get($payload, 'recommendation_subject_meta.type_code'));
+        $this->assertArrayHasKey('fit_score', (array) data_get($payload, 'score_bundle'));
+        $this->assertArrayHasKey('allow_strong_claim', (array) data_get($payload, 'claim_permissions'));
+        $this->assertSame('career_recommendation_detail_bundle', data_get($payload, 'seo_contract.surface_type'));
+        $this->assertArrayHasKey('compile_refs', (array) data_get($payload, 'provenance_meta'));
+    }
+
+    public function test_it_returns_null_without_explicit_subject_meta(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+
+        $bundle = app(CareerRecommendationDetailBundleBuilder::class)->buildByType('INTJ');
+
+        $this->assertNull($bundle);
+    }
+}


### PR DESCRIPTION
## What changed
- add backend-owned Career bundle builders under `app/Services/Career/Bundles` for first-wave `job detail` and `recommendation detail` output
- add explicit Career DTOs under `app/DTO/Career` so bundle shape is stabilized before resource/controller serialization
- add thin Career resources under `app/Http/Resources/Career` that serialize DTOs without recomputing score, trust, warning, or claim logic
- add thin Career API controllers under `app/Http/Controllers/API/V0_5/Career` and new first-wave routes for `/api/v0.5/career/jobs/{slug}` and `/api/v0.5/career/recommendations/mbti/{type}`
- expose explicit protocol sections for identity, locale policy, titles, ontology, truth, trust manifest, score bundle, warnings, claim permissions, SEO/index gate, and provenance meta
- keep recommendation detail strictly compiled-output first by reading `RecommendationSnapshot` plus explicit `recommendation_subject_meta` from `ProfileProjection`
- keep unavailable paths conservative: if there is no compiled authority snapshot or no explicit subject meta, the new endpoints return `NOT_FOUND` instead of falling back to CMS/public-surface data
- add bundle-builder unit tests and first-wave API tests while keeping B1/B2/B3 and existing CMS Career public API tests green

## Why
PR-B1 through PR-B3 established the authority rows, scoring compiler, and replay-safe materialization path, but the backend still had no stable API contract layer for emitting canonical Career bundles.

This PR adds the first backend-owned bundle output path without moving authority back into controllers, CMS services, or frontend composition. The new layer stays thin at the edge and reads only compiled authority rows plus explicit provenance and index/trust state.

## Scope
### New bundle builders
- `CareerJobDetailBundleBuilder`
- `CareerRecommendationDetailBundleBuilder`

### New DTO/resource/controller layer
- `CareerJobDetailBundle`
- `CareerRecommendationDetailBundle`
- `CareerJobDetailResource`
- `CareerRecommendationDetailResource`
- `CareerJobDetailController`
- `CareerRecommendationDetailController`

### New first-wave routes
- `GET /api/v0.5/career/jobs/{slug}`
- `GET /api/v0.5/career/recommendations/mbti/{type}`

## Guardrails in this PR
- do not reuse `CareerJobController`, `CareerRecommendationController`, `CareerJobService`, or `CareerRecommendationService` as bundle authority
- do not recompute scoring, warning, trust, or claim logic in resources or controllers
- do not fall back to mutable CMS/public-surface authority when compiled Career rows are unavailable
- keep `job detail` and `recommendation detail` as the only first-wave bundle surfaces in this PR
- keep SEO/index exposure conservative and explicit through `canonical_path`, `index_state`, `index_eligible`, and `canonical_target`
- keep provenance explicit through `content_version`, `data_version`, `logic_version`, `compiler_version`, `compiled_at`, `truth_metric_id`, `trust_manifest_id`, `index_state_id`, `compile_run_id`, `import_run_id`, and `compile_refs`

## Validation
- `vendor/bin/pint --test app/DTO/Career app/Services/Career/Bundles app/Http/Resources/Career app/Http/Controllers/API/V0_5/Career routes/api.php tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php`
- `php artisan test tests/Feature/Career/CareerFoundationSchemaTest.php tests/Feature/Career/CareerFoundationLineageTest.php tests/Feature/Career/CareerRecommendationCompilerTest.php tests/Feature/Career/CareerRecommendationProvenancePatchTest.php tests/Feature/Career/CareerAuthorityImportCommandTest.php tests/Feature/Career/CareerAuthorityCompileCommandTest.php tests/Feature/Career/CareerAuthorityRunLedgerTest.php tests/Feature/Career/CareerAuthorityReplaySafetyTest.php tests/Feature/Career/CareerAuthorityCompileGuardTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/V0_5/CareerJobPublicApiTest.php tests/Feature/V0_5/CareerRecommendationPublicApiTest.php`

## Deferred to PR-B5 or later
- frontend wiring to the new Career protocol bundle endpoints
- broader list/index/search bundle rollout
- broader alias enrichment and broader mapping classes
- public exposure beyond the first-wave `job detail + recommendation detail` surface
- transition-path deepening or queue fan-out work
