### PR TITLE
PR-B20: Career transition preview public contract hardening

### DIFF
--- a/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
+++ b/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
@@ -6,6 +6,24 @@ namespace App\DTO\Career;
 
 final class CareerTransitionPreviewBundle
 {
+    private const BUNDLE_KIND = 'career_transition_preview';
+
+    private const BUNDLE_VERSION = 'career.protocol.transition_preview.v1';
+
+    /**
+     * @var list<string>
+     */
+    private const PUBLIC_TOP_LEVEL_KEYS = [
+        'bundle_kind',
+        'bundle_version',
+        'path_type',
+        'target_job',
+        'score_summary',
+        'trust_summary',
+        'seo_contract',
+        'provenance_meta',
+    ];
+
     /**
      * @param  array<string, mixed>  $targetJob
      * @param  array<string, mixed>  $scoreSummary
@@ -27,9 +45,9 @@ final class CareerTransitionPreviewBundle
      */
     public function toArray(): array
     {
-        return [
-            'bundle_kind' => 'career_transition_preview',
-            'bundle_version' => 'career.protocol.transition_preview.v1',
+        $payload = [
+            'bundle_kind' => self::BUNDLE_KIND,
+            'bundle_version' => self::BUNDLE_VERSION,
             'path_type' => $this->pathType,
             'target_job' => $this->targetJob,
             'score_summary' => $this->scoreSummary,
@@ -37,5 +55,18 @@ final class CareerTransitionPreviewBundle
             'seo_contract' => $this->seoContract,
             'provenance_meta' => $this->provenanceMeta,
         ];
+
+        /** @var array<string, mixed> $publicPayload */
+        $publicPayload = array_intersect_key($payload, array_flip(self::PUBLIC_TOP_LEVEL_KEYS));
+
+        return $publicPayload;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function publicTopLevelKeys(): array
+    {
+        return self::PUBLIC_TOP_LEVEL_KEYS;
     }
 }

--- a/backend/app/Http/Resources/Career/CareerTransitionPreviewResource.php
+++ b/backend/app/Http/Resources/Career/CareerTransitionPreviewResource.php
@@ -23,6 +23,9 @@ final class CareerTransitionPreviewResource extends JsonResource
         /** @var CareerTransitionPreviewBundle $bundle */
         $bundle = $this->resource;
 
-        return $bundle->toArray();
+        return array_intersect_key(
+            $bundle->toArray(),
+            array_flip(CareerTransitionPreviewBundle::publicTopLevelKeys()),
+        );
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
@@ -89,6 +89,10 @@ final class CareerTransitionPreviewBundleBuilder
             return null;
         }
 
+        if (! $this->isPublicPathTypeAllowed($pathType)) {
+            return null;
+        }
+
         if (! $path->hasValidPathPayloadShape()) {
             return null;
         }
@@ -169,5 +173,10 @@ final class CareerTransitionPreviewBundleBuilder
             'integrity_state' => $value['integrity_state'] ?? null,
             'band' => $value['band'] ?? null,
         ];
+    }
+
+    private function isPublicPathTypeAllowed(TransitionPathType $pathType): bool
+    {
+        return $pathType === TransitionPathType::StableUpside;
     }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T06:50:00Z",
