### PR TITLE
PR-B7: Build career first-wave manifest and publish gate

### DIFF
--- a/backend/app/Domain/Career/Publish/FirstWaveManifestReader.php
+++ b/backend/app/Domain/Career/Publish/FirstWaveManifestReader.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use RuntimeException;
+
+final class FirstWaveManifestReader
+{
+    public function defaultPath(): string
+    {
+        return base_path('docs/career/first_wave_manifest.json');
+    }
+
+    /**
+     * @return array{
+     *   manifest_version:string,
+     *   generated_at:string,
+     *   wave_name:string,
+     *   selection_policy_version:string,
+     *   count_expected:int,
+     *   count_actual:int,
+     *   occupations:list<array<string,mixed>>
+     * }
+     */
+    public function read(?string $path = null): array
+    {
+        $resolved = $path === null || trim($path) === ''
+            ? $this->defaultPath()
+            : (str_starts_with($path, '/') ? $path : base_path($path));
+
+        if (! is_file($resolved)) {
+            throw new RuntimeException(sprintf('First-wave manifest not found at [%s].', $resolved));
+        }
+
+        $decoded = json_decode((string) file_get_contents($resolved), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException(sprintf('First-wave manifest is not valid JSON: [%s].', $resolved));
+        }
+
+        $occupations = $decoded['occupations'] ?? null;
+        if (! is_array($occupations)) {
+            throw new RuntimeException('First-wave manifest must contain an occupations list.');
+        }
+
+        $requiredMetadata = [
+            'manifest_version',
+            'generated_at',
+            'wave_name',
+            'selection_policy_version',
+            'count_expected',
+            'count_actual',
+        ];
+
+        foreach ($requiredMetadata as $field) {
+            if (($decoded[$field] ?? null) === null || $decoded[$field] === '') {
+                throw new RuntimeException(sprintf('First-wave manifest missing metadata field [%s].', $field));
+            }
+        }
+
+        $expected = (int) $decoded['count_expected'];
+        $actual = (int) $decoded['count_actual'];
+        if ($expected !== 10 || $actual !== 10 || count($occupations) !== 10) {
+            throw new RuntimeException('First-wave manifest must contain exactly 10 occupations.');
+        }
+
+        $seenSlugs = [];
+        $seenOccupationIds = [];
+
+        foreach ($occupations as $index => $occupation) {
+            if (! is_array($occupation)) {
+                throw new RuntimeException(sprintf('First-wave manifest occupation at index [%d] is invalid.', $index));
+            }
+
+            foreach ([
+                'occupation_uuid',
+                'canonical_slug',
+                'canonical_title_en',
+                'family_uuid',
+                'crosswalk_mode',
+                'wave_classification',
+                'publish_reason_codes',
+                'trust_seed',
+                'reviewer_seed',
+                'index_seed',
+                'claim_seed',
+            ] as $field) {
+                if (! array_key_exists($field, $occupation)) {
+                    throw new RuntimeException(sprintf('First-wave manifest occupation [%s] missing [%s].', $occupation['canonical_slug'] ?? $index, $field));
+                }
+            }
+
+            $slug = (string) $occupation['canonical_slug'];
+            $occupationId = (string) $occupation['occupation_uuid'];
+
+            if ($slug === '' || $occupationId === '') {
+                throw new RuntimeException(sprintf('First-wave manifest occupation at index [%d] contains blank identifiers.', $index));
+            }
+            if (isset($seenSlugs[$slug])) {
+                throw new RuntimeException(sprintf('First-wave manifest contains duplicate slug [%s].', $slug));
+            }
+            if (isset($seenOccupationIds[$occupationId])) {
+                throw new RuntimeException(sprintf('First-wave manifest contains duplicate occupation UUID [%s].', $occupationId));
+            }
+
+            $seenSlugs[$slug] = true;
+            $seenOccupationIds[$occupationId] = true;
+        }
+
+        return $decoded;
+    }
+}

