### PR TITLE
PR-B18: Career transition path taxonomy + typed payload hardening

### DIFF
--- a/backend/app/Domain/Career/Transition/TransitionPathPayload.php
+++ b/backend/app/Domain/Career/Transition/TransitionPathPayload.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Transition;
+
+final class TransitionPathPayload
+{
+    /**
+     * @param  list<string>  $steps
+     */
+    private function __construct(
+        public readonly array $steps,
+    ) {}
+
+    public static function from(mixed $payload): self
+    {
+        if (! is_array($payload)) {
+            return new self([]);
+        }
+
+        $steps = [];
+        foreach ((array) ($payload['steps'] ?? []) as $step) {
+            if (! is_string($step)) {
+                continue;
+            }
+
+            $normalized = trim($step);
+            if ($normalized === '') {
+                continue;
+            }
+
+            $steps[] = $normalized;
+        }
+
+        return new self(array_values($steps));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if ($this->steps === []) {
+            return [];
+        }
+
+        return [
+            'steps' => $this->steps,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Transition/TransitionPathType.php
+++ b/backend/app/Domain/Career/Transition/TransitionPathType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Transition;
+
+enum TransitionPathType: string
+{
+    case StableUpside = 'stable_upside';
+
+    public static function tryNormalize(mixed $value): ?self
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim(strtolower($value));
+        if ($normalized === '') {
+            return null;
+        }
+
+        return self::tryFrom($normalized);
+    }
+}

--- a/backend/app/Models/TransitionPath.php
+++ b/backend/app/Models/TransitionPath.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Domain\Career\Transition\TransitionPathPayload;
+use App\Domain\Career\Transition\TransitionPathType;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TransitionPath extends CareerImmutableFoundationModel
@@ -28,5 +30,20 @@ class TransitionPath extends CareerImmutableFoundationModel
     public function toOccupation(): BelongsTo
     {
         return $this->belongsTo(Occupation::class, 'to_occupation_id', 'id');
+    }
+
+    public function transitionPathType(): ?TransitionPathType
+    {
+        return TransitionPathType::tryNormalize($this->path_type);
+    }
+
+    public function normalizedPathPayload(): TransitionPathPayload
+    {
+        return TransitionPathPayload::from($this->path_payload);
+    }
+
+    public function hasValidPathPayloadShape(): bool
+    {
+        return $this->path_payload === null || is_array($this->path_payload);
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\Transition\TransitionPathType;
 use App\DTO\Career\CareerTransitionPreviewBundle;
 use App\Models\RecommendationSnapshot;
 use App\Models\TransitionPath;
@@ -83,10 +84,16 @@ final class CareerTransitionPreviewBundleBuilder
             return null;
         }
 
-        $pathType = trim((string) $path->path_type);
-        if ($pathType === '') {
+        $pathType = $path->transitionPathType();
+        if (! $pathType instanceof TransitionPathType) {
             return null;
         }
+
+        if (! $path->hasValidPathPayloadShape()) {
+            return null;
+        }
+
+        $normalizedPathPayload = $path->normalizedPathPayload();
 
         $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
         $claimPermissions = is_array($payload['claim_permissions'] ?? null) ? $payload['claim_permissions'] : [];
@@ -103,12 +110,15 @@ final class CareerTransitionPreviewBundleBuilder
             return null;
         }
 
+        // Normalize internal authority payloads before any future richer transition surfaces consume them.
+        $normalizedPathPayload->toArray();
+
         $scoreBundle = is_array($payload['score_bundle'] ?? null) ? $payload['score_bundle'] : [];
         $reasonCodes = is_array($claimPermissions['reason_codes'] ?? null) ? array_values($claimPermissions['reason_codes']) : [];
         $seoReasonCodes = is_array($readiness['reason_codes'] ?? null) ? array_values($readiness['reason_codes']) : [];
 
         return new CareerTransitionPreviewBundle(
-            pathType: $pathType,
+            pathType: $pathType->value,
             targetJob: [
                 'occupation_uuid' => $targetOccupation->id,
                 'canonical_slug' => $targetOccupation->canonical_slug,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -242,6 +242,32 @@
       "merged_at": "",
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-B18": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b18-career-transition-path-taxonomy-typed-payload-hardening",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Transition/TransitionPathType.php app/Domain/Career/Transition/TransitionPathPayload.php app/Models/TransitionPath.php app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php tests/Unit/Domain/Career/Transition/TransitionPathTypeTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Domain/Career/Transition/TransitionPathTypeTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -246,10 +246,10 @@
     "PR-B18": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b18-career-transition-path-taxonomy-typed-payload-hardening",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "031da8de58fc7cf2c227992a919907f24dcdf0a8",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/860",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -248,7 +248,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open",
       "branch": "codex/pr-b18-career-transition-path-taxonomy-typed-payload-hardening",
-      "commit_sha": "031da8de58fc7cf2c227992a919907f24dcdf0a8",
+      "commit_sha": "ea7193830652f08805388e2c5bc782235e3462b5",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/860",
       "checks": {
         "local": [
@@ -261,9 +261,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24276237349/job/70890571627"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24276237349/job/70890574237"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately with no executable steps and the verify-mbti matrix job was skipped, matching the current repository workflow-start failure pattern rather than a locally reproducible B18 regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -185,6 +185,31 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B18
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b18-career-transition-path-taxonomy-typed-payload-hardening
+    base: main
+    depends_on: ["PR-B17"]
+    mode: execute
+    scope: >
+      Career transition path taxonomy + typed payload hardening.
+      Introduce internal typed transition taxonomy/payload normalization behind
+      the existing B16 preview surface without expanding the public API,
+      changing schema, or adding narrative transition fields.
+    checks:
+      - "vendor/bin/pint --test app/Domain/Career/Transition/TransitionPathType.php app/Domain/Career/Transition/TransitionPathPayload.php app/Models/TransitionPath.php app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php tests/Unit/Domain/Career/Transition/TransitionPathTypeTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php"
+      - "php artisan test tests/Unit/Domain/Career/Transition/TransitionPathTypeTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
+++ b/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
@@ -55,6 +55,7 @@ final class CareerTransitionPreviewApiTest extends TestCase
                 'seo_contract' => ['canonical_path', 'canonical_target', 'index_state', 'index_eligible', 'reason_codes'],
                 'provenance_meta' => ['recommendation_snapshot_id', 'transition_path_id', 'compiler_version', 'compile_run_id'],
             ])
+            ->assertJsonMissingPath('steps')
             ->assertJsonMissingPath('why_this_path')
             ->assertJsonMissingPath('what_is_lost')
             ->assertJsonMissingPath('bridge_steps_90d');
@@ -88,6 +89,50 @@ final class CareerTransitionPreviewApiTest extends TestCase
             ->assertStatus(422)
             ->assertJsonPath('ok', false)
             ->assertJsonPath('error_code', 'VALIDATION_FAILED');
+    }
+
+    public function test_it_returns_not_found_for_unknown_internal_path_taxonomy_even_when_transition_rows_exist(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-api-invalid-taxonomy');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'bridge_path',
+            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+        ]);
+
+        $this->getJson('/api/v0.5/career/transition-preview?type=intj')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_it_returns_not_found_for_invalid_non_array_payload_shape_even_when_transition_rows_exist(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-api-invalid-payload-shape');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => 'invalid-string-payload',
+        ]);
+
+        $this->getJson('/api/v0.5/career/transition-preview?type=intj')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
     private function seedTargetOccupation(string $slug, string $title): Occupation

--- a/backend/tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php
+++ b/backend/tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Transition;
+
+use App\Domain\Career\Transition\TransitionPathPayload;
+use PHPUnit\Framework\TestCase;
+
+final class TransitionPathPayloadTest extends TestCase
+{
+    public function test_it_accepts_missing_payload_and_returns_an_empty_normalized_shape(): void
+    {
+        $this->assertSame([], TransitionPathPayload::from(null)->toArray());
+        $this->assertSame([], TransitionPathPayload::from('invalid')->toArray());
+        $this->assertSame([], TransitionPathPayload::from([])->toArray());
+    }
+
+    public function test_it_accepts_steps_as_a_list_of_strings(): void
+    {
+        $payload = TransitionPathPayload::from([
+            'steps' => [' deepen system design ', 'lead more cross-team decisions'],
+        ]);
+
+        $this->assertSame([
+            'steps' => [
+                'deepen system design',
+                'lead more cross-team decisions',
+            ],
+        ], $payload->toArray());
+    }
+
+    public function test_it_strips_invalid_steps_and_ignores_richer_narrative_fields(): void
+    {
+        $payload = TransitionPathPayload::from([
+            'steps' => ['valid step', 42, '', null, ' second step '],
+            'why_this_path' => 'fixture-only narrative',
+            'what_is_lost' => 'fixture-only tradeoff copy',
+            'bridge_steps_90d' => ['not authoritative'],
+        ]);
+
+        $this->assertSame([
+            'steps' => [
+                'valid step',
+                'second step',
+            ],
+        ], $payload->toArray());
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Transition/TransitionPathTypeTest.php
+++ b/backend/tests/Unit/Domain/Career/Transition/TransitionPathTypeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Transition;
+
+use App\Domain\Career\Transition\TransitionPathType;
+use PHPUnit\Framework\TestCase;
+
+final class TransitionPathTypeTest extends TestCase
+{
+    public function test_it_accepts_the_current_authoritative_transition_path_type(): void
+    {
+        $this->assertSame(
+            TransitionPathType::StableUpside,
+            TransitionPathType::tryNormalize('stable_upside')
+        );
+        $this->assertSame(
+            TransitionPathType::StableUpside,
+            TransitionPathType::tryNormalize(' Stable_Upside ')
+        );
+    }
+
+    public function test_it_rejects_blank_or_unknown_transition_path_types(): void
+    {
+        $this->assertNull(TransitionPathType::tryNormalize(''));
+        $this->assertNull(TransitionPathType::tryNormalize('   '));
+        $this->assertNull(TransitionPathType::tryNormalize('bridge_path'));
+        $this->assertNull(TransitionPathType::tryNormalize('hedge_path'));
+        $this->assertNull(TransitionPathType::tryNormalize(null));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
@@ -114,6 +114,74 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
         $this->assertNull(app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj'));
     }
 
+    public function test_it_excludes_paths_with_blank_or_unknown_internal_path_taxonomy(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-source-invalid-taxonomy');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'bridge_path',
+            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+        ]);
+
+        $this->assertNull(app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj'));
+    }
+
+    public function test_it_sanitizes_internal_path_payload_without_expanding_public_preview_fields(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-source-sanitized-payload');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => [
+                'steps' => ['first valid step', 99, ' second valid step '],
+                'why_this_path' => 'fixture-only narrative',
+                'what_is_lost' => 'fixture-only tradeoff',
+                'bridge_steps_90d' => ['not authoritative'],
+            ],
+        ]);
+
+        $payload = app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
+
+        $this->assertSame('stable_upside', $payload['path_type'] ?? null);
+        $this->assertArrayNotHasKey('steps', $payload);
+        $this->assertArrayNotHasKey('why_this_path', $payload);
+        $this->assertArrayNotHasKey('what_is_lost', $payload);
+        $this->assertArrayNotHasKey('bridge_steps_90d', $payload);
+    }
+
+    public function test_it_excludes_paths_with_invalid_non_array_payload_shape(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-source-invalid-payload-shape');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => 'invalid-string-payload',
+        ]);
+
+        $this->assertNull(app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj'));
+    }
+
     private function seedTargetOccupation(string $slug, string $title): Occupation
     {
         $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);


