### PR TITLE
[P0-A] Formalize MBTI lookup/questions cache and add prewarm

### DIFF
--- a/backend/app/Console/Commands/MbtiPrewarm.php
+++ b/backend/app/Console/Commands/MbtiPrewarm.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Http\Controllers\API\V0_3\ScalesController;
+use App\Http\Controllers\API\V0_3\ScalesLookupController;
+use App\Services\Content\BigFivePackLoader;
+use App\Services\Content\ClinicalComboPackLoader;
+use App\Services\Content\Eq60PackLoader;
+use App\Services\Content\QuestionsService;
+use App\Services\Content\Sds20PackLoader;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+use Throwable;
+
+final class MbtiPrewarm extends Command
+{
+    protected $signature = 'mbti:prewarm
+        {--slug=mbti-personality-test-16-personality-types : MBTI landing slug to prewarm}
+        {--locales=zh,en : Comma separated locales to prewarm}
+        {--forms=mbti_93,mbti_144 : Comma separated form codes to prewarm}';
+
+    protected $description = 'Prewarm MBTI lookup and questions caches for the hottest public locales/forms.';
+
+    public function handle(): int
+    {
+        $slug = trim((string) $this->option('slug'));
+        $locales = $this->parseCsvOption((string) $this->option('locales'));
+        $forms = $this->parseCsvOption((string) $this->option('forms'));
+
+        if ($slug === '' || $locales === [] || $forms === []) {
+            $this->error('slug, locales and forms must not be empty.');
+
+            return self::FAILURE;
+        }
+
+        $lookupController = app(ScalesLookupController::class);
+        $scalesController = app(ScalesController::class);
+        $questionsService = app(QuestionsService::class);
+        $bigFivePackLoader = app(BigFivePackLoader::class);
+        $clinicalPackLoader = app(ClinicalComboPackLoader::class);
+        $sds20PackLoader = app(Sds20PackLoader::class);
+        $eq60PackLoader = app(Eq60PackLoader::class);
+
+        $failed = false;
+
+        foreach ($locales as $locale) {
+            $lookupRequest = Request::create('/api/v0.3/scales/lookup', 'GET', [
+                'slug' => $slug,
+                'locale' => $locale,
+            ]);
+
+            try {
+                $lookupResponse = $lookupController->lookup($lookupRequest);
+                $this->line(sprintf(
+                    'lookup locale=%s status=%d cache=%s',
+                    $locale,
+                    $lookupResponse->getStatusCode(),
+                    $lookupResponse->headers->get('X-FAP-Cache', 'n/a')
+                ));
+                if ($lookupResponse->getStatusCode() !== 200) {
+                    $failed = true;
+                }
+            } catch (Throwable $e) {
+                $this->error(sprintf('lookup locale=%s failed: %s', $locale, $e->getMessage()));
+                $failed = true;
+            }
+
+            foreach ($forms as $formCode) {
+                $questionLocale = $this->normalizeQuestionLocale($locale);
+                $questionsRequest = Request::create('/api/v0.3/scales/MBTI/questions', 'GET', [
+                    'locale' => $questionLocale,
+                    'form_code' => $formCode,
+                ]);
+
+                try {
+                    $questionsResponse = $scalesController->questions(
+                        $questionsRequest,
+                        'MBTI',
+                        $questionsService,
+                        $bigFivePackLoader,
+                        $clinicalPackLoader,
+                        $sds20PackLoader,
+                        $eq60PackLoader
+                    );
+                    $this->line(sprintf(
+                        'questions locale=%s form=%s status=%d cache=%s',
+                        $questionLocale,
+                        $formCode,
+                        $questionsResponse->getStatusCode(),
+                        $questionsResponse->headers->get('X-FAP-Cache', 'n/a')
+                    ));
+                    if ($questionsResponse->getStatusCode() !== 200) {
+                        $failed = true;
+                    }
+                } catch (Throwable $e) {
+                    $this->error(sprintf(
+                        'questions locale=%s form=%s failed: %s',
+                        $questionLocale,
+                        $formCode,
+                        $e->getMessage()
+                    ));
+                    $failed = true;
+                }
+            }
+        }
+
+        if ($failed) {
+            $this->error('MBTI prewarm completed with failures.');
+
+            return self::FAILURE;
+        }
+
+        $this->info('MBTI prewarm completed successfully.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseCsvOption(string $raw): array
+    {
+        $items = array_map(
+            static fn (string $item): string => trim($item),
+            explode(',', $raw)
+        );
+
+        return array_values(array_filter($items, static fn (string $item): bool => $item !== ''));
+    }
+
+    private function normalizeQuestionLocale(string $locale): string
+    {
+        $locale = strtolower(trim($locale));
+
+        return match ($locale) {
+            'zh', 'zh-cn', 'zh_cn' => 'zh-CN',
+            'en', 'en-us', 'en_us' => 'en',
+            default => $locale !== '' ? $locale : 'zh-CN',
+        };
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_3/ScalesController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesController.php
@@ -15,12 +15,17 @@ use App\Services\Scale\ScaleCodeInputGuard;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Services\Scale\ScaleIdentityResolver;
 use App\Services\Scale\ScaleRegistry;
+use App\Support\CacheKeys;
 use App\Support\OrgContext;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 
 class ScalesController extends Controller
 {
+    private const CACHE_DEBUG_HEADER = 'X-FAP-Cache';
+
     public function __construct(
         private ScaleRegistry $registry,
         private ScaleIdentityResolver $identityResolver,
@@ -348,6 +353,32 @@ class ScalesController extends Controller
             $assetsBaseUrlOverride = $request->attributes->get('assets_base_url');
             $assetsBaseUrlOverride = is_string($assetsBaseUrlOverride) ? $assetsBaseUrlOverride : null;
 
+            $cacheStore = Cache::store((string) config('content_packs.mbti_response_cache_store', 'hot_redis'));
+            $cacheTtl = max(1, (int) config('content_packs.mbti_questions_cache_ttl_seconds', 600));
+            $cacheKey = null;
+            if ($resolvedScaleCode === 'MBTI' && $resolvedFormCode !== null) {
+                $cacheKey = CacheKeys::mbtiQuestions(
+                    $orgId,
+                    $packId,
+                    $dirVersion,
+                    $resolvedFormCode,
+                    $locale,
+                    $region,
+                    $assetsBaseUrlOverride
+                );
+                $cached = $cacheStore->get($cacheKey);
+                if (is_array($cached)) {
+                    $this->logCacheEvent('questions_hit', $cacheKey, [
+                        'org_id' => $orgId,
+                        'form_code' => $resolvedFormCode,
+                        'locale' => $locale,
+                        'region' => $region,
+                    ]);
+
+                    return $this->cacheableJson($cached, 'hit');
+                }
+            }
+
             $loaded = $questionsService->loadByPack($packId, $dirVersion, $assetsBaseUrlOverride);
             if (! ($loaded['ok'] ?? false)) {
                 $error = (string) ($loaded['error_code'] ?? $loaded['error'] ?? 'READ_FAILED');
@@ -360,7 +391,7 @@ class ScalesController extends Controller
                 ], $status);
             }
 
-            return response()->json([
+            $payload = [
                 'ok' => true,
                 'scale_code' => $scaleCodeMeta['scale_code'],
                 'region' => $region,
@@ -370,7 +401,20 @@ class ScalesController extends Controller
                 'content_package_version' => (string) ($loaded['content_package_version'] ?? ''),
                 'form_code' => $resolvedFormCode,
                 'questions' => $loaded['questions'],
-            ] + $scaleCodeMeta);
+            ] + $scaleCodeMeta;
+
+            if ($cacheKey !== null) {
+                $cacheStore->put($cacheKey, $payload, $cacheTtl);
+                $this->logCacheEvent('questions_miss', $cacheKey, [
+                    'org_id' => $orgId,
+                    'form_code' => $resolvedFormCode,
+                    'locale' => $locale,
+                    'region' => $region,
+                    'ttl' => $cacheTtl,
+                ]);
+            }
+
+            return $this->cacheableJson($payload, 'miss');
         } catch (\Throwable $e) {
             if ($e instanceof ApiProblemException) {
                 throw $e;
@@ -615,5 +659,35 @@ class ScalesController extends Controller
         $trimmed = trim((string) $value);
 
         return $trimmed !== '' ? $trimmed : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function cacheableJson(array $payload, string $state): JsonResponse
+    {
+        $response = response()->json($payload);
+        if ($this->shouldExposeCacheState()) {
+            $response->headers->set(self::CACHE_DEBUG_HEADER, $state);
+        }
+
+        return $response;
+    }
+
+    private function shouldExposeCacheState(): bool
+    {
+        return app()->environment(['local', 'testing']) || (bool) config('app.debug', false);
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function logCacheEvent(string $event, string $cacheKey, array $context = []): void
+    {
+        if (! (bool) config('content_packs.debug_log', false)) {
+            return;
+        }
+
+        Log::info('mbti.questions.cache.'.$event, ['cache_key' => $cacheKey] + $context);
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/ScalesLookupController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesLookupController.php
@@ -7,12 +7,17 @@ use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Services\Scale\ScaleIdentityResolver;
 use App\Services\Scale\ScaleRegistry;
+use App\Support\CacheKeys;
 use App\Support\OrgContext;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 
 class ScalesLookupController extends Controller
 {
+    private const CACHE_DEBUG_HEADER = 'X-FAP-Cache';
+
     public function __construct(
         private ScaleRegistry $registry,
         private ScaleIdentityResolver $identityResolver,
@@ -45,6 +50,26 @@ class ScalesLookupController extends Controller
         }
 
         $allowAlias = config('scales_lookup.alias_mode', 'compat') !== 'canonical_only';
+        $requestedLocale = $this->resolveRequestedLocale(
+            $request,
+            (string) config('content_packs.default_locale', 'en')
+        );
+        // We cannot reliably derive content version before registry resolution, so keep
+        // a request-shape key here and pair it with a short TTL.
+        $cacheKey = CacheKeys::mbtiLookup($orgId, $requestedSlug, $requestedLocale, $allowAlias);
+        $cacheStore = Cache::store((string) config('content_packs.mbti_response_cache_store', 'hot_redis'));
+        $cacheTtl = max(1, (int) config('content_packs.mbti_lookup_cache_ttl_seconds', 600));
+        $cached = $cacheStore->get($cacheKey);
+        if (is_array($cached)) {
+            $this->logCacheEvent('lookup_hit', $cacheKey, [
+                'org_id' => $orgId,
+                'slug' => $requestedSlug,
+                'locale' => $requestedLocale,
+            ]);
+
+            return $this->cacheableJson($cached, 'hit');
+        }
+
         $row = $this->registry->lookupBySlug($requestedSlug, $orgId, $allowAlias);
         if (! $row) {
             return response()->json([
@@ -69,8 +94,7 @@ class ScalesLookupController extends Controller
         $locale = $this->resolveRequestedLocale($request, (string) ($row['default_locale'] ?? 'en'));
         $seo = $this->resolveSeoByLocale($row, $locale);
         $isIndexable = $this->resolveIsIndexable($row);
-
-        return response()->json([
+        $payload = [
             'ok' => true,
             'scale_code' => $scaleCodeMeta['scale_code'],
             'scale_code_legacy' => $scaleCodeMeta['scale_code_legacy'],
@@ -105,7 +129,19 @@ class ScalesLookupController extends Controller
                 $seo,
                 $isIndexable
             ),
-        ]);
+        ];
+
+        if (($payload['scale_code'] ?? null) === 'MBTI') {
+            $cacheStore->put($cacheKey, $payload, $cacheTtl);
+            $this->logCacheEvent('lookup_miss', $cacheKey, [
+                'org_id' => $orgId,
+                'slug' => $requestedSlug,
+                'locale' => $locale,
+                'ttl' => $cacheTtl,
+            ]);
+        }
+
+        return $this->cacheableJson($payload, 'miss');
     }
 
     /**
@@ -376,5 +412,35 @@ class ScalesLookupController extends Controller
             'pack_id_v2' => $packIdV2 ?? $this->trimOrNull($row['default_pack_id'] ?? null),
             'dir_version_v2' => $dirVersionV2 ?? $this->trimOrNull($row['default_dir_version'] ?? null),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function cacheableJson(array $payload, string $state): JsonResponse
+    {
+        $response = response()->json($payload);
+        if ($this->shouldExposeCacheState()) {
+            $response->headers->set(self::CACHE_DEBUG_HEADER, $state);
+        }
+
+        return $response;
+    }
+
+    private function shouldExposeCacheState(): bool
+    {
+        return app()->environment(['local', 'testing']) || (bool) config('app.debug', false);
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function logCacheEvent(string $event, string $cacheKey, array $context = []): void
+    {
+        if (! (bool) config('content_packs.debug_log', false)) {
+            return;
+        }
+
+        Log::info('mbti.lookup.cache.'.$event, ['cache_key' => $cacheKey] + $context);
     }
 }

--- a/backend/app/Support/CacheKeys.php
+++ b/backend/app/Support/CacheKeys.php
@@ -47,12 +47,36 @@ final class CacheKeys
         return self::base().':content_packs:questions:'.$packId.':'.$dirVersion;
     }
 
-    public static function mbtiQuestions(string $packId, string $dirVersion): string
+    public static function mbtiLookup(int $orgId, string $requestedSlug, string $locale, bool $allowAlias): string
     {
-        $packId = trim($packId);
-        $dirVersion = trim($dirVersion);
+        return self::base().':mbti:lookup'
+            .':org='.self::normalizeSegment((string) $orgId)
+            .':slug='.self::normalizeSegment($requestedSlug)
+            .':locale='.self::normalizeSegment($locale)
+            .':alias='.(int) $allowAlias;
+    }
 
-        return self::base().':mbti:questions:'.$packId.':'.$dirVersion;
+    public static function mbtiQuestions(
+        int $orgId,
+        string $packId,
+        string $dirVersion,
+        string $resolvedFormCode,
+        string $locale,
+        string $region,
+        ?string $assetsBaseUrlOverride = null,
+    ): string {
+        $assetsMarker = $assetsBaseUrlOverride === null || trim($assetsBaseUrlOverride) === ''
+            ? 'default'
+            : substr(hash('sha256', trim($assetsBaseUrlOverride)), 0, 12);
+
+        return self::base().':mbti:questions'
+            .':org='.self::normalizeSegment((string) $orgId)
+            .':pack='.self::normalizeSegment($packId)
+            .':dir='.self::normalizeSegment($dirVersion)
+            .':form='.self::normalizeSegment($resolvedFormCode)
+            .':locale='.self::normalizeSegment($locale)
+            .':region='.self::normalizeSegment($region)
+            .':assets='.$assetsMarker;
     }
 
     public static function contentAsset(string $packPath, string $relPath): string
@@ -85,5 +109,17 @@ final class CacheKeys
     private static function base(): string
     {
         return self::PREFIX.':v='.self::versionTag();
+    }
+
+    private static function normalizeSegment(string $value): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return 'na';
+        }
+
+        $normalized = preg_replace('/[^a-z0-9._-]+/i', '_', $value);
+
+        return $normalized !== null && $normalized !== '' ? strtolower($normalized) : 'na';
     }
 }

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -28,6 +28,9 @@ return [
     'cache_ttl_seconds' => (int) env('FAP_PACKS_CACHE_TTL_SECONDS', 3600),
     'loader_cache_store' => env('CONTENT_LOADER_CACHE_STORE', 'array'),
     'loader_cache_ttl_seconds' => (int) env('CONTENT_LOADER_CACHE_TTL_SECONDS', 300),
+    'mbti_response_cache_store' => env('MBTI_RESPONSE_CACHE_STORE', 'hot_redis'),
+    'mbti_lookup_cache_ttl_seconds' => (int) env('MBTI_LOOKUP_CACHE_TTL_SECONDS', 600),
+    'mbti_questions_cache_ttl_seconds' => (int) env('MBTI_QUESTIONS_CACHE_TTL_SECONDS', 600),
     'debug_log' => (bool) env('FAP_PACKS_DEBUG_LOG', false),
 
     // ✅ CI/服务器建议强约束：默认 pack_id 明确指向你的主包，避免回退到 GLOBAL/en

--- a/backend/tests/Feature/Console/MbtiPrewarmCommandTest.php
+++ b/backend/tests/Feature/Console/MbtiPrewarmCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+final class MbtiPrewarmCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('content_packs.mbti_response_cache_store', 'array');
+        Config::set('content_packs.mbti_lookup_cache_ttl_seconds', 600);
+        Config::set('content_packs.mbti_questions_cache_ttl_seconds', 600);
+        Config::set('content_packs.loader_cache_store', 'array');
+        Config::set('content_packs.loader_cache_ttl_seconds', 300);
+
+        Cache::store('array')->flush();
+
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        $this->artisan('fap:scales:sync-slugs');
+    }
+
+    public function test_mbti_prewarm_command_warms_lookup_and_questions(): void
+    {
+        $this->artisan('mbti:prewarm')
+            ->expectsOutputToContain('lookup locale=zh status=200')
+            ->expectsOutputToContain('lookup locale=en status=200')
+            ->expectsOutputToContain('questions locale=zh-CN form=mbti_93 status=200')
+            ->expectsOutputToContain('questions locale=en form=mbti_144 status=200')
+            ->expectsOutputToContain('MBTI prewarm completed successfully.')
+            ->assertExitCode(0);
+
+        $this->getJson('/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh')
+            ->assertStatus(200)
+            ->assertHeader('X-FAP-Cache', 'hit');
+
+        $this->getJson('/api/v0.3/scales/MBTI/questions?locale=zh-CN&form_code=mbti_93')
+            ->assertStatus(200)
+            ->assertHeader('X-FAP-Cache', 'hit');
+
+        $this->getJson('/api/v0.3/scales/MBTI/questions?locale=en&form_code=mbti_144')
+            ->assertStatus(200)
+            ->assertHeader('X-FAP-Cache', 'hit');
+    }
+}

--- a/backend/tests/Feature/V0_3/MbtiResponseCacheTest.php
+++ b/backend/tests/Feature/V0_3/MbtiResponseCacheTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+final class MbtiResponseCacheTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('content_packs.mbti_response_cache_store', 'array');
+        Config::set('content_packs.mbti_lookup_cache_ttl_seconds', 600);
+        Config::set('content_packs.mbti_questions_cache_ttl_seconds', 600);
+        Config::set('content_packs.loader_cache_store', 'array');
+        Config::set('content_packs.loader_cache_ttl_seconds', 300);
+
+        Cache::store('array')->flush();
+
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        $this->artisan('fap:scales:sync-slugs');
+    }
+
+    public function test_mbti_lookup_returns_miss_then_hit(): void
+    {
+        $first = $this->getJson('/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh');
+        $first->assertStatus(200);
+        $first->assertHeader('X-FAP-Cache', 'miss');
+
+        $second = $this->getJson('/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh');
+        $second->assertStatus(200);
+        $second->assertHeader('X-FAP-Cache', 'hit');
+        $this->assertSame($first->json(), $second->json());
+    }
+
+    public function test_mbti_questions_93_returns_miss_then_hit(): void
+    {
+        $first = $this->getJson('/api/v0.3/scales/MBTI/questions?locale=zh-CN&form_code=mbti_93');
+        $first->assertStatus(200);
+        $first->assertHeader('X-FAP-Cache', 'miss');
+        $first->assertJsonPath('form_code', 'mbti_93');
+
+        $second = $this->getJson('/api/v0.3/scales/MBTI/questions?locale=zh-CN&form_code=mbti_93');
+        $second->assertStatus(200);
+        $second->assertHeader('X-FAP-Cache', 'hit');
+        $this->assertSame($first->json(), $second->json());
+    }
+
+    public function test_mbti_questions_144_en_returns_miss_then_hit(): void
+    {
+        $first = $this->getJson('/api/v0.3/scales/MBTI/questions?locale=en&form_code=mbti_144');
+        $first->assertStatus(200);
+        $first->assertHeader('X-FAP-Cache', 'miss');
+        $first->assertJsonPath('form_code', 'mbti_144');
+
+        $second = $this->getJson('/api/v0.3/scales/MBTI/questions?locale=en&form_code=mbti_144');
+        $second->assertStatus(200);
+        $second->assertHeader('X-FAP-Cache', 'hit');
+        $this->assertSame($first->json(), $second->json());
+    }
+}


### PR DESCRIPTION
## What changed
- formalized MBTI response cache key generation in `backend/app/Support/CacheKeys.php`
- wired controller-level cache read/write for `GET /api/v0.3/scales/lookup`
- wired controller-level cache read/write for `GET /api/v0.3/scales/{scale_code}/questions`
- centralized MBTI cache TTL/store config in `backend/config/content_packs.php`
- added `php artisan mbti:prewarm` to prewarm MBTI lookup and `mbti_93` / `mbti_144` questions for `zh` and `en`
- added feature tests for lookup/questions cache hit-miss behavior and the prewarm command

## Why
MBTI lookup/questions were still relying on high-traffic read paths that could re-enter the full generation path during cache misses or cold deploy windows. This change makes the Laravel application layer the source of truth for MBTI response caching and adds a deploy-safe prewarm path to reduce PHP-FPM read pressure during MBTI traffic spikes.

## Validation commands
- `cd backend && php -l app/Support/CacheKeys.php`
- `cd backend && php -l app/Http/Controllers/API/V0_3/ScalesLookupController.php`
- `cd backend && php -l app/Http/Controllers/API/V0_3/ScalesController.php`
- `cd backend && php -l app/Console/Commands/MbtiPrewarm.php`
- `cd backend && php artisan route:list | rg "api/v0.3/(auth/guest|scales/lookup|scales/\{scale_code\}/questions|attempts/start|attempts/submit)"`
- `cd backend && php artisan test tests/Feature/V0_3/MbtiResponseCacheTest.php tests/Feature/Console/MbtiPrewarmCommandTest.php`
- `cd backend && php artisan mbti:prewarm`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred items
- `attempts/start` idempotency is not part of this PR
- limiter values and runtime topology changes are not part of this PR
- lookup still uses a request-shape cache key with short TTL because version fields are not reliably available before lookup resolution
- prewarm is implemented here but not yet wired into deployment automation
