### PR TITLE
PR-B22: Career transition preview public raw-steps exposure

### DIFF
--- a/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
+++ b/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
@@ -17,6 +17,7 @@ final class CareerTransitionPreviewBundle
         'bundle_kind',
         'bundle_version',
         'path_type',
+        'steps',
         'target_job',
         'score_summary',
         'trust_summary',
@@ -30,9 +31,11 @@ final class CareerTransitionPreviewBundle
      * @param  array<string, mixed>  $trustSummary
      * @param  array<string, mixed>  $seoContract
      * @param  array<string, mixed>  $provenanceMeta
+     * @param  list<string>|null  $steps
      */
     public function __construct(
         public readonly string $pathType,
+        public readonly ?array $steps,
         public readonly array $targetJob,
         public readonly array $scoreSummary,
         public readonly array $trustSummary,
@@ -49,12 +52,17 @@ final class CareerTransitionPreviewBundle
             'bundle_kind' => self::BUNDLE_KIND,
             'bundle_version' => self::BUNDLE_VERSION,
             'path_type' => $this->pathType,
+            'steps' => $this->steps,
             'target_job' => $this->targetJob,
             'score_summary' => $this->scoreSummary,
             'trust_summary' => $this->trustSummary,
             'seo_contract' => $this->seoContract,
             'provenance_meta' => $this->provenanceMeta,
         ];
+
+        if ($payload['steps'] === null) {
+            unset($payload['steps']);
+        }
 
         /** @var array<string, mixed> $publicPayload */
         $publicPayload = array_intersect_key($payload, array_flip(self::PUBLIC_TOP_LEVEL_KEYS));

--- a/backend/app/Http/Resources/Career/CareerTransitionPreviewResource.php
+++ b/backend/app/Http/Resources/Career/CareerTransitionPreviewResource.php
@@ -22,10 +22,11 @@ final class CareerTransitionPreviewResource extends JsonResource
     {
         /** @var CareerTransitionPreviewBundle $bundle */
         $bundle = $this->resource;
+        $publicKeys = CareerTransitionPreviewBundle::publicTopLevelKeys();
 
         return array_intersect_key(
             $bundle->toArray(),
-            array_flip(CareerTransitionPreviewBundle::publicTopLevelKeys()),
+            array_flip($publicKeys),
         );
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
@@ -114,8 +114,9 @@ final class CareerTransitionPreviewBundleBuilder
             return null;
         }
 
-        // Normalize internal authority payloads before any future richer transition surfaces consume them.
-        $normalizedPathPayload->toArray();
+        $publicSteps = $normalizedPathPayload->steps === []
+            ? null
+            : array_values($normalizedPathPayload->steps);
 
         $scoreBundle = is_array($payload['score_bundle'] ?? null) ? $payload['score_bundle'] : [];
         $reasonCodes = is_array($claimPermissions['reason_codes'] ?? null) ? array_values($claimPermissions['reason_codes']) : [];
