### PR TITLE
PR-D2A: Career first-wave release runbook + override escalation SOP

### DIFF
--- a/backend/docs/ops/career-first-wave-override-escalation-sop.md
+++ b/backend/docs/ops/career-first-wave-override-escalation-sop.md
@@ -1,0 +1,157 @@
+# Career First-Wave Override Escalation SOP
+
+## Purpose
+
+This SOP defines the only supported escalation path for narrow source-code overrides in the Career first-wave release process.
+
+It is intentionally exceptional, narrow, and auditable.
+
+It exists to handle only the current supported override class:
+- `blocked_override_eligible`
+- supported field: `crosswalk_source_code`
+
+It does not authorize:
+- source-row invention
+- aggregate-row proxying
+- synthetic occupation composition
+- broad manual truth patching
+
+## Definitions
+
+### `blocked_override_eligible`
+
+A first-wave subject is blocked, but the blocker is explicitly marked as eligible for narrow source-code override in:
+- `docs/career/first_wave_blocked_registry.json`
+
+Current examples:
+- `software-developers`
+- `financial-analysts`
+
+These entries are blocked because the exact dataset row exists but the needed source code is missing. Under the current system, only an explicit authority-owned source-code override may resolve that blocker.
+
+### `blocked_not_safely_remediable`
+
+A first-wave subject is blocked and must not be forced through override under current evidence.
+
+Current examples:
+- `marketing-managers`
+- `elementary-school-teachers-except-special-education`
+
+These subjects are not safely remediable because the required exact source row is missing. Nearby or aggregate rows must not be used as substitutes.
+
+## Allowed mutation surface
+
+The only allowed override file is:
+- `docs/career/first_wave_authority_overrides.json`
+
+The only currently supported override field is:
+- `crosswalk_source_code`
+
+No other field should be added, mutated, or inferred as part of this SOP.
+
+## Required evidence
+
+Before proposing an override, collect and retain:
+- target `canonical_slug`
+- target `occupation_uuid`
+- blocker type from `docs/career/first_wave_blocked_registry.json`
+- proof that the subject is marked `override_eligible: true`
+- authoritative evidence for the exact `crosswalk_source_code` value being proposed
+- source reference showing why the value is authoritative
+
+Evidence is insufficient if it relies on:
+- “closest match” row selection
+- aggregate occupation groups
+- editorial inference
+- frontend rendering behavior
+- unreviewed spreadsheet heuristics without exact subject alignment
+
+## Required review and sign-off
+
+Override use requires explicit human review.
+
+Minimum review expectations:
+- confirm the subject is listed as `blocked_override_eligible`
+- confirm the evidence supports the exact `crosswalk_source_code`
+- confirm the change is limited to the supported field
+- confirm the operator understands the override is exceptional and auditable
+
+If `review_required` is true in the blocked registry, do not bypass review.
+
+## Explicitly forbidden actions
+
+The following are forbidden:
+- overriding any subject marked `blocked_not_safely_remediable`
+- adding override entries for `marketing-managers`
+- adding override entries for `elementary-school-teachers-except-special-education`
+- inventing missing source rows
+- proxying through nearby or aggregate rows
+- using the override file as a general publish-force mechanism
+- widening the override schema beyond `crosswalk_source_code`
+
+## Execution steps
+
+1. Confirm the target subject is listed in `docs/career/first_wave_blocked_registry.json` with:
+   - `override_eligible: true`
+   - `remediation_class: authority_override_possible`
+2. Gather and retain authoritative evidence for the exact `crosswalk_source_code`.
+3. Edit only `docs/career/first_wave_authority_overrides.json`.
+4. Add the narrow override entry for the approved subject.
+5. Re-run the first-wave validator:
+
+```bash
+php artisan career:validate-first-wave-publish-ready \
+  --source=/absolute/path/to/authority_source.csv \
+  --authority-overrides=/absolute/path/to/docs/career/first_wave_authority_overrides.json \
+  --materialize-missing \
+  --compile-missing \
+  --repair-safe-partials \
+  --json
+```
+
+6. Confirm the subject moves from blocked to publish-ready because `authority_override_supplied` is true.
+7. Re-check the machine-readable readiness summary:
+
+```bash
+curl -sS http://127.0.0.1/api/v0.5/career/first-wave/readiness | python3 -m json.tool
+```
+
+8. Record evidence and approval notes before release sign-off.
+
+## Validation after override
+
+Validation must show all of the following:
+- validator exits `0`
+- target subject is no longer blocked
+- `authority_override_supplied` is true for the target subject
+- the change did not alter unrelated first-wave subjects
+- readiness summary reflects the updated release picture
+
+If the override does not produce a clean, narrow outcome, remove it and stop escalation.
+
+## Rollback / removal steps
+
+If an override is later found to be incorrect:
+1. remove the relevant entry from `docs/career/first_wave_authority_overrides.json`
+2. rerun the validator with the same source dataset
+3. rerun the readiness summary check
+4. confirm the subject returns to the expected blocked state
+5. record the rollback in release evidence
+
+Do not leave a bad override in place while “temporarily” relying on tribal knowledge.
+
+## Audit note requirements
+
+For every override escalation, retain:
+- date/time
+- operator/reviewer
+- affected `canonical_slug`
+- affected `occupation_uuid`
+- blocker type
+- authoritative evidence source
+- exact override value added
+- validator output snapshot
+- readiness summary snapshot
+- rollback record if later removed
+
+The override file is a source-code artifact. Treat each change as auditable release evidence, not as an informal operator tweak.

