### PR TITLE
PR-B6: Build conservative Career search bundle API

### DIFF
--- a/backend/app/DTO/Career/CareerSearchResultBundle.php
+++ b/backend/app/DTO/Career/CareerSearchResultBundle.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerSearchResultBundle
+{
+    /**
+     * @param  array<string, mixed>  $identity
+     * @param  array<string, mixed>  $titles
+     * @param  array<string, mixed>  $seoContract
+     * @param  array<string, mixed>  $trustSummary
+     * @param  array<string, mixed>  $provenanceMeta
+     */
+    public function __construct(
+        public readonly string $matchKind,
+        public readonly string $matchedText,
+        public readonly array $identity,
+        public readonly array $titles,
+        public readonly array $seoContract,
+        public readonly array $trustSummary,
+        public readonly array $provenanceMeta,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'bundle_kind' => 'career_search_result',
+            'bundle_version' => 'career.protocol.search_result.v1',
+            'match_kind' => $this->matchKind,
+            'matched_text' => $this->matchedText,
+            'identity' => $this->identity,
+            'titles' => $this->titles,
+            'seo_contract' => $this->seoContract,
+            'trust_summary' => $this->trustSummary,
+            'provenance_meta' => $this->provenanceMeta,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerSearchController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerSearchController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerSearchResultResource;
+use App\Services\Career\Bundles\CareerSearchBundleBuilder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+final class CareerSearchController extends Controller
+{
+    public function __construct(
+        private readonly CareerSearchBundleBuilder $bundleBuilder,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $request->merge([
+            'q' => is_string($request->query('q')) ? trim((string) $request->query('q')) : $request->query('q'),
+        ]);
+
+        $validated = $request->validate([
+            'q' => ['required', 'string', 'min:1', 'max:120'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:20'],
+            'locale' => ['nullable', 'string', Rule::in(['en', 'en-US', 'zh', 'zh-CN'])],
+            'mode' => ['nullable', 'string', Rule::in(['auto', 'exact', 'prefix'])],
+        ]);
+
+        $items = CareerSearchResultResource::collection(
+            $this->bundleBuilder->build(
+                query: (string) $validated['q'],
+                limit: (int) ($validated['limit'] ?? 10),
+                locale: isset($validated['locale']) ? (string) $validated['locale'] : null,
+                mode: (string) ($validated['mode'] ?? 'auto'),
+            )
+        )->resolve();
+
+        return response()->json([
+            'bundle_kind' => 'career_search_results',
+            'bundle_version' => 'career.protocol.search_results.v1',
+            'query' => [
+                'q' => (string) $validated['q'],
+                'limit' => (int) ($validated['limit'] ?? 10),
+                'locale' => isset($validated['locale']) ? (string) $validated['locale'] : null,
+                'mode' => (string) ($validated['mode'] ?? 'auto'),
+            ],
+            'items' => $items,
+        ]);
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerSearchResultResource.php
+++ b/backend/app/Http/Resources/Career/CareerSearchResultResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerSearchResultBundle;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerSearchResultBundle
+ */
+final class CareerSearchResultResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerSearchResultBundle $bundle */
+        $bundle = $this->resource;
+
+        return $bundle->toArray();
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\DTO\Career\CareerSearchResultBundle;
+use App\Models\Occupation;
+use App\Models\OccupationAlias;
+use App\Models\RecommendationSnapshot;
+use App\Services\PublicSurface\SeoSurfaceContractService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+final class CareerSearchBundleBuilder
+{
+    private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
+
+    /**
+     * @var array<string, int>
+     */
+    private const MATCH_PRIORITY = [
+        'canonical_slug_exact' => 0,
+        'canonical_title_exact' => 1,
+        'alias_exact' => 2,
+        'canonical_slug_prefix' => 3,
+        'canonical_title_prefix' => 4,
+        'alias_prefix' => 5,
+    ];
+
+    public function __construct(
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
+    ) {}
+
+    /**
+     * @return list<CareerSearchResultBundle>
+     */
+    public function build(string $query, int $limit = 10, ?string $locale = null, string $mode = 'auto'): array
+    {
+        $normalizedQuery = $this->normalizeText($query);
+        if ($normalizedQuery === null) {
+            return [];
+        }
+
+        $mode = in_array($mode, ['auto', 'exact', 'prefix'], true) ? $mode : 'auto';
+        $limit = max(1, min($limit, 20));
+        $prefixQuery = $normalizedQuery.'%';
+        $rawQuery = trim($query);
+        $rawPrefixQuery = $rawQuery.'%';
+        $normalizedLocale = $this->normalizeLocale($locale);
+
+        $snapshots = RecommendationSnapshot::query()
+            ->with([
+                'occupation.aliases',
+                'trustManifest',
+                'indexState',
+                'compileRun',
+                'profileProjection',
+                'contextSnapshot',
+            ])
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('occupation', static function (Builder $query): void {
+                $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
+            })
+            ->whereHas('contextSnapshot', static function (Builder $query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function (Builder $query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('indexState', static function (Builder $query): void {
+                $query->where('index_eligible', true);
+            })
+            ->where(function (Builder $query) use ($mode, $normalizedQuery, $prefixQuery, $rawQuery, $rawPrefixQuery, $normalizedLocale): void {
+                $query->whereHas('occupation', function (Builder $occupationQuery) use ($mode, $normalizedQuery, $prefixQuery, $rawQuery, $rawPrefixQuery): void {
+                    $occupationQuery->where(function (Builder $matchQuery) use ($mode, $normalizedQuery, $prefixQuery, $rawQuery, $rawPrefixQuery): void {
+                        $matchQuery->where('canonical_slug', $normalizedQuery)
+                            ->orWhereRaw('LOWER(canonical_title_en) = ?', [$normalizedQuery])
+                            ->orWhere('canonical_title_zh', $rawQuery);
+
+                        if ($mode !== 'exact') {
+                            $matchQuery->orWhere('canonical_slug', 'like', $prefixQuery)
+                                ->orWhereRaw('LOWER(canonical_title_en) LIKE ?', [$prefixQuery])
+                                ->orWhere('canonical_title_zh', 'like', $rawPrefixQuery);
+                        }
+                    });
+                })->orWhereHas('occupation.aliases', function (Builder $aliasQuery) use ($mode, $normalizedQuery, $prefixQuery, $normalizedLocale): void {
+                    if ($normalizedLocale !== null) {
+                        $aliasQuery->where('lang', 'like', $normalizedLocale.'%');
+                    }
+
+                    $aliasQuery->where(function (Builder $matchQuery) use ($mode, $normalizedQuery, $prefixQuery): void {
+                        $matchQuery->where('normalized', $normalizedQuery);
+
+                        if ($mode !== 'exact') {
+                            $matchQuery->orWhere('normalized', 'like', $prefixQuery);
+                        }
+                    });
+                });
+            })
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->get();
+
+        $results = $snapshots
+            ->groupBy('occupation_id')
+            ->map(function (Collection $group) use ($normalizedQuery, $rawQuery, $normalizedLocale, $mode): ?array {
+                /** @var RecommendationSnapshot|null $snapshot */
+                $snapshot = $group
+                    ->sort(function (RecommendationSnapshot $left, RecommendationSnapshot $right): int {
+                        $leftCompiled = optional($left->compiled_at)?->getTimestamp() ?? 0;
+                        $rightCompiled = optional($right->compiled_at)?->getTimestamp() ?? 0;
+                        if ($leftCompiled !== $rightCompiled) {
+                            return $rightCompiled <=> $leftCompiled;
+                        }
+
+                        return strcmp((string) $left->id, (string) $right->id);
+                    })
+                    ->first();
+
+                if (! $snapshot instanceof RecommendationSnapshot) {
+                    return null;
+                }
+
+                $occupation = $snapshot->occupation;
+                if (! $occupation instanceof Occupation) {
+                    return null;
+                }
+
+                $match = $this->resolveMatch($occupation, $normalizedQuery, $rawQuery, $normalizedLocale, $mode);
+                if ($match === null) {
+                    return null;
+                }
+
+                return [
+                    'priority' => self::MATCH_PRIORITY[$match['kind']] ?? 999,
+                    'sort_title' => strtolower((string) ($occupation->canonical_title_en ?? '')),
+                    'sort_slug' => strtolower((string) ($occupation->canonical_slug ?? '')),
+                    'bundle' => $this->buildItem($snapshot, $occupation, $match['kind'], $match['text']),
+                ];
+            })
+            ->filter()
+            ->sortBy([
+                ['priority', 'asc'],
+                ['sort_title', 'asc'],
+                ['sort_slug', 'asc'],
+            ])
+            ->values()
+            ->take($limit)
+            ->map(static fn (array $row): CareerSearchResultBundle => $row['bundle'])
+            ->all();
+
+        return $results;
+    }
+
+    /**
+     * @return array{kind:string,text:string}|null
+     */
+    private function resolveMatch(Occupation $occupation, string $normalizedQuery, string $rawQuery, ?string $normalizedLocale, string $mode): ?array
+    {
+        $slug = $this->normalizeText($occupation->canonical_slug);
+        $titleEn = $this->normalizeText($occupation->canonical_title_en);
+        $titleZh = $this->normalizeRawText($occupation->canonical_title_zh);
+        $allowPrefix = $mode !== 'exact';
+
+        if ($slug === $normalizedQuery) {
+            return ['kind' => 'canonical_slug_exact', 'text' => (string) $occupation->canonical_slug];
+        }
+        if ($titleEn === $normalizedQuery) {
+            return ['kind' => 'canonical_title_exact', 'text' => (string) $occupation->canonical_title_en];
+        }
+        if ($titleZh !== null && $titleZh === $rawQuery) {
+            return ['kind' => 'canonical_title_exact', 'text' => (string) $occupation->canonical_title_zh];
+        }
+
+        $aliases = $occupation->aliases instanceof Collection ? $occupation->aliases : collect();
+        foreach ($aliases as $alias) {
+            if (! $alias instanceof OccupationAlias) {
+                continue;
+            }
+            if ($normalizedLocale !== null && ! str_starts_with(strtolower((string) $alias->lang), $normalizedLocale)) {
+                continue;
+            }
+
+            $aliasNormalized = $this->normalizeText($alias->normalized);
+            if ($aliasNormalized === $normalizedQuery) {
+                return ['kind' => 'alias_exact', 'text' => (string) $alias->alias];
+            }
+        }
+
+        if ($allowPrefix) {
+            if ($slug !== null && str_starts_with($slug, $normalizedQuery)) {
+                return ['kind' => 'canonical_slug_prefix', 'text' => (string) $occupation->canonical_slug];
+            }
+            if ($titleEn !== null && str_starts_with($titleEn, $normalizedQuery)) {
+                return ['kind' => 'canonical_title_prefix', 'text' => (string) $occupation->canonical_title_en];
+            }
+            if ($titleZh !== null && str_starts_with($titleZh, $rawQuery)) {
+                return ['kind' => 'canonical_title_prefix', 'text' => (string) $occupation->canonical_title_zh];
+            }
+
+            foreach ($aliases as $alias) {
+                if (! $alias instanceof OccupationAlias) {
+                    continue;
+                }
+                if ($normalizedLocale !== null && ! str_starts_with(strtolower((string) $alias->lang), $normalizedLocale)) {
+                    continue;
+                }
+
+                $aliasNormalized = $this->normalizeText($alias->normalized);
+                if ($aliasNormalized !== null && str_starts_with($aliasNormalized, $normalizedQuery)) {
+                    return ['kind' => 'alias_prefix', 'text' => (string) $alias->alias];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function buildItem(
+        RecommendationSnapshot $snapshot,
+        Occupation $occupation,
+        string $matchKind,
+        string $matchedText,
+    ): CareerSearchResultBundle {
+        $trustManifest = $snapshot->trustManifest;
+        $importRunId = $snapshot->compileRun?->import_run_id;
+
+        return new CareerSearchResultBundle(
+            matchKind: $matchKind,
+            matchedText: $matchedText,
+            identity: [
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $occupation->canonical_slug,
+            ],
+            titles: [
+                'canonical_en' => $occupation->canonical_title_en,
+                'canonical_zh' => $occupation->canonical_title_zh,
+                'search_h1_zh' => $occupation->search_h1_zh,
+            ],
+            seoContract: $this->buildSeoContract($occupation, $snapshot),
+            trustSummary: [
+                'reviewer_status' => $trustManifest?->reviewer_status,
+                'reviewed_at' => optional($trustManifest?->reviewed_at)->toISOString(),
+                'content_version' => $trustManifest?->content_version,
+                'data_version' => $trustManifest?->data_version,
+                'logic_version' => $trustManifest?->logic_version,
+            ],
+            provenanceMeta: [
+                'compiler_version' => $snapshot->compiler_version,
+                'compiled_at' => optional($snapshot->compiled_at)->toISOString(),
+                'trust_manifest_id' => $snapshot->trust_manifest_id,
+                'index_state_id' => $snapshot->index_state_id,
+                'compile_run_id' => $snapshot->compile_run_id,
+                'import_run_id' => $importRunId,
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildSeoContract(Occupation $occupation, RecommendationSnapshot $snapshot): array
+    {
+        $indexState = $snapshot->indexState;
+        $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
+        $canonicalTarget = $indexState?->canonical_target;
+        $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_search_result_bundle',
+            'canonical_url' => $canonicalTarget ?: $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $canonicalTarget,
+            'index_state' => $indexState?->index_state,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    private function normalizeLocale(?string $locale): ?string
+    {
+        $normalized = $this->normalizeText($locale);
+        if ($normalized === null) {
+            return null;
+        }
+
+        return match ($normalized) {
+            'zh', 'zh-cn' => 'zh',
+            'en', 'en-us' => 'en',
+            default => null,
+        };
+    }
+
+    private function normalizeText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        return mb_strtolower($normalized, 'UTF-8');
+    }
+
+    private function normalizeRawText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2413,6 +2413,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/search": {
+            "get": {
+                "operationId": "get_api_v0_5_career_search",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerSearchController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/cms/articles": {
             "post": {
                 "operationId": "post_api_v0_5_cms_articles",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobListController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationIndexController;
+use App\Http\Controllers\API\V0_5\Career\CareerSearchController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
 use App\Http\Controllers\API\V0_5\Cms\CareerGuideController;
 use App\Http\Controllers\API\V0_5\Cms\CareerJobController;
@@ -401,6 +402,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);
     Route::get('/career/recommendations/mbti', [CareerRecommendationIndexController::class, 'index']);
     Route::get('/career/recommendations/mbti/{type}', [CareerRecommendationDetailController::class, 'show']);
+    Route::get('/career/search', [CareerSearchController::class, 'index']);
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);

--- a/backend/tests/Feature/Career/CareerSearchApiTest.php
+++ b/backend/tests/Feature/Career/CareerSearchApiTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\OccupationAlias;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerSearchApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_a_resource_backed_lightweight_search_response(): void
+    {
+        $chain = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'backend-architect-search-api',
+        ]));
+        $chain['occupation']->update([
+            'canonical_title_en' => 'Backend Search Architect',
+        ]);
+        OccupationAlias::query()->create([
+            'occupation_id' => $chain['occupation']->id,
+            'alias' => 'Search Architecture Lead',
+            'normalized' => 'search architecture lead',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.96,
+        ]);
+
+        $this->getJson('/api/v0.5/career/search?q=backend-architect-search&limit=5&mode=prefix')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_search_results')
+            ->assertJsonPath('query.q', 'backend-architect-search')
+            ->assertJsonPath('query.limit', 5)
+            ->assertJsonPath('items.0.identity.canonical_slug', 'backend-architect-search-api')
+            ->assertJsonPath('items.0.match_kind', 'canonical_slug_prefix')
+            ->assertJsonMissingPath('items.0.score_summary')
+            ->assertJsonStructure([
+                'bundle_kind',
+                'bundle_version',
+                'query' => ['q', 'limit', 'locale', 'mode'],
+                'items' => [[
+                    'match_kind',
+                    'matched_text',
+                    'identity' => ['occupation_uuid', 'canonical_slug'],
+                    'titles',
+                    'seo_contract' => ['canonical_path', 'canonical_target', 'index_state', 'index_eligible', 'reason_codes'],
+                    'trust_summary',
+                    'provenance_meta' => ['compiler_version', 'compile_run_id'],
+                ]],
+            ]);
+    }
+
+    public function test_it_rejects_empty_query_conservatively(): void
+    {
+        $this->getJson('/api/v0.5/career/search?q=')
+            ->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'VALIDATION_FAILED');
+    }
+
+    public function test_it_rejects_whitespace_only_query_conservatively(): void
+    {
+        $this->getJson('/api/v0.5/career/search?q=%20%20%20')
+            ->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'VALIDATION_FAILED');
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     * @return array<string, mixed>
+     */
+    private function compileJobChain(array $chain): array
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-search-api-'.$chain['occupation']->canonical_slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+
+        $snapshot = app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        return [
+            'importRun' => $importRun,
+            'compileRun' => $compileRun,
+            'snapshot' => $snapshot,
+        ] + $chain;
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\OccupationAlias;
+use App\Services\Career\Bundles\CareerSearchBundleBuilder;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerSearchBundleBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_supports_canonical_slug_exact_and_prefix_matching(): void
+    {
+        $exact = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'backend-architect',
+        ]));
+        $prefix = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'backend-architect-lead',
+        ]));
+
+        $results = app(CareerSearchBundleBuilder::class)->build('backend-architect');
+
+        $this->assertCount(2, $results);
+        $this->assertSame('canonical_slug_exact', $results[0]->matchKind);
+        $this->assertSame('backend-architect', $results[0]->identity['canonical_slug']);
+        $this->assertSame('canonical_slug_prefix', $results[1]->matchKind);
+        $this->assertSame('backend-architect-lead', $results[1]->identity['canonical_slug']);
+        $this->assertSame($exact['compileRun']->id, $results[0]->provenanceMeta['compile_run_id']);
+        $this->assertSame($prefix['compileRun']->id, $results[1]->provenanceMeta['compile_run_id']);
+    }
+
+    public function test_it_supports_canonical_title_exact_and_prefix_matching(): void
+    {
+        $exact = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'distributed-platform-architect',
+        ]));
+        $prefix = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'distributed-platform-lead',
+        ]));
+
+        $exact['occupation']->update([
+            'canonical_title_en' => 'Distributed Platform Architect',
+            'canonical_title_zh' => '分布式平台架构师',
+        ]);
+        $prefix['occupation']->update([
+            'canonical_title_en' => 'Distributed Platform Lead',
+            'canonical_title_zh' => '分布式平台负责人',
+        ]);
+
+        $exactResults = app(CareerSearchBundleBuilder::class)->build('Distributed Platform Architect');
+        $prefixResults = app(CareerSearchBundleBuilder::class)->build('Distributed Platform');
+
+        $this->assertSame('canonical_title_exact', $exactResults[0]->matchKind);
+        $this->assertSame('Distributed Platform Architect', $exactResults[0]->matchedText);
+        $this->assertSame('canonical_title_prefix', $prefixResults[0]->matchKind);
+        $this->assertSame('Distributed Platform Architect', $prefixResults[0]->matchedText);
+    }
+
+    public function test_it_supports_alias_exact_and_prefix_matching(): void
+    {
+        $exact = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'platform-ops-architect',
+        ]));
+        $prefix = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'platform-ops-specialist',
+        ]));
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $exact['occupation']->id,
+            'alias' => 'Cloud Platform Architect',
+            'normalized' => 'cloud platform architect',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.94,
+        ]);
+        OccupationAlias::query()->create([
+            'occupation_id' => $prefix['occupation']->id,
+            'alias' => 'Cloud Platform Specialist',
+            'normalized' => 'cloud platform specialist',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.92,
+            'confidence_score' => 0.9,
+        ]);
+
+        $exactResults = app(CareerSearchBundleBuilder::class)->build('cloud platform architect');
+        $prefixResults = app(CareerSearchBundleBuilder::class)->build('cloud platform');
+
+        $this->assertSame('alias_exact', $exactResults[0]->matchKind);
+        $this->assertSame('Cloud Platform Architect', $exactResults[0]->matchedText);
+        $this->assertSame('alias_prefix', $prefixResults[0]->matchKind);
+        $this->assertSame('Cloud Platform Architect', $prefixResults[0]->matchedText);
+    }
+
+    public function test_exact_beats_prefix_and_canonical_matches_beat_alias_matches(): void
+    {
+        $canonical = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'backend-architect-canonical',
+        ]));
+        $canonical['occupation']->update(['canonical_title_en' => 'Backend Architect']);
+
+        $aliasOnly = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'platform-architecture-specialist',
+        ]));
+        $aliasOnly['occupation']->update(['canonical_title_en' => 'Platform Architecture Specialist']);
+        OccupationAlias::query()->create([
+            'occupation_id' => $aliasOnly['occupation']->id,
+            'alias' => 'Backend Architect',
+            'normalized' => 'backend architect',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.9,
+            'confidence_score' => 0.88,
+        ]);
+
+        $results = app(CareerSearchBundleBuilder::class)->build('backend architect');
+
+        $this->assertCount(2, $results);
+        $this->assertSame('canonical_title_exact', $results[0]->matchKind);
+        $this->assertSame('backend-architect-canonical', $results[0]->identity['canonical_slug']);
+        $this->assertSame('alias_exact', $results[1]->matchKind);
+    }
+
+    public function test_it_excludes_non_indexable_rows_ignores_crosswalk_codes_and_omits_score_summary(): void
+    {
+        $visible = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'backend-architect-visible-search',
+        ]));
+        OccupationAlias::query()->create([
+            'occupation_id' => $visible['occupation']->id,
+            'alias' => 'Search Safe Architect',
+            'normalized' => 'search safe architect',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.96,
+        ]);
+
+        $hidden = $this->compileJobChain(CareerFoundationFixture::seedTrustLimitedCrossMarketChain());
+        OccupationAlias::query()->create([
+            'occupation_id' => $hidden['occupation']->id,
+            'alias' => 'Search Safe Architect',
+            'normalized' => 'search safe architect',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.91,
+            'confidence_score' => 0.89,
+        ]);
+
+        $results = app(CareerSearchBundleBuilder::class)->build('search safe architect');
+        $payload = $results[0]->toArray();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('backend-architect-visible-search', $results[0]->identity['canonical_slug']);
+        $this->assertArrayNotHasKey('score_summary', $payload);
+        $this->assertSame([], app(CareerSearchBundleBuilder::class)->build('15-1252'));
+    }
+
+    public function test_it_scopes_alias_matching_by_locale_when_locale_is_supplied(): void
+    {
+        $en = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'cloud-architect-en',
+        ]));
+        $zh = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'cloud-architect-zh',
+        ]));
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $en['occupation']->id,
+            'alias' => 'Cloud Reliability Architect',
+            'normalized' => 'cloud reliability architect',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.96,
+        ]);
+        OccupationAlias::query()->create([
+            'occupation_id' => $zh['occupation']->id,
+            'alias' => '云可靠性架构师',
+            'normalized' => '云可靠性架构师',
+            'lang' => 'zh-CN',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.96,
+        ]);
+
+        $enResults = app(CareerSearchBundleBuilder::class)->build('cloud reliability architect', locale: 'en-US');
+        $zhResults = app(CareerSearchBundleBuilder::class)->build('云可靠性架构师', locale: 'zh-CN');
+
+        $this->assertCount(1, $enResults);
+        $this->assertSame('cloud-architect-en', $enResults[0]->identity['canonical_slug']);
+        $this->assertSame('alias_exact', $enResults[0]->matchKind);
+
+        $this->assertCount(1, $zhResults);
+        $this->assertSame('cloud-architect-zh', $zhResults[0]->identity['canonical_slug']);
+        $this->assertSame('alias_exact', $zhResults[0]->matchKind);
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     * @return array<string, mixed>
+     */
+    private function compileJobChain(array $chain, ?Carbon $compiledAt = null): array
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-search-'.$chain['occupation']->canonical_slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+
+        $snapshot = app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        if ($compiledAt !== null) {
+            $snapshot->forceFill(['compiled_at' => $compiledAt])->save();
+        }
+
+        return [
+            'importRun' => $importRun,
+            'compileRun' => $compileRun,
+            'snapshot' => $snapshot,
+        ] + $chain;
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated backend-owned conservative Career search bundle stack
- add `CareerSearchBundleBuilder` for exact/prefix matching over canonical slug, canonical title, and conservative aliases only
- add `CareerSearchResultBundle`, `CareerSearchResultResource`, and `CareerSearchController`
- expose exactly one new endpoint: `GET /api/v0.5/career/search`
- keep search result payloads lightweight and authority-safe by exposing only `match_kind`, `matched_text`, `identity`, `titles`, `seo_contract`, `trust_summary`, and `provenance_meta`
- default search to public-safe rows only by respecting `index_state` and `index_eligible`
- exclude fuzzy matching, semantic retrieval, crosswalk-driven public discovery, score summaries, and detail-level narrative/warning surfaces
- update the OpenAPI snapshot to include the new search route
- add unit tests for slug/title/alias exact+prefix matching, canonical-vs-alias precedence, locale-scoped alias matching, non-indexable exclusion, and crosswalk non-leakage
- add feature tests for the new search API response shape and conservative empty-query handling

## Why
PR-B1 through PR-B5 established Career authority rows, scoring, detail bundles, and lightweight list/index bundles, but backend-owned search was still missing.

This PR adds the narrowest safe public search surface needed for the next frontend step without turning Career search into a fuzzy, semantic, or CMS-backed discovery system.

## Scope
### New API
- `GET /api/v0.5/career/search`

### Supported matching
- canonical slug exact
- canonical slug prefix
- canonical title exact
- canonical title prefix
- alias exact
- alias prefix

## Guardrails in this PR
- do not reuse CMS Career services or controllers as search authority
- do not expose crosswalk-driven public discovery
- do not add fuzzy or semantic search
- do not expose score summaries or ranking-style bundles
- do not expose detail warnings, claim matrices, matched jobs/guides, or ontology dumps
- keep search public-safe and deterministic

## Validation
- `vendor/bin/pint --test ...`
- `php artisan test tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/OpenApiDiffTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerRecommendationIndexApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/V0_5/CareerJobPublicApiTest.php tests/Feature/V0_5/CareerRecommendationPublicApiTest.php`