@@ -123,6 +124,7 @@ final class CareerTransitionPreviewBundleBuilder
 
         return new CareerTransitionPreviewBundle(
             pathType: $pathType->value,
+            steps: $publicSteps,
             targetJob: [
                 'occupation_uuid' => $targetOccupation->id,
                 'canonical_slug' => $targetOccupation->canonical_slug,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T07:55:00Z",
+  "updated_at": "2026-04-11T08:10:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -391,10 +391,10 @@
     "PR-B22": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b22-career-transition-preview-public-raw-steps-exposure",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "6cc2ae5135e659e1efab9e09c53bf1969ba45d72",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/864",
       "checks": {
         "local": [
           {
@@ -410,9 +410,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24277615957/job/70894141660"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24277615957/job/70894144282"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "required_github_checks_failed",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T07:20:00Z",
+  "updated_at": "2026-04-11T07:55:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -377,6 +377,36 @@
           },
           {
             "command": "php artisan test tests/Unit/Services/Career/Transition/CareerTransitionStepAuthorTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B22": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b22-career-transition-preview-public-raw-steps-exposure",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php app/DTO/Career/CareerTransitionPreviewBundle.php app/Http/Resources/Career/CareerTransitionPreviewResource.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
             "status": "passed"
           }
         ],

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -286,6 +286,31 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B22
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b22-career-transition-preview-public-raw-steps-exposure
+    base: main
+    depends_on: ["PR-B21"]
+    mode: execute
+    scope: >
+      Career transition preview public raw-steps exposure.
+      Expose only raw machine-coded transition steps on the B16 preview surface
+      without changing writer semantics, schema, or introducing narrative fields.
+    checks:
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php app/DTO/Career/CareerTransitionPreviewBundle.php app/Http/Resources/Career/CareerTransitionPreviewResource.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php"
+      - "php artisan test tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
+++ b/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Domain\Career\Transition\TransitionPathPayload;
 use App\DTO\Career\CareerTransitionPreviewBundle;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
@@ -34,7 +35,13 @@ final class CareerTransitionPreviewApiTest extends TestCase
             'from_occupation_id' => $snapshot->occupation_id,
             'to_occupation_id' => $target->id,
             'path_type' => 'stable_upside',
-            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+            'path_payload' => [
+                'steps' => [
+                    TransitionPathPayload::STEP_SKILL_OVERLAP,
+                    TransitionPathPayload::STEP_TASK_OVERLAP,
+                    TransitionPathPayload::STEP_TOOL_OVERLAP,
+                ],
+            ],
         ]);
 
         $response = $this->getJson('/api/v0.5/career/transition-preview?type=intj')
@@ -42,11 +49,15 @@ final class CareerTransitionPreviewApiTest extends TestCase
             ->assertJsonPath('bundle_kind', 'career_transition_preview')
             ->assertJsonPath('bundle_version', 'career.protocol.transition_preview.v1')
             ->assertJsonPath('path_type', 'stable_upside')
+            ->assertJsonPath('steps.0', TransitionPathPayload::STEP_SKILL_OVERLAP)
+            ->assertJsonPath('steps.1', TransitionPathPayload::STEP_TASK_OVERLAP)
+            ->assertJsonPath('steps.2', TransitionPathPayload::STEP_TOOL_OVERLAP)
             ->assertJsonPath('target_job.canonical_slug', 'registered-nurses')
             ->assertJsonPath('trust_summary.allow_transition_recommendation', true)
             ->assertJsonPath('seo_contract.index_eligible', true)
             ->assertJsonStructure([
                 'path_type',
+                'steps',
                 'target_job' => ['occupation_uuid', 'canonical_slug', 'title'],
                 'score_summary' => [
                     'mobility_score' => ['value', 'integrity_state', 'band'],
@@ -56,7 +67,6 @@ final class CareerTransitionPreviewApiTest extends TestCase
                 'seo_contract' => ['canonical_path', 'canonical_target', 'index_state', 'index_eligible', 'reason_codes'],
                 'provenance_meta' => ['recommendation_snapshot_id', 'transition_path_id', 'compiler_version', 'compile_run_id'],
             ])
-            ->assertJsonMissingPath('steps')
             ->assertJsonMissingPath('why_this_path')
             ->assertJsonMissingPath('what_is_lost')
             ->assertJsonMissingPath('bridge_steps_90d');
@@ -64,6 +74,7 @@ final class CareerTransitionPreviewApiTest extends TestCase
         /** @var array<string, mixed> $payload */
         $payload = $response->json();
         $this->assertSame(CareerTransitionPreviewBundle::publicTopLevelKeys(), array_keys($payload));
+        $this->assertSame(TransitionPathPayload::allowedStepLabels(), $payload['steps']);
     }
 
     public function test_it_returns_not_found_when_no_safe_preview_exists(): void
@@ -79,7 +90,9 @@ final class CareerTransitionPreviewApiTest extends TestCase
             'from_occupation_id' => $snapshot->occupation_id,
             'to_occupation_id' => $target->id,
             'path_type' => 'stable_upside',
-            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+            'path_payload' => [
+                'steps' => [TransitionPathPayload::STEP_SKILL_OVERLAP],
+            ],
         ]);
 
         $this->getJson('/api/v0.5/career/transition-preview?type=intj')
@@ -109,7 +122,9 @@ final class CareerTransitionPreviewApiTest extends TestCase
             'from_occupation_id' => $snapshot->occupation_id,
             'to_occupation_id' => $target->id,
             'path_type' => 'bridge_path',
-            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+            'path_payload' => [
+                'steps' => [TransitionPathPayload::STEP_SKILL_OVERLAP],
+            ],
         ]);
 
         $this->getJson('/api/v0.5/career/transition-preview?type=intj')

--- a/backend/tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php
+++ b/backend/tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php
@@ -123,8 +123,10 @@ final class FirstWaveTransitionPathMaterializationTest extends TestCase
         $this->getJson('/api/v0.5/career/transition-preview?type=intj')
             ->assertOk()
             ->assertJsonPath('path_type', 'stable_upside')
+            ->assertJsonPath('steps.0', TransitionPathPayload::STEP_SKILL_OVERLAP)
+            ->assertJsonPath('steps.1', TransitionPathPayload::STEP_TASK_OVERLAP)
+            ->assertJsonPath('steps.2', TransitionPathPayload::STEP_TOOL_OVERLAP)
             ->assertJsonPath('target_job.canonical_slug', $path->toOccupation?->canonical_slug)
-            ->assertJsonMissingPath('steps')
             ->assertJsonMissingPath('why_this_path')
             ->assertJsonMissingPath('what_is_lost')
             ->assertJsonMissingPath('bridge_steps_90d');


### PR DESCRIPTION
## What changed
- expose production-written transition preview `steps` publicly as raw machine-coded `string[]`
- pass through allowlisted normalized `steps` from the preview builder without adding labels, prose, timeline, or tradeoff semantics
- extend the transition preview DTO/resource public contract while keeping all other B16 fields and gating semantics unchanged
- update API and materialization regression coverage to lock the new raw-step shape and continued absence of narrative fields
- register B22 in the PR train manifest/state with the local verification results

## Why
- B21 made transition path steps production-written, deterministic, and allowlist-bound, but they were still internal-only
- B22 exposes the smallest truthful public expansion: raw structural step codes only
- the preview remains compact and authority-backed without inventing user-facing copy or broadening transition semantics

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php app/DTO/Career/CareerTransitionPreviewBundle.php app/Http/Resources/Career/CareerTransitionPreviewResource.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php`
- `php artisan test tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no label/prose mapping for step codes
- no narrative fields such as `why_this_path`, `what_is_lost`, or `bridge_steps_90d`
- no writer/materialization changes, no schema changes, and no frontend impact
