### PR TITLE
PR-B13: Career first-wave clean-environment publish-ready determinism + override governance hardening

### DIFF
--- a/backend/app/Services/Career/Import/FirstWaveAuthorityMaterializationService.php
+++ b/backend/app/Services/Career/Import/FirstWaveAuthorityMaterializationService.php
@@ -11,12 +11,23 @@ use App\Domain\Career\Publish\FirstWaveManifestReader;
 use App\Domain\Career\Publish\FirstWavePublishSeedMaterializer;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
+use App\Models\ContextSnapshot;
+use App\Models\EditorialPatch;
 use App\Models\IndexState;
 use App\Models\Occupation;
+use App\Models\OccupationAlias;
+use App\Models\OccupationCrosswalk;
 use App\Models\OccupationFamily;
+use App\Models\OccupationSkillGraph;
 use App\Models\OccupationTruthMetric;
+use App\Models\ProfileProjection;
+use App\Models\ProjectionLineage;
+use App\Models\RecommendationSnapshot;
+use App\Models\SourceTrace;
+use App\Models\TransitionPath;
 use App\Models\TrustManifest;
 use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -56,6 +67,8 @@ final class FirstWaveAuthorityMaterializationService
 
             $manifestBySlug[(string) $occupation['canonical_slug']] = $occupation;
         }
+
+        $this->resetManifestAuthorityState($manifestOccupations);
 
         $authorityOverrides = $this->authorityOverrideReader->bySlug($authorityOverridePath);
         $dataset = $this->datasetReader->read($sourcePath);
@@ -300,6 +313,122 @@ final class FirstWaveAuthorityMaterializationService
         }
 
         return $metadata;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $manifestOccupations
