### PR TITLE
PR-D1A: Add Career batch manifest template and gold diff tooling

### DIFF
--- a/backend/docs/career/career-batch-manifest.example.json
+++ b/backend/docs/career/career-batch-manifest.example.json
@@ -1,0 +1,84 @@
+{
+  "manifest_version": "career_batch_manifest.template.v1",
+  "manifest_kind": "career_batch_draft_template",
+  "generated_from": "docs/career/career-batch-manifest.template.json",
+  "generated_at": "2026-04-09T00:00:00Z",
+  "wave_name": "career_batch_example",
+  "batch_id": "batch-example-001",
+  "scope": {
+    "intended_count": 1,
+    "first_wave_overlap_allowed": false,
+    "authority_owner": "laravel_engine"
+  },
+  "engine_boundary": {
+    "engine_owned_truth_fields": [
+      "crosswalk_mode",
+      "wave_classification",
+      "publish_reason_codes",
+      "trust_seed",
+      "reviewer_seed",
+      "index_seed",
+      "claim_seed",
+      "score_summary",
+      "trust_summary",
+      "claim_permissions",
+      "seo_contract",
+      "provenance_meta"
+    ],
+    "authoring_rule": "Codex may draft structure, alias candidates, and editorial placeholders only. Truth, scores, trust, claims, and publish state must be computed by the Laravel authority layer.",
+    "forbidden_actions": [
+      "truth_compute",
+      "score_compute",
+      "trust_compile",
+      "claim_compile",
+      "publish_state_inference"
+    ]
+  },
+  "occupations": [
+    {
+      "draft_id": "draft-example-occupation-001",
+      "occupation_uuid": "11111111-2222-4333-8444-555555555555",
+      "canonical_slug": "occupational-therapy-assistants",
+      "canonical_title_en": "Occupational Therapy Assistants",
+      "canonical_title_zh": null,
+      "family_uuid": "66666666-7777-4888-8999-aaaaaaaaaaaa",
+      "source_refs": [
+        {
+          "kind": "raw_truth_seed",
+          "ref": "ai_exposure_342_sheet:occupational-therapy-assistants"
+        }
+      ],
+      "alias_candidates": [
+        {
+          "alias": "Occupational Therapy Assistant",
+          "lang": "en",
+          "register": "canonical_variant",
+          "notes": "Singular professional title variant."
+        }
+      ],
+      "editorial_patch": {
+        "summary_seed": "Draft summary placeholder only; not authoritative truth.",
+        "audience_notes": [
+          "Review tone and candidate audience before publish gate."
+        ],
+        "risk_notes": [
+          "Do not infer salary, outlook, or trust from this draft."
+        ],
+        "cta_notes": [
+          "Keep next-step language generic until engine outputs are available."
+        ]
+      },
+      "human_moat_tags": [
+        "in_person_support",
+        "patient_interaction"
+      ],
+      "task_prototype_signature": {
+        "prototype_version": "draft-prototype-v1",
+        "draft_prompt_version": "career-batch-draft-v1",
+        "review_profile": "career-generalist"
+      },
+      "authoring_status": "draft",
+      "notes": "Illustrative example only. Not production truth."
+    }
+  ]
+}

