### PR TITLE
PR-B8: Career first-wave alias hardening for conservative search

### DIFF
--- a/backend/app/Domain/Career/Import/FirstWaveAliasCatalogReader.php
+++ b/backend/app/Domain/Career/Import/FirstWaveAliasCatalogReader.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Import;
+
+use App\Domain\Career\Publish\FirstWaveManifestReader;
+use RuntimeException;
+
+final class FirstWaveAliasCatalogReader
+{
+    public function __construct(
+        private readonly FirstWaveManifestReader $manifestReader,
+    ) {}
+
+    public function defaultPath(): string
+    {
+        return base_path('docs/career/first_wave_aliases.json');
+    }
+
+    /**
+     * @return array{
+     *   version:string,
+     *   wave_name:string,
+     *   scope_source:string,
+     *   count_expected:int,
+     *   count_actual:int,
+     *   policy:array<string,mixed>,
+     *   items:list<array<string,mixed>>
+     * }
+     */
+    public function read(?string $path = null): array
+    {
+        $resolved = $path === null || trim($path) === ''
+            ? $this->defaultPath()
+            : (str_starts_with($path, '/') ? $path : base_path($path));
+
+        if (! is_file($resolved)) {
+            throw new RuntimeException(sprintf('First-wave alias catalog not found at [%s].', $resolved));
+        }
+
+        $decoded = json_decode((string) file_get_contents($resolved), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException(sprintf('First-wave alias catalog is not valid JSON: [%s].', $resolved));
+        }
+
+        foreach (['version', 'wave_name', 'scope_source', 'count_expected', 'count_actual', 'policy', 'items'] as $field) {
+            if (! array_key_exists($field, $decoded)) {
+                throw new RuntimeException(sprintf('First-wave alias catalog missing field [%s].', $field));
+            }
+        }
+
+        if (! is_array($decoded['policy']) || ! is_array($decoded['items'])) {
+            throw new RuntimeException('First-wave alias catalog policy and items must be arrays.');
+        }
+
+        $manifest = $this->manifestReader->read();
+        $manifestSlugs = array_values(array_map(
+            static fn (array $occupation): string => (string) $occupation['canonical_slug'],
+            $manifest['occupations']
+        ));
+        sort($manifestSlugs);
+
+        $expected = (int) $decoded['count_expected'];
+        $actual = (int) $decoded['count_actual'];
+        if ($expected !== 10 || $actual !== 10 || count($decoded['items']) !== 10) {
+            throw new RuntimeException('First-wave alias catalog must contain exactly 10 items.');
+        }
+
+        $seenSlugs = [];
+        $catalogSlugs = [];
+
+        foreach ($decoded['items'] as $index => $item) {
+            if (! is_array($item)) {
+                throw new RuntimeException(sprintf('First-wave alias catalog item at index [%d] is invalid.', $index));
+            }
+
+            foreach (['canonical_slug', 'approved_alias_rows', 'blocked_aliases'] as $field) {
+                if (! array_key_exists($field, $item)) {
+                    throw new RuntimeException(sprintf('First-wave alias catalog item [%d] missing [%s].', $index, $field));
+                }
+            }
+
+            $slug = trim((string) $item['canonical_slug']);
+            if ($slug === '') {
+                throw new RuntimeException(sprintf('First-wave alias catalog item [%d] contains blank slug.', $index));
+            }
+            if (isset($seenSlugs[$slug])) {
+                throw new RuntimeException(sprintf('First-wave alias catalog contains duplicate slug [%s].', $slug));
+            }
+
+            if (! is_array($item['approved_alias_rows']) || ! is_array($item['blocked_aliases'])) {
+                throw new RuntimeException(sprintf('First-wave alias catalog item [%s] must contain alias arrays.', $slug));
+            }
+
+            $catalogSlugs[] = $slug;
+            $seenSlugs[$slug] = true;
+
+            foreach ($item['approved_alias_rows'] as $aliasIndex => $aliasRow) {
+                if (! is_array($aliasRow)) {
+                    throw new RuntimeException(sprintf('First-wave alias row [%s:%d] is invalid.', $slug, $aliasIndex));
+                }
+
+                foreach (['alias', 'normalized', 'lang', 'register', 'precision', 'confidence'] as $field) {
+                    if (! array_key_exists($field, $aliasRow)) {
+                        throw new RuntimeException(sprintf('First-wave alias row [%s:%d] missing [%s].', $slug, $aliasIndex, $field));
+                    }
+                }
+
+                if (trim((string) $aliasRow['alias']) === '' || trim((string) $aliasRow['normalized']) === '') {
+                    throw new RuntimeException(sprintf('First-wave alias row [%s:%d] contains blank alias fields.', $slug, $aliasIndex));
+                }
+            }
+
+            foreach ($item['blocked_aliases'] as $blockedIndex => $blockedAlias) {
+                if (trim((string) $blockedAlias) === '') {
+                    throw new RuntimeException(sprintf('First-wave blocked alias [%s:%d] must not be blank.', $slug, $blockedIndex));
+                }
+            }
+        }
+
+        sort($catalogSlugs);
+        if ($catalogSlugs !== $manifestSlugs) {
+            throw new RuntimeException('First-wave alias catalog slugs must exactly match the first-wave manifest scope.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, array{canonical_slug:string,approved_alias_rows:list<array<string,mixed>>,blocked_aliases:list<string>}>
+     */
+    public function bySlug(?string $path = null): array
+    {
+        $catalog = $this->read($path);
+
+        $indexed = [];
+        foreach ($catalog['items'] as $item) {
+            $indexed[(string) $item['canonical_slug']] = $item;
+        }
+
+        return $indexed;
+    }
+}

--- a/backend/app/Domain/Career/Import/FirstWaveAliasHardeningService.php
+++ b/backend/app/Domain/Career/Import/FirstWaveAliasHardeningService.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Import;
+
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+
+final class FirstWaveAliasHardeningService
+{
+    /**
+     * @var array<string, array{canonical_slug:string,approved_alias_rows:list<array<string,mixed>>,blocked_aliases:list<string>}>|null
+     */
+    private ?array $catalog = null;
+
+    public function __construct(
+        private readonly FirstWaveAliasCatalogReader $catalogReader,
+    ) {}
+
+    /**
+     * @return array{
+     *   in_scope:bool,
+     *   blocked_aliases:list<string>,
+     *   alias_payloads:list<array<string,mixed>>
+     * }
+     */
+    public function resolveAliasPayloads(
+        string $canonicalSlug,
+        Occupation $occupation,
+        OccupationFamily $family,
+        CareerImportRun $importRun,
+    ): array {
+        $entry = $this->catalog()[$canonicalSlug] ?? null;
+        if (! is_array($entry)) {
+            return [
+                'in_scope' => false,
+                'blocked_aliases' => [],
+                'alias_payloads' => [],
+            ];
+        }
+
+        $blockedAliases = array_values(array_filter(array_map(
+            fn (mixed $alias): string => $this->normalizeText($alias),
+            $entry['blocked_aliases'] ?? [],
+        )));
+        $blockedSet = array_fill_keys($blockedAliases, true);
+
+        $payloads = [];
+        $seen = [];
+
+        foreach ($entry['approved_alias_rows'] as $row) {
+            $alias = trim((string) ($row['alias'] ?? ''));
+            $normalized = trim((string) ($row['normalized'] ?? ''));
+            $lang = trim((string) ($row['lang'] ?? ''));
+
+            if ($alias === '' || $normalized === '' || $lang === '') {
+                continue;
+            }
+
+            $aliasKey = $this->normalizeText($alias);
+            if ($aliasKey === '' || isset($blockedSet[$aliasKey])) {
+                continue;
+            }
+
+            $dedupeKey = sprintf('%s|%s', strtolower($lang), $this->normalizeText($normalized));
+            if (isset($seen[$dedupeKey])) {
+                continue;
+            }
+
+            $payloads[] = [
+                'occupation_id' => $occupation->id,
+                'family_id' => $family->id,
+                'alias' => $alias,
+                'normalized' => $this->normalizeText($normalized),
+                'lang' => $lang,
+                'register' => (string) ($row['register'] ?? 'alias'),
+                'intent_scope' => 'exact',
+                'target_kind' => 'occupation',
+                'precision_score' => (float) ($row['precision'] ?? 1.0),
+                'confidence_score' => (float) ($row['confidence'] ?? 1.0),
+                'seniority_hint' => null,
+                'function_hint' => null,
+                'import_run_id' => $importRun->id,
+                'row_fingerprint' => null,
+            ];
+
+            $seen[$dedupeKey] = true;
+        }
+
+        return [
+            'in_scope' => true,
+            'blocked_aliases' => $blockedAliases,
+            'alias_payloads' => $payloads,
+        ];
+    }
+
+    /**
+     * @return array<string, array{canonical_slug:string,approved_alias_rows:list<array<string,mixed>>,blocked_aliases:list<string>}>
+     */
+    private function catalog(): array
+    {
+        if ($this->catalog === null) {
+            $this->catalog = $this->catalogReader->bySlug();
+        }
+
+        return $this->catalog;
+    }
+
+    private function normalizeText(mixed $value): string
+    {
+        return mb_strtolower(trim((string) $value), 'UTF-8');
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Collection;
 
 final class CareerSearchBundleBuilder
 {
-    private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
+    private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance'];
 
     /**
      * @var array<string, int>

--- a/backend/app/Services/Career/Import/CareerAuthorityMaterializer.php
+++ b/backend/app/Services/Career/Import/CareerAuthorityMaterializer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Career\Import;
 
 use App\Domain\Career\Import\CrosswalkSeedPolicy;
+use App\Domain\Career\Import\FirstWaveAliasHardeningService;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\ContextSnapshot;
@@ -31,6 +32,7 @@ final class CareerAuthorityMaterializer
     public function __construct(
         private readonly CrosswalkSeedPolicy $crosswalkSeedPolicy,
         private readonly CareerRecommendationCompiler $compiler,
+        private readonly FirstWaveAliasHardeningService $firstWaveAliasHardeningService,
     ) {}
 
     /**
@@ -409,6 +411,13 @@ final class CareerAuthorityMaterializer
         CareerImportRun $importRun
     ): array {
         $payloads = [];
+        $hardening = $this->firstWaveAliasHardeningService->resolveAliasPayloads(
+            (string) $normalized['canonical_slug'],
+            $occupation,
+            $family,
+            $importRun,
+        );
+        $blockedSet = array_fill_keys($hardening['blocked_aliases'], true);
 
         foreach ([
             [
@@ -424,6 +433,9 @@ final class CareerAuthorityMaterializer
         ] as $candidate) {
             $alias = trim((string) ($candidate['alias'] ?? ''));
             if ($alias === '') {
+                continue;
+            }
+            if (isset($blockedSet[mb_strtolower($alias, 'UTF-8')])) {
                 continue;
             }
 
@@ -445,11 +457,28 @@ final class CareerAuthorityMaterializer
             ];
         }
 
+        $payloads = [...$payloads, ...$hardening['alias_payloads']];
+
+        $deduped = [];
+        $seen = [];
+        foreach ($payloads as $payload) {
+            $normalizedAlias = mb_strtolower(trim((string) ($payload['normalized'] ?? '')), 'UTF-8');
+            $lang = strtolower(trim((string) ($payload['lang'] ?? '')));
+            $dedupeKey = sprintf('%s|%s', $lang, $normalizedAlias);
+
+            if ($normalizedAlias === '' || isset($seen[$dedupeKey])) {
+                continue;
+            }
+
+            $seen[$dedupeKey] = true;
+            $deduped[] = $payload;
+        }
+
         return array_map(function (array $payload): array {
             $payload['row_fingerprint'] = $this->fingerprint(Arr::except($payload, ['occupation_id', 'family_id', 'import_run_id', 'row_fingerprint']));
 
             return $payload;
-        }, $payloads);
+        }, $deduped);
     }
 
     /**

--- a/backend/docs/career/first_wave_aliases.json
+++ b/backend/docs/career/first_wave_aliases.json
@@ -1,0 +1,300 @@
+{
+  "version": "first_wave_aliases_v1",
+  "wave_name": "career_first_wave_10",
+  "scope_source": "backend/docs/career/first_wave_manifest.json",
+  "count_expected": 10,
+  "count_actual": 10,
+  "policy": {
+    "allowed_match_scope": [
+      "canonical_slug_exact",
+      "canonical_slug_prefix",
+      "canonical_title_exact",
+      "canonical_title_prefix",
+      "alias_exact",
+      "alias_prefix"
+    ],
+    "disallowed_scope": [
+      "fuzzy_matching",
+      "semantic_retrieval",
+      "crosswalk_public_discovery",
+      "broad_slang_discovery"
+    ],
+    "rules": [
+      "Only aliases explicitly listed here are approved for first-wave hardening.",
+      "Do not derive public aliases from crosswalk titles or source codes.",
+      "Do not add broad slang family aliases in B8.",
+      "Chinese aliases must remain conservative and role-specific."
+    ]
+  },
+  "items": [
+    {
+      "canonical_slug": "software-developers",
+      "approved_alias_rows": [
+        {
+          "alias": "Software Developer",
+          "normalized": "software developer",
+          "lang": "en",
+          "register": "canonical_variant",
+          "precision": 0.99,
+          "confidence": 0.99
+        },
+        {
+          "alias": "Software Developers",
+          "normalized": "software developers",
+          "lang": "en",
+          "register": "canonical",
+          "precision": 1.0,
+          "confidence": 1.0
+        },
+        {
+          "alias": "Application Developer",
+          "normalized": "application developer",
+          "lang": "en",
+          "register": "nearby_professional",
+          "precision": 0.88,
+          "confidence": 0.86
+        },
+        {
+          "alias": "软件开发工程师",
+          "normalized": "软件开发工程师",
+          "lang": "zh-CN",
+          "register": "canonical_translation",
+          "precision": 0.96,
+          "confidence": 0.95
+        },
+        {
+          "alias": "软件工程师",
+          "normalized": "软件工程师",
+          "lang": "zh-CN",
+          "register": "market_title",
+          "precision": 0.82,
+          "confidence": 0.8
+        }
+      ],
+      "blocked_aliases": [
+        "码农",
+        "程序员",
+        "开发"
+      ]
+    },
+    {
+      "canonical_slug": "data-scientists",
+      "approved_alias_rows": [
+        {
+          "alias": "Data Scientist",
+          "normalized": "data scientist",
+          "lang": "en",
+          "register": "canonical_variant",
+          "precision": 0.99,
+          "confidence": 0.99
+        },
+        {
+          "alias": "Data Scientists",
+          "normalized": "data scientists",
+          "lang": "en",
+          "register": "canonical",
+          "precision": 1.0,
+          "confidence": 1.0
+        },
+        {
+          "alias": "数据科学家",
+          "normalized": "数据科学家",
+          "lang": "zh-CN",
+          "register": "canonical_translation",
+          "precision": 0.98,
+          "confidence": 0.98
+        }
+      ],
+      "blocked_aliases": [
+        "算法",
+        "AI scientist",
+        "机器学习工程师"
+      ]
+    },
+    {
+      "canonical_slug": "accountants-and-auditors",
+      "approved_alias_rows": [
+        {
+          "alias": "Accountant",
+          "normalized": "accountant",
+          "lang": "en",
+          "register": "role_variant",
+          "precision": 0.9,
+          "confidence": 0.89
+        },
+        {
+          "alias": "Auditor",
+          "normalized": "auditor",
+          "lang": "en",
+          "register": "role_variant",
+          "precision": 0.9,
+          "confidence": 0.89
+        },
+        {
+          "alias": "Accountants and Auditors",
+          "normalized": "accountants and auditors",
+          "lang": "en",
+          "register": "canonical",
+          "precision": 1.0,
+          "confidence": 1.0
+        },
+        {
+          "alias": "会计师",
+          "normalized": "会计师",
+          "lang": "zh-CN",
+          "register": "canonical_translation",
+          "precision": 0.94,
+          "confidence": 0.93
+        },
+        {
+          "alias": "审计师",
+          "normalized": "审计师",
+          "lang": "zh-CN",
+          "register": "canonical_translation",
+          "precision": 0.94,
+          "confidence": 0.93
+        }
+      ],
+      "blocked_aliases": [
+        "财务",
+        "会计",
+        "审计"
+      ]
+    },
+    {
+      "canonical_slug": "financial-analysts",
+      "approved_alias_rows": [
+        {
+          "alias": "Financial Analyst",
+          "normalized": "financial analyst",
+          "lang": "en",
+          "register": "canonical_variant",
+          "precision": 0.99,
+          "confidence": 0.99
+        },
+        {
+          "alias": "金融分析师",
+          "normalized": "金融分析师",
+          "lang": "zh-CN",
+          "register": "canonical_translation",
+          "precision": 0.98,
+          "confidence": 0.97
+        },
+        {
+          "alias": "投资分析师",
+          "normalized": "投资分析师",
+          "lang": "zh-CN",
+          "register": "nearby_professional",
+          "precision": 0.83,
+          "confidence": 0.81
+        }
+      ],
+      "blocked_aliases": [
+        "证券分析师",
+        "商业分析师"
+      ]
+    },
+    {
+      "canonical_slug": "project-management-specialists",
+      "approved_alias_rows": [
+        {
+          "alias": "Project Management Specialist",
+          "normalized": "project management specialist",
+          "lang": "en",
+          "register": "canonical_variant",
+          "precision": 0.99,
+          "confidence": 0.99
+        },
+        {
+          "alias": "Project Management Specialists",
+          "normalized": "project management specialists",
+          "lang": "en",
+          "register": "canonical",
+          "precision": 1.0,
+          "confidence": 1.0
+        },
+        {
+          "alias": "项目管理专员",
+          "normalized": "项目管理专员",
+          "lang": "zh-CN",
+          "register": "canonical_translation",
+          "precision": 0.97,
+          "confidence": 0.96
+        },
+        {
+          "alias": "项目管理专家",
+          "normalized": "项目管理专家",
+          "lang": "zh-CN",
+          "register": "market_title",
+          "precision": 0.84,
+          "confidence": 0.82
+        }
+      ],
+      "blocked_aliases": [
+        "项目经理",
+        "PM"
+      ]
+    },
+    {
+      "canonical_slug": "human-resources-specialists",
+      "approved_alias_rows": [],
+      "blocked_aliases": []
+    },
+    {
+      "canonical_slug": "marketing-managers",
+      "approved_alias_rows": [],
+      "blocked_aliases": []
+    },
+    {
+      "canonical_slug": "registered-nurses",
+      "approved_alias_rows": [],
+      "blocked_aliases": []
+    },
+    {
+      "canonical_slug": "elementary-school-teachers-except-special-education",
+      "approved_alias_rows": [],
+      "blocked_aliases": []
+    },
+    {
+      "canonical_slug": "management-analysts",
+      "approved_alias_rows": [
+        {
+          "alias": "Management Analyst",
+          "normalized": "management analyst",
+          "lang": "en",
+          "register": "canonical_variant",
+          "precision": 0.99,
+          "confidence": 0.99
+        },
+        {
+          "alias": "Management Analysts",
+          "normalized": "management analysts",
+          "lang": "en",
+          "register": "canonical",
+          "precision": 1.0,
+          "confidence": 1.0
+        },
+        {
+          "alias": "管理分析师",
+          "normalized": "管理分析师",
+          "lang": "zh-CN",
+          "register": "canonical_translation",
+          "precision": 0.97,
+          "confidence": 0.96
+        },
+        {
+          "alias": "管理咨询分析师",
+          "normalized": "管理咨询分析师",
+          "lang": "zh-CN",
+          "register": "professional_variant",
+          "precision": 0.9,
+          "confidence": 0.88
+        }
+      ],
+      "blocked_aliases": [
+        "咨询顾问",
+        "商业分析师"
+      ]
+    }
+  ]
+}

--- a/backend/tests/Feature/Career/CareerSearchApiTest.php
+++ b/backend/tests/Feature/Career/CareerSearchApiTest.php
@@ -20,6 +20,7 @@ final class CareerSearchApiTest extends TestCase
     {
         $chain = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'backend-architect-search-api',
+            'crosswalk_mode' => 'exact',
         ]));
         $chain['occupation']->update([
             'canonical_title_en' => 'Backend Search Architect',

--- a/backend/tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Services\Career\Import\CareerAuthorityMaterializer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerAuthorityMaterializerAliasHardeningTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_materializes_only_manifest_scoped_approved_aliases_and_skips_blocked_aliases(): void
+    {
+        $run = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b8-materializer',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+
+        app(CareerAuthorityMaterializer::class)->materializeImportRow($this->normalizedRow('software-developers', 'Software Developers'), $run);
+
+        $occupation = Occupation::query()->where('canonical_slug', 'software-developers')->firstOrFail();
+        $normalizedAliases = $occupation->aliases()->pluck('normalized')->all();
+
+        $this->assertContains('software developer', $normalizedAliases);
+        $this->assertContains('application developer', $normalizedAliases);
+        $this->assertContains('软件开发工程师', $normalizedAliases);
+        $this->assertNotContains('程序员', $normalizedAliases);
+        $this->assertNotContains('码农', $normalizedAliases);
+    }
+
+    public function test_it_does_not_add_extra_aliases_for_first_wave_entries_without_approved_rows(): void
+    {
+        $run = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b8-materializer-empty',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+
+        app(CareerAuthorityMaterializer::class)->materializeImportRow($this->normalizedRow('marketing-managers', 'Marketing Managers'), $run);
+
+        $occupation = Occupation::query()->where('canonical_slug', 'marketing-managers')->firstOrFail();
+        $normalizedAliases = $occupation->aliases()->pluck('normalized')->all();
+
+        $this->assertSame(['marketing managers', 'marketing managers 中文'], $normalizedAliases);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizedRow(string $slug, string $title): array
+    {
+        $titleZh = $title.' 中文';
+
+        return [
+            'family_slug' => 'test-family-'.$slug,
+            'family_title_en' => 'Test Family',
+            'family_title_zh' => '测试家族',
+            'canonical_slug' => $slug,
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $titleZh,
+            'structural_stability' => 0.9,
+            'task_prototype_signature' => ['analysis' => 0.8],
+            'market_semantics_gap' => 0.1,
+            'regulatory_divergence' => 0.05,
+            'toolchain_divergence' => 0.07,
+            'skill_gap_threshold' => 0.3,
+            'trust_inheritance_scope' => ['allow_task_truth' => true],
+            'crosswalk_source_system' => 'us_soc',
+            'crosswalk_source_code' => '15-1252',
+            'crosswalk_source_title' => $title,
+            'mapping_mode' => 'exact',
+            'source_title' => 'Fixture Source',
+            'bls_url' => 'https://example.test/bls/'.$slug,
+            'source_url' => 'https://example.test/source/'.$slug,
+            'median_pay_usd_annual' => 120000,
+            'jobs_2024' => 1000,
+            'projected_jobs_2034' => 1200,
+            'employment_change' => 200,
+            'outlook_pct_2024_2034' => 20,
+            'outlook_description' => 'Much faster than average',
+            'entry_education' => "Bachelor's degree",
+            'work_experience' => 'None',
+            'on_the_job_training' => 'None',
+            'ai_exposure' => 4.5,
+            'ai_rationale' => 'fixture rationale',
+            'skill_graph' => [
+                'stack_key' => 'core',
+                'skill_overlap_graph' => ['analysis' => 0.8],
+            ],
+            'canonical_path' => '/career/jobs/'.$slug,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php
@@ -22,9 +22,11 @@ final class CareerSearchBundleBuilderTest extends TestCase
     {
         $exact = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'backend-architect',
+            'crosswalk_mode' => 'exact',
         ]));
         $prefix = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'backend-architect-lead',
+            'crosswalk_mode' => 'exact',
         ]));
 
         $results = app(CareerSearchBundleBuilder::class)->build('backend-architect');
@@ -42,9 +44,11 @@ final class CareerSearchBundleBuilderTest extends TestCase
     {
         $exact = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'distributed-platform-architect',
+            'crosswalk_mode' => 'exact',
         ]));
         $prefix = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'distributed-platform-lead',
+            'crosswalk_mode' => 'exact',
         ]));
 
         $exact['occupation']->update([
@@ -69,9 +73,11 @@ final class CareerSearchBundleBuilderTest extends TestCase
     {
         $exact = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'platform-ops-architect',
+            'crosswalk_mode' => 'exact',
         ]));
         $prefix = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'platform-ops-specialist',
+            'crosswalk_mode' => 'exact',
         ]));
 
         OccupationAlias::query()->create([
@@ -110,11 +116,13 @@ final class CareerSearchBundleBuilderTest extends TestCase
     {
         $canonical = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'backend-architect-canonical',
+            'crosswalk_mode' => 'exact',
         ]));
         $canonical['occupation']->update(['canonical_title_en' => 'Backend Architect']);
 
         $aliasOnly = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'platform-architecture-specialist',
+            'crosswalk_mode' => 'exact',
         ]));
         $aliasOnly['occupation']->update(['canonical_title_en' => 'Platform Architecture Specialist']);
         OccupationAlias::query()->create([
@@ -141,6 +149,7 @@ final class CareerSearchBundleBuilderTest extends TestCase
     {
         $visible = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'backend-architect-visible-search',
+            'crosswalk_mode' => 'exact',
         ]));
         OccupationAlias::query()->create([
             'occupation_id' => $visible['occupation']->id,
@@ -180,9 +189,11 @@ final class CareerSearchBundleBuilderTest extends TestCase
     {
         $en = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'cloud-architect-en',
+            'crosswalk_mode' => 'exact',
         ]));
         $zh = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
             'slug' => 'cloud-architect-zh',
+            'crosswalk_mode' => 'exact',
         ]));
 
         OccupationAlias::query()->create([
@@ -218,6 +229,28 @@ final class CareerSearchBundleBuilderTest extends TestCase
         $this->assertCount(1, $zhResults);
         $this->assertSame('cloud-architect-zh', $zhResults[0]->identity['canonical_slug']);
         $this->assertSame('alias_exact', $zhResults[0]->matchKind);
+    }
+
+    public function test_it_excludes_direct_match_rows_from_public_safe_search_scope(): void
+    {
+        $direct = $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'direct-match-architect',
+            'crosswalk_mode' => 'direct_match',
+        ]));
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $direct['occupation']->id,
+            'alias' => 'Direct Match Architect',
+            'normalized' => 'direct match architect',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.95,
+        ]);
+
+        $this->assertSame([], app(CareerSearchBundleBuilder::class)->build('direct match architect'));
     }
 
     /**

--- a/backend/tests/Unit/Services/Career/FirstWaveAliasCatalogReaderTest.php
+++ b/backend/tests/Unit/Services/Career/FirstWaveAliasCatalogReaderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Import\FirstWaveAliasCatalogReader;
+use Tests\TestCase;
+
+final class FirstWaveAliasCatalogReaderTest extends TestCase
+{
+    public function test_it_reads_an_alias_catalog_aligned_to_the_first_wave_manifest(): void
+    {
+        $catalog = app(FirstWaveAliasCatalogReader::class)->read();
+
+        $this->assertSame('first_wave_aliases_v1', $catalog['version']);
+        $this->assertSame(10, $catalog['count_expected']);
+        $this->assertSame(10, $catalog['count_actual']);
+        $this->assertCount(10, $catalog['items']);
+    }
+
+    public function test_it_keeps_missing_first_wave_alias_entries_explicitly_empty(): void
+    {
+        $catalog = app(FirstWaveAliasCatalogReader::class)->bySlug();
+
+        $this->assertSame([], $catalog['human-resources-specialists']['approved_alias_rows']);
+        $this->assertSame([], $catalog['marketing-managers']['approved_alias_rows']);
+        $this->assertSame([], $catalog['registered-nurses']['approved_alias_rows']);
+        $this->assertSame([], $catalog['elementary-school-teachers-except-special-education']['approved_alias_rows']);
+    }
+}

--- a/backend/tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php
+++ b/backend/tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Import\FirstWaveAliasHardeningService;
+use App\Models\CareerImportRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class FirstWaveAliasHardeningServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_only_returns_approved_first_wave_aliases(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'software-developers',
+            'crosswalk_mode' => 'exact',
+        ]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b8-software-developers',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+
+        $resolved = app(FirstWaveAliasHardeningService::class)->resolveAliasPayloads(
+            'software-developers',
+            $chain['occupation'],
+            $chain['family'],
+            $importRun,
+        );
+
+        $this->assertTrue($resolved['in_scope']);
+        $this->assertContains('程序员', $resolved['blocked_aliases']);
+        $this->assertSame(
+            ['software developer', 'software developers', 'application developer', '软件开发工程师', '软件工程师'],
+            array_values(array_map(static fn (array $payload): string => (string) $payload['normalized'], $resolved['alias_payloads']))
+        );
+    }
+
+    public function test_it_returns_no_alias_payloads_for_first_wave_entries_without_approved_alias_rows(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'marketing-managers',
+            'crosswalk_mode' => 'exact',
+        ]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b8-marketing-managers',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+
+        $resolved = app(FirstWaveAliasHardeningService::class)->resolveAliasPayloads(
+            'marketing-managers',
+            $chain['occupation'],
+            $chain['family'],
+            $importRun,
+        );
+
+        $this->assertTrue($resolved['in_scope']);
+        $this->assertSame([], $resolved['alias_payloads']);
+        $this->assertSame([], $resolved['blocked_aliases']);
+    }
+
+    public function test_it_leaves_non_first_wave_occupations_out_of_scope(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'cloud-platform-architect',
+            'crosswalk_mode' => 'exact',
+        ]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b8-cloud-platform-architect',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+
+        $resolved = app(FirstWaveAliasHardeningService::class)->resolveAliasPayloads(
+            'cloud-platform-architect',
+            $chain['occupation'],
+            $chain['family'],
+            $importRun,
+        );
+
+        $this->assertFalse($resolved['in_scope']);
+        $this->assertSame([], $resolved['alias_payloads']);
+    }
+}


### PR DESCRIPTION
## What changed
- add a first-wave alias authority file at `docs/career/first_wave_aliases.json`
- add a first-wave alias catalog reader and alias hardening service
- harden alias materialization only for occupations in the B7 first-wave manifest
- keep blocked aliases out of public-safe alias rows
- tighten B6 public-safe search scope by removing `direct_match`
- add unit and feature tests for alias ingestion, alias hardening, materialization, and B6 search regressions

## Why
- B8 should improve first-wave conservative search only
- first-wave alias scope must stay bounded by the B7 manifest
- only explicitly approved aliases should be materialized
- public search must not widen into crosswalk discovery or `direct_match`

## Validation
- `python3 -m json.tool docs/career/first_wave_manifest.json >/dev/null`
- `python3 -m json.tool docs/career/first_wave_aliases.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Import/FirstWaveAliasCatalogReader.php app/Domain/Career/Import/FirstWaveAliasHardeningService.php app/Services/Career/Import/CareerAuthorityMaterializer.php app/Services/Career/Bundles/CareerSearchBundleBuilder.php tests/Unit/Services/Career/FirstWaveAliasCatalogReaderTest.php tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php tests/Feature/Career/CareerSearchApiTest.php`
- `php artisan test tests/Unit/Services/Career/FirstWaveAliasCatalogReaderTest.php tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php tests/Feature/Career/CareerSearchApiTest.php`

## Deferred
- no frontend changes
- no search API shape changes
- no fuzzy or semantic retrieval
- no full 342 alias rollout