### PR DESCRIPTION
## What changed
- add an internal typed transition path taxonomy that currently locks authoritative path types to `stable_upside`
- add an internal transition path payload normalizer that only recognizes an optional `steps` list and strips richer narrative-like payload fields from trusted authority
- harden the transition preview builder to consume typed path taxonomy and reject invalid payload shapes without expanding the B16 public API
- extend unit and feature coverage for taxonomy validation, payload normalization, invalid payload rejection, and B16 preview regression safety
- register B18 in the PR train manifest/state and record local verification results

## Why
- B16 already exposes a minimal safe transition preview, but the underlying `transition_paths` authority was still relying on raw `path_type` strings and untyped JSON payloads
- this PR hardens that internal authority layer first so future transition surfaces can build on a typed backend contract instead of fixture-like payload conventions
- the scope stays intentionally narrow: no schema changes, no narrative expansion, and no public response growth

## Validation
- `vendor/bin/pint --test app/Domain/Career/Transition/TransitionPathType.php app/Domain/Career/Transition/TransitionPathPayload.php app/Models/TransitionPath.php app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php tests/Unit/Domain/Career/Transition/TransitionPathTypeTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`
- `php artisan test tests/Unit/Domain/Career/Transition/TransitionPathTypeTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`

## Intentionally deferred
- no B16 public contract expansion and no OpenAPI snapshot update
- no DB schema/migration changes
- no narrative fields such as `why_this_path`, `what_is_lost`, `bridge_steps_90d`, or public `steps`
- no attribution, frontend, or scoring changes
