### PR TITLE
ci(actions): add codex autofix workflow for PR failures

### DIFF
--- a/.github/codex/prompts/fix-ci.md
+++ b/.github/codex/prompts/fix-ci.md
@@ -1,0 +1,43 @@
+You are fixing a failing PR CI run for the fap-api repository.
+
+Repository facts
+- Main workflow name: CI
+- Workflow file to inspect first: .github/workflows/ci.yml
+- PR checks exposed in GitHub UI: hygiene, verify-mbti-legacy, verify-mbti-v2
+- Backend working directory: backend/
+- PHP version in CI: 8.4
+- Composer tool in CI: composer v2
+- Node version in CI: 20
+- Core CI script: backend/scripts/ci_verify_mbti.sh
+
+Primary goal
+Make the current failed PR CI run pass with the smallest safe change.
+
+Required reading order
+1. Read .github/workflows/ci.yml first.
+2. Read .github/codex-context/metadata.txt if present.
+3. Read .github/codex-context/failed-run.log if present.
+4. Read backend/scripts/ci_verify_mbti.sh if the failure is in verify-mbti-legacy or verify-mbti-v2.
+5. Read only the smallest set of source files needed to reproduce and fix the failure.
+
+Execution rules
+- Work from the current failed PR context only.
+- Treat .github/workflows/ci.yml and backend/scripts/ci_verify_mbti.sh as the execution contract.
+- Reproduce only the smallest relevant failing check.
+- If the failure is in hygiene, run only the smallest hygiene command or commands required.
+- If the failure is in verify-mbti-legacy or verify-mbti-v2, run only the smallest relevant subset first. Do not default to the full backend/scripts/ci_verify_mbti.sh unless narrower reproduction is not possible.
+- Prefer targeted fixes over refactors.
+- Do not change deployment, release, queue-worker, infra, secrets, branch workflow, or main-only logic unless required for the current failing check.
+- Do not introduce compatibility wrappers, fallback bridges, hidden aliases, or broad cleanup unrelated to the failing contract.
+- Keep the patch reviewable and safe to push back to the same PR branch.
+
+Validation
+- Re-run only the smallest relevant validation command or commands needed to verify the fix.
+- Use backend/ as the working directory for Laravel, Composer, PHPUnit, and script commands.
+
+Final summary must include
+1. root cause
+2. files changed
+3. commands run
+4. why the patch is minimal
+5. any remaining risk or follow-up

--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -1,0 +1,151 @@
+name: Codex Auto-Fix on PR CI Failure
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: codex-autofix-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  autofix:
+    if: >
+      ${{
+        github.event.workflow_run.conclusion == 'failure' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.head_branch != 'main' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        !startsWith(github.event.workflow_run.head_branch, 'codex/autofix-') &&
+        !startsWith(github.event.workflow_run.head_branch, 'autofix/') &&
+        github.event.workflow_run.actor.login != 'github-actions[bot]'
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      FAILED_WORKFLOW_ID: ${{ github.event.workflow_run.id }}
+      FAILED_WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+      FAILED_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      FAILED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+
+    steps:
+      - name: Check out failing PR head branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.FAILED_HEAD_BRANCH }}
+          fetch-depth: 0
+
+      - name: Check whether branch moved after failed run
+        id: staleness
+        run: |
+          current_sha="$(git rev-parse HEAD)"
+          if [ "$current_sha" = "$FAILED_HEAD_SHA" ]; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "Branch moved after the failed run. Skipping stale autofix."
+          fi
+
+      - name: Loop guard for prior autofix commit
+        id: loop_guard
+        if: steps.staleness.outputs.stale != 'true'
+        run: |
+          subject="$(git log -1 --pretty=%s)"
+          if printf '%s' "$subject" | grep -q '^\[codex-autofix\]'; then
+            echo "already_autofixed=true" >> "$GITHUB_OUTPUT"
+            echo "Latest commit is already an autofix commit. Skipping."
+          else
+            echo "already_autofixed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure backend manifest files are present
+        if: steps.staleness.outputs.stale != 'true' && steps.loop_guard.outputs.already_autofixed != 'true'
+        run: |
+          test -f backend/composer.json
+          test -f .github/codex/prompts/fix-ci.md
+
+      - name: Capture failed run context
+        if: steps.staleness.outputs.stale != 'true' && steps.loop_guard.outputs.already_autofixed != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p .github/codex-context
+
+          cat > .github/codex-context/metadata.txt <<EOF
+          workflow: ${FAILED_WORKFLOW_NAME}
+          workflow_run_id: ${FAILED_WORKFLOW_ID}
+          branch: ${FAILED_HEAD_BRANCH}
+          sha: ${FAILED_HEAD_SHA}
+          EOF
+
+          gh run view "${FAILED_WORKFLOW_ID}" --log-failed > .github/codex-context/failed-run.log || true
+
+      - name: Set up PHP 8.4 and Composer v2
+        if: steps.staleness.outputs.stale != 'true' && steps.loop_guard.outputs.already_autofixed != 'true'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          coverage: none
+
+      - name: Set up Node 20
+        if: steps.staleness.outputs.stale != 'true' && steps.loop_guard.outputs.already_autofixed != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install backend dependencies
+        if: steps.staleness.outputs.stale != 'true' && steps.loop_guard.outputs.already_autofixed != 'true'
+        working-directory: backend
+        run: |
+          composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run Codex autofix
+        if: steps.staleness.outputs.stale != 'true' && steps.loop_guard.outputs.already_autofixed != 'true'
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/fix-ci.md
+          sandbox: workspace-write
+          safety-strategy: drop-sudo
+
+      - name: Detect repository changes
+        id: changes
+        if: steps.staleness.outputs.stale != 'true' && steps.loop_guard.outputs.already_autofixed != 'true'
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes produced by Codex."
+          fi
+
+      - name: Check remote branch is still unchanged
+        id: remote_guard
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git fetch origin "${FAILED_HEAD_BRANCH}"
+          remote_sha="$(git rev-parse "origin/${FAILED_HEAD_BRANCH}")"
+
+          if [ "$remote_sha" = "$FAILED_HEAD_SHA" ]; then
+            echo "can_push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "can_push=false" >> "$GITHUB_OUTPUT"
+            echo "Remote branch moved during autofix. Skipping push."
+          fi
+
+      - name: Commit and push autofix back to PR branch
+        if: steps.changes.outputs.has_changes == 'true' && steps.remote_guard.outputs.can_push == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          git commit -m "[codex-autofix] fix failing CI in ${FAILED_WORKFLOW_NAME}"
+          git push origin "HEAD:${FAILED_HEAD_BRANCH}"


### PR DESCRIPTION
## Summary
- add a workflow_run-based Codex autofix workflow for failed PR CI runs
- add the fap-api-specific Codex prompt used by the autofix workflow
- keep the strategy single-shot: push one autofix commit back to the PR branch and stop

## Tests
- not run (workflow and prompt only)