### PR TITLE
[ops] Add Codex PR train minimal infrastructure

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,73 @@
+# Night PR Train Rules
+
+## Scope discipline
+- One PR = one scope.
+- Never combine adjacent PR scopes.
+- Never “fix future PRs” inside the current PR.
+- Stop immediately if changed files drift outside the declared scope and `stop_if_changed_files_outside_scope` is true.
+
+## Branch discipline
+- Always start from the latest `main`.
+- Always pull with `git pull --ff-only origin main` before creating a PR.
+- Stop if the worktree is dirty before starting a PR.
+- Stop if the target branch already exists locally or remotely with unrelated commits.
+
+## Dependency discipline
+- A PR may start only when all `depends_on` items are already merged into `main`.
+- If a dependency is not merged, mark the current item `blocked_dependency` in `docs/codex/pr-train-state.json` and stop.
+
+## Verification discipline
+- Run all local checks listed in the PR manifest before push.
+- If local checks fail, do not open a PR.
+- Record failed checks in `docs/codex/pr-train-state.json`.
+- Never continue to the next PR after a failed check.
+
+## PR discipline
+- Open exactly one PR for the current task.
+- The PR title must match the PR id and scope from the manifest.
+- The PR body must include:
+  - what changed
+  - why
+  - validation commands
+  - intentionally deferred items
+- If a PR is open and checks are pending, wait; do not start the next PR.
+
+## Merge discipline
+- Merge only when the current PR satisfies its `merge_policy`.
+- Use squash merge unless the manifest explicitly says otherwise.
+- After merge, delete the remote branch.
+- If running in a local clone, run `scripts/post_merge_cleanup.sh <branch> [base]`.
+- If running outside a local clone, do not claim local cleanup was executed.
+
+## State ledger discipline
+- Record every state transition in `docs/codex/pr-train-state.json`.
+- Update at minimum:
+  - status
+  - commit_sha
+  - pr_url
+  - checks
+  - failure_reason
+  - merged_at
+  - remote_branch_deleted
+  - local_cleanup_executed
+- Never continue after a failed PR unless the manifest explicitly allows retry.
+
+## Failure policy
+- Stop immediately on:
+  - preflight failure
+  - failed local checks
+  - failed required GitHub checks
+  - merge block
+  - review requirement block
+  - ambiguous repository state
+- Do not improvise around failures.
+- Prefer stopping cleanly over partial progress.
+
+## Local vs cloud execution
+- If operating in a cloud-only environment, remote branch deletion is allowed, but local cleanup must be reported as not executed.
+- If operating in a local clone, keep the local worktree clean between PRs.
+
+## Truth boundary
+- Codex may draft, refactor, and open PRs.
+- Laravel/backend or the declared authority layer remains the source of truth where the manifest says so.
+- Never replace an authority layer with frontend or CMS fallback logic.

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,0 +1,78 @@
+{
+  "train_name": "career-night-train",
+  "started_at": "",
+  "updated_at": "",
+  "mode": "local_clone_preferred",
+  "base_branch": "main",
+  "stop_on_failure": true,
+  "items": {
+    "PR-B7": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "pending",
+      "branch": "codex/pr-b7-career-first-wave-manifest-publish-gate",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-F6": {
+      "repo": "fap-web",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-web",
+      "status": "pending",
+      "branch": "codex/pr-f6-career-launch-manifest-smoke-alignment",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B8": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "pending",
+      "branch": "codex/pr-b8-career-first-wave-alias-hardening",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-D1": {
+      "repo": "fap-web",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-web",
+      "status": "pending",
+      "branch": "codex/pr-d1-career-batch-production-sop",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    }
+  }
+}

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1,0 +1,102 @@
+train_name: career-night-train
+base_branch: main
+merge_method: squash
+stop_on_failure: true
+require_clean_worktree: true
+execution_mode: local_clone_preferred
+
+prs:
+  - id: PR-B7
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b7-career-first-wave-manifest-publish-gate
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave 10 occupations manifest + publish gate.
+      Freeze the first-wave set, stable/candidate/hold, exact/trust_inheritance scope,
+      and minimal reviewer/trust/index publish thresholds.
+    checks:
+      - "vendor/bin/pint --test"
+      - "php artisan test"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
+  - id: PR-F6
+    repo: fap-web
+    repo_path: /Users/rainie/Desktop/GitHub/fap-web
+    branch: codex/pr-f6-career-launch-manifest-smoke-alignment
+    base: main
+    depends_on: ["PR-B7"]
+    mode: execute
+    scope: >
+      Career launch manifest + smoke matrix + frontend exposure alignment.
+      Align /career, /career/jobs, /career/recommendations, detail pages, and query pages
+      into a unified launch manifest with stable/candidate/hold/noindex route policy.
+    checks:
+      - "pnpm verify:pr"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
+  - id: PR-B8
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b8-career-first-wave-alias-hardening
+    base: main
+    depends_on: ["PR-B7"]
+    mode: execute
+    scope: >
+      Career first-wave alias hardening for conservative search.
+      Only harden alias/crosswalk for the first-wave 10 occupations.
+      Keep search scope limited to slug/title exact-prefix and conservative alias.
+    checks:
+      - "vendor/bin/pint --test"
+      - "php artisan test"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
+  - id: PR-D1
+    repo: fap-web
+    repo_path: /Users/rainie/Desktop/GitHub/fap-web
+    branch: codex/pr-d1-career-batch-production-sop
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Codex batch production SOP + review checklist + gold diff tooling.
+      Create the documentation/tooling baseline for 342 occupations batch production:
+      batch manifest template, review checklist, gold diff rules, and the hard rule
+      that Codex may draft but Laravel is the source of truth.
+    checks:
+      - "pnpm verify:pr"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true

--- a/backend/scripts/post_merge_cleanup.sh
+++ b/backend/scripts/post_merge_cleanup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH="${1:?branch required}"
+BASE="${2:-main}"
+
+git fetch origin --prune
+git checkout "$BASE"
+git pull --ff-only origin "$BASE"
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git branch -D "$BRANCH"
+fi
+
+git fetch origin --prune


### PR DESCRIPTION
## Summary
This PR adds the minimum repository-side infrastructure for a Codex-driven PR train in `fap-api` without changing any backend business logic and without starting the train itself.

It adds exactly four files:
- `AGENTS.md`
- `docs/codex/pr-train.yaml`
- `docs/codex/pr-train-state.json`
- `scripts/post_merge_cleanup.sh`

## Why
`fap-web` already has the same minimal PR train infrastructure merged. This PR brings `fap-api` to the same baseline so cross-repo PR trains can be orchestrated safely later, while keeping this change repo-infrastructure only.

## Scope boundaries
Included:
- add the four minimal infrastructure files
- create `docs/codex/`
- make `scripts/post_merge_cleanup.sh` executable

Excluded:
- no backend API changes
- no migration, model, service, job, or test changes
- no runbooks or prompts
- no PR train execution

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `bash -n scripts/post_merge_cleanup.sh`
- `test -f AGENTS.md && test -f docs/codex/pr-train.yaml && test -x scripts/post_merge_cleanup.sh`
