### PR TITLE
PR-B11: Add authority-owned matched-job readiness exposure to career recommendation detail bundle

### DIFF
--- a/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
+++ b/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
@@ -15,6 +15,7 @@ final class CareerRecommendationDetailBundle
      * @param  array<string, mixed>  $claimPermissions
      * @param  array<string, mixed>  $integritySummary
      * @param  array<string, mixed>  $trustManifest
+     * @param  list<array<string, mixed>>  $matchedJobs
      * @param  array<string, mixed>  $seoContract
      * @param  array<string, mixed>  $provenanceMeta
      */
@@ -27,6 +28,7 @@ final class CareerRecommendationDetailBundle
         public readonly array $claimPermissions,
         public readonly array $integritySummary,
         public readonly array $trustManifest,
+        public readonly array $matchedJobs,
         public readonly array $seoContract,
         public readonly array $provenanceMeta,
     ) {}
@@ -47,6 +49,7 @@ final class CareerRecommendationDetailBundle
             'claim_permissions' => $this->claimPermissions,
             'integrity_summary' => $this->integritySummary,
             'trust_manifest' => $this->trustManifest,
+            'matched_jobs' => $this->matchedJobs,
             'seo_contract' => $this->seoContract,
             'provenance_meta' => $this->provenanceMeta,
         ];

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Services\Career\Bundles;
 
 use App\DTO\Career\CareerRecommendationDetailBundle;
+use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
 use App\Services\PublicSurface\SeoSurfaceContractService;
+use Illuminate\Support\Collection;
 
 final class CareerRecommendationDetailBundleBuilder
 {
@@ -24,34 +26,9 @@ final class CareerRecommendationDetailBundleBuilder
 
         $canonicalType = strtoupper(strtok($normalizedType, '-') ?: $normalizedType);
 
-        $snapshot = RecommendationSnapshot::query()
-            ->with([
-                'occupation.family',
-                'truthMetric.sourceTrace',
-                'trustManifest',
-                'indexState',
-                'profileProjection',
-                'contextSnapshot',
-                'compileRun',
-            ])
-            ->whereNotNull('compiled_at')
-            ->whereNotNull('compile_run_id')
-            ->whereHas('contextSnapshot', static function ($query): void {
-                $query->where('context_payload->materialization', 'career_first_wave');
-            })
-            ->whereHas('profileProjection', static function ($query): void {
-                $query->where('projection_payload->materialization', 'career_first_wave');
-            })
-            ->whereHas('profileProjection', function ($query) use ($normalizedType, $canonicalType): void {
-                $query->where(function ($inner) use ($normalizedType, $canonicalType): void {
-                    $inner->where('projection_payload->recommendation_subject_meta->type_code', $normalizedType)
-                        ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $normalizedType)
-                        ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $canonicalType);
-                });
-            })
-            ->orderByDesc('compiled_at')
-            ->orderByDesc('created_at')
-            ->first();
+        $snapshots = $this->matchingSnapshots($normalizedType, $canonicalType);
+        /** @var RecommendationSnapshot|null $snapshot */
+        $snapshot = $snapshots->first();
 
         if (! $snapshot instanceof RecommendationSnapshot || ! $snapshot->occupation) {
             return null;
@@ -111,6 +88,7 @@ final class CareerRecommendationDetailBundleBuilder
                 'locale_context' => is_array($trustManifest?->locale_context) ? $trustManifest->locale_context : [],
                 'methodology' => is_array($trustManifest?->methodology) ? $trustManifest->methodology : [],
             ],
+            matchedJobs: $this->buildMatchedJobs($snapshots),
             seoContract: $this->buildSeoContract($snapshot, $subjectMeta, $requestedType),
             provenanceMeta: [
                 'content_version' => $trustManifest?->content_version,
@@ -128,6 +106,103 @@ final class CareerRecommendationDetailBundleBuilder
                 'compile_refs' => $this->normalizeArray($payload['compile_refs'] ?? []),
             ],
         );
