### PR TITLE
PR-B17: Career transition preview attribution taxonomy + daily read model extension

### DIFF
--- a/backend/app/Services/Analytics/CareerAttributionEventMapper.php
+++ b/backend/app/Services/Analytics/CareerAttributionEventMapper.php
@@ -23,6 +23,8 @@ final class CareerAttributionEventMapper
         'career_job_detail_cta_click',
         'career_recommendation_result_click',
         'career_recommendation_matched_job_click',
+        'career_transition_preview_view',
+        'career_transition_preview_target_click',
         'career_ready_surface_exposed',
         'career_blocked_surface_exposed',
     ];

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T04:55:00Z",
+  "updated_at": "2026-04-11T04:59:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -192,10 +192,10 @@
     "PR-B17": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b17-career-transition-preview-attribution-daily-extension",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "0025ed318a6b077b1d059b58d6fcce718605b60e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/859",
       "checks": {
         "local": [
           {
@@ -207,9 +207,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24274977919/job/70887163190"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24274977919/job/70887166440"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions jobs were not started successfully; hygiene failed immediately and MBTI verification was skipped, consistent with the current repository CI/billing blockage.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-10T10:25:00Z",
+  "updated_at": "2026-04-11T04:55:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -184,6 +184,32 @@
         ]
       },
       "failure_reason": "GitHub hygiene check failed because CAE/H-02 guard reported backend/.env exists in workspace.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B17": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b17-career-transition-preview-attribution-daily-extension",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -160,6 +160,31 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B17
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b17-career-transition-preview-attribution-daily-extension
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career transition preview attribution taxonomy + daily read model extension.
+      Extend the B15 Career attribution taxonomy so transition preview view/click
+      events are accepted and aggregated distinctly without changing table grain,
+      public payloads, scoring, or transition preview API contracts.
+    checks:
+      - "vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php"
+      - "php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
@@ -58,10 +58,24 @@ final class CareerAttributionDailyBuilderTest extends TestCase
             'subject_key' => 'intj',
             'query_mode' => 'non_query',
         ], 'anon_d', 'session_d');
+        $this->insertCareerEvent($orgId, 'career_transition_preview_view', $day->copy()->addMinutes(5), [
+            'entry_surface' => 'career_recommendation_detail_transition_preview',
+            'route_family' => 'recommendation_detail',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'registered-nurses',
+            'query_mode' => 'non_query',
+        ], 'anon_e', 'session_e');
+        $this->insertCareerEvent($orgId, 'career_transition_preview_target_click', $day->copy()->addMinutes(6), [
+            'entry_surface' => 'career_recommendation_detail_transition_preview',
+            'route_family' => 'recommendation_detail',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'registered-nurses',
+            'query_mode' => 'non_query',
+        ], 'anon_f', 'session_f');
 
         $result = app(CareerAttributionDailyBuilder::class)->refresh($day, $day, [$orgId], false);
 
-        $this->assertSame(4, (int) ($result['upserted_rows'] ?? 0));
+        $this->assertSame(6, (int) ($result['upserted_rows'] ?? 0));
 
         $readyRow = DB::table('analytics_career_attribution_daily')
             ->where('day', $day->toDateString())
@@ -103,6 +117,28 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         $this->assertNotNull($recommendationRow);
         $this->assertSame('recommendation_type', $recommendationRow->subject_kind);
         $this->assertSame('unknown', $recommendationRow->readiness_class);
+
+        $transitionPreviewViewRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_transition_preview_view')
+            ->where('subject_key', 'registered-nurses')
+            ->first();
+
+        $this->assertNotNull($transitionPreviewViewRow);
+        $this->assertSame('career_recommendation_detail_transition_preview', $transitionPreviewViewRow->surface);
+        $this->assertSame('recommendation_detail', $transitionPreviewViewRow->route_family);
+        $this->assertSame('job_slug', $transitionPreviewViewRow->subject_kind);
+        $this->assertSame('publish_ready', $transitionPreviewViewRow->readiness_class);
+
+        $transitionPreviewClickRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_transition_preview_target_click')
+            ->where('subject_key', 'registered-nurses')
+            ->first();
+
+        $this->assertNotNull($transitionPreviewClickRow);
+        $this->assertSame('career_recommendation_detail_transition_preview', $transitionPreviewClickRow->surface);
+        $this->assertSame('recommendation_detail', $transitionPreviewClickRow->route_family);
+        $this->assertSame('job_slug', $transitionPreviewClickRow->subject_kind);
+        $this->assertSame('publish_ready', $transitionPreviewClickRow->readiness_class);
     }
 
     private function materializeCurrentFirstWaveFixture(): void

--- a/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
@@ -104,6 +104,93 @@ final class CareerAttributionEventIngestTest extends TestCase
         $this->assertSame('software-developers', $meta['subject_key'] ?? null);
     }
 