--- a/backend/docs/career/career-batch-manifest.template.json
+++ b/backend/docs/career/career-batch-manifest.template.json
@@ -1,0 +1,83 @@
+{
+  "manifest_version": "career_batch_manifest.template.v1",
+  "manifest_kind": "career_batch_draft_template",
+  "generated_from": "docs/career/career-batch-manifest.template.json",
+  "generated_at": "2026-04-09T00:00:00Z",
+  "wave_name": "career_batch_draft",
+  "batch_id": "<batch_id>",
+  "scope": {
+    "intended_count": 0,
+    "first_wave_overlap_allowed": false,
+    "authority_owner": "laravel_engine"
+  },
+  "engine_boundary": {
+    "engine_owned_truth_fields": [
+      "crosswalk_mode",
+      "wave_classification",
+      "publish_reason_codes",
+      "trust_seed",
+      "reviewer_seed",
+      "index_seed",
+      "claim_seed",
+      "score_summary",
+      "trust_summary",
+      "claim_permissions",
+      "seo_contract",
+      "provenance_meta"
+    ],
+    "authoring_rule": "Codex may draft structure, alias candidates, and editorial placeholders only. Truth, scores, trust, claims, and publish state must be computed by the Laravel authority layer.",
+    "forbidden_actions": [
+      "truth_compute",
+      "score_compute",
+      "trust_compile",
+      "claim_compile",
+      "publish_state_inference"
+    ]
+  },
+  "occupations": [
+    {
+      "draft_id": "<draft_id>",
+      "occupation_uuid": "<occupation_uuid>",
+      "canonical_slug": "<canonical_slug>",
+      "canonical_title_en": "<canonical_title_en>",
+      "canonical_title_zh": "<canonical_title_zh_or_null>",
+      "family_uuid": "<family_uuid>",
+      "source_refs": [
+        {
+          "kind": "raw_truth_seed",
+          "ref": "<source_reference>"
+        }
+      ],
+      "alias_candidates": [
+        {
+          "alias": "<alias>",
+          "lang": "<lang>",
+          "register": "<register>",
+          "notes": "<why_this_alias_is_conservative>"
+        }
+      ],
+      "editorial_patch": {
+        "summary_seed": "<editorial_summary_seed>",
+        "audience_notes": [
+          "<audience_note>"
+        ],
+        "risk_notes": [
+          "<risk_note>"
+        ],
+        "cta_notes": [
+          "<cta_note>"
+        ]
+      },
+      "human_moat_tags": [
+        "<human_moat_tag>"
+      ],
+      "task_prototype_signature": {
+        "prototype_version": "<prototype_version>",
+        "draft_prompt_version": "<draft_prompt_version>",
+        "review_profile": "<review_profile>"
+      },
+      "authoring_status": "draft",
+      "notes": "<optional_notes>"
+    }
+  ]
+}

--- a/backend/docs/career/career-gold-diff-rules.md
+++ b/backend/docs/career/career-gold-diff-rules.md
@@ -1,0 +1,116 @@
+# Career Gold Diff Rules
+
+## Purpose
+- Validate the structural integrity of future Career batch draft manifests.
+- Keep Codex draft artifacts inside controlled authoring boundaries.
+- Prevent later batch work from mutating frozen first-wave authority artifacts.
+
+## What Gold Diff Validates
+- Required top-level schema keys are present.
+- Required occupation-level keys are present.
+- Unexpected top-level and occupation-level keys are rejected.
+- Forbidden engine-owned keys are absent from batch draft manifests.
+- `manifest_version` and `manifest_kind` are present.
+- `manifest_kind` must remain `career_batch_draft_template`.
+- `scope.first_wave_overlap_allowed` must remain `false`.
+- Duplicate `draft_id`, `occupation_uuid`, and `canonical_slug` values are rejected.
+- First-wave boundary drift is rejected:
+  - a batch draft must not reuse any `canonical_slug` already frozen in `docs/career/first_wave_manifest.json`
+- The file remains machine-readable JSON.
+
+## Required Top-Level Keys
+- `manifest_version`
+- `manifest_kind`
+- `generated_from`
+- `generated_at`
+- `wave_name`
+- `batch_id`
+- `scope`
+- `engine_boundary`
+- `occupations`
+
+## Required Occupation-Level Keys
+- `draft_id`
+- `occupation_uuid`
+- `canonical_slug`
+- `canonical_title_en`
+- `canonical_title_zh`
+- `family_uuid`
+- `source_refs`
+- `alias_candidates`
+- `editorial_patch`
+- `human_moat_tags`
+- `task_prototype_signature`
+- `authoring_status`
+- `notes`
+
+## Allowed Top-Level Keys
+- `manifest_version`
+- `manifest_kind`
+- `generated_from`
+- `generated_at`
+- `wave_name`
+- `batch_id`
+- `scope`
+- `engine_boundary`
+- `occupations`
+
+## Allowed Occupation-Level Keys
+- `draft_id`
+- `occupation_uuid`
+- `canonical_slug`
+- `canonical_title_en`
+- `canonical_title_zh`
+- `family_uuid`
+- `source_refs`
+- `alias_candidates`
+- `editorial_patch`
+- `human_moat_tags`
+- `task_prototype_signature`
+- `authoring_status`
+- `notes`
+
+## Allowed Editorial-Only Fields
+- `alias_candidates`
+- `editorial_patch`
+- `human_moat_tags`
+- `task_prototype_signature`
+- `notes`
+
+These fields may hold structured draft guidance, but they are still non-authoritative.
+
+## Forbidden Engine-Owned Keys
+- `crosswalk_mode`
+- `wave_classification`
+- `publish_reason_codes`
+- `trust_seed`
+- `reviewer_seed`
+- `index_seed`
+- `claim_seed`
+- `score_summary`
+- `trust_summary`
+- `claim_permissions`
+- `seo_contract`
+- `provenance_meta`
+
+## First-Wave Boundary Protection
+- `docs/career/first_wave_manifest.json` is frozen publish truth for the first-wave 10 occupations.
+- `docs/career/first_wave_aliases.json` is frozen first-wave alias authority.
+- Batch draft manifests must not:
+  - reuse first-wave `canonical_slug` values
+  - edit or reinterpret first-wave publish seeds
+  - treat test fixtures as replacement authority
+
+## What Gold Diff Must NOT Do
+- No truth compute.
+- No score compute.
+- No trust compile.
+- No claim compile.
+- No auto-fix.
+- No file mutation.
+- No alias invention beyond the provided draft payload.
+
+## Review Rule
+- Passing gold diff only means the draft is structurally acceptable.
+- It does not mean the draft is publish-ready.
+- Laravel engine outputs remain the only valid authority for truth, trust, claim, and publish decisions.

