### PR TITLE
PR-B5: Build Career lightweight list and index bundles

### DIFF
--- a/backend/app/DTO/Career/CareerJobListItemBundle.php
+++ b/backend/app/DTO/Career/CareerJobListItemBundle.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerJobListItemBundle
+{
+    /**
+     * @param  array<string, mixed>  $identity
+     * @param  array<string, mixed>  $titles
+     * @param  array<string, mixed>  $truthSummary
+     * @param  array<string, mixed>  $trustSummary
+     * @param  array<string, mixed>  $scoreSummary
+     * @param  array<string, mixed>  $seoContract
+     * @param  array<string, mixed>  $provenanceMeta
+     */
+    public function __construct(
+        public readonly array $identity,
+        public readonly array $titles,
+        public readonly array $truthSummary,
+        public readonly array $trustSummary,
+        public readonly array $scoreSummary,
+        public readonly array $seoContract,
+        public readonly array $provenanceMeta,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'bundle_kind' => 'career_job_list_item',
+            'bundle_version' => 'career.protocol.job_list_item.v1',
+            'identity' => $this->identity,
+            'titles' => $this->titles,
+            'truth_summary' => $this->truthSummary,
+            'trust_summary' => $this->trustSummary,
+            'score_summary' => $this->scoreSummary,
+            'seo_contract' => $this->seoContract,
+            'provenance_meta' => $this->provenanceMeta,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerRecommendationIndexItemBundle.php
+++ b/backend/app/DTO/Career/CareerRecommendationIndexItemBundle.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerRecommendationIndexItemBundle
+{
+    /**
+     * @param  array<string, mixed>  $recommendationSubjectMeta
+     * @param  array<string, mixed>  $scoreSummary
+     * @param  array<string, mixed>  $trustSummary
+     * @param  array<string, mixed>  $seoContract
+     * @param  array<string, mixed>  $provenanceMeta
+     */
+    public function __construct(
+        public readonly array $recommendationSubjectMeta,
+        public readonly array $scoreSummary,
+        public readonly array $trustSummary,
+        public readonly array $seoContract,
+        public readonly array $provenanceMeta,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'bundle_kind' => 'career_recommendation_index_item',
+            'bundle_version' => 'career.protocol.recommendation_index_item.v1',
+            'recommendation_subject_meta' => $this->recommendationSubjectMeta,
+            'score_summary' => $this->scoreSummary,
+            'trust_summary' => $this->trustSummary,
+            'seo_contract' => $this->seoContract,
+            'provenance_meta' => $this->provenanceMeta,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerJobListController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerJobListController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerJobListItemResource;
+use App\Services\Career\Bundles\CareerJobListBundleBuilder;
+use Illuminate\Http\JsonResponse;
+
+final class CareerJobListController extends Controller
+{
+    public function __construct(
+        private readonly CareerJobListBundleBuilder $bundleBuilder,
+    ) {}
+
+    public function index(): JsonResponse
+    {
+        $items = CareerJobListItemResource::collection(
+            $this->bundleBuilder->build()
+        )->resolve();
+
+        return response()->json([
+            'bundle_kind' => 'career_job_index',
+            'bundle_version' => 'career.protocol.job_index.v1',
+            'items' => $items,
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerRecommendationIndexController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerRecommendationIndexController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerRecommendationIndexItemResource;
+use App\Services\Career\Bundles\CareerRecommendationIndexBundleBuilder;
+use Illuminate\Http\JsonResponse;
+
+final class CareerRecommendationIndexController extends Controller
+{
+    public function __construct(
+        private readonly CareerRecommendationIndexBundleBuilder $bundleBuilder,
+    ) {}
+
+    public function index(): JsonResponse
+    {
+        $items = CareerRecommendationIndexItemResource::collection(
+            $this->bundleBuilder->build()
+        )->resolve();
+
+        return response()->json([
+            'bundle_kind' => 'career_recommendation_index',
+            'bundle_version' => 'career.protocol.recommendation_index.v1',
+            'items' => $items,
+        ]);
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerJobListItemResource.php
+++ b/backend/app/Http/Resources/Career/CareerJobListItemResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerJobListItemBundle;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerJobListItemBundle
+ */
+final class CareerJobListItemResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerJobListItemBundle $bundle */
+        $bundle = $this->resource;
+
+        return $bundle->toArray();
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerRecommendationIndexItemResource.php
+++ b/backend/app/Http/Resources/Career/CareerRecommendationIndexItemResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerRecommendationIndexItemBundle;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerRecommendationIndexItemBundle
+ */
+final class CareerRecommendationIndexItemResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerRecommendationIndexItemBundle $bundle */
+        $bundle = $this->resource;
+
+        return $bundle->toArray();
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -46,11 +46,24 @@ final class CareerJobListBundleBuilder
             })
             ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
-            ->get()
-            ->unique('occupation_id')
+            ->get();
+
+        $selectedSnapshots = $snapshots
+            ->groupBy('occupation_id')
+            ->map(function (Collection $group) use ($includeNonIndexable): ?RecommendationSnapshot {
+                /** @var RecommendationSnapshot|null $selected */
+                $selected = $group
+                    ->sort(function (RecommendationSnapshot $left, RecommendationSnapshot $right) use ($includeNonIndexable): int {
+                        return $this->compareSnapshots($left, $right, $includeNonIndexable);
+                    })
+                    ->first();
+
+                return $selected;
+            })
+            ->filter()
             ->values();
 
-        $items = $snapshots
+        $items = $selectedSnapshots
             ->map(function (RecommendationSnapshot $snapshot) use ($includeNonIndexable): ?CareerJobListItemBundle {
                 $occupation = $snapshot->occupation;
                 if (! $occupation instanceof Occupation) {
@@ -74,6 +87,25 @@ final class CareerJobListBundleBuilder
         ])->values();
 
         return $items->all();
+    }
+
+    private function compareSnapshots(RecommendationSnapshot $left, RecommendationSnapshot $right, bool $includeNonIndexable): int
+    {
+        if (! $includeNonIndexable) {
+            $leftEligible = (bool) ($left->indexState?->index_eligible ?? false);
+            $rightEligible = (bool) ($right->indexState?->index_eligible ?? false);
+            if ($leftEligible !== $rightEligible) {
+                return $leftEligible ? -1 : 1;
+            }
+        }
+
+        $leftCompiled = optional($left->compiled_at)?->getTimestamp() ?? 0;
+        $rightCompiled = optional($right->compiled_at)?->getTimestamp() ?? 0;
+        if ($leftCompiled !== $rightCompiled) {
+            return $rightCompiled <=> $leftCompiled;
+        }
+
+        return strcmp((string) $left->id, (string) $right->id);
     }
 
     private function buildItem(RecommendationSnapshot $snapshot, Occupation $occupation): CareerJobListItemBundle

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\DTO\Career\CareerJobListItemBundle;
+use App\Models\Occupation;
+use App\Models\RecommendationSnapshot;
+use App\Services\PublicSurface\SeoSurfaceContractService;
+use Illuminate\Support\Collection;
+
+final class CareerJobListBundleBuilder
+{
+    private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
+
+    public function __construct(
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
+    ) {}
+
+    /**
+     * @return list<CareerJobListItemBundle>
+     */
+    public function build(bool $includeNonIndexable = false): array
+    {
+        $snapshots = RecommendationSnapshot::query()
+            ->with([
+                'occupation.editorialPatches' => fn ($query) => $query->orderByDesc('updated_at')->orderByDesc('created_at'),
+                'truthMetric',
+                'trustManifest',
+                'indexState',
+                'compileRun',
+                'profileProjection',
+                'contextSnapshot',
+            ])
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('occupation', static function ($query): void {
+                $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
+            })
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->get()
+            ->unique('occupation_id')
+            ->values();
+
+        $items = $snapshots
+            ->map(function (RecommendationSnapshot $snapshot) use ($includeNonIndexable): ?CareerJobListItemBundle {
+                $occupation = $snapshot->occupation;
+                if (! $occupation instanceof Occupation) {
+                    return null;
+                }
+
+                $indexState = $snapshot->indexState;
+                if (! $includeNonIndexable && ! (bool) ($indexState?->index_eligible ?? false)) {
+                    return null;
+                }
+
+                return $this->buildItem($snapshot, $occupation);
+            })
+            ->filter()
+            ->values();
+
+        /** @var Collection<int, CareerJobListItemBundle> $items */
+        $items = $items->sortBy(static fn (CareerJobListItemBundle $item): array => [
+            strtolower((string) ($item->titles['canonical_en'] ?? '')),
+            strtolower((string) ($item->identity['canonical_slug'] ?? '')),
+        ])->values();
+
+        return $items->all();
+    }
+
+    private function buildItem(RecommendationSnapshot $snapshot, Occupation $occupation): CareerJobListItemBundle
+    {
+        $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
+        $truthMetric = $snapshot->truthMetric;
+        $trustManifest = $snapshot->trustManifest;
+        $indexState = $snapshot->indexState;
+        $editorialPatch = $occupation->editorialPatches->first();
+        $claimPermissions = is_array($payload['claim_permissions'] ?? null) ? $payload['claim_permissions'] : [];
+        $importRunId = $truthMetric?->import_run_id
+            ?? $trustManifest?->import_run_id
+            ?? $indexState?->import_run_id;
+
+        return new CareerJobListItemBundle(
+            identity: [
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $occupation->canonical_slug,
+                'entity_level' => $occupation->entity_level,
+                'family_uuid' => $occupation->family_id,
+            ],
+            titles: [
+                'canonical_en' => $occupation->canonical_title_en,
+                'canonical_zh' => $occupation->canonical_title_zh,
+                'search_h1_zh' => $occupation->search_h1_zh,
+            ],
+            truthSummary: [
+                'truth_market' => $truthMetric?->truth_market,
+                'median_pay_usd_annual' => $claimPermissions['allow_salary_comparison'] ?? false
+                    ? $truthMetric?->median_pay_usd_annual
+                    : null,
+                'outlook_pct_2024_2034' => $truthMetric?->outlook_pct_2024_2034,
+                'outlook_description' => $truthMetric?->outlook_description,
+                'ai_exposure' => $claimPermissions['allow_ai_strategy'] ?? false
+                    ? $truthMetric?->ai_exposure
+                    : null,
+            ],
+            trustSummary: [
+                'reviewer_status' => $trustManifest?->reviewer_status,
+                'reviewed_at' => optional($trustManifest?->reviewed_at)->toISOString(),
+                'content_version' => $trustManifest?->content_version,
+                'data_version' => $trustManifest?->data_version,
+                'logic_version' => $trustManifest?->logic_version,
+                'editorial_patch_required' => (bool) ($editorialPatch?->required ?? false),
+                'editorial_patch_status' => $editorialPatch?->status,
+                'allow_strong_claim' => (bool) ($claimPermissions['allow_strong_claim'] ?? false),
+                'allow_salary_comparison' => (bool) ($claimPermissions['allow_salary_comparison'] ?? false),
+                'allow_ai_strategy' => (bool) ($claimPermissions['allow_ai_strategy'] ?? false),
+                'reason_codes' => is_array($claimPermissions['reason_codes'] ?? null) ? $claimPermissions['reason_codes'] : [],
+            ],
+            scoreSummary: [
+                'fit_score' => $this->compactScore($payload['score_bundle']['fit_score'] ?? null),
+                'confidence_score' => $this->compactScore($payload['score_bundle']['confidence_score'] ?? null),
+            ],
+            seoContract: $this->buildSeoContract($occupation, $snapshot),
+            provenanceMeta: [
+                'content_version' => $trustManifest?->content_version,
+                'data_version' => $trustManifest?->data_version,
+                'logic_version' => $trustManifest?->logic_version,
+                'compiler_version' => $snapshot->compiler_version,
+                'compiled_at' => optional($snapshot->compiled_at)->toISOString(),
+                'truth_metric_id' => $snapshot->truth_metric_id,
+                'trust_manifest_id' => $snapshot->trust_manifest_id,
+                'index_state_id' => $snapshot->index_state_id,
+                'compile_run_id' => $snapshot->compile_run_id,
+                'import_run_id' => $importRunId,
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildSeoContract(Occupation $occupation, RecommendationSnapshot $snapshot): array
+    {
+        $indexState = $snapshot->indexState;
+        $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
+        $canonicalTarget = $indexState?->canonical_target;
+        $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_job_list_item_bundle',
+            'canonical_url' => $canonicalTarget ?: $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $canonicalTarget,
+            'index_state' => $indexState?->index_state,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function compactScore(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [
+                'value' => null,
+                'integrity_state' => null,
+                'band' => null,
+            ];
+        }
+
+        return [
+            'value' => $value['value'] ?? null,
+            'integrity_state' => $value['integrity_state'] ?? null,
+            'band' => $value['band'] ?? null,
+        ];
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\DTO\Career\CareerRecommendationIndexItemBundle;
+use App\Models\RecommendationSnapshot;
+use App\Services\PublicSurface\SeoSurfaceContractService;
+use Illuminate\Support\Collection;
+
+final class CareerRecommendationIndexBundleBuilder
+{
+    private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
+
+    public function __construct(
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
+    ) {}
+
+    /**
+     * @return list<CareerRecommendationIndexItemBundle>
+     */
+    public function build(bool $includeNonIndexable = false): array
+    {
+        $snapshots = RecommendationSnapshot::query()
+            ->with([
+                'occupation',
+                'trustManifest',
+                'indexState',
+                'profileProjection',
+                'contextSnapshot',
+                'compileRun',
+            ])
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('occupation', static function ($query): void {
+                $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
+            })
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave')
+                    ->whereNotNull('projection_payload->recommendation_subject_meta');
+            })
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->get();
+
+        $grouped = $snapshots
+            ->map(function (RecommendationSnapshot $snapshot): ?array {
+                $subjectMeta = $this->subjectMeta($snapshot);
+                $routeSubject = $this->routeSubject($subjectMeta);
+
+                if ($routeSubject === null) {
+                    return null;
+                }
+
+                return [
+                    'route_subject' => $routeSubject,
+                    'snapshot' => $snapshot,
+                ];
+            })
+            ->filter()
+            ->groupBy('route_subject');
+
+        $items = $grouped
+            ->map(function (Collection $group) use ($includeNonIndexable): ?CareerRecommendationIndexItemBundle {
+                $selected = $group
+                    ->sort(function (array $left, array $right): int {
+                        /** @var RecommendationSnapshot $leftSnapshot */
+                        $leftSnapshot = $left['snapshot'];
+                        /** @var RecommendationSnapshot $rightSnapshot */
+                        $rightSnapshot = $right['snapshot'];
+
+                        return $this->compareSnapshots($leftSnapshot, $rightSnapshot);
+                    })
+                    ->first();
+
+                if (! is_array($selected)) {
+                    return null;
+                }
+
+                /** @var RecommendationSnapshot $snapshot */
+                $snapshot = $selected['snapshot'];
+                $indexState = $snapshot->indexState;
+                if (! $includeNonIndexable && ! (bool) ($indexState?->index_eligible ?? false)) {
+                    return null;
+                }
+
+                return $this->buildItem($snapshot);
+            })
+            ->filter()
+            ->values();
+
+        /** @var Collection<int, CareerRecommendationIndexItemBundle> $items */
+        $items = $items->sortBy(static fn (CareerRecommendationIndexItemBundle $item): array => [
+            strtolower((string) ($item->recommendationSubjectMeta['public_route_slug'] ?? '')),
+            strtolower((string) ($item->recommendationSubjectMeta['type_code'] ?? '')),
+        ])->values();
+
+        return $items->all();
+    }
+
+    private function buildItem(RecommendationSnapshot $snapshot): CareerRecommendationIndexItemBundle
+    {
+        $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
+        $subjectMeta = $this->subjectMeta($snapshot);
+        $trustManifest = $snapshot->trustManifest;
+        $indexState = $snapshot->indexState;
+        $importRunId = $trustManifest?->import_run_id
+            ?? $indexState?->import_run_id;
+        $claimPermissions = is_array($payload['claim_permissions'] ?? null) ? $payload['claim_permissions'] : [];
+
+        return new CareerRecommendationIndexItemBundle(
+            recommendationSubjectMeta: $subjectMeta,
+            scoreSummary: [
+                'fit_score' => $this->compactScore($payload['score_bundle']['fit_score'] ?? null),
+                'confidence_score' => $this->compactScore($payload['score_bundle']['confidence_score'] ?? null),
+            ],
+            trustSummary: [
+                'reviewer_status' => $trustManifest?->reviewer_status,
+                'reviewed_at' => optional($trustManifest?->reviewed_at)->toISOString(),
+                'content_version' => $trustManifest?->content_version,
+                'data_version' => $trustManifest?->data_version,
+                'logic_version' => $trustManifest?->logic_version,
+                'allow_strong_claim' => (bool) ($claimPermissions['allow_strong_claim'] ?? false),
+                'allow_salary_comparison' => (bool) ($claimPermissions['allow_salary_comparison'] ?? false),
+                'allow_ai_strategy' => (bool) ($claimPermissions['allow_ai_strategy'] ?? false),
+                'reason_codes' => is_array($claimPermissions['reason_codes'] ?? null) ? $claimPermissions['reason_codes'] : [],
+            ],
+            seoContract: $this->buildSeoContract($snapshot, $subjectMeta),
+            provenanceMeta: [
+                'content_version' => $trustManifest?->content_version,
+                'data_version' => $trustManifest?->data_version,
+                'logic_version' => $trustManifest?->logic_version,
+                'compiler_version' => $snapshot->compiler_version,
+                'compiled_at' => optional($snapshot->compiled_at)->toISOString(),
+                'truth_metric_id' => $snapshot->truth_metric_id,
+                'trust_manifest_id' => $snapshot->trust_manifest_id,
+                'index_state_id' => $snapshot->index_state_id,
+                'compile_run_id' => $snapshot->compile_run_id,
+                'import_run_id' => $importRunId,
+            ],
+        );
+    }
+
+    private function compareSnapshots(RecommendationSnapshot $left, RecommendationSnapshot $right): int
+    {
+        $leftEligible = (bool) ($left->indexState?->index_eligible ?? false);
+        $rightEligible = (bool) ($right->indexState?->index_eligible ?? false);
+        if ($leftEligible !== $rightEligible) {
+            return $leftEligible ? -1 : 1;
+        }
+
+        $leftCompiled = optional($left->compiled_at)?->getTimestamp() ?? 0;
+        $rightCompiled = optional($right->compiled_at)?->getTimestamp() ?? 0;
+        if ($leftCompiled !== $rightCompiled) {
+            return $rightCompiled <=> $leftCompiled;
+        }
+
+        $leftSlug = strtolower((string) ($left->occupation?->canonical_slug ?? ''));
+        $rightSlug = strtolower((string) ($right->occupation?->canonical_slug ?? ''));
+        if ($leftSlug !== $rightSlug) {
+            return $leftSlug <=> $rightSlug;
+        }
+
+        return strcmp((string) $left->id, (string) $right->id);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildSeoContract(RecommendationSnapshot $snapshot, array $subjectMeta): array
+    {
+        $indexState = $snapshot->indexState;
+        $routeSubject = $this->routeSubject($subjectMeta) ?? 'unknown';
+        $canonicalPath = '/career/recommendations/mbti/'.$routeSubject;
+        $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_recommendation_index_item_bundle',
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => (string) ($subjectMeta['display_title'] ?? $subjectMeta['type_code'] ?? $routeSubject),
+            'description' => (string) ($subjectMeta['display_title'] ?? $routeSubject),
+            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $indexState?->canonical_target,
+            'index_state' => $indexState?->index_state,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function subjectMeta(RecommendationSnapshot $snapshot): array
+    {
+        $projectionPayload = is_array($snapshot->profileProjection?->projection_payload) ? $snapshot->profileProjection->projection_payload : [];
+        $subjectMeta = is_array($projectionPayload['recommendation_subject_meta'] ?? null)
+            ? $projectionPayload['recommendation_subject_meta']
+            : [];
+
+        $routeSubject = $this->routeSubject($subjectMeta);
+
+        return [
+            'type_code' => $subjectMeta['type_code'] ?? null,
+            'canonical_type_code' => $subjectMeta['canonical_type_code'] ?? null,
+            'display_title' => $subjectMeta['display_title'] ?? $subjectMeta['type_code'] ?? null,
+            'public_route_slug' => $routeSubject,
+        ];
+    }
+
+    private function routeSubject(array $subjectMeta): ?string
+    {
+        $candidates = [
+            $subjectMeta['public_route_slug'] ?? null,
+            $subjectMeta['route_type'] ?? null,
+            $subjectMeta['canonical_type_code'] ?? null,
+            $subjectMeta['type_code'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_scalar($candidate)) {
+                continue;
+            }
+
+            $normalized = strtolower(trim((string) $candidate));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function compactScore(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [
+                'value' => null,
+                'integrity_state' => null,
+                'band' => null,
+            ];
+        }
+
+        return [
+            'value' => $value['value'] ?? null,
+            'integrity_state' => $value['integrity_state'] ?? null,
+            'band' => $value['band'] ?? null,
+        ];
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2345,6 +2345,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/jobs": {
+            "get": {
+                "operationId": "get_api_v0_5_career_jobs",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerJobListController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/jobs/{slug}": {
             "get": {
                 "operationId": "get_api_v0_5_career_jobs_slug_",
@@ -2357,6 +2374,23 @@
                     }
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerJobDetailController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/career/recommendations/mbti": {
+            "get": {
+                "operationId": "get_api_v0_5_career_recommendations_mbti",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerRecommendationIndexController@index",
                 "x-laravel-middleware": [
                     "api"
                 ]

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -30,7 +30,9 @@ use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
+use App\Http\Controllers\API\V0_5\Career\CareerJobListController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationDetailController;
+use App\Http\Controllers\API\V0_5\Career\CareerRecommendationIndexController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
 use App\Http\Controllers\API\V0_5\Cms\CareerGuideController;
 use App\Http\Controllers\API\V0_5\Cms\CareerJobController;
@@ -395,7 +397,9 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
 });
 
 Route::prefix('v0.5')->group(function () {
+    Route::get('/career/jobs', [CareerJobListController::class, 'index']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);
+    Route::get('/career/recommendations/mbti', [CareerRecommendationIndexController::class, 'index']);
     Route::get('/career/recommendations/mbti/{type}', [CareerRecommendationDetailController::class, 'show']);
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerJobListApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobListApiTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerJobListApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_a_resource_backed_lightweight_job_index(): void
+    {
+        $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-index']));
+        $this->compileJobChain(CareerFoundationFixture::seedMissingTruthChain());
+
+        $this->getJson('/api/v0.5/career/jobs')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_job_index')
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.identity.canonical_slug', 'backend-architect-index')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', true)
+            ->assertJsonStructure([
+                'bundle_kind',
+                'bundle_version',
+                'items' => [[
+                    'identity',
+                    'titles',
+                    'truth_summary',
+                    'trust_summary',
+                    'score_summary',
+                    'seo_contract' => ['canonical_path', 'index_state', 'index_eligible', 'reason_codes'],
+                    'provenance_meta' => ['compiler_version', 'compile_run_id'],
+                ]],
+            ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     */
+    private function compileJobChain(array $chain): void
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-job-api-'.$chain['occupation']->canonical_slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+    }
+}

--- a/backend/tests/Feature/Career/CareerRecommendationIndexApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationIndexApiTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerRecommendationIndexApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_a_resource_backed_lightweight_recommendation_index(): void
+    {
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-intj-index']),
+            [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+                'display_title' => 'INTJ-A Career Match',
+                'public_route_slug' => 'intj',
+            ]
+        );
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedTrustLimitedCrossMarketChain(),
+            [
+                'type_code' => 'ENFP-T',
+                'canonical_type_code' => 'ENFP',
+                'display_title' => 'ENFP-T Career Match',
+                'public_route_slug' => 'enfp',
+            ]
+        );
+
+        $this->getJson('/api/v0.5/career/recommendations/mbti')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_recommendation_index')
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.recommendation_subject_meta.public_route_slug', 'intj')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', true)
+            ->assertJsonStructure([
+                'bundle_kind',
+                'bundle_version',
+                'items' => [[
+                    'recommendation_subject_meta',
+                    'score_summary',
+                    'trust_summary',
+                    'seo_contract' => ['canonical_path', 'index_state', 'index_eligible', 'reason_codes'],
+                    'provenance_meta' => ['compiler_version', 'compile_run_id'],
+                ]],
+            ]);
+    }
+
+    public function test_it_returns_an_empty_index_when_no_public_safe_subjects_exist(): void
+    {
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedTrustLimitedCrossMarketChain(),
+            [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+                'display_title' => 'INTJ-A Career Match',
+                'public_route_slug' => 'intj',
+            ]
+        );
+
+        $this->getJson('/api/v0.5/career/recommendations/mbti')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_recommendation_index')
+            ->assertJsonCount(0, 'items');
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     * @param  array<string, mixed>  $subjectMeta
+     */
+    private function compileRecommendationChain(array $chain, array $subjectMeta): void
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-rec-api-'.$chain['occupation']->canonical_slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'materialization' => 'career_first_wave',
+                    'recommendation_subject_meta' => $subjectMeta,
+                ]
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Services\Career\Bundles\CareerJobListBundleBuilder;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerJobListBundleBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_only_first_wave_indexable_jobs_by_default(): void
+    {
+        $indexable = $this->compileJobChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-index'])
+        );
+        $this->compileJobChain(
+            CareerFoundationFixture::seedMissingTruthChain()
+        );
+
+        $items = app(CareerJobListBundleBuilder::class)->build();
+
+        $this->assertCount(1, $items);
+        $payload = $items[0]->toArray();
+
+        $this->assertSame('backend-architect-index', data_get($payload, 'identity.canonical_slug'));
+        $this->assertTrue((bool) data_get($payload, 'seo_contract.index_eligible'));
+        $this->assertSame(
+            $indexable['compileRun']->id,
+            data_get($payload, 'provenance_meta.compile_run_id')
+        );
+    }
+
+    public function test_it_can_include_non_indexable_jobs_when_explicitly_requested(): void
+    {
+        $this->compileJobChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-visible'])
+        );
+        $this->compileJobChain(
+            CareerFoundationFixture::seedTrustLimitedCrossMarketChain()
+        );
+
+        $items = app(CareerJobListBundleBuilder::class)->build(includeNonIndexable: true);
+        $payloads = array_map(static fn ($item): array => $item->toArray(), $items);
+
+        $this->assertCount(2, $payloads);
+        $this->assertContains('backend-architect-visible', array_column(array_column($payloads, 'identity'), 'canonical_slug'));
+        $this->assertContains('backend-architect-cn-market', array_column(array_column($payloads, 'identity'), 'canonical_slug'));
+        $this->assertFalse((bool) data_get(
+            collect($payloads)->firstWhere('identity.canonical_slug', 'backend-architect-cn-market'),
+            'seo_contract.index_eligible'
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     * @return array<string, mixed>
+     */
+    private function compileJobChain(array $chain): array
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-job-list-'.$chain['occupation']->canonical_slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        return [
+            'importRun' => $importRun,
+            'compileRun' => $compileRun,
+        ] + $chain;
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
@@ -59,11 +59,40 @@ final class CareerJobListBundleBuilderTest extends TestCase
         ));
     }
 
+    public function test_it_prefers_an_older_indexable_snapshot_over_a_newer_non_indexable_snapshot_for_the_same_job(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-stable']);
+        $this->compileJobChain($chain, now()->subMinutes(5));
+
+        $chain['occupation']->indexStates()->create([
+            'index_state' => 'trust_limited',
+            'index_eligible' => false,
+            'canonical_path' => '/career/jobs/backend-architect-stable',
+            'canonical_target' => null,
+            'reason_codes' => ['trust_limited'],
+            'changed_at' => now()->subSeconds(30),
+        ]);
+
+        $this->compileJobChain($chain, now()->subMinute());
+
+        $items = app(CareerJobListBundleBuilder::class)->build();
+
+        $this->assertCount(1, $items);
+        $payload = $items[0]->toArray();
+
+        $this->assertSame('backend-architect-stable', data_get($payload, 'identity.canonical_slug'));
+        $this->assertTrue((bool) data_get($payload, 'seo_contract.index_eligible'));
+        $this->assertContains(
+            data_get($payload, 'trust_summary.reviewer_status'),
+            ['approved', 'reviewed']
+        );
+    }
+
     /**
      * @param  array<string, mixed>  $chain
      * @return array<string, mixed>
      */
-    private function compileJobChain(array $chain): array
+    private function compileJobChain(array $chain, ?\Illuminate\Support\Carbon $compiledAt = null): array
     {
         $importRun = CareerImportRun::query()->create([
             'dataset_name' => 'fixture',
@@ -97,14 +126,19 @@ final class CareerJobListBundleBuilderTest extends TestCase
             ),
         ]);
 
-        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+        $snapshot = app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
             'compile_run_id' => $compileRun->id,
             'import_run_id' => $importRun->id,
         ]);
 
+        if ($compiledAt !== null) {
+            $snapshot->forceFill(['compiled_at' => $compiledAt])->save();
+        }
+
         return [
             'importRun' => $importRun,
             'compileRun' => $compileRun,
+            'snapshot' => $snapshot,
         ] + $chain;
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Services\Career\Bundles\CareerRecommendationIndexBundleBuilder;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerRecommendationIndexBundleBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_groups_recommendation_subjects_deterministically_by_public_route_slug(): void
+    {
+        $older = $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-intj-older']),
+            [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+                'display_title' => 'INTJ-A Career Match',
+                'public_route_slug' => 'intj',
+            ],
+            now()->subMinutes(9)
+        );
+        $newer = $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-intj-newer']),
+            [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+                'display_title' => 'INTJ-A Career Match',
+                'public_route_slug' => 'intj',
+            ],
+            now()->subMinutes(1)
+        );
+
+        $items = app(CareerRecommendationIndexBundleBuilder::class)->build(includeNonIndexable: true);
+
+        $this->assertCount(1, $items);
+        $payload = $items[0]->toArray();
+
+        $this->assertSame('intj', data_get($payload, 'recommendation_subject_meta.public_route_slug'));
+        $this->assertSame($newer['compileRun']->id, data_get($payload, 'provenance_meta.compile_run_id'));
+        $this->assertNotSame($older['compileRun']->id, data_get($payload, 'provenance_meta.compile_run_id'));
+    }
+
+    public function test_it_excludes_non_indexable_recommendation_subjects_by_default(): void
+    {
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedTrustLimitedCrossMarketChain(),
+            [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+                'display_title' => 'INTJ-A Career Match',
+                'public_route_slug' => 'intj',
+            ]
+        );
+
+        $items = app(CareerRecommendationIndexBundleBuilder::class)->build();
+
+        $this->assertSame([], $items);
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     * @param  array<string, mixed>  $subjectMeta
+     * @return array<string, mixed>
+     */
+    private function compileRecommendationChain(array $chain, array $subjectMeta, ?\Illuminate\Support\Carbon $compiledAt = null): array
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-rec-index-'.$chain['occupation']->canonical_slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'captured_at' => $compiledAt ?? now()->subMinutes(2),
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'materialization' => 'career_first_wave',
+                    'recommendation_subject_meta' => $subjectMeta,
+                ]
+            ),
+        ]);
+
+        $snapshot = app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        if ($compiledAt !== null) {
+            $snapshot->forceFill(['compiled_at' => $compiledAt])->save();
+        }
+
+        return [
+            'importRun' => $importRun,
+            'compileRun' => $compileRun,
+            'snapshot' => $snapshot,
+        ] + $chain;
+    }
+}


### PR DESCRIPTION
## What changed
- add backend-owned lightweight Career bundle builders for first-wave `job list/index` and `recommendation index` output
- add explicit lightweight DTOs under `backend/app/DTO/Career` so compact list/index bundle shape is stabilized before resource/controller serialization
- add thin Career resources under `backend/app/Http/Resources/Career` that serialize lightweight DTOs without recomputing score, trust, claim, or SEO logic
- add thin Career API controllers under `backend/app/Http/Controllers/API/V0_5/Career` and new first-wave routes for:
  - `GET /api/v0.5/career/jobs`
  - `GET /api/v0.5/career/recommendations/mbti`
- keep new surfaces lightweight and explicit by exposing only compact `identity`, `titles`, `truth_summary`, `trust_summary`, `score_summary`, `seo_contract`, and `provenance_meta` sections for job list items
- keep recommendation index items lightweight by exposing only compact `recommendation_subject_meta`, `score_summary`, `trust_summary`, `seo_contract`, and `provenance_meta`
- keep bundle authority in dedicated backend bundle builders rather than CMS services, public-surface controllers, or controller-inline array assembly
- restrict lightweight list/index reads to first-wave materialized compile chains and safe crosswalk modes (`exact`, `trust_inheritance`, plus legacy-safe `direct_match` fixture compatibility)
- implement deterministic recommendation subject grouping in the builder so recommendation index route identity stays stable and does not drift at controller time
- ensure the job index prefers a public-safe/indexable snapshot for an occupation when a newer snapshot has become non-indexable, instead of dropping that occupation from the lightweight index entirely
- sync the OpenAPI route contract snapshot so the new B5 list/index endpoints are reflected in `backend/docs/contracts/openapi.snapshot.json`
- add unit builder tests and feature API tests while keeping B1/B2/B3/B4 and existing CMS Career smoke/public API tests green

## Why
PR-B1 through PR-B4 established immutable Career authority rows, white-box scoring, first-wave materialization, and backend-owned detail bundle surfaces, but the backend still had no lightweight authority path for list/index rollout.

This PR adds the smallest safe read-side bundle layer needed for the next frontend rollout step without moving authority back into CMS services, public-surface controllers, or ad hoc controller assembly.

The follow-up fix in this PR also tightens snapshot selection for job index output so a newer non-indexable snapshot cannot accidentally suppress an older still-public-safe occupation card.

## Scope
### New lightweight bundle builders
- `CareerJobListBundleBuilder`
- `CareerRecommendationIndexBundleBuilder`

### New lightweight DTO/resource/controller layer
- `CareerJobListItemBundle`
- `CareerRecommendationIndexItemBundle`
- `CareerJobListItemResource`
- `CareerRecommendationIndexItemResource`
- `CareerJobListController`
- `CareerRecommendationIndexController`

### New first-wave routes
- `GET /api/v0.5/career/jobs`
- `GET /api/v0.5/career/recommendations/mbti`

## Guardrails in this PR
- do not reuse `CareerJobService`, `CareerRecommendationService`, or CMS Career controllers as authority on the new path
- do not assemble list/index arrays inline in controllers
- do not recompute scoring, trust, claim, or SEO gates in resources or controllers
- keep list/index bundles lightweight: no heavy narrative blocks, no detail-level truth dumps, no matched jobs/guides, and no explanation synthesis
- only expose explicit backend fields; do not infer trust/claim/index semantics from field presence
- keep recommendation grouping deterministic and builder-owned
- keep job index selection public-safe so the latest noindex snapshot does not erase an otherwise eligible occupation card
- keep scope constrained to first-wave safe authority rows only
- do not invent rollout flags such as `dataset_eligible` or `article_eligible`
- defer broad search rollout; no full-text, fuzzy, semantic, or broad alias discovery in this PR

## Validation
- `vendor/bin/pint --test backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php backend/app/DTO/Career/CareerJobListItemBundle.php backend/app/DTO/Career/CareerRecommendationIndexItemBundle.php backend/app/Http/Resources/Career/CareerJobListItemResource.php backend/app/Http/Resources/Career/CareerRecommendationIndexItemResource.php backend/app/Http/Controllers/API/V0_5/Career/CareerJobListController.php backend/app/Http/Controllers/API/V0_5/Career/CareerRecommendationIndexController.php backend/routes/api.php backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php backend/tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php backend/tests/Feature/Career/CareerJobListApiTest.php backend/tests/Feature/Career/CareerRecommendationIndexApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php tests/Feature/Career/CareerRecommendationIndexApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerRecommendationIndexApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/V0_5/CareerJobPublicApiTest.php tests/Feature/V0_5/CareerRecommendationPublicApiTest.php`

## Deferred to PR-F2 or later
- conservative public search endpoint rollout
- broader alias enrichment and broader crosswalk discovery
- list/index/search frontend wiring
- broader search platform design
- any scoring, import pipeline, or detail bundle redesign
