### PR TITLE
PR-B23: Career family hub authority bundle + API

### DIFF
--- a/backend/app/DTO/Career/CareerFamilyHubBundle.php
+++ b/backend/app/DTO/Career/CareerFamilyHubBundle.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFamilyHubBundle
+{
+    /**
+     * @param  array<string, mixed>  $family
+     * @param  list<array<string, mixed>>  $visibleChildren
+     * @param  array<string, int>  $counts
+     */
+    public function __construct(
+        public readonly array $family,
+        public readonly array $visibleChildren,
+        public readonly array $counts,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'bundle_kind' => 'career_family_hub',
+            'bundle_version' => 'career.protocol.family_hub.v1',
+            'family' => $this->family,
+            'visible_children' => $this->visibleChildren,
+            'counts' => $this->counts,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFamilyHubController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFamilyHubController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerFamilyHubResource;
+use App\Services\Career\Bundles\CareerFamilyHubBundleBuilder;
+use Illuminate\Http\JsonResponse;
+
+final class CareerFamilyHubController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerFamilyHubBundleBuilder $bundleBuilder,
+    ) {}
+
+    public function show(string $slug): JsonResponse|CareerFamilyHubResource
+    {
+        $bundle = $this->bundleBuilder->buildBySlug($slug);
+
+        if ($bundle === null) {
+            return $this->notFoundResponse('career family hub unavailable.');
+        }
+
+        return new CareerFamilyHubResource($bundle);
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerFamilyHubResource.php
+++ b/backend/app/Http/Resources/Career/CareerFamilyHubResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerFamilyHubBundle;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerFamilyHubBundle
+ */
+final class CareerFamilyHubResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerFamilyHubBundle $bundle */
+        $bundle = $this->resource;
+
+        return $bundle->toArray();
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\Domain\Career\Publish\FirstWaveReadinessSummaryService;
+use App\DTO\Career\CareerFamilyHubBundle;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use App\Models\RecommendationSnapshot;
+use App\Services\PublicSurface\SeoSurfaceContractService;
+use Illuminate\Support\Collection;
+
+final class CareerFamilyHubBundleBuilder
+{
+    private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
+
+    public function __construct(
+        private readonly FirstWaveReadinessSummaryService $readinessSummaryService,
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
+    ) {}
+
+    public function buildBySlug(string $slug): ?CareerFamilyHubBundle
+    {
+        $family = OccupationFamily::query()
+            ->with('occupations')
+            ->where('canonical_slug', trim($slug))
+            ->first();
+
+        if (! $family instanceof OccupationFamily) {
+            return null;
+        }
+
+        /** @var Collection<int, Occupation> $occupations */
+        $occupations = $family->occupations instanceof Collection
+            ? $family->occupations
+            : collect();
+
+        $readinessSummary = $this->readinessSummaryService->build();
+        $readinessBySlug = collect($readinessSummary->occupations)
+            ->filter(static fn (mixed $row): bool => is_array($row) && is_string($row['canonical_slug'] ?? null))
+            ->keyBy(static fn (array $row): string => (string) $row['canonical_slug']);
+
+        $counts = $this->buildCounts($occupations, $readinessBySlug);
+        $visibleChildren = $this->buildVisibleChildren($occupations, $readinessBySlug);
+        $counts['visible_children_count'] = count($visibleChildren);
+
+        return new CareerFamilyHubBundle(
+            family: [
+                'family_uuid' => $family->id,
+                'canonical_slug' => $family->canonical_slug,
+                'title_en' => $family->title_en,
+                'title_zh' => $family->title_zh,
+            ],
+            visibleChildren: $visibleChildren,
+            counts: $counts,
+        );
+    }
+
+    /**
+     * @param  Collection<int, Occupation>  $occupations
+     * @param  Collection<string, array<string, mixed>>  $readinessBySlug
+     * @return array<string, int>
+     */
+    private function buildCounts(Collection $occupations, Collection $readinessBySlug): array
+    {
+        $counts = [
+            'visible_children_count' => 0,
+            'publish_ready_count' => 0,
+            'blocked_override_eligible_count' => 0,
+            'blocked_not_safely_remediable_count' => 0,
+            'blocked_total' => 0,
+        ];
+
+        foreach ($occupations as $occupation) {
+            $row = $readinessBySlug->get((string) $occupation->canonical_slug);
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $status = (string) ($row['status'] ?? '');
+
+            if ($status === 'publish_ready') {
+                $counts['publish_ready_count']++;
+
+                continue;
+            }
+
+            if ($status === 'blocked_override_eligible') {
+                $counts['blocked_override_eligible_count']++;
+                $counts['blocked_total']++;
+
+                continue;
+            }
+
+            if ($status === 'blocked_not_safely_remediable') {
+                $counts['blocked_not_safely_remediable_count']++;
+                $counts['blocked_total']++;
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param  Collection<int, Occupation>  $occupations
+     * @param  Collection<string, array<string, mixed>>  $readinessBySlug
+     * @return list<array<string, mixed>>
+     */
+    private function buildVisibleChildren(Collection $occupations, Collection $readinessBySlug): array
+    {
+        $eligibleOccupationIds = $occupations
+            ->filter(function (Occupation $occupation) use ($readinessBySlug): bool {
+                $row = $readinessBySlug->get((string) $occupation->canonical_slug);
+                if (! is_array($row)) {
+                    return false;
+                }
+
+                return (string) ($row['status'] ?? '') === 'publish_ready'
+                    && (bool) ($row['index_eligible'] ?? false)
+                    && in_array((string) $occupation->crosswalk_mode, self::SAFE_CROSSWALK_MODES, true);
+            })
+            ->pluck('id')
+            ->all();
+
+        if ($eligibleOccupationIds === []) {
+            return [];
+        }
+
+        $snapshots = RecommendationSnapshot::query()
+            ->with([
+                'occupation',
+                'trustManifest',
+                'indexState',
+                'contextSnapshot',
+                'profileProjection',
+                'compileRun',
+            ])
+            ->whereIn('occupation_id', $eligibleOccupationIds)
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('indexState', static function ($query): void {
+                $query->where('index_eligible', true);
+            })
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->get()
+            ->groupBy('occupation_id')
+            ->map(function (Collection $group): ?RecommendationSnapshot {
+                /** @var RecommendationSnapshot|null $selected */
+                $selected = $group
+                    ->sort(function (RecommendationSnapshot $left, RecommendationSnapshot $right): int {
+                        $leftCompiled = optional($left->compiled_at)?->getTimestamp() ?? 0;
+                        $rightCompiled = optional($right->compiled_at)?->getTimestamp() ?? 0;
+                        if ($leftCompiled !== $rightCompiled) {
+                            return $rightCompiled <=> $leftCompiled;
+                        }
+
+                        return strcmp((string) $left->id, (string) $right->id);
+                    })
+                    ->first();
+
+                return $selected;
+            })
+            ->filter(static fn (mixed $snapshot): bool => $snapshot instanceof RecommendationSnapshot)
+            ->map(function (RecommendationSnapshot $snapshot) use ($readinessBySlug): ?array {
+                $occupation = $snapshot->occupation;
+                if (! $occupation instanceof Occupation) {
+                    return null;
+                }
+
+                $row = $readinessBySlug->get((string) $occupation->canonical_slug);
+                if (! is_array($row) || (string) ($row['status'] ?? '') !== 'publish_ready' || ! (bool) ($row['index_eligible'] ?? false)) {
+                    return null;
+                }
+
+                return [
+                    'occupation_uuid' => $occupation->id,
+                    'canonical_slug' => $occupation->canonical_slug,
+                    'canonical_title_en' => $occupation->canonical_title_en,
+                    'canonical_title_zh' => $occupation->canonical_title_zh,
+                    'seo_contract' => $this->buildSeoContract($occupation, $snapshot),
+                    'trust_summary' => [
+                        'reviewer_status' => $row['reviewer_status'] ?? $snapshot->trustManifest?->reviewer_status,
+                    ],
+                ];
+            })
+            ->filter()
+            ->sortBy(static fn (array $item): array => [
+                strtolower((string) ($item['canonical_title_en'] ?? '')),
+                strtolower((string) ($item['canonical_slug'] ?? '')),
+            ])
+            ->values()
+            ->all();
+
+        /** @var list<array<string, mixed>> $snapshots */
+        return $snapshots;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildSeoContract(Occupation $occupation, RecommendationSnapshot $snapshot): array
+    {
+        $indexState = $snapshot->indexState;
+        $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
+        $canonicalTarget = $indexState?->canonical_target;
+        $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_family_hub_child',
+            'canonical_url' => $canonicalTarget ?: $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $canonicalTarget,
+            'index_state' => $indexState?->index_state,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T08:10:00Z",
+  "updated_at": "2026-04-11T12:30:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -424,6 +424,36 @@
         ]
       },
       "failure_reason": "required_github_checks_failed",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B23": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b23-career-family-hub-authority-bundle-api",
+      "commit_sha": "aa1b7944736e83878aec038a3caec0a4b763d310",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/DTO/Career/CareerFamilyHubBundle.php app/Http/Resources/Career/CareerFamilyHubResource.php app/Http/Controllers/API/V0_5/Career/CareerFamilyHubController.php routes/api.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Feature/Career/CareerFamilyHubApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T12:30:00Z",
+  "updated_at": "2026-04-11T16:20:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -432,10 +432,10 @@
     "PR-B23": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b23-career-family-hub-authority-bundle-api",
-      "commit_sha": "aa1b7944736e83878aec038a3caec0a4b763d310",
-      "pr_url": "",
+      "commit_sha": "773937fa6044c35366d2a6b2b6a9e01f3cc5f3f6",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/865",
       "checks": {
         "local": [
           {
@@ -451,9 +451,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24278341877/job/70895992139"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24278341877/job/70895994155"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately again and the MBTI matrix job was skipped; local B23 verification passed and the failure pattern matches the current repository workflow-start issue rather than a locally reproducible regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -311,6 +311,33 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B23
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b23-career-family-hub-authority-bundle-api
+    base: main
+    depends_on: ["PR-B22"]
+    mode: execute
+    scope: >
+      Career family hub authority bundle + API.
+      Add a dedicated backend-owned family hub endpoint with minimal
+      authority-backed identity, publish-ready visible children, and
+      derived blocked/ready counts without changing existing jobs,
+      recommendations, search, or detail contracts.
+    checks:
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/DTO/Career/CareerFamilyHubBundle.php app/Http/Resources/Career/CareerFamilyHubResource.php app/Http/Controllers/API/V0_5/Career/CareerFamilyHubController.php routes/api.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Feature/Career/CareerFamilyHubApiTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2362,6 +2362,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/family/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_career_family_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerFamilyHubController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/first-wave/readiness": {
             "get": {
                 "operationId": "get_api_v0_5_career_first_wave_readiness",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -30,6 +30,7 @@ use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
+use App\Http\Controllers\API\V0_5\Career\CareerFamilyHubController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobListController;
@@ -402,6 +403,7 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
 
 Route::prefix('v0.5')->group(function () {
     Route::post('/career/attribution/events', [CareerAttributionEventController::class, 'store']);
+    Route::get('/career/family/{slug}', [CareerFamilyHubController::class, 'show']);
     Route::get('/career/first-wave/readiness', [CareerFirstWaveReadinessController::class, 'show']);
     Route::get('/career/jobs', [CareerJobListController::class, 'index']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerFamilyHubApiTest.php
+++ b/backend/tests/Feature/Career/CareerFamilyHubApiTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFamilyHubApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_a_minimal_family_hub_bundle_with_visible_children_and_counts(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $family = OccupationFamily::query()->where('canonical_slug', 'computer-and-information-technology')->firstOrFail();
+
+        $this->getJson('/api/v0.5/career/family/computer-and-information-technology')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_family_hub')
+            ->assertJsonPath('bundle_version', 'career.protocol.family_hub.v1')
+            ->assertJsonPath('family.family_uuid', $family->id)
+            ->assertJsonPath('family.canonical_slug', 'computer-and-information-technology')
+            ->assertJsonPath('counts.visible_children_count', 1)
+            ->assertJsonPath('counts.publish_ready_count', 1)
+            ->assertJsonPath('counts.blocked_override_eligible_count', 0)
+            ->assertJsonPath('counts.blocked_not_safely_remediable_count', 0)
+            ->assertJsonPath('counts.blocked_total', 0)
+            ->assertJsonPath('visible_children.0.canonical_slug', 'data-scientists')
+            ->assertJsonPath('visible_children.0.seo_contract.index_eligible', true)
+            ->assertJsonPath('visible_children.0.trust_summary.reviewer_status', 'approved')
+            ->assertJsonMissingPath('visible_children.1')
+            ->assertJsonStructure([
+                'bundle_kind',
+                'bundle_version',
+                'family' => [
+                    'family_uuid',
+                    'canonical_slug',
+                    'title_en',
+                    'title_zh',
+                ],
+                'visible_children' => [[
+                    'occupation_uuid',
+                    'canonical_slug',
+                    'canonical_title_en',
+                    'canonical_title_zh',
+                    'seo_contract' => ['canonical_path', 'index_state', 'index_eligible', 'reason_codes'],
+                    'trust_summary' => ['reviewer_status'],
+                ]],
+                'counts' => [
+                    'visible_children_count',
+                    'publish_ready_count',
+                    'blocked_override_eligible_count',
+                    'blocked_not_safely_remediable_count',
+                    'blocked_total',
+                ],
+            ]);
+    }
+
+    public function test_it_returns_not_found_for_unknown_family_slug(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $this->getJson('/api/v0.5/career/family/unknown-family')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_it_returns_an_empty_visible_children_list_for_existing_families_without_public_safe_children(): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'empty-family-api',
+            'title_en' => 'Empty Family',
+            'title_zh' => '空家族',
+        ]);
+
+        $this->getJson('/api/v0.5/career/family/empty-family-api')
+            ->assertOk()
+            ->assertJsonPath('family.family_uuid', $family->id)
+            ->assertJsonPath('counts.visible_children_count', 0)
+            ->assertJsonPath('counts.publish_ready_count', 0)
+            ->assertJsonPath('counts.blocked_override_eligible_count', 0)
+            ->assertJsonPath('counts.blocked_not_safely_remediable_count', 0)
+            ->assertJsonPath('counts.blocked_total', 0)
+            ->assertJsonPath('visible_children', []);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Models\OccupationFamily;
+use App\Services\Career\Bundles\CareerFamilyHubBundleBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFamilyHubBundleBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_family_hub_with_publish_ready_visible_children_and_blocked_counts(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $bundle = app(CareerFamilyHubBundleBuilder::class)->buildBySlug('computer-and-information-technology');
+
+        $this->assertNotNull($bundle);
+
+        $payload = $bundle->toArray();
+        $family = OccupationFamily::query()->where('canonical_slug', 'computer-and-information-technology')->firstOrFail();
+
+        $this->assertSame('career_family_hub', $payload['bundle_kind']);
+        $this->assertSame('career.protocol.family_hub.v1', $payload['bundle_version']);
+        $this->assertSame($family->id, data_get($payload, 'family.family_uuid'));
+        $this->assertSame('computer-and-information-technology', data_get($payload, 'family.canonical_slug'));
+        $this->assertSame(1, data_get($payload, 'counts.visible_children_count'));
+        $this->assertSame(1, data_get($payload, 'counts.publish_ready_count'));
+        $this->assertSame(0, data_get($payload, 'counts.blocked_override_eligible_count'));
+        $this->assertSame(0, data_get($payload, 'counts.blocked_not_safely_remediable_count'));
+        $this->assertSame(0, data_get($payload, 'counts.blocked_total'));
+        $this->assertCount(1, $payload['visible_children']);
+        $this->assertSame('data-scientists', data_get($payload, 'visible_children.0.canonical_slug'));
+        $this->assertSame('approved', data_get($payload, 'visible_children.0.trust_summary.reviewer_status'));
+    }
+
+    public function test_it_returns_an_empty_but_valid_bundle_when_a_family_has_no_visible_children(): void
+    {
+        OccupationFamily::query()->create([
+            'canonical_slug' => 'empty-family',
+            'title_en' => 'Empty Family',
+            'title_zh' => '空家族',
+        ]);
+
+        $bundle = app(CareerFamilyHubBundleBuilder::class)->buildBySlug('empty-family');
+
+        $this->assertNotNull($bundle);
+
+        $payload = $bundle->toArray();
+
+        $this->assertSame([], $payload['visible_children']);
+        $this->assertSame(0, data_get($payload, 'counts.visible_children_count'));
+        $this->assertSame(0, data_get($payload, 'counts.publish_ready_count'));
+        $this->assertSame(0, data_get($payload, 'counts.blocked_override_eligible_count'));
+        $this->assertSame(0, data_get($payload, 'counts.blocked_not_safely_remediable_count'));
+        $this->assertSame(0, data_get($payload, 'counts.blocked_total'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated backend-owned Career family hub endpoint at `GET /api/v0.5/career/family/{slug}`
- introduce a minimal authority-backed family hub bundle with family identity, publish-ready visible children, and derived blocked/ready counts
- restrict visible child listing to first-wave compiled, publish-ready, index-eligible occupations and keep blocked or candidate children out of the public list
- add focused builder and API coverage while keeping existing jobs, recommendations, search, and detail contracts unchanged
- update the route-contract OpenAPI snapshot and register B23 in the PR train ledger

## Why
- the backend already had real family authority primitives (`occupation_families`, `occupations.family_id`, readiness truth), but no dedicated family authority surface
- this PR establishes the minimal backend substrate needed for later `/career/family/[slug]` and family fallback work without overreaching into explorer, disambiguation, or narrative UX
- the contract stays intentionally narrow and only exposes child rows that are already public-safe

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/DTO/Career/CareerFamilyHubBundle.php app/Http/Resources/Career/CareerFamilyHubResource.php app/Http/Controllers/API/V0_5/Career/CareerFamilyHubController.php routes/api.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Feature/Career/CareerFamilyHubApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no family alias/disambiguation public contract
- no explorer or search fallback behavior
- no family-level narrative or recommendation guidance
- no frontend, schema, or scoring changes