+    }
+
+    /**
+     * @return Collection<int, RecommendationSnapshot>
+     */
+    private function matchingSnapshots(string $normalizedType, string $canonicalType): Collection
+    {
+        /** @var Collection<int, RecommendationSnapshot> $snapshots */
+        $snapshots = RecommendationSnapshot::query()
+            ->with([
+                'occupation.family',
+                'truthMetric.sourceTrace',
+                'trustManifest',
+                'indexState',
+                'profileProjection',
+                'contextSnapshot',
+                'compileRun',
+            ])
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', function ($query) use ($normalizedType, $canonicalType): void {
+                $query->where(function ($inner) use ($normalizedType, $canonicalType): void {
+                    $inner->where('projection_payload->recommendation_subject_meta->type_code', $normalizedType)
+                        ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $normalizedType)
+                        ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $canonicalType);
+                });
+            })
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->get();
+
+        return $snapshots;
+    }
+
+    /**
+     * @param  Collection<int, RecommendationSnapshot>  $snapshots
+     * @return list<array<string, mixed>>
+     */
+    private function buildMatchedJobs(Collection $snapshots): array
+    {
+        $items = $snapshots
+            ->groupBy('occupation_id')
+            ->map(function (Collection $group): ?RecommendationSnapshot {
+                /** @var RecommendationSnapshot|null $selected */
+                $selected = $group
+                    ->sort(function (RecommendationSnapshot $left, RecommendationSnapshot $right): int {
+                        return $this->compareSnapshots($left, $right);
+                    })
+                    ->first();
+
+                return $selected;
+            })
+            ->filter(static fn (mixed $snapshot): bool => $snapshot instanceof RecommendationSnapshot)
+            ->map(function (RecommendationSnapshot $snapshot): ?array {
+                $occupation = $snapshot->occupation;
+                if (! $occupation instanceof Occupation || $snapshot->indexState === null || $snapshot->trustManifest === null) {
+                    return null;
+                }
+
+                return [
+                    'occupation_uuid' => $occupation->id,
+                    'canonical_slug' => $occupation->canonical_slug,
+                    'title' => $occupation->canonical_title_en,
+                    'seo_contract' => $this->buildMatchedJobSeoContract($occupation, $snapshot),
+                    'trust_summary' => [
+                        'reviewer_status' => $snapshot->trustManifest?->reviewer_status,
+                    ],
+                ];
+            })
+            ->filter()
+            ->sortBy(static fn (array $item): array => [
+                strtolower((string) ($item['title'] ?? '')),
+                strtolower((string) ($item['canonical_slug'] ?? '')),
+            ])
+            ->values();
+
+        /** @var list<array<string, mixed>> $matchedJobs */
+        $matchedJobs = $items->all();
+
+        return $matchedJobs;
+    }
+
+    private function compareSnapshots(RecommendationSnapshot $left, RecommendationSnapshot $right): int
+    {
+        $leftCompiled = optional($left->compiled_at)?->getTimestamp() ?? 0;
+        $rightCompiled = optional($right->compiled_at)?->getTimestamp() ?? 0;
+        if ($leftCompiled !== $rightCompiled) {
+            return $rightCompiled <=> $leftCompiled;
+        }
+
+        return strcmp((string) $left->id, (string) $right->id);
     }
 
     /**
@@ -162,6 +237,23 @@ final class CareerRecommendationDetailBundleBuilder
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
             'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildMatchedJobSeoContract(Occupation $occupation, RecommendationSnapshot $snapshot): array
+    {
+        $indexState = $snapshot->indexState;
+        $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $indexState?->canonical_target,
+            'index_state' => $indexState?->index_state,
+            'index_eligible' => (bool) ($indexState?->index_eligible ?? false),
+            'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
         ];
     }
 

--- a/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
@@ -17,11 +17,88 @@ final class CareerRecommendationDetailApiTest extends TestCase
 
     public function test_it_returns_a_resource_backed_recommendation_detail_bundle_with_provenance_and_claims(): void
     {
-        $chain = CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+        $this->compileRecommendationChain(CareerFoundationFixture::seedTrustLimitedCrossMarketChain());
+
+        $response = $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_recommendation_detail')
+            ->assertJsonPath('recommendation_subject_meta.type_code', 'INTJ-A')
+            ->assertJsonPath('claim_permissions.allow_salary_comparison', false)
+            ->assertJsonPath('seo_contract.canonical_path', '/career/recommendations/mbti/intj')
+            ->assertJsonPath('seo_contract.index_eligible', false)
+            ->assertJsonPath('matched_jobs.0.canonical_slug', 'backend-architect-cn-market')
+            ->assertJsonPath('matched_jobs.0.seo_contract.index_eligible', false)
+            ->assertJsonPath('matched_jobs.0.seo_contract.index_state', 'trust_limited')
+            ->assertJsonPath('matched_jobs.0.trust_summary.reviewer_status', 'pending')
+            ->assertJsonStructure([
+                'identity',
+                'recommendation_subject_meta',
+                'supporting_truth_summary',
+                'score_bundle' => ['fit_score'],
+                'warnings',
+                'claim_permissions',
+                'integrity_summary',
+                'trust_manifest',
+                'matched_jobs' => [[
+                    'occupation_uuid',
+                    'canonical_slug',
+                    'title',
+                    'seo_contract' => ['canonical_path', 'canonical_target', 'index_state', 'index_eligible', 'reason_codes'],
+                    'trust_summary' => ['reviewer_status'],
+                ]],
+                'seo_contract',
+                'provenance_meta' => ['compiler_version', 'compile_refs'],
+            ]);
+
+        $this->assertIsString((string) $response->json('matched_jobs.0.occupation_uuid'));
+        $this->assertNotSame('', (string) $response->json('matched_jobs.0.occupation_uuid'));
+    }
+
+    public function test_it_returns_authority_owned_matched_jobs_without_using_heavy_job_payload_fields(): void
+    {
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-intj-api'])
+        );
+        $this->compileRecommendationChain(CareerFoundationFixture::seedTrustLimitedCrossMarketChain());
+
+        $response = $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
+            ->assertOk();
+
+        $matchedJobs = (array) $response->json('matched_jobs');
+
+        $this->assertCount(2, $matchedJobs);
+        $this->assertSame(
+            ['backend-architect-cn-market', 'backend-architect-intj-api'],
+            array_map(
+                static fn (array $job): string => (string) ($job['canonical_slug'] ?? ''),
+                $matchedJobs
+            )
+        );
+        $this->assertArrayNotHasKey('summary', $matchedJobs[0]);
+        $this->assertArrayNotHasKey('fit_bucket', $matchedJobs[0]);
+        $this->assertArrayNotHasKey('score_bundle', $matchedJobs[0]);
+    }
+
+    public function test_it_returns_conservative_not_found_when_subject_meta_bundle_is_unavailable(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
+
+        $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     */
+    private function compileRecommendationChain(array $chain): void
+    {
         $importRun = CareerImportRun::query()->create([
             'dataset_name' => 'fixture',
             'dataset_version' => 'v1',
-            'dataset_checksum' => 'checksum-rec-api',
+            'dataset_checksum' => 'checksum-rec-api-'.$chain['occupation']->canonical_slug,
             'scope_mode' => 'first_wave_trust_inheritance',
             'dry_run' => false,
             'status' => 'completed',
@@ -60,36 +137,5 @@ final class CareerRecommendationDetailApiTest extends TestCase
             'compile_run_id' => $compileRun->id,
             'import_run_id' => $importRun->id,
         ]);
-
-        $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
-            ->assertOk()
-            ->assertJsonPath('bundle_kind', 'career_recommendation_detail')
-            ->assertJsonPath('recommendation_subject_meta.type_code', 'INTJ-A')
-            ->assertJsonPath('claim_permissions.allow_salary_comparison', false)
-            ->assertJsonPath('seo_contract.canonical_path', '/career/recommendations/mbti/intj')
-            ->assertJsonPath('seo_contract.index_eligible', false)
-            ->assertJsonStructure([
-                'identity',
-                'recommendation_subject_meta',
-                'supporting_truth_summary',
-                'score_bundle' => ['fit_score'],
-                'warnings',
-                'claim_permissions',
-                'integrity_summary',
-                'trust_manifest',
-                'seo_contract',
-                'provenance_meta' => ['compiler_version', 'compile_refs'],
-            ]);
-    }
-
-    public function test_it_returns_conservative_not_found_when_subject_meta_bundle_is_unavailable(): void
-    {
-        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
-        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation']);
-
-        $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
-            ->assertStatus(404)
-            ->assertJsonPath('ok', false)
-            ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php
@@ -18,49 +18,7 @@ final class CareerRecommendationDetailBundleBuilderTest extends TestCase
 
     public function test_it_builds_a_recommendation_bundle_from_compiled_snapshot_and_subject_meta(): void
     {
-        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
-        $importRun = CareerImportRun::query()->create([
-            'dataset_name' => 'fixture',
-            'dataset_version' => 'v1',
-            'dataset_checksum' => 'checksum-build-rec',
-            'scope_mode' => 'first_wave_exact',
-            'dry_run' => false,
-            'status' => 'completed',
-            'started_at' => now()->subMinutes(10),
-            'finished_at' => now()->subMinutes(9),
-        ]);
-        $compileRun = CareerCompileRun::query()->create([
-            'import_run_id' => $importRun->id,
-            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
-            'scope_mode' => 'first_wave_exact',
-            'dry_run' => false,
-            'status' => 'completed',
-            'started_at' => now()->subMinutes(8),
-            'finished_at' => now()->subMinutes(7),
-        ]);
-        $chain['contextSnapshot']->update([
-            'compile_run_id' => $compileRun->id,
-            'context_payload' => ['materialization' => 'career_first_wave'],
-        ]);
-        $chain['childProjection']->update([
-            'compile_run_id' => $compileRun->id,
-            'projection_payload' => array_merge(
-                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
-                [
-                    'materialization' => 'career_first_wave',
-                    'recommendation_subject_meta' => [
-                        'type_code' => 'INTJ-A',
-                        'canonical_type_code' => 'INTJ',
-                        'display_title' => 'INTJ-A Career Match',
-                    ],
-                ],
-            ),
-        ]);
-
-        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
-            'compile_run_id' => $compileRun->id,
-            'import_run_id' => $importRun->id,
-        ]);
+        $this->compileRecommendationChain(CareerFoundationFixture::seedHighTrustCompleteChain());
 
         $bundle = app(CareerRecommendationDetailBundleBuilder::class)->buildByType('intj');
 