+     */
+    private function resetManifestAuthorityState(array $manifestOccupations): void
+    {
+        $slugs = array_values(array_unique(array_filter(array_map(
+            static fn (mixed $occupation): string => is_array($occupation)
+                ? trim((string) ($occupation['canonical_slug'] ?? ''))
+                : '',
+            $manifestOccupations
+        ))));
+
+        if ($slugs === []) {
+            return;
+        }
+
+        $occupationIds = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->pluck('id')
+            ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+            ->values()
+            ->all();
+
+        if ($occupationIds === []) {
+            return;
+        }
+
+        DB::transaction(function () use ($occupationIds): void {
+            $snapshotIds = RecommendationSnapshot::query()
+                ->whereIn('occupation_id', $occupationIds)
+                ->whereHas('contextSnapshot', function ($query): void {
+                    $query->where('context_payload->materialization', 'career_first_wave');
+                })
+                ->whereHas('profileProjection', function ($query): void {
+                    $query->where('projection_payload->materialization', 'career_first_wave');
+                })
+                ->pluck('id')
+                ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+                ->values()
+                ->all();
+
+            $contextIds = array_values(array_unique(array_merge(
+                RecommendationSnapshot::query()
+                    ->whereIn('id', $snapshotIds)
+                    ->pluck('context_snapshot_id')
+                    ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+                    ->values()
+                    ->all(),
+                ContextSnapshot::query()
+                    ->whereIn('current_occupation_id', $occupationIds)
+                    ->where('context_payload->materialization', 'career_first_wave')
+                    ->pluck('id')
+                    ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+                    ->values()
+                    ->all(),
+            )));
+
+            $projectionIds = array_values(array_unique(array_merge(
+                RecommendationSnapshot::query()
+                    ->whereIn('id', $snapshotIds)
+                    ->pluck('profile_projection_id')
+                    ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+                    ->values()
+                    ->all(),
+                ProfileProjection::query()
+                    ->whereIn('context_snapshot_id', $contextIds)
+                    ->pluck('id')
+                    ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+                    ->values()
+                    ->all(),
+            )));
+
+            $sourceTraceIds = OccupationTruthMetric::query()
+                ->whereIn('occupation_id', $occupationIds)
+                ->pluck('source_trace_id')
+                ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+                ->unique()
+                ->values()
+                ->all();
+
+            if ($snapshotIds !== []) {
+                TransitionPath::query()->whereIn('recommendation_snapshot_id', $snapshotIds)->delete();
+                RecommendationSnapshot::query()->whereIn('id', $snapshotIds)->delete();
+            }
+
+            if ($projectionIds !== []) {
+                ProjectionLineage::query()
+                    ->whereIn('child_projection_id', $projectionIds)
+                    ->orWhereIn('parent_projection_id', $projectionIds)
+                    ->delete();
+                ProfileProjection::query()->whereIn('id', $projectionIds)->delete();
+            }
+
+            if ($contextIds !== []) {
+                ContextSnapshot::query()->whereIn('id', $contextIds)->delete();
+            }
+
+            OccupationAlias::query()->whereIn('occupation_id', $occupationIds)->delete();
+            OccupationCrosswalk::query()->whereIn('occupation_id', $occupationIds)->delete();
+            OccupationSkillGraph::query()->whereIn('occupation_id', $occupationIds)->delete();
+            EditorialPatch::query()->whereIn('occupation_id', $occupationIds)->delete();
+            IndexState::query()->whereIn('occupation_id', $occupationIds)->delete();
+            TrustManifest::query()->whereIn('occupation_id', $occupationIds)->delete();
+            OccupationTruthMetric::query()->whereIn('occupation_id', $occupationIds)->delete();
+
+            if ($sourceTraceIds !== []) {
+                SourceTrace::query()
+                    ->whereIn('id', $sourceTraceIds)
+                    ->whereNotIn('id', OccupationTruthMetric::query()
+                        ->select('source_trace_id')
+                        ->whereNotNull('source_trace_id'))
+                    ->delete();
+            }
+        });
     }
 
     /**

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-09T16:55:00Z",
+  "updated_at": "2026-04-09T09:25:42Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -80,6 +80,48 @@
           },
           {
             "command": "php artisan test tests/Unit/Services/Career/FirstWaveAuthorityOverrideReaderTest.php tests/Unit/Services/Career/FirstWaveBlockedGovernancePolicyTest.php tests/Unit/Services/Career/FirstWavePublishReadyValidatorTest.php tests/Feature/Career/FirstWavePublishReadyCommandTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:validate-first-wave-publish-ready --source=/Users/rainie/Desktop/AI_Exposure_342_Occupations.xlsx --materialize-missing --compile-missing --repair-safe-partials --json",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B13": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b13-clean-environment-determinism",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/career/first_wave_authority_overrides.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/career/first_wave_blocked_registry.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Import/FirstWaveAuthorityMaterializationService.php tests/Feature/Career/FirstWavePublishReadyCommandTest.php tests/Unit/Services/Career/FirstWavePublishReadyValidatorTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/FirstWavePublishReadyCommandTest.php tests/Unit/Services/Career/FirstWavePublishReadyValidatorTest.php tests/Unit/Services/Career/FirstWaveAuthorityOverrideReaderTest.php tests/Unit/Services/Career/FirstWaveBlockedGovernancePolicyTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php",
             "status": "passed"
           },
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-09T09:25:42Z",
+  "updated_at": "2026-04-09T09:27:37Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -98,10 +98,10 @@
     "PR-B13": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b13-clean-environment-determinism",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "11a8af51a0c363ff7acb910bf0f65a28bf53eab2",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/853",
       "checks": {
         "local": [
           {
@@ -129,7 +129,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-legacy",
+            "status": "pending"
+          },
+          {
+            "name": "verify-mbti-v2",
+            "status": "pending"
+          }
+        ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -105,6 +105,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B13
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b13-clean-environment-determinism
+    base: main
+    depends_on: ["PR-B12"]
+    mode: execute
+    scope: >
+      Career first-wave clean-environment publish-ready determinism + override governance hardening.
+      Make first-wave validation reproducible from committed truth, prevent stale local authority
+      residue from changing publish-ready counts, and preserve narrow audited override governance
+      without populating speculative production override values.
+    checks:
+      - "python3 -m json.tool docs/career/first_wave_authority_overrides.json >/dev/null"
+      - "python3 -m json.tool docs/career/first_wave_blocked_registry.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Import/FirstWaveAuthorityMaterializationService.php tests/Feature/Career/FirstWavePublishReadyCommandTest.php tests/Unit/Services/Career/FirstWavePublishReadyValidatorTest.php"
+      - "php artisan test tests/Feature/Career/FirstWavePublishReadyCommandTest.php tests/Unit/Services/Career/FirstWavePublishReadyValidatorTest.php tests/Unit/Services/Career/FirstWaveAuthorityOverrideReaderTest.php tests/Unit/Services/Career/FirstWaveBlockedGovernancePolicyTest.php"
+      - "php artisan test tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php"
+      - "php artisan career:validate-first-wave-publish-ready --source=/Users/rainie/Desktop/AI_Exposure_342_Occupations.xlsx --materialize-missing --compile-missing --repair-safe-partials --json"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/FirstWavePublishReadyCommandTest.php
+++ b/backend/tests/Feature/Career/FirstWavePublishReadyCommandTest.php
@@ -177,4 +177,81 @@ final class FirstWavePublishReadyCommandTest extends TestCase
         $this->assertSame('blocked', $elementary['status']);
         $this->assertSame('blocked_not_safely_remediable', $elementary['blocked_governance_status']);
     }
+
+    public function test_it_rebuilds_from_committed_truth_instead_of_reusing_stale_first_wave_state(): void
+    {
+        CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'software-developers',
+            'crosswalk_mode' => 'exact',
+        ]);
+
+        $firstExitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_override_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--json' => true,
+        ]);
+        $firstReport = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+
+        $secondExitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_override_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--json' => true,
+        ]);
+        $secondReport = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $firstExitCode);
+        $this->assertSame(0, $secondExitCode);
+
+        $firstSoftware = collect($firstReport['occupations'])->firstWhere('canonical_slug', 'software-developers');
+        $firstFinancial = collect($firstReport['occupations'])->firstWhere('canonical_slug', 'financial-analysts');
+        $firstMarketing = collect($firstReport['occupations'])->firstWhere('canonical_slug', 'marketing-managers');
+        $firstElementary = collect($firstReport['occupations'])->firstWhere('canonical_slug', 'elementary-school-teachers-except-special-education');
+
+        $this->assertIsArray($firstSoftware);
+        $this->assertSame('blocked', $firstSoftware['status']);
+        $this->assertSame('blocked_override_eligible', $firstSoftware['blocked_governance_status']);
+        $this->assertFalse($firstSoftware['authority_override_supplied']);
+
+        $this->assertIsArray($firstFinancial);
+        $this->assertSame('blocked', $firstFinancial['status']);
+        $this->assertSame('blocked_override_eligible', $firstFinancial['blocked_governance_status']);
+        $this->assertFalse($firstFinancial['authority_override_supplied']);
+
+        $this->assertIsArray($firstMarketing);
+        $this->assertSame('blocked', $firstMarketing['status']);
+        $this->assertSame('blocked_not_safely_remediable', $firstMarketing['blocked_governance_status']);
+
+        $this->assertIsArray($firstElementary);
+        $this->assertSame('blocked', $firstElementary['status']);
+        $this->assertSame('blocked_not_safely_remediable', $firstElementary['blocked_governance_status']);
+
+        $this->assertSame(
+            [
+                'counts' => $firstReport['counts'],
+                'occupations' => collect($firstReport['occupations'])
+                    ->map(static fn (array $occupation): array => [
+                        'canonical_slug' => $occupation['canonical_slug'],
+                        'status' => $occupation['status'],
+                        'missing_requirements' => $occupation['missing_requirements'],
+                        'blocked_governance_status' => $occupation['blocked_governance_status'],
+                        'authority_override_supplied' => $occupation['authority_override_supplied'],
+                    ])
+                    ->all(),
+            ],
+            [
+                'counts' => $secondReport['counts'],
+                'occupations' => collect($secondReport['occupations'])
+                    ->map(static fn (array $occupation): array => [
+                        'canonical_slug' => $occupation['canonical_slug'],
+                        'status' => $occupation['status'],
+                        'missing_requirements' => $occupation['missing_requirements'],
+                        'blocked_governance_status' => $occupation['blocked_governance_status'],
+                        'authority_override_supplied' => $occupation['authority_override_supplied'],
+                    ])
+                    ->all(),
+            ]
+        );
+    }
 }

--- a/backend/tests/Unit/Services/Career/FirstWavePublishReadyValidatorTest.php
+++ b/backend/tests/Unit/Services/Career/FirstWavePublishReadyValidatorTest.php
@@ -232,6 +232,9 @@ final class FirstWavePublishReadyValidatorTest extends TestCase
 
         $this->assertSame('publish_ready', $row['status']);
         $this->assertSame([], $row['missing_requirements']);
+        $this->assertNull($row['blocked_governance_status']);
+        $this->assertNull($row['blocker_type']);
+        $this->assertFalse($row['authority_override_supplied']);
         $this->assertSame(1, $report['counts']['publish_ready']);
         $this->assertSame(9, $report['counts']['blocked']);
     }


### PR DESCRIPTION
## What changed
- harden first-wave validation so materialization rebuilds manifest-scoped authority state from committed inputs instead of reusing stale local first-wave residue
- keep production override truth authoritative by leaving the production override file empty and requiring explicit override files only in fixture scope
- add deterministic command coverage proving repeated clean-state validations produce the same normalized report
- tighten validator regression coverage so publish-ready subjects do not retain blocked governance metadata
- register PR-B13 in the local PR train manifest and state ledger

## Why
- after B12, the override path was narrow and auditable, but local validator output could still drift if a workstation already had old first-wave authority rows materialized
- that made local publish-ready counts non-reproducible from committed truth, especially for override-eligible subjects like `software-developers`
- this PR makes the validation path deterministic, keeps override governance explicit, and avoids populating speculative production override values

## Validation
- `python3 -m json.tool docs/career/first_wave_authority_overrides.json >/dev/null`
- `python3 -m json.tool docs/career/first_wave_blocked_registry.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Import/FirstWaveAuthorityMaterializationService.php tests/Feature/Career/FirstWavePublishReadyCommandTest.php tests/Unit/Services/Career/FirstWavePublishReadyValidatorTest.php`
- `php artisan test tests/Feature/Career/FirstWavePublishReadyCommandTest.php tests/Unit/Services/Career/FirstWavePublishReadyValidatorTest.php tests/Unit/Services/Career/FirstWaveAuthorityOverrideReaderTest.php tests/Unit/Services/Career/FirstWaveBlockedGovernancePolicyTest.php`
- `php artisan test tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php`
- `php artisan career:validate-first-wave-publish-ready --source=/Users/rainie/Desktop/AI_Exposure_342_Occupations.xlsx --materialize-missing --compile-missing --repair-safe-partials --json`
- repeated validator run diff on normalized output: no diff

## Intentionally deferred
- no production source-code override values were added
- no attempt to remediate `marketing-managers` or `elementary-school-teachers-except-special-education`
- no public API shape changes
- no frontend changes
- no full 342 rollout work