+  "updated_at": "2026-04-11T07:00:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -328,10 +328,10 @@
     "PR-B20": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b20-career-transition-preview-public-contract-hardening",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "6132e0180b71293ebe592bc251b941bd8e3fe895",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/862",
       "checks": {
         "local": [
           {
@@ -343,9 +343,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24276937992/job/70892406549"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24276937992/job/70892408459"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately again and the MBTI matrix job was skipped; local B20 verification passed and the failure pattern matches the current repository workflow-start issue rather than a locally reproducible regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T06:31:30Z",
+  "updated_at": "2026-04-11T06:50:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -320,6 +320,32 @@
         ]
       },
       "failure_reason": "GitHub hygiene failed immediately again and the MBTI matrix job was skipped; local B19 verification passed and the failure pattern matches the current repository workflow-start issue rather than a locally reproducible regression.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B20": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b20-career-transition-preview-public-contract-hardening",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php app/DTO/Career/CareerTransitionPreviewBundle.php app/Http/Resources/Career/CareerTransitionPreviewResource.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -236,6 +236,31 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B20
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b20-career-transition-preview-public-contract-hardening
+    base: main
+    depends_on: ["PR-B19"]
+    mode: execute
+    scope: >
+      Career transition preview public contract hardening.
+      Tighten the existing B16 preview public contract so it stays aligned with
+      B19 production-written transition truth without expanding fields, changing
+      schema, or exposing internal payload richness.
+    checks:
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php app/DTO/Career/CareerTransitionPreviewBundle.php app/Http/Resources/Career/CareerTransitionPreviewResource.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
+++ b/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\DTO\Career\CareerTransitionPreviewBundle;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\Occupation;
@@ -36,7 +37,7 @@ final class CareerTransitionPreviewApiTest extends TestCase
             'path_payload' => ['steps' => ['fixture-only transition evidence']],
         ]);
 
-        $this->getJson('/api/v0.5/career/transition-preview?type=intj')
+        $response = $this->getJson('/api/v0.5/career/transition-preview?type=intj')
             ->assertOk()
             ->assertJsonPath('bundle_kind', 'career_transition_preview')
             ->assertJsonPath('bundle_version', 'career.protocol.transition_preview.v1')
@@ -59,6 +60,10 @@ final class CareerTransitionPreviewApiTest extends TestCase
             ->assertJsonMissingPath('why_this_path')
             ->assertJsonMissingPath('what_is_lost')
             ->assertJsonMissingPath('bridge_steps_90d');
+
+        /** @var array<string, mixed> $payload */
+        $payload = $response->json();
+        $this->assertSame(CareerTransitionPreviewBundle::publicTopLevelKeys(), array_keys($payload));
     }
 
     public function test_it_returns_not_found_when_no_safe_preview_exists(): void

--- a/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career;
 
+use App\DTO\Career\CareerTransitionPreviewBundle;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\Occupation;
@@ -39,6 +40,7 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
 
         $payload = app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
 
+        $this->assertSame(CareerTransitionPreviewBundle::publicTopLevelKeys(), array_keys($payload));
         $this->assertSame('career_transition_preview', $payload['bundle_kind']);
         $this->assertSame('career.protocol.transition_preview.v1', $payload['bundle_version']);
         $this->assertSame('stable_upside', $payload['path_type']);
@@ -156,6 +158,7 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
 
         $payload = app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
 
+        $this->assertSame(CareerTransitionPreviewBundle::publicTopLevelKeys(), array_keys($payload));
         $this->assertSame('stable_upside', $payload['path_type'] ?? null);
         $this->assertArrayNotHasKey('steps', $payload);
         $this->assertArrayNotHasKey('why_this_path', $payload);


### PR DESCRIPTION
## What changed
- harden the B16 transition preview public contract without expanding its response shape
- explicitly restrict public preview `path_type` semantics to the currently production-written value `stable_upside`
- add defensive DTO/resource allowlists so richer internal or fixture-only payload fields cannot leak into the serialized preview response
- strengthen builder and API regression coverage to lock public output to the compact contract backed by B19 production-written truth
- register B20 in the PR train manifest/state with the local verification results

## Why
- B19 made `transition_paths` production-written, but the public preview surface still needed a stricter boundary between production truth and richer internal or fixture-only payload conventions
- this PR keeps the preview compact and trustworthy by aligning public semantics with what the backend actually writes today
- the scope stays intentionally narrow: no new public fields, no writer/materialization changes, and no schema or OpenAPI expansion

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php app/DTO/Career/CareerTransitionPreviewBundle.php app/Http/Resources/Career/CareerTransitionPreviewResource.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`

## Intentionally deferred
- no public `steps` field and no narrative fields such as `why_this_path`, `what_is_lost`, or `bridge_steps_90d`
- no transition writer/materialization changes
- no OpenAPI snapshot change, no schema change, and no frontend impact
