### PR TITLE
PR-B16: Career transition preview authority bundle + API

### DIFF
--- a/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
+++ b/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerTransitionPreviewBundle
+{
+    /**
+     * @param  array<string, mixed>  $targetJob
+     * @param  array<string, mixed>  $scoreSummary
+     * @param  array<string, mixed>  $trustSummary
+     * @param  array<string, mixed>  $seoContract
+     * @param  array<string, mixed>  $provenanceMeta
+     */
+    public function __construct(
+        public readonly string $pathType,
+        public readonly array $targetJob,
+        public readonly array $scoreSummary,
+        public readonly array $trustSummary,
+        public readonly array $seoContract,
+        public readonly array $provenanceMeta,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'bundle_kind' => 'career_transition_preview',
+            'bundle_version' => 'career.protocol.transition_preview.v1',
+            'path_type' => $this->pathType,
+            'target_job' => $this->targetJob,
+            'score_summary' => $this->scoreSummary,
+            'trust_summary' => $this->trustSummary,
+            'seo_contract' => $this->seoContract,
+            'provenance_meta' => $this->provenanceMeta,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerTransitionPreviewController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerTransitionPreviewController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerTransitionPreviewResource;
+use App\Services\Career\Bundles\CareerTransitionPreviewBundleBuilder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class CareerTransitionPreviewController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerTransitionPreviewBundleBuilder $bundleBuilder,
+    ) {}
+
+    public function show(Request $request): JsonResponse|CareerTransitionPreviewResource
+    {
+        $validated = $request->validate([
+            'type' => ['required', 'string', 'min:1', 'max:16'],
+        ]);
+
+        $bundle = $this->bundleBuilder->buildByType((string) $validated['type']);
+
+        if ($bundle === null) {
+            return $this->notFoundResponse('career transition preview unavailable.');
+        }
+
+        return new CareerTransitionPreviewResource($bundle);
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerTransitionPreviewResource.php
+++ b/backend/app/Http/Resources/Career/CareerTransitionPreviewResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerTransitionPreviewBundle;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerTransitionPreviewBundle
+ */
+final class CareerTransitionPreviewResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerTransitionPreviewBundle $bundle */
+        $bundle = $this->resource;
+
+        return $bundle->toArray();
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\DTO\Career\CareerTransitionPreviewBundle;
+use App\Models\RecommendationSnapshot;
+use App\Models\TransitionPath;
+use App\Services\Career\CareerTransitionPreviewReadinessLookup;
+use Illuminate\Support\Collection;
+
+final class CareerTransitionPreviewBundleBuilder
+{
+    public function __construct(
+        private readonly CareerTransitionPreviewReadinessLookup $readinessLookup,
+    ) {}
+
+    public function buildByType(string $type): ?CareerTransitionPreviewBundle
+    {
+        $requestedType = trim($type);
+        $normalizedType = strtoupper($requestedType);
+        if ($normalizedType === '') {
+            return null;
+        }
+
+        $canonicalType = strtoupper(strtok($normalizedType, '-') ?: $normalizedType);
+
+        $paths = $this->matchingTransitionPaths($normalizedType, $canonicalType);
+        foreach ($paths as $path) {
+            $bundle = $this->buildFromPath($path);
+            if ($bundle instanceof CareerTransitionPreviewBundle) {
+                return $bundle;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Collection<int, TransitionPath>
+     */
+    private function matchingTransitionPaths(string $normalizedType, string $canonicalType): Collection
+    {
+        /** @var Collection<int, TransitionPath> $paths */
+        $paths = TransitionPath::query()
+            ->with([
+                'recommendationSnapshot.profileProjection',
+                'recommendationSnapshot.contextSnapshot',
+                'recommendationSnapshot.compileRun',
+                'toOccupation',
+            ])
+            ->whereHas('recommendationSnapshot', static function ($query): void {
+                $query->whereNotNull('compiled_at')
+                    ->whereNotNull('compile_run_id');
+            })
+            ->whereHas('recommendationSnapshot.contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('recommendationSnapshot.profileProjection', function ($query) use ($normalizedType, $canonicalType): void {
+                $query->where('projection_payload->materialization', 'career_first_wave')
+                    ->where(function ($inner) use ($normalizedType, $canonicalType): void {
+                        $inner->where('projection_payload->recommendation_subject_meta->type_code', $normalizedType)
+                            ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $normalizedType)
+                            ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $canonicalType)
+                            ->orWhere('projection_payload->recommendation_subject_meta->public_route_slug', strtolower($normalizedType))
+                            ->orWhere('projection_payload->recommendation_subject_meta->public_route_slug', strtolower($canonicalType));
+                    });
+            })
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->get();
+
+        return $paths;
+    }
+
+    private function buildFromPath(TransitionPath $path): ?CareerTransitionPreviewBundle
+    {
+        $snapshot = $path->recommendationSnapshot;
+        $targetOccupation = $path->toOccupation;
+
+        if (! $snapshot instanceof RecommendationSnapshot || $targetOccupation === null) {
+            return null;
+        }
+
+        $pathType = trim((string) $path->path_type);
+        if ($pathType === '') {
+            return null;
+        }
+
+        $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
+        $claimPermissions = is_array($payload['claim_permissions'] ?? null) ? $payload['claim_permissions'] : [];
+        if (($claimPermissions['allow_transition_recommendation'] ?? false) !== true) {
+            return null;
+        }
+
+        $readiness = $this->readinessLookup->bySlug((string) $targetOccupation->canonical_slug);
+        if ($readiness === null) {
+            return null;
+        }
+
+        if (($readiness['status'] ?? null) !== 'publish_ready' || ($readiness['index_eligible'] ?? false) !== true) {
+            return null;
+        }
+
+        $scoreBundle = is_array($payload['score_bundle'] ?? null) ? $payload['score_bundle'] : [];
+        $reasonCodes = is_array($claimPermissions['reason_codes'] ?? null) ? array_values($claimPermissions['reason_codes']) : [];
+        $seoReasonCodes = is_array($readiness['reason_codes'] ?? null) ? array_values($readiness['reason_codes']) : [];
+
+        return new CareerTransitionPreviewBundle(
+            pathType: $pathType,
+            targetJob: [
+                'occupation_uuid' => $targetOccupation->id,
+                'canonical_slug' => $targetOccupation->canonical_slug,
+                'title' => $targetOccupation->canonical_title_en,
+            ],
+            scoreSummary: [
+                'mobility_score' => $this->compactScore($scoreBundle['mobility_score'] ?? null),
+                'confidence_score' => $this->compactScore($scoreBundle['confidence_score'] ?? null),
+            ],
+            trustSummary: [
+                'allow_transition_recommendation' => true,
+                'reviewer_status' => $readiness['reviewer_status'] ?? null,
+                'reason_codes' => $reasonCodes,
+            ],
+            seoContract: [
+                'canonical_path' => '/career/jobs/'.$targetOccupation->canonical_slug,
+                'canonical_target' => null,
+                'index_state' => $readiness['index_state'] ?? null,
+                'index_eligible' => true,
+                'reason_codes' => $seoReasonCodes,
+            ],
+            provenanceMeta: [
+                'recommendation_snapshot_id' => $snapshot->id,
+                'transition_path_id' => $path->id,
+                'compiler_version' => $snapshot->compiler_version,
+                'compiled_at' => optional($snapshot->compiled_at)->toISOString(),
+                'compile_run_id' => $snapshot->compile_run_id,
+                'import_run_id' => $snapshot->compileRun?->import_run_id,
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function compactScore(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [
+                'value' => null,
+                'integrity_state' => null,
+                'band' => null,
+            ];
+        }
+
+        return [
+            'value' => $value['value'] ?? null,
+            'integrity_state' => $value['integrity_state'] ?? null,
+            'band' => $value['band'] ?? null,
+        ];
+    }
+}

--- a/backend/app/Services/Career/CareerTransitionPreviewReadinessLookup.php
+++ b/backend/app/Services/Career/CareerTransitionPreviewReadinessLookup.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career;
+
+use App\Domain\Career\Publish\FirstWaveReadinessSummaryService;
+
+class CareerTransitionPreviewReadinessLookup
+{
+    /**
+     * @var array<string, array<string, mixed>>|null
+     */
+    private ?array $rowsBySlug = null;
+
+    public function __construct(
+        private readonly FirstWaveReadinessSummaryService $readinessSummaryService,
+    ) {}
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function bySlug(string $canonicalSlug): ?array
+    {
+        if ($this->rowsBySlug === null) {
+            $summary = $this->readinessSummaryService->build()->toArray();
+            $rows = is_array($summary['occupations'] ?? null) ? $summary['occupations'] : [];
+            $this->rowsBySlug = [];
+
+            foreach ($rows as $row) {
+                if (! is_array($row)) {
+                    continue;
+                }
+
+                $slug = (string) ($row['canonical_slug'] ?? '');
+                if ($slug === '') {
+                    continue;
+                }
+
+                $this->rowsBySlug[$slug] = $row;
+            }
+        }
+
+        return $this->rowsBySlug[$canonicalSlug] ?? null;
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2464,6 +2464,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/transition-preview": {
+            "get": {
+                "operationId": "get_api_v0_5_career_transition_preview",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerTransitionPreviewController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/cms/articles": {
             "post": {
                 "operationId": "post_api_v0_5_cms_articles",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -36,6 +36,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerJobListController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationIndexController;
 use App\Http\Controllers\API\V0_5\Career\CareerSearchController;
+use App\Http\Controllers\API\V0_5\Career\CareerTransitionPreviewController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
 use App\Http\Controllers\API\V0_5\Cms\CareerGuideController;
 use App\Http\Controllers\API\V0_5\Cms\CareerJobController;
@@ -406,6 +407,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);
     Route::get('/career/recommendations/mbti', [CareerRecommendationIndexController::class, 'index']);
     Route::get('/career/recommendations/mbti/{type}', [CareerRecommendationDetailController::class, 'show']);
+    Route::get('/career/transition-preview', [CareerTransitionPreviewController::class, 'show']);
     Route::get('/career/search', [CareerSearchController::class, 'index']);
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
+++ b/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\RecommendationSnapshot;
+use App\Models\TransitionPath;
+use App\Services\Career\CareerRecommendationCompiler;
+use App\Services\Career\CareerTransitionPreviewReadinessLookup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerTransitionPreviewApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_a_compact_transition_preview_for_an_eligible_subject(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-api-publish-ready');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+        ]);
+
+        $this->getJson('/api/v0.5/career/transition-preview?type=intj')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_transition_preview')
+            ->assertJsonPath('bundle_version', 'career.protocol.transition_preview.v1')
+            ->assertJsonPath('path_type', 'stable_upside')
+            ->assertJsonPath('target_job.canonical_slug', 'registered-nurses')
+            ->assertJsonPath('trust_summary.allow_transition_recommendation', true)
+            ->assertJsonPath('seo_contract.index_eligible', true)
+            ->assertJsonStructure([
+                'path_type',
+                'target_job' => ['occupation_uuid', 'canonical_slug', 'title'],
+                'score_summary' => [
+                    'mobility_score' => ['value', 'integrity_state', 'band'],
+                    'confidence_score' => ['value', 'integrity_state', 'band'],
+                ],
+                'trust_summary' => ['allow_transition_recommendation', 'reviewer_status', 'reason_codes'],
+                'seo_contract' => ['canonical_path', 'canonical_target', 'index_state', 'index_eligible', 'reason_codes'],
+                'provenance_meta' => ['recommendation_snapshot_id', 'transition_path_id', 'compiler_version', 'compile_run_id'],
+            ])
+            ->assertJsonMissingPath('why_this_path')
+            ->assertJsonMissingPath('what_is_lost')
+            ->assertJsonMissingPath('bridge_steps_90d');
+    }
+
+    public function test_it_returns_not_found_when_no_safe_preview_exists(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-api-blocked');
+        $target = $this->seedTargetOccupation('software-developers', 'Software Developers');
+        $this->mockReadinessSummary([
+            $this->readinessRow('software-developers', 'blocked_override_eligible', false, 'noindex', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+        ]);
+
+        $this->getJson('/api/v0.5/career/transition-preview?type=intj')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_it_validates_the_required_type_query_param(): void
+    {
+        $this->getJson('/api/v0.5/career/transition-preview')
+            ->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'VALIDATION_FAILED');
+    }
+
+    private function seedTargetOccupation(string $slug, string $title): Occupation
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+        $chain['occupation']->update([
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+        ]);
+
+        return $chain['occupation']->fresh();
+    }
+
+    private function compileRecommendationChain(string $slug): RecommendationSnapshot
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-transition-api-'.$slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'materialization' => 'career_first_wave',
+                    'recommendation_subject_meta' => [
+                        'type_code' => 'INTJ-A',
+                        'canonical_type_code' => 'INTJ',
+                        'display_title' => 'INTJ-A Career Match',
+                        'public_route_slug' => 'intj',
+                    ],
+                ],
+            ),
+        ]);
+
+        return app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $occupations
+     */
+    private function mockReadinessSummary(array $occupations): void
+    {
+        $lookup = Mockery::mock(CareerTransitionPreviewReadinessLookup::class);
+        foreach ($occupations as $row) {
+            $lookup->shouldReceive('bySlug')
+                ->with((string) ($row['canonical_slug'] ?? ''))
+                ->andReturn($row);
+        }
+        $lookup->shouldReceive('bySlug')->andReturn(null);
+
+        $this->app->instance(CareerTransitionPreviewReadinessLookup::class, $lookup);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readinessRow(
+        string $canonicalSlug,
+        string $status,
+        bool $indexEligible,
+        string $indexState,
+        string $reviewerStatus,
+    ): array {
+        return [
+            'occupation_uuid' => 'uuid-'.$canonicalSlug,
+            'canonical_slug' => $canonicalSlug,
+            'canonical_title_en' => $canonicalSlug,
+            'status' => $status,
+            'blocker_type' => null,
+            'remediation_class' => null,
+            'authority_override_supplied' => false,
+            'review_required' => false,
+            'crosswalk_mode' => 'exact',
+            'reviewer_status' => $reviewerStatus,
+            'index_state' => $indexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => [$status],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\RecommendationSnapshot;
+use App\Models\TransitionPath;
+use App\Services\Career\Bundles\CareerTransitionPreviewBundleBuilder;
+use App\Services\Career\CareerRecommendationCompiler;
+use App\Services\Career\CareerTransitionPreviewReadinessLookup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerTransitionPreviewBundleBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_minimal_publish_ready_transition_preview(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-source-publish-ready');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+        ]);
+
+        $payload = app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
+
+        $this->assertSame('career_transition_preview', $payload['bundle_kind']);
+        $this->assertSame('career.protocol.transition_preview.v1', $payload['bundle_version']);
+        $this->assertSame('stable_upside', $payload['path_type']);
+        $this->assertSame('registered-nurses', data_get($payload, 'target_job.canonical_slug'));
+        $this->assertSame(true, data_get($payload, 'trust_summary.allow_transition_recommendation'));
+        $this->assertSame('publish_ready', data_get($payload, 'seo_contract.reason_codes.0'));
+        $this->assertSame(true, data_get($payload, 'seo_contract.index_eligible'));
+        $this->assertSame($snapshot->id, data_get($payload, 'provenance_meta.recommendation_snapshot_id'));
+        $this->assertNotNull(data_get($payload, 'score_summary.mobility_score.value'));
+        $this->assertNull(data_get($payload, 'why_this_path'));
+        $this->assertNull(data_get($payload, 'what_is_lost'));
+        $this->assertNull(data_get($payload, 'bridge_steps_90d'));
+    }
+
+    public function test_it_excludes_blocked_override_eligible_targets(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-source-override');
+        $target = $this->seedTargetOccupation('software-developers', 'Software Developers');
+        $this->mockReadinessSummary([
+            $this->readinessRow('software-developers', 'blocked_override_eligible', false, 'noindex', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+        ]);
+
+        $this->assertNull(app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj'));
+    }
+
+    public function test_it_excludes_blocked_not_safely_remediable_targets(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-source-blocked');
+        $target = $this->seedTargetOccupation('marketing-managers', 'Marketing Managers');
+        $this->mockReadinessSummary([
+            $this->readinessRow('marketing-managers', 'blocked_not_safely_remediable', false, 'noindex', 'pending'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+        ]);
+
+        $this->assertNull(app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj'));
+    }
+
+    public function test_it_excludes_paths_when_transition_claim_permission_is_not_allowed(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-source-no-claim');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
+        $payload['claim_permissions']['allow_transition_recommendation'] = false;
+        $snapshot->update(['snapshot_payload' => $payload]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+        ]);
+
+        $this->assertNull(app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj'));
+    }
+
+    private function seedTargetOccupation(string $slug, string $title): Occupation
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+        $chain['occupation']->update([
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+        ]);
+
+        return $chain['occupation']->fresh();
+    }
+
+    private function compileRecommendationChain(string $slug): RecommendationSnapshot
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-transition-preview-'.$slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'materialization' => 'career_first_wave',
+                    'recommendation_subject_meta' => [
+                        'type_code' => 'INTJ-A',
+                        'canonical_type_code' => 'INTJ',
+                        'display_title' => 'INTJ-A Career Match',
+                        'public_route_slug' => 'intj',
+                    ],
+                ],
+            ),
+        ]);
+
+        return app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $occupations
+     */
+    private function mockReadinessSummary(array $occupations): void
+    {
+        $lookup = Mockery::mock(CareerTransitionPreviewReadinessLookup::class);
+        foreach ($occupations as $row) {
+            $lookup->shouldReceive('bySlug')
+                ->with((string) ($row['canonical_slug'] ?? ''))
+                ->andReturn($row);
+        }
+        $lookup->shouldReceive('bySlug')->andReturn(null);
+
+        $this->app->instance(CareerTransitionPreviewReadinessLookup::class, $lookup);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readinessRow(
+        string $canonicalSlug,
+        string $status,
+        bool $indexEligible,
+        string $indexState,
+        string $reviewerStatus,
+    ): array {
+        return [
+            'occupation_uuid' => 'uuid-'.$canonicalSlug,
+            'canonical_slug' => $canonicalSlug,
+            'canonical_title_en' => $canonicalSlug,
+            'status' => $status,
+            'blocker_type' => null,
+            'remediation_class' => null,
+            'authority_override_supplied' => false,
+            'review_required' => false,
+            'crosswalk_mode' => 'exact',
+            'reviewer_status' => $reviewerStatus,
+            'index_state' => $indexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => [$status],
+        ];
+    }
+}


### PR DESCRIPTION
## What changed
- add a backend-owned Career transition preview surface with a compact typed bundle and a dedicated `GET /api/v0.5/career/transition-preview` endpoint
- build the preview from authoritative transition rows plus existing recommendation snapshot scores, claim permissions, provenance, and first-wave readiness truth
- keep the preview first-wave-only and publish-ready-gated so blocked and override-eligible blocked targets do not leak into a public-safe transition surface
- add focused builder and API coverage, and update the OpenAPI snapshot for the new endpoint

## Why
- the backend already had `transition_paths`, recommendation authority, `mobility_score`, `confidence_score`, and `allow_transition_recommendation`, but it did not yet expose a backend-owned transition preview surface
- this PR fills that gap without mutating existing jobs/recommendations/search/detail contracts and without inventing narrative path semantics that the backend does not yet authoritatively support
- the result is a minimal, credible transition preview contract that frontend can consume later without depending on CMS or controller-time copy assembly

## Validation
- `vendor/bin/pint --test app/DTO/Career/CareerTransitionPreviewBundle.php app/Http/Resources/Career/CareerTransitionPreviewResource.php app/Services/Career/CareerTransitionPreviewReadinessLookup.php app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php app/Http/Controllers/API/V0_5/Career/CareerTransitionPreviewController.php routes/api.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerRecommendationIndexApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no free-form transition narrative fields such as `why_this_path`, `what_is_lost`, or `bridge_steps_90d`
- no changes to scoring formulas, ranking semantics, or existing jobs/recommendations/search/detail payloads
- no strategy-pack orchestration, frontend wiring, or transition UI work