--- a/backend/docs/ops/career-first-wave-release-runbook.md
+++ b/backend/docs/ops/career-first-wave-release-runbook.md
@@ -1,0 +1,215 @@
+# Career First-Wave Release Runbook
+
+## Scope and authority boundary
+
+This runbook defines the backend-operated release procedure for the current Career first-wave set after B7-B15.
+
+It is limited to:
+- first-wave publish-readiness validation
+- first-wave readiness summary interpretation
+- first-wave override-aware release decisions
+- Career attribution daily refresh sanity checks
+
+It does not define:
+- frontend smoke or rollback execution
+- dashboard or analytics UI procedures
+- content authoring workflow
+- new source-of-truth generation
+
+Authority stays backend-owned:
+- Laravel validator output is the release authority for publish-ready vs blocked state.
+- `docs/career/first_wave_manifest.json` is the frozen first-wave subject scope.
+- `docs/career/first_wave_blocked_registry.json` is the blocked-governance registry.
+- `docs/career/first_wave_authority_overrides.json` is the narrow source-code override surface.
+- `GET /api/v0.5/career/first-wave/readiness` is the machine-readable release summary surface.
+
+Do not treat `docs/codex/*` as production release truth.
+
+## Source-of-truth files
+
+Primary first-wave files:
+- `docs/career/first_wave_manifest.json`
+- `docs/career/first_wave_blocked_registry.json`
+- `docs/career/first_wave_authority_overrides.json`
+
+Supporting boundary/reference docs:
+- `docs/career/career-gold-diff-rules.md`
+- `docs/data/ingestion.md`
+- `docs/ops/funnel-conversion.md`
+
+Do not edit the three first-wave JSON files casually during release execution. Any intended override change must follow `docs/ops/career-first-wave-override-escalation-sop.md`.
+
+## Preflight checks
+
+Run these checks before making a release decision:
+
+```bash
+python3 -m json.tool docs/career/first_wave_blocked_registry.json >/dev/null
+python3 -m json.tool docs/career/first_wave_authority_overrides.json >/dev/null
+```
+
+Then run the first-wave validator using the currently approved authority dataset:
+
+```bash
+php artisan career:validate-first-wave-publish-ready \
+  --source=/absolute/path/to/authority_source.csv \
+  --materialize-missing \
+  --compile-missing \
+  --repair-safe-partials \
+  --json
+```
+
+Preflight expectations:
+- validator exits `0`
+- output is machine-readable JSON
+- counts and occupation statuses reconcile with the committed first-wave scope
+- no ad hoc local residue changes the release outcome between clean reruns
+
+If the validator cannot be rerun cleanly, stop release work and resolve environment/process issues first.
+
+## First-wave validator command and how to read it
+
+Primary command:
+
+```bash
+php artisan career:validate-first-wave-publish-ready \
+  --source=/absolute/path/to/authority_source.csv \
+  --materialize-missing \
+  --compile-missing \
+  --repair-safe-partials \
+  --json
+```
+
+Key output areas:
+- `counts.publish_ready`
+- `counts.partial`
+- `counts.blocked`
+- per-occupation:
+  - `status`
+  - `missing_requirements`
+  - `blocked_governance_status`
+  - `override_eligible`
+  - `authority_override_supplied`
+  - `remediation_class`
+
+Interpretation rules:
+- `publish_ready`
+  - safe for first-wave release truth
+- `partial`
+  - not publish-ready
+  - requires remediation before release
+- `blocked` + `blocked_governance_status=blocked_override_eligible`
+  - may be escalated through the narrow override SOP
+- `blocked` + `blocked_governance_status=blocked_not_safely_remediable`
+  - not releasable under current evidence
+  - must not be forced through source-code override
+
+Do not collapse `partial` and `blocked` into one bucket operationally. The validator is the authority for the difference.
+
+## B14 readiness summary API and how to read it
+
+Machine-readable summary endpoint:
+
+```bash
+curl -sS http://127.0.0.1/api/v0.5/career/first-wave/readiness | python3 -m json.tool
+```
+
+Public route:
+- `GET /api/v0.5/career/first-wave/readiness`
+
+Key fields:
+- `summary_kind`
+- `summary_version`
+- `wave_name`
+- `counts.total`
+- `counts.publish_ready`
+- `counts.blocked_override_eligible`
+- `counts.blocked_not_safely_remediable`
+- `counts.blocked_total`
+- `occupations[*].status`
+- `occupations[*].reason_codes`
+
+Operational use:
+- use the validator as the release authority
+- use the readiness API as the release read-model confirmation surface
+- counts should reconcile with the current committed first-wave state
+
+If the validator output and readiness summary disagree, stop release work and resolve the drift before proceeding.
+
+## Release decision rules
+
+Release is acceptable only when all of the following hold:
+- the committed first-wave scope is intact
+- blocked registry and override JSON are valid
+- validator runs cleanly from the approved source
+- readiness summary reflects the same publish-ready/blocked picture
+- any override-backed release decision is already documented and approved under the override SOP
+
+Stop release if any of the following occur:
+- validator output is non-deterministic across reruns
+- a first-wave subject is blocked and not safely remediable
+- an override is proposed for anything other than the supported narrow case
+- a missing source row is being “solved” by proxy rows, aggregate rows, or editorial guesswork
+- readiness summary drifts from validator truth
+
+## B15 attribution refresh check
+
+Career attribution daily read-model refresh command:
+
+```bash
+php artisan analytics:refresh-career-attribution-daily \
+  --from=YYYY-MM-DD \
+  --to=YYYY-MM-DD
+```
+
+Use `--dry-run` when you only need scope visibility:
+
+```bash
+php artisan analytics:refresh-career-attribution-daily \
+  --from=YYYY-MM-DD \
+  --to=YYYY-MM-DD \
+  --dry-run
+```
+
+What to inspect:
+- `from=...`
+- `to=...`
+- `org_scope=...`
+- `attempted_rows=...`
+- `deleted_rows=...`
+- `upserted_rows=...`
+
+Operational meaning:
+- this is not a release gate for first-wave truth
+- it is a release-adjacent sanity check that the Career attribution read model refreshes cleanly after B15
+
+If the command errors, treat it as an ops issue to resolve before claiming full release-operability coverage.
+
+## Evidence to retain for release sign-off
+
+Retain all of the following:
+- deployed/backend commit SHA
+- validator stdout JSON
+- readiness summary JSON snapshot
+- current `first_wave_authority_overrides.json` state
+- any override approval link or ticket reference
+- attribution daily refresh command output
+
+Recommended evidence bundle:
+- release timestamp
+- operator name
+- source dataset reference
+- exact command invocations
+- pass/fail conclusion
+
+## Explicit non-goals and forbidden actions
+
+This runbook does not authorize:
+- editing `docs/career/first_wave_manifest.json` during normal release execution
+- source-row invention
+- aggregate-row proxying
+- replacing backend truth with frontend or CMS interpretation
+- broad override filling as a routine workflow
+- frontend smoke/rollback steps inside backend release truth docs
+
+If the current system cannot support a proposed operational step directly, do not add it to the release procedure as if it already exists.