@@ -73,6 +31,21 @@ final class CareerRecommendationDetailBundleBuilderTest extends TestCase
         $this->assertArrayHasKey('allow_strong_claim', (array) data_get($payload, 'claim_permissions'));
         $this->assertSame('career_recommendation_detail_bundle', data_get($payload, 'seo_contract.surface_type'));
         $this->assertSame('/career/recommendations/mbti/intj', data_get($payload, 'seo_contract.canonical_path'));
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'occupation_uuid',
+                'canonical_slug',
+                'title',
+                'seo_contract',
+                'trust_summary',
+            ], JSON_THROW_ON_ERROR),
+            json_encode(array_keys((array) data_get($payload, 'matched_jobs.0')), JSON_THROW_ON_ERROR),
+        );
+        $this->assertSame('backend-architect', data_get($payload, 'matched_jobs.0.canonical_slug'));
+        $this->assertSame(true, data_get($payload, 'matched_jobs.0.seo_contract.index_eligible'));
+        $this->assertSame('approved', data_get($payload, 'matched_jobs.0.trust_summary.reviewer_status'));
+        $this->assertNull(data_get($payload, 'matched_jobs.0.summary'));
+        $this->assertNull(data_get($payload, 'matched_jobs.0.fit_bucket'));
         $this->assertArrayHasKey('compile_refs', (array) data_get($payload, 'provenance_meta'));
     }
 
