### PR TITLE
PR-B21: Career transition path internal step authoring + production payload enrichment

### DIFF
--- a/backend/app/Domain/Career/Transition/TransitionPathPayload.php
+++ b/backend/app/Domain/Career/Transition/TransitionPathPayload.php
@@ -6,6 +6,12 @@ namespace App\Domain\Career\Transition;
 
 final class TransitionPathPayload
 {
+    public const STEP_SKILL_OVERLAP = 'skill_overlap';
+
+    public const STEP_TASK_OVERLAP = 'task_overlap';
+
+    public const STEP_TOOL_OVERLAP = 'tool_overlap';
+
     /**
      * @param  list<string>  $steps
      */
@@ -26,14 +32,14 @@ final class TransitionPathPayload
             }
 
             $normalized = trim($step);
-            if ($normalized === '') {
+            if ($normalized === '' || ! in_array($normalized, self::allowedStepLabels(), true)) {
                 continue;
             }
 
             $steps[] = $normalized;
         }
 
-        return new self(array_values($steps));
+        return new self(array_values(array_unique($steps)));
     }
 
     /**
@@ -47,6 +53,18 @@ final class TransitionPathPayload
 
         return [
             'steps' => $this->steps,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedStepLabels(): array
+    {
+        return [
+            self::STEP_SKILL_OVERLAP,
+            self::STEP_TASK_OVERLAP,
+            self::STEP_TOOL_OVERLAP,
         ];
     }
 }

--- a/backend/app/Services/Career/Transition/CareerTransitionPathWriter.php
+++ b/backend/app/Services/Career/Transition/CareerTransitionPathWriter.php
@@ -16,6 +16,7 @@ final class CareerTransitionPathWriter
 {
     public function __construct(
         private readonly CareerTransitionPreviewReadinessLookup $readinessLookup,
+        private readonly CareerTransitionStepAuthor $stepAuthor,
     ) {}
 
     public function rewriteForSnapshot(RecommendationSnapshot $snapshot): int
@@ -43,7 +44,9 @@ final class CareerTransitionPathWriter
                 return 0;
             }
 
-            $pathPayload = TransitionPathPayload::from(null);
+            $pathPayload = TransitionPathPayload::from([
+                'steps' => $this->stepAuthor->authorForOccupation($sourceOccupation),
+            ]);
 
             TransitionPath::query()->create([
                 'recommendation_snapshot_id' => $snapshot->id,

--- a/backend/app/Services/Career/Transition/CareerTransitionStepAuthor.php
+++ b/backend/app/Services/Career/Transition/CareerTransitionStepAuthor.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Transition;
+
+use App\Domain\Career\Transition\TransitionPathPayload;
+use App\Models\Occupation;
+use App\Models\OccupationSkillGraph;
+
+final class CareerTransitionStepAuthor
+{
+    /**
+     * @return list<string>
+     */
+    public function authorForOccupation(Occupation $sourceOccupation): array
+    {
+        $skillGraph = $sourceOccupation->skillGraphs()
+            ->orderBy('stack_key')
+            ->orderByDesc('updated_at')
+            ->first();
+
+        if (! $skillGraph instanceof OccupationSkillGraph) {
+            return [];
+        }
+
+        $labels = [];
+
+        foreach ($this->graphFieldMap() as $label => $field) {
+            if ($this->graphHasAuthoritativeSignal($skillGraph->{$field} ?? null)) {
+                $labels[] = $label;
+            }
+        }
+
+        return TransitionPathPayload::from(['steps' => $labels])->steps;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function graphFieldMap(): array
+    {
+        return [
+            TransitionPathPayload::STEP_SKILL_OVERLAP => 'skill_overlap_graph',
+            TransitionPathPayload::STEP_TASK_OVERLAP => 'task_overlap_graph',
+            TransitionPathPayload::STEP_TOOL_OVERLAP => 'tool_overlap_graph',
+        ];
+    }
+
+    private function graphHasAuthoritativeSignal(mixed $graph): bool
+    {
+        if (! is_array($graph) || $graph === []) {
+            return false;
+        }
+
+        foreach ($graph as $value) {
+            if (is_numeric($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T07:00:00Z",
+  "updated_at": "2026-04-11T07:20:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -357,6 +357,32 @@
         ]
       },
       "failure_reason": "GitHub hygiene failed immediately again and the MBTI matrix job was skipped; local B20 verification passed and the failure pattern matches the current repository workflow-start issue rather than a locally reproducible regression.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B21": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b21-career-transition-path-internal-step-authoring-production-payload-enrichment",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Transition/CareerTransitionStepAuthor.php app/Services/Career/Transition/CareerTransitionPathWriter.php app/Domain/Career/Transition/TransitionPathPayload.php tests/Unit/Services/Career/Transition/CareerTransitionStepAuthorTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/Transition/CareerTransitionStepAuthorTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -261,6 +261,31 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B21
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b21-career-transition-path-internal-step-authoring-production-payload-enrichment
+    base: main
+    depends_on: ["PR-B20"]
+    mode: execute
+    scope: >
+      Career transition path internal step authoring + production payload enrichment.
+      Add deterministic machine-coded internal transition steps to production-written
+      transition path payloads without changing the B16 public API, schema, or
+      narrative semantics.
+    checks:
+      - "vendor/bin/pint --test app/Services/Career/Transition/CareerTransitionStepAuthor.php app/Services/Career/Transition/CareerTransitionPathWriter.php app/Domain/Career/Transition/TransitionPathPayload.php tests/Unit/Services/Career/Transition/CareerTransitionStepAuthorTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php"
+      - "php artisan test tests/Unit/Services/Career/Transition/CareerTransitionStepAuthorTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php
+++ b/backend/tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Domain\Career\Transition\TransitionPathPayload;
 use App\Models\ProfileProjection;
 use App\Models\TransitionPath;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -33,7 +34,9 @@ final class FirstWaveTransitionPathMaterializationTest extends TestCase
         $path = TransitionPath::query()->with(['recommendationSnapshot', 'fromOccupation', 'toOccupation'])->latest('created_at')->firstOrFail();
         $this->assertSame('stable_upside', $path->path_type);
         $this->assertSame($path->from_occupation_id, $path->to_occupation_id);
-        $this->assertSame([], $path->normalizedPathPayload()->toArray());
+        $this->assertSame([
+            'steps' => TransitionPathPayload::allowedStepLabels(),
+        ], $path->normalizedPathPayload()->toArray());
         $this->assertNotNull($path->recommendationSnapshot?->compile_run_id);
     }
 
@@ -67,6 +70,16 @@ final class FirstWaveTransitionPathMaterializationTest extends TestCase
         $this->assertSame(
             TransitionPath::query()->count(),
             TransitionPath::query()->distinct('recommendation_snapshot_id')->count('recommendation_snapshot_id')
+        );
+        $this->assertSame(
+            array_fill(0, TransitionPath::query()->count(), [
+                'steps' => TransitionPathPayload::allowedStepLabels(),
+            ]),
+            TransitionPath::query()
+                ->orderBy('recommendation_snapshot_id')
+                ->get()
+                ->map(static fn (TransitionPath $path): array => $path->normalizedPathPayload()->toArray())
+                ->all()
         );
         $this->assertNotSame($firstFingerprints, TransitionPath::query()
             ->orderBy('recommendation_snapshot_id')

--- a/backend/tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php
+++ b/backend/tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php
@@ -19,13 +19,14 @@ final class TransitionPathPayloadTest extends TestCase
     public function test_it_accepts_steps_as_a_list_of_strings(): void
     {
         $payload = TransitionPathPayload::from([
-            'steps' => [' deepen system design ', 'lead more cross-team decisions'],
+            'steps' => [' skill_overlap ', 'task_overlap', 'tool_overlap'],
         ]);
 
         $this->assertSame([
             'steps' => [
-                'deepen system design',
-                'lead more cross-team decisions',
+                'skill_overlap',
+                'task_overlap',
+                'tool_overlap',
             ],
         ], $payload->toArray());
     }
@@ -33,7 +34,7 @@ final class TransitionPathPayloadTest extends TestCase
     public function test_it_strips_invalid_steps_and_ignores_richer_narrative_fields(): void
     {
         $payload = TransitionPathPayload::from([
-            'steps' => ['valid step', 42, '', null, ' second step '],
+            'steps' => ['skill_overlap', 'deepen system design', 42, '', null, ' task_overlap ', 'skill_overlap'],
             'why_this_path' => 'fixture-only narrative',
             'what_is_lost' => 'fixture-only tradeoff copy',
             'bridge_steps_90d' => ['not authoritative'],
@@ -41,8 +42,8 @@ final class TransitionPathPayloadTest extends TestCase
 
         $this->assertSame([
             'steps' => [
-                'valid step',
-                'second step',
+                'skill_overlap',
+                'task_overlap',
             ],
         ], $payload->toArray());
     }

--- a/backend/tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php
+++ b/backend/tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career\Transition;
 
+use App\Domain\Career\Transition\TransitionPathPayload;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\RecommendationSnapshot;
@@ -32,7 +33,9 @@ final class CareerTransitionPathWriterTest extends TestCase
         $this->assertSame($snapshot->occupation_id, $path->from_occupation_id);
         $this->assertSame($snapshot->occupation_id, $path->to_occupation_id);
         $this->assertSame('stable_upside', $path->path_type);
-        $this->assertSame([], $path->normalizedPathPayload()->toArray());
+        $this->assertSame([
+            'steps' => TransitionPathPayload::allowedStepLabels(),
+        ], $path->normalizedPathPayload()->toArray());
     }
 
     public function test_it_rewrites_stale_rows_for_the_same_snapshot_without_duplicates(): void
@@ -54,7 +57,9 @@ final class CareerTransitionPathWriterTest extends TestCase
         $this->assertSame(1, TransitionPath::query()->where('recommendation_snapshot_id', $snapshot->id)->count());
         $path = TransitionPath::query()->where('recommendation_snapshot_id', $snapshot->id)->sole();
         $this->assertSame('stable_upside', $path->path_type);
-        $this->assertSame([], $path->normalizedPathPayload()->toArray());
+        $this->assertSame([
+            'steps' => TransitionPathPayload::allowedStepLabels(),
+        ], $path->normalizedPathPayload()->toArray());
     }
 
     public function test_it_rejects_snapshots_without_transition_claim_permission(): void

--- a/backend/tests/Unit/Services/Career/Transition/CareerTransitionStepAuthorTest.php
+++ b/backend/tests/Unit/Services/Career/Transition/CareerTransitionStepAuthorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career\Transition;
+
+use App\Domain\Career\Transition\TransitionPathPayload;
+use App\Models\Occupation;
+use App\Models\OccupationSkillGraph;
+use App\Services\Career\Transition\CareerTransitionStepAuthor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerTransitionStepAuthorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_authors_deterministic_machine_coded_step_labels_from_authoritative_overlap_graphs(): void
+    {
+        $occupation = $this->seedOccupationWithGraphs([
+            'skill_overlap_graph' => ['distributed_systems' => 0.82],
+            'task_overlap_graph' => ['api_contracts' => 0.91],
+            'tool_overlap_graph' => ['kubernetes' => 0.71],
+        ]);
+
+        $steps = app(CareerTransitionStepAuthor::class)->authorForOccupation($occupation);
+
+        $this->assertSame([
+            TransitionPathPayload::STEP_SKILL_OVERLAP,
+            TransitionPathPayload::STEP_TASK_OVERLAP,
+            TransitionPathPayload::STEP_TOOL_OVERLAP,
+        ], $steps);
+    }
+
+    public function test_it_only_emits_allowed_internal_step_labels(): void
+    {
+        $occupation = $this->seedOccupationWithGraphs([
+            'skill_overlap_graph' => ['self_baseline' => 1.0],
+            'task_overlap_graph' => ['self_baseline' => 1.0],
+            'tool_overlap_graph' => ['self_baseline' => 1.0],
+        ]);
+
+        $steps = app(CareerTransitionStepAuthor::class)->authorForOccupation($occupation);
+
+        $this->assertSame(TransitionPathPayload::allowedStepLabels(), $steps);
+    }
+
+    public function test_it_returns_an_empty_step_list_when_no_authoritative_overlap_graph_exists(): void
+    {
+        $occupation = $this->seedOccupationWithoutGraphs();
+
+        $steps = app(CareerTransitionStepAuthor::class)->authorForOccupation($occupation);
+
+        $this->assertSame([], $steps);
+    }
+
+    /**
+     * @param  array<string, array<string, float>>  $graphs
+     */
+    private function seedOccupationWithGraphs(array $graphs): Occupation
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
+
+        $chain['skillGraph']->delete();
+
+        OccupationSkillGraph::query()->create([
+            'occupation_id' => $chain['occupation']->id,
+            'stack_key' => 'core',
+            'skill_overlap_graph' => $graphs['skill_overlap_graph'] ?? [],
+            'task_overlap_graph' => $graphs['task_overlap_graph'] ?? [],
+            'tool_overlap_graph' => $graphs['tool_overlap_graph'] ?? [],
+        ]);
+
+        return $chain['occupation']->fresh();
+    }
+
+    private function seedOccupationWithoutGraphs(): Occupation
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
+
+        $chain['skillGraph']->delete();
+
+        return $chain['occupation']->fresh();
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated internal `CareerTransitionStepAuthor` that derives deterministic machine-coded transition step labels from authoritative overlap graphs
- enrich production-written `transition_paths.path_payload` at write time with internal-only machine-coded `steps`
- tighten `TransitionPathPayload` so it only accepts the current internal step-label allowlist and strips non-authoritative values
- extend writer, materialization, and regression coverage while keeping the B16 public transition preview contract unchanged
- register B21 in the PR train manifest/state with the local verification results

## Why
- B19 made `transition_paths` production-written, but the payload was still effectively empty
- B21 strengthens internal transition authority without expanding the public API or inventing narrative guidance
- this creates a deterministic backend-owned payload foundation for future contract work while preserving the compact B16 preview surface

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Transition/CareerTransitionStepAuthor.php app/Services/Career/Transition/CareerTransitionPathWriter.php app/Domain/Career/Transition/TransitionPathPayload.php tests/Unit/Services/Career/Transition/CareerTransitionStepAuthorTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`
- `php artisan test tests/Unit/Services/Career/Transition/CareerTransitionStepAuthorTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`

## Intentionally deferred
- no public `steps` exposure and no narrative fields such as `why_this_path`, `what_is_lost`, or `bridge_steps_90d`
- no transition writer/materialization gating changes
- no OpenAPI snapshot change, no schema change, and no frontend impact