### PR DESCRIPTION
## What changed
- add a backend-owned Career first-wave release runbook grounded in the current B7-B15 authority flow
- add a narrow Career first-wave override escalation SOP that documents the only supported override surface and validation path
- keep the docs tied to real existing commands, APIs, and committed truth files instead of speculative future ops steps

## Why
- Career first-wave authority, readiness, blocked governance, and attribution refresh capabilities are already merged, but the release and override operating procedure was still implicit
- this PR closes that gap with docs-only artifacts that operators can execute and audit without changing runtime code or truth JSON
- the SOP keeps override behavior intentionally narrow and explicitly forbids source-row invention or aggregate-row proxying

## Validation
- `test -f docs/ops/career-first-wave-release-runbook.md`
- `test -f docs/ops/career-first-wave-override-escalation-sop.md`
- `python3 - <<"PY"`
  `from pathlib import Path`
  `for p in [Path("docs/ops/career-first-wave-release-runbook.md"), Path("docs/ops/career-first-wave-override-escalation-sop.md")]:`
  `    text = p.read_text()`
  `    assert "career:validate-first-wave-publish-ready" in text`
  `print("docs-ok")`
  `PY`

## Intentionally deferred
- no frontend smoke or rollback doc changes; those belong in the frontend-side D2B scope
- no changes to runtime code, API contracts, or first-wave truth JSON
- no changes to `docs/codex/*` ownership or train orchestration docs