--- a/backend/app/Domain/Career/Publish/FirstWavePublishGate.php
+++ b/backend/app/Domain/Career/Publish/FirstWavePublishGate.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Domain\Career\IndexStateValue;
+use App\Domain\Career\ReviewerStatus;
+use Illuminate\Support\Arr;
+
+final class FirstWavePublishGate
+{
+    /**
+     * @return array{classification:string,reasons:list<string>,publishable:bool}
+     */
+    public function evaluate(array $subject): array
+    {
+        $crosswalkMode = strtolower(trim((string) ($subject['crosswalk_mode'] ?? '')));
+        $confidenceScore = (int) round((float) Arr::get($subject, 'trust_seed.confidence_score', $subject['confidence_score'] ?? 0));
+        $reviewerStatus = strtolower(trim((string) Arr::get($subject, 'reviewer_seed.status', $subject['reviewer_status'] ?? '')));
+        $indexState = strtolower(trim((string) Arr::get($subject, 'index_seed.state', $subject['index_state'] ?? '')));
+        $indexEligible = (bool) Arr::get($subject, 'index_seed.index_eligible', $subject['index_eligible'] ?? false);
+        $allowStrongClaim = (bool) Arr::get($subject, 'claim_seed.allow_strong_claim', $subject['allow_strong_claim'] ?? false);
+
+        $reasons = [PublishReasonCode::MANIFEST_FIRST_WAVE_SELECTED];
+
+        if (in_array($crosswalkMode, ['local_heavy_interpretation', 'family_proxy', 'unmapped'], true)) {
+            $reasons[] = PublishReasonCode::CROSSWALK_MODE_DISALLOWED;
+            $reasons[] = PublishReasonCode::HOLD_SCOPE_RESTRICTED;
+
+            return [
+                'classification' => WaveClassification::HOLD,
+                'reasons' => $reasons,
+                'publishable' => false,
+            ];
+        }
+
+        if (in_array($crosswalkMode, ['exact', 'trust_inheritance'], true)) {
+            $reasons[] = PublishReasonCode::CROSSWALK_MODE_ALLOWED;
+        } else {
+            $reasons[] = PublishReasonCode::CROSSWALK_MODE_CANDIDATE_ONLY;
+        }
+
+        if ($confidenceScore >= 75) {
+            $reasons[] = PublishReasonCode::CONFIDENCE_READY;
+        } elseif ($confidenceScore >= 60) {
+            $reasons[] = PublishReasonCode::CONFIDENCE_BORDERLINE;
+        } else {
+            $reasons[] = PublishReasonCode::CONFIDENCE_TOO_LOW;
+        }
+
+        if ($reviewerStatus === ReviewerStatus::APPROVED) {
+            $reasons[] = PublishReasonCode::REVIEWER_APPROVED;
+        } elseif (in_array($reviewerStatus, [ReviewerStatus::PENDING, ReviewerStatus::IN_REVIEW], true)) {
+            $reasons[] = PublishReasonCode::REVIEWER_PENDING;
+        } else {
+            $reasons[] = PublishReasonCode::REVIEWER_BLOCKED;
+        }
+
+        if ($indexEligible && $indexState === IndexStateValue::INDEXABLE) {
+            $reasons[] = PublishReasonCode::INDEX_ELIGIBLE;
+        } else {
+            $reasons[] = PublishReasonCode::INDEX_INELIGIBLE;
+        }
+
+        if ($allowStrongClaim) {
+            $reasons[] = PublishReasonCode::STRONG_CLAIM_ALLOWED;
+        } else {
+            $reasons[] = PublishReasonCode::STRONG_CLAIM_BLOCKED;
+        }
+
+        if (
+            in_array($crosswalkMode, ['exact', 'trust_inheritance'], true)
+            && $confidenceScore >= 75
+            && $reviewerStatus === ReviewerStatus::APPROVED
+            && $indexEligible
+            && $indexState === IndexStateValue::INDEXABLE
+            && $allowStrongClaim
+        ) {
+            $reasons[] = PublishReasonCode::STABLE_PUBLISH_READY;
+
+            return [
+                'classification' => WaveClassification::STABLE,
+                'reasons' => array_values(array_unique($reasons)),
+                'publishable' => true,
+            ];
+        }
+
+        if (
+            $confidenceScore < 60
+            || $reviewerStatus === ReviewerStatus::CHANGES_REQUIRED
+            || $indexState === IndexStateValue::UNAVAILABLE
+        ) {
+            $reasons[] = PublishReasonCode::HOLD_SCOPE_RESTRICTED;
+
+            return [
+                'classification' => WaveClassification::HOLD,
+                'reasons' => array_values(array_unique($reasons)),
+                'publishable' => false,
+            ];
+        }
+
+        $reasons[] = PublishReasonCode::CANDIDATE_REVIEW_REQUIRED;
+
+        return [
+            'classification' => WaveClassification::CANDIDATE,
+            'reasons' => array_values(array_unique($reasons)),
+            'publishable' => false,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/PublishReasonCode.php
+++ b/backend/app/Domain/Career/Publish/PublishReasonCode.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+final class PublishReasonCode
+{
+    public const MANIFEST_FIRST_WAVE_SELECTED = 'manifest_first_wave_selected';
+
+    public const CROSSWALK_MODE_ALLOWED = 'crosswalk_mode_allowed';
+
+    public const CROSSWALK_MODE_CANDIDATE_ONLY = 'crosswalk_mode_candidate_only';
+
+    public const CROSSWALK_MODE_DISALLOWED = 'crosswalk_mode_disallowed';
+
+    public const CONFIDENCE_READY = 'confidence_ready';
+
+    public const CONFIDENCE_BORDERLINE = 'confidence_borderline';
+
+    public const CONFIDENCE_TOO_LOW = 'confidence_too_low';
+
+    public const REVIEWER_APPROVED = 'reviewer_approved';
+
+    public const REVIEWER_PENDING = 'reviewer_pending';
+
+    public const REVIEWER_BLOCKED = 'reviewer_blocked';
+
+    public const INDEX_ELIGIBLE = 'index_eligible';
+
+    public const INDEX_INELIGIBLE = 'index_ineligible';
+
+    public const STRONG_CLAIM_ALLOWED = 'strong_claim_allowed';
+
+    public const STRONG_CLAIM_BLOCKED = 'strong_claim_blocked';
+
+    public const STABLE_PUBLISH_READY = 'stable_publish_ready';
+
+    public const CANDIDATE_REVIEW_REQUIRED = 'candidate_review_required';
+
+    public const HOLD_SCOPE_RESTRICTED = 'hold_scope_restricted';
+}

--- a/backend/app/Domain/Career/Publish/WaveClassification.php
+++ b/backend/app/Domain/Career/Publish/WaveClassification.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+final class WaveClassification
+{
+    public const STABLE = 'stable';
+
+    public const CANDIDATE = 'candidate';
+
+    public const HOLD = 'hold';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return [
+            self::STABLE,
+            self::CANDIDATE,
+            self::HOLD,
+        ];
+    }
+}

--- a/backend/docs/career/first_wave_manifest.json
+++ b/backend/docs/career/first_wave_manifest.json
@@ -1,0 +1,340 @@
+{
+  "manifest_version": "2026.04.09.first_wave.v1",
+  "generated_at": "2026-04-09T00:00:00Z",
+  "wave_name": "career_first_wave_10",
+  "selection_policy_version": "first_wave_publish_gate.v1",
+  "count_expected": 10,
+  "count_actual": 10,
+  "occupations": [
+    {
+      "occupation_uuid": "664c2c76-4ee7-41c4-98fd-ffd1dc3ad308",
+      "canonical_slug": "software-developers",
+      "canonical_title_en": "Software Developers",
+      "canonical_title_zh": null,
+      "family_uuid": "f639c622-1a90-4b6d-a67c-081f6de2f48f",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 91,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the software engineering track."
+    },
+    {
+      "occupation_uuid": "fdffb946-2c8f-4f3d-91c4-d351bf6bf6b2",
+      "canonical_slug": "data-scientists",
+      "canonical_title_en": "Data Scientists",
+      "canonical_title_zh": null,
+      "family_uuid": "f639c622-1a90-4b6d-a67c-081f6de2f48f",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 90,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the computer and mathematical track."
+    },
+    {
+      "occupation_uuid": "383cccee-0364-4866-9dc1-f7cd1cfcdf51",
+      "canonical_slug": "accountants-and-auditors",
+      "canonical_title_en": "Accountants and Auditors",
+      "canonical_title_zh": null,
+      "family_uuid": "37ec69bd-655e-4ab4-b8ea-349632e87159",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 89,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the business and financial track."
+    },
+    {
+      "occupation_uuid": "2c9477ed-73bb-489b-9ef2-b52c5b10f086",
+      "canonical_slug": "financial-analysts",
+      "canonical_title_en": "Financial Analysts",
+      "canonical_title_zh": null,
+      "family_uuid": "37ec69bd-655e-4ab4-b8ea-349632e87159",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 88,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the business and financial track."
+    },
+    {
+      "occupation_uuid": "36060017-d3cb-42f7-bdc6-ead26c925cf5",
+      "canonical_slug": "project-management-specialists",
+      "canonical_title_en": "Project Management Specialists",
+      "canonical_title_zh": null,
+      "family_uuid": "37ec69bd-655e-4ab4-b8ea-349632e87159",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 87,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the business and financial track."
+    },
+    {
+      "occupation_uuid": "615bdd41-1b3d-40c0-94cc-ab6ee08dbbe7",
+      "canonical_slug": "human-resources-specialists",
+      "canonical_title_en": "Human Resources Specialists",
+      "canonical_title_zh": null,
+      "family_uuid": "37ec69bd-655e-4ab4-b8ea-349632e87159",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 86,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the business and financial track."
+    },
+    {
+      "occupation_uuid": "b4d2f69d-399e-4642-9693-ae8cb9e01bf2",
+      "canonical_slug": "marketing-managers",
+      "canonical_title_en": "Marketing Managers",
+      "canonical_title_zh": null,
+      "family_uuid": "a0352070-41e8-4cc9-b54d-06d6401d097c",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 89,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the management track."
+    },
+    {
+      "occupation_uuid": "be1bd5aa-353b-4760-a11d-0d44b1fe1810",
+      "canonical_slug": "registered-nurses",
+      "canonical_title_en": "Registered Nurses",
+      "canonical_title_zh": null,
+      "family_uuid": "3d7712d5-9ab5-4eda-88b0-e295149a7a9d",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 90,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the healthcare practitioners track."
+    },
+    {
+      "occupation_uuid": "2dd747a0-bbb4-41d0-8936-7d5a72850312",
+      "canonical_slug": "elementary-school-teachers-except-special-education",
+      "canonical_title_en": "Elementary School Teachers, Except Special Education",
+      "canonical_title_zh": null,
+      "family_uuid": "bd6cec47-a589-4f5e-901e-ddef0f620de7",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 88,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the education track."
+    },
+    {
+      "occupation_uuid": "bf7beb7c-9881-456e-a65e-447c9477e9cc",
+      "canonical_slug": "management-analysts",
+      "canonical_title_en": "Management Analysts",
+      "canonical_title_zh": null,
+      "family_uuid": "a0352070-41e8-4cc9-b54d-06d6401d097c",
+      "crosswalk_mode": "exact",
+      "wave_classification": "stable",
+      "publish_reason_codes": [
+        "manifest_first_wave_selected",
+        "crosswalk_mode_allowed",
+        "confidence_ready",
+        "reviewer_approved",
+        "index_eligible",
+        "strong_claim_allowed",
+        "stable_publish_ready"
+      ],
+      "trust_seed": {
+        "confidence_score": 87,
+        "source_ready": true
+      },
+      "reviewer_seed": {
+        "status": "approved"
+      },
+      "index_seed": {
+        "state": "indexable",
+        "index_eligible": true
+      },
+      "claim_seed": {
+        "allow_strong_claim": true
+      },
+      "notes": "Manifest-scoped first-wave launch seed for the management and consulting track."
+    }
+  ]
+}

--- a/backend/tests/Unit/Services/Career/FirstWaveManifestReaderTest.php
+++ b/backend/tests/Unit/Services/Career/FirstWaveManifestReaderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\FirstWaveManifestReader;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class FirstWaveManifestReaderTest extends TestCase
+{
+    #[Test]
+    public function it_reads_the_first_wave_manifest_and_freezes_the_expected_ten_occupations(): void
+    {
+        $manifest = app(FirstWaveManifestReader::class)->read();
+
+        $this->assertSame('career_first_wave_10', $manifest['wave_name']);
+        $this->assertSame(10, $manifest['count_expected']);
+        $this->assertSame(10, $manifest['count_actual']);
+        $this->assertCount(10, $manifest['occupations']);
+        $this->assertSame([
+            'software-developers',
+            'data-scientists',
+            'accountants-and-auditors',
+            'financial-analysts',
+            'project-management-specialists',
+            'human-resources-specialists',
+            'marketing-managers',
+            'registered-nurses',
+            'elementary-school-teachers-except-special-education',
+            'management-analysts',
+        ], array_column($manifest['occupations'], 'canonical_slug'));
+    }
+
+    #[Test]
+    public function it_requires_machine_readable_publish_seed_fields_for_each_manifest_entry(): void
+    {
+        $manifest = app(FirstWaveManifestReader::class)->read();
+
+        foreach ($manifest['occupations'] as $occupation) {
+            foreach ([
+                'occupation_uuid',
+                'canonical_slug',
+                'canonical_title_en',
+                'family_uuid',
+                'crosswalk_mode',
+                'wave_classification',
+                'publish_reason_codes',
+                'trust_seed',
+                'reviewer_seed',
+                'index_seed',
+                'claim_seed',
+            ] as $requiredField) {
+                $this->assertArrayHasKey($requiredField, $occupation);
+            }
+        }
+    }
+}

--- a/backend/tests/Unit/Services/Career/FirstWavePublishGateTest.php
+++ b/backend/tests/Unit/Services/Career/FirstWavePublishGateTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\IndexStateValue;
+use App\Domain\Career\Publish\FirstWaveManifestReader;
+use App\Domain\Career\Publish\FirstWavePublishGate;
+use App\Domain\Career\Publish\PublishReasonCode;
+use App\Domain\Career\Publish\WaveClassification;
+use App\Domain\Career\ReviewerStatus;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class FirstWavePublishGateTest extends TestCase
+{
+    #[Test]
+    public function it_keeps_the_manifest_and_publish_gate_aligned_without_silent_drift(): void
+    {
+        $reader = app(FirstWaveManifestReader::class);
+        $gate = app(FirstWavePublishGate::class);
+        $manifest = $reader->read();
+
+        foreach ($manifest['occupations'] as $occupation) {
+            $result = $gate->evaluate($occupation);
+
+            $this->assertSame($occupation['wave_classification'], $result['classification']);
+            $this->assertSame($occupation['publish_reason_codes'], $result['reasons']);
+            $this->assertTrue($result['publishable']);
+        }
+    }
+
+    #[Test]
+    public function it_accepts_exact_and_trust_inheritance_as_stable_when_publish_seeds_are_ready(): void
+    {
+        $gate = app(FirstWavePublishGate::class);
+
+        foreach (['exact', 'trust_inheritance'] as $crosswalkMode) {
+            $result = $gate->evaluate([
+                'crosswalk_mode' => $crosswalkMode,
+                'trust_seed' => ['confidence_score' => 81],
+                'reviewer_seed' => ['status' => ReviewerStatus::APPROVED],
+                'index_seed' => ['state' => IndexStateValue::INDEXABLE, 'index_eligible' => true],
+                'claim_seed' => ['allow_strong_claim' => true],
+            ]);
+
+            $this->assertSame(WaveClassification::STABLE, $result['classification']);
+            $this->assertContains(PublishReasonCode::CROSSWALK_MODE_ALLOWED, $result['reasons']);
+            $this->assertContains(PublishReasonCode::STABLE_PUBLISH_READY, $result['reasons']);
+        }
+    }
+
+    #[Test]
+    public function it_classifies_candidate_cases_deterministically_with_explicit_reason_codes(): void
+    {
+        $gate = app(FirstWavePublishGate::class);
+
+        $result = $gate->evaluate([
+            'crosswalk_mode' => 'functional_equivalent',
+            'trust_seed' => ['confidence_score' => 68],
+            'reviewer_seed' => ['status' => ReviewerStatus::IN_REVIEW],
+            'index_seed' => ['state' => IndexStateValue::NOINDEX, 'index_eligible' => false],
+            'claim_seed' => ['allow_strong_claim' => false],
+        ]);
+
+        $this->assertSame(WaveClassification::CANDIDATE, $result['classification']);
+        $this->assertContains(PublishReasonCode::CROSSWALK_MODE_CANDIDATE_ONLY, $result['reasons']);
+        $this->assertContains(PublishReasonCode::CONFIDENCE_BORDERLINE, $result['reasons']);
+        $this->assertContains(PublishReasonCode::REVIEWER_PENDING, $result['reasons']);
+        $this->assertContains(PublishReasonCode::INDEX_INELIGIBLE, $result['reasons']);
+        $this->assertContains(PublishReasonCode::STRONG_CLAIM_BLOCKED, $result['reasons']);
+        $this->assertContains(PublishReasonCode::CANDIDATE_REVIEW_REQUIRED, $result['reasons']);
+    }
+
+    #[Test]
+    public function it_marks_disallowed_modes_and_low_confidence_subjects_as_hold(): void
+    {
+        $gate = app(FirstWavePublishGate::class);
+
+        $disallowedModeResult = $gate->evaluate([
+            'crosswalk_mode' => 'unmapped',
+            'trust_seed' => ['confidence_score' => 82],
+            'reviewer_seed' => ['status' => ReviewerStatus::APPROVED],
+            'index_seed' => ['state' => IndexStateValue::INDEXABLE, 'index_eligible' => true],
+            'claim_seed' => ['allow_strong_claim' => true],
+        ]);
+
+        $lowConfidenceResult = $gate->evaluate([
+            'crosswalk_mode' => 'exact',
+            'trust_seed' => ['confidence_score' => 54],
+            'reviewer_seed' => ['status' => ReviewerStatus::CHANGES_REQUIRED],
+            'index_seed' => ['state' => IndexStateValue::UNAVAILABLE, 'index_eligible' => false],
+            'claim_seed' => ['allow_strong_claim' => false],
+        ]);
+
+        $this->assertSame(WaveClassification::HOLD, $disallowedModeResult['classification']);
+        $this->assertContains(PublishReasonCode::CROSSWALK_MODE_DISALLOWED, $disallowedModeResult['reasons']);
+        $this->assertContains(PublishReasonCode::HOLD_SCOPE_RESTRICTED, $disallowedModeResult['reasons']);
+
+        $this->assertSame(WaveClassification::HOLD, $lowConfidenceResult['classification']);
+        $this->assertContains(PublishReasonCode::CONFIDENCE_TOO_LOW, $lowConfidenceResult['reasons']);
+        $this->assertContains(PublishReasonCode::REVIEWER_BLOCKED, $lowConfidenceResult['reasons']);
+        $this->assertContains(PublishReasonCode::INDEX_INELIGIBLE, $lowConfidenceResult['reasons']);
+        $this->assertContains(PublishReasonCode::HOLD_SCOPE_RESTRICTED, $lowConfidenceResult['reasons']);
+    }
+}


### PR DESCRIPTION
## What changed
- add a machine-readable first-wave manifest for the agreed 10 occupations
- add backend publish-gate classes for first-wave stable / candidate / hold classification
- add explicit publish reason codes
- add tests to keep the manifest and publish gate aligned

## Why
- the first-wave 10 occupations need to be explicit and machine-readable
- publish readiness should be enforced in backend policy code, not inferred implicitly from current rows
- B7 freezes the first-wave publish contract without broadening into the full 342 rollout

## Validation
- `python3 -m json.tool backend/docs/career/first_wave_manifest.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish tests/Unit/Services/Career/FirstWaveManifestReaderTest.php tests/Unit/Services/Career/FirstWavePublishGateTest.php`
- `php artisan test tests/Unit/Services/Career/FirstWaveManifestReaderTest.php tests/Unit/Services/Career/FirstWavePublishGateTest.php`
- `php artisan test tests/Feature/Career tests/Unit/Services/Career`

## Notes
- full-repo `vendor/bin/pint --test` currently fails on pre-existing out-of-scope style debt and is not introduced by this PR
- full-repo `php artisan test` currently has unrelated baseline failures outside the Career scope and is not introduced by this PR

## Deferred
- no frontend changes
- no controller/API expansion
- no full 342 rollout
- no review dashboard or ops console