@@ -171,5 +144,82 @@ final class CareerRecommendationDetailBundleBuilderTest extends TestCase
             $compileRun->id,
             data_get($bundle?->toArray(), 'provenance_meta.compile_run_id')
         );
+    }
+
+    public function test_it_builds_authority_owned_matched_jobs_with_compact_readiness_only(): void
+    {
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-intj-match'])
+        );
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedTrustLimitedCrossMarketChain()
+        );
+
+        $payload = app(CareerRecommendationDetailBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
+
+        $this->assertCount(2, (array) data_get($payload, 'matched_jobs'));
+        $this->assertSame(
+            ['backend-architect-cn-market', 'backend-architect-intj-match'],
+            array_map(
+                static fn (array $job): string => (string) ($job['canonical_slug'] ?? ''),
+                (array) data_get($payload, 'matched_jobs')
+            )
+        );
+        $this->assertSame(false, data_get($payload, 'matched_jobs.0.seo_contract.index_eligible'));
+        $this->assertSame('trust_limited', data_get($payload, 'matched_jobs.0.seo_contract.index_state'));
+        $this->assertSame(['fixture'], data_get($payload, 'matched_jobs.0.seo_contract.reason_codes'));
+        $this->assertSame('pending', data_get($payload, 'matched_jobs.0.trust_summary.reviewer_status'));
+        $this->assertSame(true, data_get($payload, 'matched_jobs.1.seo_contract.index_eligible'));
+        $this->assertNull(data_get($payload, 'matched_jobs.0.score_bundle'));
+        $this->assertNull(data_get($payload, 'matched_jobs.0.claim_permissions'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     */
+    private function compileRecommendationChain(array $chain): void
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-build-rec-'.$chain['occupation']->canonical_slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'materialization' => 'career_first_wave',
+                    'recommendation_subject_meta' => [
+                        'type_code' => 'INTJ-A',
+                        'canonical_type_code' => 'INTJ',
+                        'display_title' => 'INTJ-A Career Match',
+                    ],
+                ],
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
     }
 }


### PR DESCRIPTION
## What changed
- add an authority-owned `matched_jobs` source on the Career recommendation detail bundle path
- extend the authority recommendation detail bundle with compact matched-job readiness fields only
- source matched jobs from first-wave authority recommendation snapshots instead of the legacy CMS recommendation API
- add focused bundle-builder and API tests to guard additive matched-job readiness exposure without flattening recommendation semantics

## Why
- frontend F7 intentionally left recommendation detail `matched_jobs` untouched because the authority bundle had no per-job readiness signals
- backend already has truthful job authority signals after B7-B10, but it did not expose them on the recommendation detail path
- this PR closes that gap with a minimal additive bundle extension while keeping recommendation-first semantics intact

## Validation
- `vendor/bin/pint --test app/DTO/Career/CareerRecommendationDetailBundle.php app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerRecommendationIndexApiTest.php`
- `php artisan test tests/Feature/V0_5/CareerRecommendationPublicApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php`

## Intentionally deferred
- no recommendation ranking changes
- no legacy CMS recommendation API changes
- no heavy job payload fields on `matched_jobs`
- no frontend changes
