### PR TITLE
PR-B15: Career attribution ingest + daily read model

### DIFF
--- a/backend/app/Console/Commands/RefreshCareerAttributionDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshCareerAttributionDailyCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Analytics\CareerAttributionDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+final class RefreshCareerAttributionDailyCommand extends Command
+{
+    protected $signature = 'analytics:refresh-career-attribution-daily
+        {--from= : Inclusive start date (Y-m-d)}
+        {--to= : Inclusive end date (Y-m-d)}
+        {--org=* : Limit refresh to one or more org ids}
+        {--dry-run : Preview aggregation without writing rows}';
+
+    protected $description = 'Refresh Career attribution daily read model grouped by surface, route family, subject, and readiness class.';
+
+    public function __construct(
+        private readonly CareerAttributionDailyBuilder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $from = $this->parseDateOption((string) $this->option('from'), now()->subDays(6)->toDateString());
+        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $orgIds = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            (array) $this->option('org')
+        ), static fn (int $value): bool => $value >= 0));
+
+        $dryRun = (bool) $this->option('dry-run');
+        $result = $this->builder->refresh($from, $to, $orgIds, $dryRun);
+
+        $this->line('from='.$result['from']);
+        $this->line('to='.$result['to']);
+        $this->line('org_scope='.(empty($result['org_scope']) ? '*' : implode(',', $result['org_scope'])));
+        $this->line('dry_run='.(($result['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('attempted_rows='.(string) ($result['attempted_rows'] ?? 0));
+        $this->line('deleted_rows='.(string) ($result['deleted_rows'] ?? 0));
+        $this->line('upserted_rows='.(string) ($result['upserted_rows'] ?? 0));
+
+        if (($result['attempted_rows'] ?? 0) === 0) {
+            $this->warn('No Career attribution rows were generated for the selected scope.');
+        } else {
+            $this->info($dryRun ? 'dry-run complete' : 'refresh complete');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function parseDateOption(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -8,13 +8,13 @@ use App\Console\Commands\ArchiveColdData;
 use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
+use App\Console\Commands\CareerCompileAuthorityWave;
+use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CiScaleImpact;
 use App\Console\Commands\CommerceCompensatePendingOrders;
 use App\Console\Commands\CommerceReconcile;
 use App\Console\Commands\CommerceRepairPaidOrders;
 use App\Console\Commands\CommerceRepairPostCommitFailed;
-use App\Console\Commands\CareerCompileAuthorityWave;
-use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\ContentCompile;
 use App\Console\Commands\ContentLint;
 use App\Console\Commands\Eq60PsychometricsReport;
@@ -26,6 +26,7 @@ use App\Console\Commands\FapValidateReport;
 use App\Console\Commands\FapWeeklyReport;
 use App\Console\Commands\MbtiUpgradeLegacyPartialUnlocks;
 use App\Console\Commands\MetricsWeeklyValidity;
+use App\Console\Commands\MbtiPrewarm;
 use App\Console\Commands\NormsBig5BootstrapBuild;
 use App\Console\Commands\NormsBig5DriftCheck;
 use App\Console\Commands\NormsBig5MonthlyDriftCheck;
@@ -65,6 +66,7 @@ use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
 use App\Console\Commands\QualityDailySummary;
+use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\StorageControlPlaneSnapshot;
@@ -95,6 +97,7 @@ class Kernel extends ConsoleKernel
         FapWeeklyReport::class,
         PersonalityImportDesktopCloneBaseline::class,
         MetricsWeeklyValidity::class,
+        MbtiPrewarm::class,
         MbtiUpgradeLegacyPartialUnlocks::class,
         AdminBootstrapOwner::class,
         OpsDeployEvent::class,
@@ -127,6 +130,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPostCommitFailed::class,
         CareerImportAuthorityWave::class,
         CareerCompileAuthorityWave::class,
+        RefreshCareerAttributionDailyCommand::class,
         PacksPublish::class,
         PacksRollback::class,
         Packs2Publish::class,

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerAttributionEventController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerAttributionEventController.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Controller;
+use App\Services\Analytics\CareerAttributionEventMapper;
+use App\Services\Analytics\EventRecorder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class CareerAttributionEventController extends Controller
+{
+    public function __construct(
+        private readonly CareerAttributionEventMapper $mapper,
+        private readonly EventRecorder $eventRecorder,
+    ) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        $this->authorizeIngest($request);
+
+        $data = $request->validate([
+            'eventName' => ['required', 'string', 'max:64'],
+            'payload' => ['nullable', 'array'],
+            'anonymousId' => ['nullable', 'string', 'max:128'],
+            'sessionId' => ['nullable', 'string', 'max:128'],
+            'requestId' => ['nullable', 'string', 'max:128'],
+            'path' => ['nullable', 'string', 'max:2048'],
+            'timestamp' => ['nullable', 'date'],
+        ]);
+
+        $mapped = $this->mapper->map($data, $this->resolveOrgId($request));
+
+        $this->eventRecorder->record(
+            $mapped['event_code'],
+            null,
+            $mapped['meta'],
+            $mapped['context'],
+        );
+
+        return response()->json([
+            'ok' => true,
+            'event_code' => $mapped['event_code'],
+            'org_id' => (int) ($mapped['context']['org_id'] ?? 0),
+        ], 202);
+    }
+
+    private function authorizeIngest(Request $request): void
+    {
+        $configuredToken = trim((string) config('fap.events.ingest_token', ''));
+        if ($configuredToken === '') {
+            return;
+        }
+
+        $provided = trim((string) ($request->bearerToken() ?? ''));
+        if ($provided === '') {
+            $provided = trim((string) $request->header('X-Track-Ingest-Token', ''));
+        }
+
+        if ($provided === '' || ! hash_equals($configuredToken, $provided)) {
+            abort(response()->json([
+                'ok' => false,
+                'error_code' => 'UNAUTHORIZED',
+                'message' => 'Invalid ingest token.',
+            ], 401));
+        }
+    }
+
+    private function resolveOrgId(Request $request): int
+    {
+        $attr = $request->attributes->get('org_id');
+        if (is_numeric($attr)) {
+            return max(0, (int) $attr);
+        }
+
+        $header = trim((string) ($request->header('X-Org-Id') ?? ''));
+        if ($header !== '' && preg_match('/^\d+$/', $header) === 1) {
+            return (int) $header;
+        }
+
+        return 0;
+    }
+}

--- a/backend/app/Services/Analytics/CareerAttributionDailyBuilder.php
+++ b/backend/app/Services/Analytics/CareerAttributionDailyBuilder.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Domain\Career\Publish\FirstWaveReadinessSummaryService;
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+
+final class CareerAttributionDailyBuilder
+{
+    /**
+     * @param  list<int>  $orgIds
+     * @return array{rows:list<array<string,mixed>>,attempted_rows:int,org_scope:list<int>,from:string,to:string}
+     */
+    public function build(\DateTimeInterface $from, \DateTimeInterface $to, array $orgIds = []): array
+    {
+        if (! SchemaBaseline::hasTable('events')) {
+            return [
+                'rows' => [],
+                'attempted_rows' => 0,
+                'org_scope' => [],
+                'from' => CarbonImmutable::parse($from)->toDateString(),
+                'to' => CarbonImmutable::parse($to)->toDateString(),
+            ];
+        }
+
+        $fromAt = CarbonImmutable::parse($from)->startOfDay();
+        $toAt = CarbonImmutable::parse($to)->endOfDay();
+        $normalizedOrgIds = $this->normalizeOrgIds($orgIds);
+        $readinessBySlug = $this->loadReadinessBySlug();
+
+        $query = DB::table('events')
+            ->select(['event_name', 'org_id', 'locale', 'anon_id', 'session_id', 'occurred_at', 'meta_json'])
+            ->whereBetween('occurred_at', [$fromAt, $toAt])
+            ->where('scale_code', 'CAREER')
+            ->whereIn('event_name', CareerAttributionEventMapper::ALLOWED_EVENT_NAMES)
+            ->orderBy('occurred_at');
+
+        if ($normalizedOrgIds !== []) {
+            $query->whereIn('org_id', $normalizedOrgIds);
+        }
+
+        $rows = [];
+
+        foreach ($query->get() as $event) {
+            $day = $this->normalizeDay($event->occurred_at ?? null);
+            if ($day === null) {
+                continue;
+            }
+
+            $meta = is_array($event->meta_json ?? null)
+                ? $event->meta_json
+                : (json_decode((string) ($event->meta_json ?? '{}'), true) ?: []);
+
+            $surface = $this->normalizeDimension($meta['entry_surface'] ?? null, 128, 'unknown');
+            $routeFamily = $this->normalizeDimension($meta['route_family'] ?? null, 64, 'unknown');
+            $subjectKind = $this->normalizeDimension($meta['subject_kind'] ?? null, 32, 'none');
+            $subjectKey = $subjectKind === 'none'
+                ? ''
+                : $this->normalizeDimension($meta['subject_key'] ?? null, 128, '');
+            $queryMode = $this->normalizeDimension($meta['query_mode'] ?? null, 16, 'non_query');
+            $readinessClass = $this->deriveReadinessClass($subjectKind, $subjectKey, $readinessBySlug);
+            $locale = $this->normalizeDimension($event->locale ?? null, 16, 'en');
+            $eventName = $this->normalizeDimension($event->event_name ?? null, 64, '');
+
+            if ($eventName === '') {
+                continue;
+            }
+
+            $key = implode('|', [
+                $day,
+                max(0, (int) ($event->org_id ?? 0)),
+                $locale,
+                $surface,
+                $routeFamily,
+                $eventName,
+                $subjectKind,
+                $subjectKey,
+                $readinessClass,
+                $queryMode,
+            ]);
+
+            if (! isset($rows[$key])) {
+                $rows[$key] = [
+                    'day' => $day,
+                    'org_id' => max(0, (int) ($event->org_id ?? 0)),
+                    'locale' => $locale,
+                    'surface' => $surface,
+                    'route_family' => $routeFamily,
+                    'event_name' => $eventName,
+                    'subject_kind' => $subjectKind,
+                    'subject_key' => $subjectKey,
+                    'readiness_class' => $readinessClass,
+                    'query_mode' => $queryMode,
+                    'event_count' => 0,
+                    'unique_anon_count' => 0,
+                    'unique_session_count' => 0,
+                    '__anon_ids' => [],
+                    '__session_ids' => [],
+                ];
+            }
+
+            $rows[$key]['event_count']++;
+
+            $anonId = trim((string) ($event->anon_id ?? ''));
+            if ($anonId !== '') {
+                $rows[$key]['__anon_ids'][$anonId] = true;
+            }
+
+            $sessionId = trim((string) ($event->session_id ?? ''));
+            if ($sessionId !== '') {
+                $rows[$key]['__session_ids'][$sessionId] = true;
+            }
+        }
+
+        $now = now();
+        $finalRows = array_values(array_map(function (array $row) use ($now): array {
+            $row['unique_anon_count'] = count($row['__anon_ids']);
+            $row['unique_session_count'] = count($row['__session_ids']);
+            unset($row['__anon_ids'], $row['__session_ids']);
+            $row['last_refreshed_at'] = $now;
+            $row['updated_at'] = $now;
+
+            return $row;
+        }, $rows));
+
+        return [
+            'rows' => $finalRows,
+            'attempted_rows' => count($finalRows),
+            'org_scope' => $normalizedOrgIds,
+            'from' => $fromAt->toDateString(),
+            'to' => $toAt->toDateString(),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array{rows:list<array<string,mixed>>,attempted_rows:int,deleted_rows:int,upserted_rows:int,org_scope:list<int>,from:string,to:string,dry_run:bool}
+     */
+    public function refresh(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        bool $dryRun = false,
+    ): array {
+        $payload = $this->build($from, $to, $orgIds);
+        $rows = $payload['rows'];
+        $deletedRows = 0;
+        $upsertedRows = 0;
+
+        if (! $dryRun) {
+            DB::transaction(function () use ($payload, $rows, &$deletedRows, &$upsertedRows): void {
+                $deletedRows = $this->deleteScope($payload['from'], $payload['to'], $payload['org_scope']);
+
+                if ($rows === []) {
+                    return;
+                }
+
+                DB::table('analytics_career_attribution_daily')->upsert(
+                    $rows,
+                    ['day', 'org_id', 'locale', 'surface', 'route_family', 'event_name', 'subject_kind', 'subject_key', 'readiness_class', 'query_mode'],
+                    ['event_count', 'unique_anon_count', 'unique_session_count', 'last_refreshed_at', 'updated_at']
+                );
+
+                $upsertedRows = count($rows);
+            });
+        }
+
+        return $payload + [
+            'deleted_rows' => $deletedRows,
+            'upserted_rows' => $upsertedRows,
+            'dry_run' => $dryRun,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function loadReadinessBySlug(): array
+    {
+        try {
+            $summary = app(FirstWaveReadinessSummaryService::class)->build()->toArray();
+        } catch (\Throwable) {
+            return [];
+        }
+
+        $map = [];
+
+        foreach ((array) ($summary['occupations'] ?? []) as $occupation) {
+            if (! is_array($occupation)) {
+                continue;
+            }
+
+            $slug = trim((string) ($occupation['canonical_slug'] ?? ''));
+            $status = trim((string) ($occupation['status'] ?? ''));
+            if ($slug === '' || $status === '') {
+                continue;
+            }
+
+            $map[$slug] = $status;
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param  array<string, string>  $readinessBySlug
+     */
+    private function deriveReadinessClass(string $subjectKind, string $subjectKey, array $readinessBySlug): string
+    {
+        if ($subjectKind !== 'job_slug' || $subjectKey === '') {
+            return 'unknown';
+        }
+
+        return $readinessBySlug[$subjectKey] ?? 'unknown';
+    }
+
+    private function normalizeDay(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($value)->toDateString();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function normalizeDimension(mixed $value, int $maxLength, string $fallback): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return $fallback;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<int>
+     */
+    private function normalizeOrgIds(array $orgIds): array
+    {
+        $normalized = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            $orgIds
+        ), static fn (int $value): bool => $value >= 0));
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     */
+    private function deleteScope(string $from, string $to, array $orgIds): int
+    {
+        if (! SchemaBaseline::hasTable('analytics_career_attribution_daily')) {
+            return 0;
+        }
+
+        $query = DB::table('analytics_career_attribution_daily')
+            ->whereBetween('day', [$from, $to]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        return $query->delete();
+    }
+}

--- a/backend/app/Services/Analytics/CareerAttributionEventMapper.php
+++ b/backend/app/Services/Analytics/CareerAttributionEventMapper.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use Illuminate\Validation\ValidationException;
+
+final class CareerAttributionEventMapper
+{
+    /**
+     * @var list<string>
+     */
+    public const ALLOWED_EVENT_NAMES = [
+        'career_landing_view',
+        'career_job_index_view',
+        'career_job_detail_view',
+        'career_recommendation_index_view',
+        'career_recommendation_detail_view',
+        'career_job_search_submit',
+        'career_job_search_result_click',
+        'career_job_index_result_click',
+        'career_job_detail_cta_click',
+        'career_recommendation_result_click',
+        'career_recommendation_matched_job_click',
+        'career_ready_surface_exposed',
+        'career_blocked_surface_exposed',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_ROUTE_FAMILIES = [
+        'landing',
+        'jobs',
+        'jobs_search',
+        'job_detail',
+        'recommendations',
+        'recommendation_detail',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_SUBJECT_KINDS = [
+        'none',
+        'job_slug',
+        'recommendation_type',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_QUERY_MODES = [
+        'query',
+        'non_query',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $envelope
+     * @return array{event_code:string,meta:array<string,mixed>,context:array<string,mixed>}
+     */
+    public function map(array $envelope, int $orgId): array
+    {
+        $payload = is_array($envelope['payload'] ?? null) ? $envelope['payload'] : [];
+        $normalized = EventNormalizer::normalize([
+            'event_name' => $envelope['eventName'] ?? null,
+            'event_code' => $envelope['eventName'] ?? null,
+            'occurred_at' => $envelope['timestamp'] ?? null,
+            'anon_id' => $envelope['anonymousId'] ?? null,
+            'session_id' => $envelope['sessionId'] ?? null,
+            'request_id' => $envelope['requestId'] ?? null,
+            'locale' => $payload['locale'] ?? null,
+            'meta_json' => $payload,
+        ], [
+            'occurred_at' => $envelope['timestamp'] ?? null,
+            'anon_id' => $envelope['anonymousId'] ?? null,
+            'session_id' => $envelope['sessionId'] ?? null,
+            'request_id' => $envelope['requestId'] ?? null,
+            'locale' => $payload['locale'] ?? null,
+        ]);
+
+        $columns = is_array($normalized['columns'] ?? null) ? $normalized['columns'] : [];
+        $eventCode = strtolower(trim((string) ($columns['event_name'] ?? '')));
+        if (! in_array($eventCode, self::ALLOWED_EVENT_NAMES, true)) {
+            throw ValidationException::withMessages([
+                'eventName' => 'eventName is not supported by career attribution ingest.',
+            ]);
+        }
+
+        $path = $this->normalizePath($envelope['path'] ?? null) ?? '/';
+        $routeFamily = $this->normalizeEnum(
+            $payload['route_family'] ?? null,
+            self::ALLOWED_ROUTE_FAMILIES,
+            'route_family'
+        );
+        $subjectKind = $this->normalizeEnum(
+            $payload['subject_kind'] ?? null,
+            self::ALLOWED_SUBJECT_KINDS,
+            'subject_kind'
+        );
+        $queryMode = $this->normalizeEnum(
+            $payload['query_mode'] ?? null,
+            self::ALLOWED_QUERY_MODES,
+            'query_mode'
+        );
+        $subjectKey = $this->normalizeSubjectKey($payload['subject_key'] ?? null, $subjectKind);
+
+        $meta = [
+            'entry_surface' => $this->normalizeOptionalString($payload['entry_surface'] ?? null, 128) ?? 'unknown',
+            'source_page_type' => $this->normalizeOptionalString($payload['source_page_type'] ?? null, 64) ?? 'unknown',
+            'target_action' => $this->normalizeOptionalString($payload['target_action'] ?? null, 128),
+            'landing_path' => $this->normalizePath($payload['landing_path'] ?? null) ?? $path,
+            'route_family' => $routeFamily,
+            'subject_kind' => $subjectKind,
+            'subject_key' => $subjectKey,
+            'query_mode' => $queryMode,
+        ];
+
+        return [
+            'event_code' => $eventCode,
+            'meta' => $meta,
+            'context' => [
+                'org_id' => max(0, $orgId),
+                'anon_id' => $columns['anon_id'] ?? null,
+                'session_id' => $columns['session_id'] ?? null,
+                'request_id' => $columns['request_id'] ?? null,
+                'channel' => 'web',
+                'locale' => $this->normalizeLocale($columns['locale'] ?? null, $path),
+                'occurred_at' => $columns['occurred_at'] ?? null,
+                'scale_code' => 'CAREER',
+                'scale_code_v2' => 'CAREER',
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $allowed
+     */
+    private function normalizeEnum(mixed $value, array $allowed, string $field): string
+    {
+        $normalized = strtolower(trim((string) $value));
+        if ($normalized === '') {
+            throw ValidationException::withMessages([
+                "payload.$field" => "payload.$field is required.",
+            ]);
+        }
+
+        if (! in_array($normalized, $allowed, true)) {
+            throw ValidationException::withMessages([
+                "payload.$field" => "payload.$field is not supported by career attribution ingest.",
+            ]);
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeSubjectKey(mixed $value, string $subjectKind): string
+    {
+        if ($subjectKind === 'none') {
+            return '';
+        }
+
+        $normalized = $this->normalizeOptionalString($value, 128);
+        if ($normalized === null) {
+            throw ValidationException::withMessages([
+                'payload.subject_key' => 'payload.subject_key is required when subject_kind is not none.',
+            ]);
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeLocale(mixed $value, string $path): string
+    {
+        $normalized = strtolower((string) $this->normalizeOptionalString($value, 16));
+        if ($normalized !== '') {
+            return $normalized;
+        }
+
+        return str_starts_with($path, '/zh') ? 'zh' : 'en';
+    }
+
+    private function normalizePath(mixed $value): ?string
+    {
+        $normalized = $this->normalizeOptionalString($value, 2048);
+        if ($normalized === null) {
+            return null;
+        }
+
+        return str_starts_with($normalized, '/') ? $normalized : '/'.$normalized;
+    }
+
+    private function normalizeOptionalString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Services/Analytics/EventRecorder.php
+++ b/backend/app/Services/Analytics/EventRecorder.php
@@ -48,6 +48,7 @@ final class EventRecorder
             $context['scale_uid'] ?? null,
         ], false);
 
+        $occurredAt = $this->resolveOccurredAt($context['occurred_at'] ?? null);
         $now = now();
         $payload = [
             'id' => (string) Str::uuid(),
@@ -65,7 +66,9 @@ final class EventRecorder
             'dir_version' => $context['dir_version'] ?? null,
             'pack_semver' => $context['pack_semver'] ?? null,
             'meta_json' => $meta,
-            'occurred_at' => $now,
+            'occurred_at' => $occurredAt,
+            'region' => $context['region'] ?? null,
+            'locale' => $context['locale'] ?? null,
             'created_at' => $now,
             'updated_at' => $now,
         ];
@@ -100,6 +103,23 @@ final class EventRecorder
                 'exception' => $e,
             ]);
         }
+    }
+
+    private function resolveOccurredAt(mixed $value): Carbon
+    {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance(\DateTimeImmutable::createFromInterface($value));
+        }
+
+        if (is_string($value) && trim($value) !== '') {
+            return Carbon::parse($value);
+        }
+
+        return now();
     }
 
     public function recordFromRequest(Request $request, string $eventCode, ?int $userId, array $meta = []): void

--- a/backend/database/migrations/2026_04_10_190000_create_analytics_career_attribution_daily_table.php
+++ b/backend/database/migrations/2026_04_10_190000_create_analytics_career_attribution_daily_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('analytics_career_attribution_daily')) {
+            return;
+        }
+
+        Schema::create('analytics_career_attribution_daily', function (Blueprint $table): void {
+            $table->id();
+            $table->date('day');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('locale', 16)->default('en');
+            $table->string('surface', 128)->default('unknown');
+            $table->string('route_family', 64)->default('unknown');
+            $table->string('event_name', 64)->default('');
+            $table->string('subject_kind', 32)->default('none');
+            $table->string('subject_key', 128)->default('');
+            $table->string('readiness_class', 64)->default('unknown');
+            $table->string('query_mode', 16)->default('non_query');
+
+            $table->unsignedInteger('event_count')->default(0);
+            $table->unsignedInteger('unique_anon_count')->default(0);
+            $table->unsignedInteger('unique_session_count')->default(0);
+
+            $table->timestamp('last_refreshed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(
+                ['day', 'org_id', 'locale', 'surface', 'route_family', 'event_name', 'subject_kind', 'subject_key', 'readiness_class', 'query_mode'],
+                'analytics_career_attr_daily_unique'
+            );
+            $table->index(['day', 'org_id'], 'analytics_career_attr_daily_day_org_idx');
+            $table->index(['surface', 'event_name'], 'analytics_career_attr_daily_surface_event_idx');
+            $table->index(['subject_kind', 'subject_key', 'readiness_class'], 'analytics_career_attr_daily_subject_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2345,6 +2345,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/attribution/events": {
+            "post": {
+                "operationId": "post_api_v0_5_career_attribution_events",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerAttributionEventController@store",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/first-wave/readiness": {
             "get": {
                 "operationId": "get_api_v0_5_career_first_wave_readiness",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -29,6 +29,7 @@ use App\Http\Controllers\API\V0_4\BootController;
 use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
+use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobListController;
@@ -399,6 +400,7 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
 });
 
 Route::prefix('v0.5')->group(function () {
+    Route::post('/career/attribution/events', [CareerAttributionEventController::class, 'store']);
     Route::get('/career/first-wave/readiness', [CareerFirstWaveReadinessController::class, 'show']);
     Route::get('/career/jobs', [CareerJobListController::class, 'index']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);

--- a/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\CareerAttributionDailyBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerAttributionDailyBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_refresh_builds_career_rows_grouped_by_surface_subject_and_readiness_class(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $orgId = 21;
+        $day = now()->startOfDay()->setDate(2026, 4, 10)->setTime(9, 0);
+
+        $this->insertCareerEvent($orgId, 'career_job_index_result_click', $day, [
+            'entry_surface' => 'career_job_index',
+            'route_family' => 'jobs',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'data-scientists',
+            'query_mode' => 'non_query',
+        ], 'anon_a', 'session_a');
+        $this->insertCareerEvent($orgId, 'career_job_index_result_click', $day->copy()->addMinute(), [
+            'entry_surface' => 'career_job_index',
+            'route_family' => 'jobs',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'data-scientists',
+            'query_mode' => 'non_query',
+        ], 'anon_a', 'session_a');
+        $this->insertCareerEvent($orgId, 'career_job_search_result_click', $day->copy()->addMinutes(2), [
+            'entry_surface' => 'career_job_search',
+            'route_family' => 'jobs_search',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'software-developers',
+            'query_mode' => 'query',
+        ], 'anon_b', 'session_b');
+        $this->insertCareerEvent($orgId, 'career_recommendation_matched_job_click', $day->copy()->addMinutes(3), [
+            'entry_surface' => 'career_recommendation_detail',
+            'route_family' => 'recommendation_detail',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'marketing-managers',
+            'query_mode' => 'non_query',
+        ], 'anon_c', 'session_c');
+        $this->insertCareerEvent($orgId, 'career_recommendation_result_click', $day->copy()->addMinutes(4), [
+            'entry_surface' => 'career_recommendation_index',
+            'route_family' => 'recommendations',
+            'subject_kind' => 'recommendation_type',
+            'subject_key' => 'intj',
+            'query_mode' => 'non_query',
+        ], 'anon_d', 'session_d');
+
+        $result = app(CareerAttributionDailyBuilder::class)->refresh($day, $day, [$orgId], false);
+
+        $this->assertSame(4, (int) ($result['upserted_rows'] ?? 0));
+
+        $readyRow = DB::table('analytics_career_attribution_daily')
+            ->where('day', $day->toDateString())
+            ->where('org_id', $orgId)
+            ->where('event_name', 'career_job_index_result_click')
+            ->where('subject_key', 'data-scientists')
+            ->first();
+
+        $this->assertNotNull($readyRow);
+        $this->assertSame('publish_ready', $readyRow->readiness_class);
+        $this->assertSame(2, (int) $readyRow->event_count);
+        $this->assertSame(1, (int) $readyRow->unique_anon_count);
+        $this->assertSame(1, (int) $readyRow->unique_session_count);
+
+        $blockedRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_job_search_result_click')
+            ->where('subject_key', 'software-developers')
+            ->first();
+
+        $this->assertNotNull($blockedRow);
+        $this->assertSame('blocked_override_eligible', $blockedRow->readiness_class);
+        $this->assertSame('query', $blockedRow->query_mode);
+        $this->assertSame('jobs_search', $blockedRow->route_family);
+
+        $matchedJobRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_recommendation_matched_job_click')
+            ->where('subject_key', 'marketing-managers')
+            ->first();
+
+        $this->assertNotNull($matchedJobRow);
+        $this->assertSame('blocked_not_safely_remediable', $matchedJobRow->readiness_class);
+        $this->assertSame('recommendation_detail', $matchedJobRow->route_family);
+
+        $recommendationRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_recommendation_result_click')
+            ->where('subject_key', 'intj')
+            ->first();
+
+        $this->assertNotNull($recommendationRow);
+        $this->assertSame('recommendation_type', $recommendationRow->subject_kind);
+        $this->assertSame('unknown', $recommendationRow->readiness_class);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    private function insertCareerEvent(
+        int $orgId,
+        string $eventCode,
+        \DateTimeInterface $occurredAt,
+        array $meta,
+        string $anonId,
+        string $sessionId,
+    ): void {
+        $row = [
+            'id' => (string) Str::uuid(),
+            'event_code' => $eventCode,
+            'event_name' => $eventCode,
+            'org_id' => $orgId,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'session_id' => $sessionId,
+            'request_id' => 'req_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 12),
+            'attempt_id' => null,
+            'meta_json' => json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $occurredAt,
+            'created_at' => $occurredAt,
+            'updated_at' => $occurredAt,
+            'scale_code' => 'CAREER',
+            'channel' => 'web',
+            'locale' => 'zh',
+        ];
+
+        if (Schema::hasColumn('events', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'CAREER';
+        }
+
+        DB::table('events')->insert($row);
+    }
+}

--- a/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class CareerAttributionEventIngestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ingest_endpoint_persists_career_event_with_normalized_dimensions(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.5/career/attribution/events', [
+            'eventName' => 'career_job_search_submit',
+            'anonymousId' => 'anon_b15_001',
+            'sessionId' => 'session_b15_001',
+            'requestId' => 'request_b15_001',
+            'path' => '/zh/career/jobs?q=data',
+            'timestamp' => '2026-04-10T19:00:00+08:00',
+            'payload' => [
+                'entry_surface' => 'career_job_index',
+                'source_page_type' => 'job_index',
+                'target_action' => 'submit_search',
+                'landing_path' => '/zh/career/jobs?q=data',
+                'route_family' => 'jobs_search',
+                'subject_kind' => 'none',
+                'query_mode' => 'query',
+                'locale' => 'zh',
+                'query_text' => 'data scientist',
+            ],
+        ]);
+
+        $response->assertStatus(202)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('event_code', 'career_job_search_submit');
+
+        $row = DB::table('events')
+            ->where('event_code', 'career_job_search_submit')
+            ->where('anon_id', 'anon_b15_001')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('CAREER', $row->scale_code);
+        $this->assertSame('zh', $row->locale);
+
+        $meta = is_array($row->meta_json ?? null)
+            ? $row->meta_json
+            : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
+
+        $this->assertSame('career_job_index', $meta['entry_surface'] ?? null);
+        $this->assertSame('jobs_search', $meta['route_family'] ?? null);
+        $this->assertSame('query', $meta['query_mode'] ?? null);
+        $this->assertArrayNotHasKey('query_text', $meta);
+        $this->assertArrayNotHasKey('raw_payload', $meta);
+    }
+
+    public function test_ingest_endpoint_keeps_recommendation_interactions_distinct_from_job_interactions(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.5/career/attribution/events', [
+            'eventName' => 'career_recommendation_matched_job_click',
+            'anonymousId' => 'anon_b15_002',
+            'path' => '/zh/career/recommendations/mbti/intj',
+            'timestamp' => '2026-04-10T19:05:00+08:00',
+            'payload' => [
+                'entry_surface' => 'career_recommendation_detail',
+                'source_page_type' => 'recommendation_detail',
+                'target_action' => 'matched_job_click',
+                'landing_path' => '/zh/career/recommendations/mbti/intj',
+                'route_family' => 'recommendation_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'software-developers',
+                'query_mode' => 'non_query',
+                'locale' => 'zh',
+            ],
+        ]);
+
+        $response->assertStatus(202);
+
+        $row = DB::table('events')
+            ->where('event_code', 'career_recommendation_matched_job_click')
+            ->where('anon_id', 'anon_b15_002')
+            ->first();
+
+        $this->assertNotNull($row);
+        $meta = is_array($row->meta_json ?? null)
+            ? $row->meta_json
+            : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
+
+        $this->assertSame('career_recommendation_detail', $meta['entry_surface'] ?? null);
+        $this->assertSame('recommendation_detail', $meta['route_family'] ?? null);
+        $this->assertSame('job_slug', $meta['subject_kind'] ?? null);
+        $this->assertSame('software-developers', $meta['subject_key'] ?? null);
+    }
+
+    public function test_ingest_endpoint_rejects_invalid_event_name(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.5/career/attribution/events', [
+            'eventName' => 'career_unknown_event',
+            'payload' => [
+                'entry_surface' => 'career_job_index',
+                'source_page_type' => 'job_index',
+                'route_family' => 'jobs',
+                'subject_kind' => 'none',
+                'query_mode' => 'non_query',
+            ],
+        ]);
+
+        $response->assertStatus(422);
+    }
+}

--- a/backend/tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class RefreshCareerAttributionDailyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_refresh_command_outputs_scope_and_writes_daily_rows(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $occurredAt = now()->startOfDay()->setDate(2026, 4, 10)->setTime(9, 15);
+        $row = [
+            'id' => (string) Str::uuid(),
+            'event_code' => 'career_job_index_result_click',
+            'event_name' => 'career_job_index_result_click',
+            'org_id' => 5,
+            'user_id' => null,
+            'anon_id' => 'anon_cmd_001',
+            'session_id' => 'session_cmd_001',
+            'request_id' => 'request_cmd_001',
+            'attempt_id' => null,
+            'meta_json' => json_encode([
+                'entry_surface' => 'career_job_index',
+                'route_family' => 'jobs',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'data-scientists',
+                'query_mode' => 'non_query',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $occurredAt,
+            'created_at' => $occurredAt,
+            'updated_at' => $occurredAt,
+            'scale_code' => 'CAREER',
+            'channel' => 'web',
+            'locale' => 'zh',
+        ];
+
+        if (Schema::hasColumn('events', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'CAREER';
+        }
+
+        DB::table('events')->insert($row);
+
+        $this->artisan('analytics:refresh-career-attribution-daily', [
+            '--from' => '2026-04-10',
+            '--to' => '2026-04-10',
+            '--org' => [5],
+        ])->expectsOutputToContain('attempted_rows=1')
+            ->expectsOutputToContain('upserted_rows=1')
+            ->assertSuccessful();
+
+        $row = DB::table('analytics_career_attribution_daily')
+            ->where('day', '2026-04-10')
+            ->where('org_id', 5)
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('publish_ready', $row->readiness_class);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a backend-owned Career attribution ingest endpoint at `/api/v0.5/career/attribution/events` with a bounded Career-specific event taxonomy
- add a Career attribution event mapper that validates and normalizes safe dimensions before persistence into the shared `events` table
- add `analytics_career_attribution_daily`, a Career daily read model grouped by day, surface, route family, event, subject, readiness class, and query mode
- add a Career daily builder and refresh command that derive readiness class later from B14 first-wave readiness truth instead of freezing it into raw event payloads
- update the OpenAPI snapshot and add focused ingest / daily builder / refresh command coverage

## Why
- Career surfaces are already live after B7-B14 and F1-F9, but backend did not yet have a formal attribution ingest path or a Career daily aggregate model
- this PR closes that gap without changing existing Career jobs, recommendations, search, or detail API contracts
- the implementation mirrors the existing MBTI attribution pattern while keeping Career semantics explicit and separate from MBTI or generic analytics taxonomy

## Validation
- `vendor/bin/pint --test app/Services/Analytics/EventRecorder.php app/Services/Analytics/CareerAttributionEventMapper.php app/Http/Controllers/API/V0_5/Career/CareerAttributionEventController.php app/Services/Analytics/CareerAttributionDailyBuilder.php app/Console/Commands/RefreshCareerAttributionDailyCommand.php app/Console/Kernel.php routes/api.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php`
- `php artisan test tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerRecommendationIndexApiTest.php tests/Feature/Career/CareerSearchApiTest.php`

## Intentionally deferred
- no frontend event wiring or dashboard/report UI work
- no changes to existing Career jobs / recommendations / search / detail response shapes
- no raw query text persistence in the daily read model
- no ingest-time freezing of readiness class; readiness stays derive-later from backend authority