+    public function test_ingest_endpoint_accepts_transition_preview_events_without_collapsing_them_into_other_recommendation_events(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $viewResponse = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.5/career/attribution/events', [
+            'eventName' => 'career_transition_preview_view',
+            'anonymousId' => 'anon_b17_001',
+            'path' => '/en/career/recommendations/mbti/intj-a',
+            'timestamp' => '2026-04-11T09:00:00+08:00',
+            'payload' => [
+                'entry_surface' => 'career_recommendation_detail_transition_preview',
+                'source_page_type' => 'career_recommendation_detail',
+                'target_action' => 'view_transition_preview',
+                'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                'route_family' => 'recommendation_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'registered-nurses',
+                'query_mode' => 'non_query',
+                'locale' => 'en',
+            ],
+        ]);
+
+        $clickResponse = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.5/career/attribution/events', [
+            'eventName' => 'career_transition_preview_target_click',
+            'anonymousId' => 'anon_b17_002',
+            'path' => '/en/career/recommendations/mbti/intj-a',
+            'timestamp' => '2026-04-11T09:01:00+08:00',
+            'payload' => [
+                'entry_surface' => 'career_recommendation_detail_transition_preview',
+                'source_page_type' => 'career_recommendation_detail',
+                'target_action' => 'open_transition_target_job',
+                'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                'route_family' => 'recommendation_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'registered-nurses',
+                'query_mode' => 'non_query',
+                'locale' => 'en',
+            ],
+        ]);
+
+        $viewResponse->assertStatus(202)
+            ->assertJsonPath('event_code', 'career_transition_preview_view');
+        $clickResponse->assertStatus(202)
+            ->assertJsonPath('event_code', 'career_transition_preview_target_click');
+
+        $viewRow = DB::table('events')
+            ->where('event_code', 'career_transition_preview_view')
+            ->where('anon_id', 'anon_b17_001')
+            ->first();
+        $clickRow = DB::table('events')
+            ->where('event_code', 'career_transition_preview_target_click')
+            ->where('anon_id', 'anon_b17_002')
+            ->first();
+
+        $this->assertNotNull($viewRow);
+        $this->assertNotNull($clickRow);
+        $this->assertDatabaseMissing('events', [
+            'event_code' => 'career_recommendation_result_click',
+            'anon_id' => 'anon_b17_001',
+        ]);
+        $this->assertDatabaseMissing('events', [
+            'event_code' => 'career_recommendation_matched_job_click',
+            'anon_id' => 'anon_b17_002',
+        ]);
+
+        $viewMeta = is_array($viewRow->meta_json ?? null)
+            ? $viewRow->meta_json
+            : (json_decode((string) ($viewRow->meta_json ?? '{}'), true) ?: []);
+        $clickMeta = is_array($clickRow->meta_json ?? null)
+            ? $clickRow->meta_json
+            : (json_decode((string) ($clickRow->meta_json ?? '{}'), true) ?: []);
+
+        $this->assertSame('career_recommendation_detail_transition_preview', $viewMeta['entry_surface'] ?? null);
+        $this->assertSame('view_transition_preview', $viewMeta['target_action'] ?? null);
+        $this->assertSame('job_slug', $viewMeta['subject_kind'] ?? null);
+        $this->assertSame('registered-nurses', $viewMeta['subject_key'] ?? null);
+
+        $this->assertSame('career_recommendation_detail_transition_preview', $clickMeta['entry_surface'] ?? null);
+        $this->assertSame('open_transition_target_job', $clickMeta['target_action'] ?? null);
+        $this->assertSame('job_slug', $clickMeta['subject_kind'] ?? null);
+        $this->assertSame('registered-nurses', $clickMeta['subject_key'] ?? null);
+    }
+
     public function test_ingest_endpoint_rejects_invalid_event_name(): void
     {
         config()->set('fap.events.ingest_token', 'ingest_test_token');


### PR DESCRIPTION
## What changed
- extend the Career attribution taxonomy with two distinct transition preview events: `career_transition_preview_view` and `career_transition_preview_target_click`
- update the Career attribution ingest mapper allowlist so the backend accepts those new events without collapsing them into recommendation result clicks or matched-job clicks
- extend the Career attribution daily builder coverage through focused analytics tests so transition preview view/click rows aggregate separately under the existing daily grain
- record the B17 manifest/state entry in the PR train ledger with the local verification results

## Why
- B15 already introduced backend-owned Career attribution ingest and daily aggregation, and B16/F11 introduced a real transition preview surface on recommendation detail
- without B17, transition preview behavior would remain outside the official Career attribution taxonomy, or worse, be forced into existing matched-job/recommendation click semantics
- this PR closes that gap with the smallest safe backend change: taxonomy extension plus analytics test coverage, with no schema redesign and no public payload changes

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php`
- `php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`

## Intentionally deferred
- no analytics table grain or schema changes
- no preview-absent or preview-suppressed event family
- no frontend changes and no transition preview API contract changes
- no dashboard/reporting or broader analytics redesign