--- a/backend/scripts/career_gold_diff.sh
+++ b/backend/scripts/career_gold_diff.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIRST_WAVE_MANIFEST="${REPO_ROOT}/docs/career/first_wave_manifest.json"
+FIRST_WAVE_ALIASES="${REPO_ROOT}/docs/career/first_wave_aliases.json"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/career_gold_diff.sh CANDIDATE_JSON [--assert-frozen-clean]
+
+Behavior:
+  - validates the candidate batch manifest structurally
+  - rejects forbidden engine-owned fields
+  - rejects missing required keys
+  - rejects duplicate draft_id / occupation_uuid / canonical_slug values
+  - rejects canonical_slug overlap with frozen first-wave manifest
+
+This helper is validation-only.
+It never rewrites files and never computes truth, scores, trust, or claims.
+EOF
+}
+
+if [ "${1:-}" = "" ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq not found."
+  exit 1
+fi
+
+CANDIDATE_PATH="$1"
+ASSERT_FROZEN_CLEAN=0
+
+if [ "${2:-}" = "--assert-frozen-clean" ]; then
+  ASSERT_FROZEN_CLEAN=1
+fi
+
+if [ ! -f "${CANDIDATE_PATH}" ]; then
+  echo "FAIL: candidate manifest not found at ${CANDIDATE_PATH}."
+  exit 1
+fi
+
+if ! jq -e . "${CANDIDATE_PATH}" >/dev/null 2>&1; then
+  echo "FAIL: candidate manifest is not valid JSON."
+  exit 1
+fi
+
+if ! jq -e . "${FIRST_WAVE_MANIFEST}" >/dev/null 2>&1; then
+  echo "FAIL: frozen first-wave manifest is not valid JSON."
+  exit 1
+fi
+
+if ! jq -e . "${FIRST_WAVE_ALIASES}" >/dev/null 2>&1; then
+  echo "FAIL: frozen first-wave aliases file is not valid JSON."
+  exit 1
+fi
+
+if [ "${ASSERT_FROZEN_CLEAN}" = "1" ]; then
+  if ! git -C "${REPO_ROOT}" diff --quiet -- "${FIRST_WAVE_MANIFEST}" "${FIRST_WAVE_ALIASES}"; then
+    echo "FAIL: frozen first-wave files have local modifications."
+    exit 1
+  fi
+fi
+
+TOP_LEVEL_REQUIRED='[
+  "manifest_version",
+  "manifest_kind",
+  "generated_from",
+  "generated_at",
+  "wave_name",
+  "batch_id",
+  "scope",
+  "engine_boundary",
+  "occupations"
+]'
+
+ITEM_REQUIRED='[
+  "draft_id",
+  "occupation_uuid",
+  "canonical_slug",
+  "canonical_title_en",
+  "canonical_title_zh",
+  "family_uuid",
+  "source_refs",
+  "alias_candidates",
+  "editorial_patch",
+  "human_moat_tags",
+  "task_prototype_signature",
+  "authoring_status",
+  "notes"
+]'
+
+TOP_LEVEL_ALLOWED="${TOP_LEVEL_REQUIRED}"
+ITEM_ALLOWED="${ITEM_REQUIRED}"
+
+FORBIDDEN_FIELDS='[
+  "crosswalk_mode",
+  "wave_classification",
+  "publish_reason_codes",
+  "trust_seed",
+  "reviewer_seed",
+  "index_seed",
+  "claim_seed",
+  "score_summary",
+  "trust_summary",
+  "claim_permissions",
+  "seo_contract",
+  "provenance_meta"
+]'
+
+TMPDIR="$(mktemp -d 2>/dev/null || mktemp -d -t career_gold_diff)"
+cleanup() {
+  rm -rf "${TMPDIR}"
+}
+trap cleanup EXIT
+
+MISSING_TOP="${TMPDIR}/missing_top.txt"
+MISSING_ITEM="${TMPDIR}/missing_item.txt"
+UNEXPECTED_TOP="${TMPDIR}/unexpected_top.txt"
+UNEXPECTED_ITEM="${TMPDIR}/unexpected_item.txt"
+FORBIDDEN_FOUND="${TMPDIR}/forbidden.txt"
+DUP_DRAFT="${TMPDIR}/dup_draft.txt"
+DUP_OCC="${TMPDIR}/dup_occ.txt"
+DUP_SLUG="${TMPDIR}/dup_slug.txt"
+FIRST_WAVE_OVERLAP="${TMPDIR}/first_wave_overlap.txt"
+INVALID_KIND="${TMPDIR}/invalid_kind.txt"
+INVALID_SCOPE="${TMPDIR}/invalid_scope.txt"
+
+jq -r --argjson required "${TOP_LEVEL_REQUIRED}" '
+  $required[] as $key | select(has($key) | not) | $key
+' "${CANDIDATE_PATH}" > "${MISSING_TOP}"
+
+jq -r --argjson allowed "${TOP_LEVEL_ALLOWED}" '
+  keys_unsorted[] | select(($allowed | index(.)) == null)
+' "${CANDIDATE_PATH}" > "${UNEXPECTED_TOP}"
+
+jq -r --argjson required "${ITEM_REQUIRED}" '
+  .occupations[]? as $item
+  | $required[] as $key
+  | select($item | has($key) | not)
+  | $key
+' "${CANDIDATE_PATH}" > "${MISSING_ITEM}"
+
+jq -r --argjson allowed "${ITEM_ALLOWED}" '
+  .occupations[]? as $item
+  | ($item.canonical_slug // "<missing-slug>") as $slug
+  | ($item | keys_unsorted[]) as $key
+  | select(($allowed | index($key)) == null)
+  | "\($slug)\t\($key)"
+' "${CANDIDATE_PATH}" > "${UNEXPECTED_ITEM}"
+
+jq -r --argjson forbidden "${FORBIDDEN_FIELDS}" '
+  .occupations[]? as $item
+  | ($item.canonical_slug // "<missing-slug>") as $slug
+  | $forbidden[] as $key
+  | select($item | has($key))
+  | "\($slug)\t\($key)"
+' "${CANDIDATE_PATH}" > "${FORBIDDEN_FOUND}"
+
+jq -r '.occupations[]?.draft_id // empty' "${CANDIDATE_PATH}" | sort | uniq -d > "${DUP_DRAFT}"
+jq -r '.occupations[]?.occupation_uuid // empty' "${CANDIDATE_PATH}" | sort | uniq -d > "${DUP_OCC}"
+jq -r '.occupations[]?.canonical_slug // empty' "${CANDIDATE_PATH}" | sort | uniq -d > "${DUP_SLUG}"
+
+jq -r '.occupations[]?.canonical_slug // empty' "${FIRST_WAVE_MANIFEST}" | sort -u > "${TMPDIR}/first_wave_slugs.txt"
+jq -r '.occupations[]?.canonical_slug // empty' "${CANDIDATE_PATH}" | sort -u > "${TMPDIR}/candidate_slugs.txt"
+comm -12 "${TMPDIR}/first_wave_slugs.txt" "${TMPDIR}/candidate_slugs.txt" > "${FIRST_WAVE_OVERLAP}"
+
+jq -r 'select(.manifest_kind != "career_batch_draft_template") | .manifest_kind // "<missing-manifest-kind>"' \
+  "${CANDIDATE_PATH}" > "${INVALID_KIND}"
+
+jq -r 'select(.scope.first_wave_overlap_allowed != false) | (.scope.first_wave_overlap_allowed | tostring)' \
+  "${CANDIDATE_PATH}" > "${INVALID_SCOPE}"
+
+fail=0
+
+if [ -s "${MISSING_TOP}" ]; then
+  echo "FAIL: missing top-level keys:"
+  cat "${MISSING_TOP}"
+  fail=1
+fi
+
+if [ -s "${MISSING_ITEM}" ]; then
+  echo "FAIL: missing occupation-level keys:"
+  cat "${MISSING_ITEM}"
+  fail=1
+fi
+
+if [ -s "${UNEXPECTED_TOP}" ]; then
+  echo "FAIL: unexpected top-level keys:"
+  cat "${UNEXPECTED_TOP}"
+  fail=1
+fi
+
+if [ -s "${UNEXPECTED_ITEM}" ]; then
+  echo "FAIL: unexpected occupation-level keys:"
+  cat "${UNEXPECTED_ITEM}"
+  fail=1
+fi
+
+if [ -s "${FORBIDDEN_FOUND}" ]; then
+  echo "FAIL: forbidden engine-owned fields present:"
+  cat "${FORBIDDEN_FOUND}"
+  fail=1
+fi
+
+if [ -s "${DUP_DRAFT}" ]; then
+  echo "FAIL: duplicate draft_id values:"
+  cat "${DUP_DRAFT}"
+  fail=1
+fi
+
+if [ -s "${DUP_OCC}" ]; then
+  echo "FAIL: duplicate occupation_uuid values:"
+  cat "${DUP_OCC}"
+  fail=1
+fi
+
+if [ -s "${DUP_SLUG}" ]; then
+  echo "FAIL: duplicate canonical_slug values:"
+  cat "${DUP_SLUG}"
+  fail=1
+fi
+
+if [ -s "${FIRST_WAVE_OVERLAP}" ]; then
+  echo "FAIL: candidate manifest overlaps frozen first-wave slugs:"
+  cat "${FIRST_WAVE_OVERLAP}"
+  fail=1
+fi
+
+if [ -s "${INVALID_KIND}" ]; then
+  echo "FAIL: manifest_kind must equal career_batch_draft_template:"
+  cat "${INVALID_KIND}"
+  fail=1
+fi
+
+if [ -s "${INVALID_SCOPE}" ]; then
+  echo "FAIL: scope.first_wave_overlap_allowed must be false:"
+  cat "${INVALID_SCOPE}"
+  fail=1
+fi
+
+if [ "${fail}" -ne 0 ]; then
+  exit 1
+fi
+
+echo "career gold diff validation ok"
+echo "candidate=${CANDIDATE_PATH}"
+echo "frozen_first_wave_manifest=${FIRST_WAVE_MANIFEST}"
+echo "frozen_first_wave_aliases=${FIRST_WAVE_ALIASES}"


### PR DESCRIPTION
## What changed
- add a machine-readable Career batch manifest template for post-first-wave draft production
- add a small illustrative batch manifest example
- add Career gold diff rules documenting required keys, forbidden engine-owned fields, and first-wave boundary protection
- add a validation-only `scripts/career_gold_diff.sh` helper for structural checks

## Why
- D1A is the backend-side governance foundation for future 342-occupation batch production
- Codex draft artifacts need a clear structural template, but truth, scores, trust, claims, and publish state must remain Laravel-engine authority
- frozen first-wave artifacts must stay protected from later batch authoring work

## Validation
- `python3 -m json.tool docs/career/career-batch-manifest.template.json >/dev/null`
- `python3 -m json.tool docs/career/career-batch-manifest.example.json >/dev/null`
- `bash -n scripts/career_gold_diff.sh`
- `scripts/career_gold_diff.sh docs/career/career-batch-manifest.example.json --assert-frozen-clean`
- negative check: inject a forbidden field and verify the helper fails

## Notes
- this PR is docs/tooling only
- the helper is validation-only and never rewrites files
- the helper explicitly rejects overlap with `docs/career/first_wave_manifest.json`

## Deferred
- no runtime business logic
- no controller/model/API changes
- no full 342 production execution
- no auto-fix or normalization behavior in the helper
