### PR TITLE
PR-B24: Career alias / disambiguation authority API

### DIFF
--- a/backend/app/DTO/Career/CareerAliasResolutionBundle.php
+++ b/backend/app/DTO/Career/CareerAliasResolutionBundle.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerAliasResolutionBundle
+{
+    /**
+     * @param  array{raw:string,normalized:string,locale:?string}  $query
+     * @param  array<string, mixed>  $resolution
+     */
+    public function __construct(
+        public readonly array $query,
+        public readonly array $resolution,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'bundle_kind' => 'career_alias_resolution',
+            'bundle_version' => 'career.protocol.alias_resolution.v1',
+            'query' => $this->query,
+            'resolution' => $this->resolution,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerAliasResolutionController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerAliasResolutionController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerAliasResolutionResource;
+use App\Services\Career\Bundles\CareerAliasResolutionBundleBuilder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+final class CareerAliasResolutionController extends Controller
+{
+    public function __construct(
+        private readonly CareerAliasResolutionBundleBuilder $bundleBuilder,
+    ) {}
+
+    public function show(Request $request): JsonResponse|CareerAliasResolutionResource
+    {
+        $request->merge([
+            'q' => is_string($request->query('q')) ? trim((string) $request->query('q')) : $request->query('q'),
+        ]);
+
+        $validated = $request->validate([
+            'q' => ['required', 'string', 'min:1', 'max:120'],
+            'locale' => ['nullable', 'string', Rule::in(['en', 'en-US', 'zh', 'zh-CN'])],
+        ]);
+
+        $bundle = $this->bundleBuilder->build(
+            query: (string) $validated['q'],
+            locale: isset($validated['locale']) ? (string) $validated['locale'] : null,
+        );
+
+        return new CareerAliasResolutionResource($bundle);
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerAliasResolutionResource.php
+++ b/backend/app/Http/Resources/Career/CareerAliasResolutionResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerAliasResolutionBundle;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerAliasResolutionBundle
+ */
+final class CareerAliasResolutionResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerAliasResolutionBundle $bundle */
+        $bundle = $this->resource;
+
+        return $bundle->toArray();
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
@@ -1,0 +1,550 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\Domain\Career\Publish\FirstWaveReadinessSummaryService;
+use App\DTO\Career\CareerAliasResolutionBundle;
+use App\Models\Occupation;
+use App\Models\OccupationAlias;
+use App\Models\OccupationFamily;
+use App\Models\RecommendationSnapshot;
+use App\Services\PublicSurface\SeoSurfaceContractService;
+use Illuminate\Support\Collection;
+
+final class CareerAliasResolutionBundleBuilder
+{
+    private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
+
+    public function __construct(
+        private readonly FirstWaveReadinessSummaryService $readinessSummaryService,
+        private readonly SeoSurfaceContractService $seoSurfaceContractService,
+    ) {}
+
+    public function build(string $query, ?string $locale = null): CareerAliasResolutionBundle
+    {
+        $rawQuery = trim($query);
+        $normalizedQuery = $this->normalizeText($rawQuery) ?? '';
+        $normalizedLocale = $this->normalizeLocale($locale);
+        $readinessBySlug = $this->readinessRowsBySlug();
+
+        $exactCandidates = [
+            ...$this->matchOccupationCandidates($normalizedQuery, $rawQuery, $normalizedLocale, $readinessBySlug, exactOnly: true),
+            ...$this->matchFamilyCandidates($normalizedQuery, $rawQuery, $normalizedLocale, exactOnly: true),
+        ];
+
+        $candidates = $exactCandidates !== []
+            ? $this->dedupeCandidates($exactCandidates)
+            : $this->dedupeCandidates([
+                ...$this->matchOccupationCandidates($normalizedQuery, $rawQuery, $normalizedLocale, $readinessBySlug, exactOnly: false),
+                ...$this->matchFamilyCandidates($normalizedQuery, $rawQuery, $normalizedLocale, exactOnly: false),
+            ]);
+
+        return new CareerAliasResolutionBundle(
+            query: [
+                'raw' => $rawQuery,
+                'normalized' => $normalizedQuery,
+                'locale' => $normalizedLocale,
+            ],
+            resolution: $this->buildResolution($candidates),
+        );
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidates
+     * @return array<string, mixed>
+     */
+    private function buildResolution(array $candidates): array
+    {
+        if ($candidates === []) {
+            return [
+                'resolved_kind' => 'none',
+            ];
+        }
+
+        if (count($candidates) === 1) {
+            $candidate = $candidates[0];
+            $resolvedKind = (string) ($candidate['candidate_kind'] ?? 'none');
+
+            return match ($resolvedKind) {
+                'occupation' => [
+                    'resolved_kind' => 'occupation',
+                    'occupation' => $this->occupationPayload($candidate),
+                ],
+                'family' => [
+                    'resolved_kind' => 'family',
+                    'family' => $this->familyPayload($candidate),
+                ],
+                default => ['resolved_kind' => 'none'],
+            };
+        }
+
+        return [
+            'resolved_kind' => 'ambiguous',
+            'candidates' => array_map(function (array $candidate): array {
+                $kind = (string) ($candidate['candidate_kind'] ?? 'none');
+
+                return $kind === 'occupation'
+                    ? ['candidate_kind' => 'occupation'] + $this->occupationPayload($candidate)
+                    : ['candidate_kind' => 'family'] + $this->familyPayload($candidate);
+            }, $candidates),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function occupationPayload(array $candidate): array
+    {
+        return [
+            'occupation_uuid' => $candidate['occupation_uuid'] ?? null,
+            'canonical_slug' => $candidate['canonical_slug'] ?? null,
+            'canonical_title_en' => $candidate['canonical_title_en'] ?? null,
+            'canonical_title_zh' => $candidate['canonical_title_zh'] ?? null,
+            'seo_contract' => $candidate['seo_contract'] ?? [],
+            'trust_summary' => $candidate['trust_summary'] ?? [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function familyPayload(array $candidate): array
+    {
+        return [
+            'family_uuid' => $candidate['family_uuid'] ?? null,
+            'canonical_slug' => $candidate['canonical_slug'] ?? null,
+            'title_en' => $candidate['title_en'] ?? null,
+            'title_zh' => $candidate['title_zh'] ?? null,
+        ];
+    }
+
+    /**
+     * @param  Collection<string, array<string, mixed>>  $readinessBySlug
+     * @return list<array<string, mixed>>
+     */
+    private function matchOccupationCandidates(
+        string $normalizedQuery,
+        string $rawQuery,
+        ?string $normalizedLocale,
+        Collection $readinessBySlug,
+        bool $exactOnly,
+    ): array {
+        if ($normalizedQuery === '') {
+            return [];
+        }
+
+        $snapshots = RecommendationSnapshot::query()
+            ->with([
+                'occupation.aliases',
+                'trustManifest',
+                'indexState',
+                'profileProjection',
+                'contextSnapshot',
+                'compileRun',
+            ])
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('occupation', function ($query): void {
+                $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
+            })
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('indexState', static function ($query): void {
+                $query->where('index_eligible', true);
+            })
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->get()
+            ->groupBy('occupation_id')
+            ->map(function (Collection $group): ?RecommendationSnapshot {
+                /** @var RecommendationSnapshot|null $selected */
+                $selected = $group
+                    ->sort(function (RecommendationSnapshot $left, RecommendationSnapshot $right): int {
+                        $leftCompiled = optional($left->compiled_at)?->getTimestamp() ?? 0;
+                        $rightCompiled = optional($right->compiled_at)?->getTimestamp() ?? 0;
+                        if ($leftCompiled !== $rightCompiled) {
+                            return $rightCompiled <=> $leftCompiled;
+                        }
+
+                        return strcmp((string) $left->id, (string) $right->id);
+                    })
+                    ->first();
+
+                return $selected;
+            })
+            ->filter(static fn (mixed $snapshot): bool => $snapshot instanceof RecommendationSnapshot);
+
+        $candidates = [];
+
+        foreach ($snapshots as $snapshot) {
+            if (! $snapshot instanceof RecommendationSnapshot) {
+                continue;
+            }
+
+            $occupation = $snapshot->occupation;
+            if (! $occupation instanceof Occupation) {
+                continue;
+            }
+
+            $readiness = $readinessBySlug->get((string) $occupation->canonical_slug);
+            if (! is_array($readiness)
+                || (string) ($readiness['status'] ?? '') !== 'publish_ready'
+                || ! (bool) ($readiness['index_eligible'] ?? false)
+            ) {
+                continue;
+            }
+
+            $matchTier = $this->resolveOccupationMatchTier($occupation, $normalizedQuery, $rawQuery, $normalizedLocale, $exactOnly);
+            if ($matchTier === null) {
+                continue;
+            }
+
+            $candidates[] = [
+                'candidate_key' => 'occupation:'.$occupation->id,
+                'candidate_kind' => 'occupation',
+                'match_tier' => $matchTier,
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $occupation->canonical_slug,
+                'canonical_title_en' => $occupation->canonical_title_en,
+                'canonical_title_zh' => $occupation->canonical_title_zh,
+                'seo_contract' => $this->buildOccupationSeoContract($occupation, $snapshot),
+                'trust_summary' => [
+                    'reviewer_status' => $readiness['reviewer_status'] ?? $snapshot->trustManifest?->reviewer_status,
+                ],
+            ];
+        }
+
+        return $this->filterBestTier($candidates);
+    }
+
+    private function resolveOccupationMatchTier(
+        Occupation $occupation,
+        string $normalizedQuery,
+        string $rawQuery,
+        ?string $normalizedLocale,
+        bool $exactOnly,
+    ): ?string {
+        $canonicalSlug = $this->normalizeText($occupation->canonical_slug);
+        $canonicalTitleEn = $this->normalizeText($occupation->canonical_title_en);
+        $canonicalTitleZh = $this->normalizeRawText($occupation->canonical_title_zh);
+
+        if ($canonicalSlug === $normalizedQuery
+            || $canonicalTitleEn === $normalizedQuery
+            || ($canonicalTitleZh !== null && $canonicalTitleZh === $rawQuery)
+            || $this->matchesOccupationAlias($occupation, $normalizedQuery, $normalizedLocale, exact: true)
+        ) {
+            return 'exact';
+        }
+
+        if ($exactOnly) {
+            return null;
+        }
+
+        if (($canonicalSlug !== null && str_starts_with($canonicalSlug, $normalizedQuery))
+            || ($canonicalTitleEn !== null && str_starts_with($canonicalTitleEn, $normalizedQuery))
+            || ($canonicalTitleZh !== null && str_starts_with($canonicalTitleZh, $rawQuery))
+            || $this->matchesOccupationAlias($occupation, $normalizedQuery, $normalizedLocale, exact: false)
+        ) {
+            return 'prefix';
+        }
+
+        return null;
+    }
+
+    private function matchesOccupationAlias(
+        Occupation $occupation,
+        string $normalizedQuery,
+        ?string $normalizedLocale,
+        bool $exact,
+    ): bool {
+        $aliases = $occupation->aliases instanceof Collection ? $occupation->aliases : collect();
+
+        foreach ($aliases as $alias) {
+            if (! $alias instanceof OccupationAlias) {
+                continue;
+            }
+
+            if ($normalizedLocale !== null && ! str_starts_with(strtolower((string) $alias->lang), $normalizedLocale)) {
+                continue;
+            }
+
+            $aliasNormalized = $this->normalizeText($alias->normalized);
+            if ($aliasNormalized === null) {
+                continue;
+            }
+
+            if ($exact && $aliasNormalized === $normalizedQuery) {
+                return true;
+            }
+
+            if (! $exact && str_starts_with($aliasNormalized, $normalizedQuery)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function matchFamilyCandidates(
+        string $normalizedQuery,
+        string $rawQuery,
+        ?string $normalizedLocale,
+        bool $exactOnly,
+    ): array {
+        if ($normalizedQuery === '') {
+            return [];
+        }
+
+        $families = OccupationFamily::query()
+            ->with('aliases')
+            ->orderBy('title_en')
+            ->orderBy('canonical_slug')
+            ->get();
+
+        $candidates = [];
+
+        foreach ($families as $family) {
+            if (! $family instanceof OccupationFamily) {
+                continue;
+            }
+
+            $matchTier = $this->resolveFamilyMatchTier($family, $normalizedQuery, $rawQuery, $normalizedLocale, $exactOnly);
+            if ($matchTier === null) {
+                continue;
+            }
+
+            $candidates[] = [
+                'candidate_key' => 'family:'.$family->id,
+                'candidate_kind' => 'family',
+                'match_tier' => $matchTier,
+                'family_uuid' => $family->id,
+                'canonical_slug' => $family->canonical_slug,
+                'title_en' => $family->title_en,
+                'title_zh' => $family->title_zh,
+            ];
+        }
+
+        return $this->filterBestTier($candidates);
+    }
+
+    private function resolveFamilyMatchTier(
+        OccupationFamily $family,
+        string $normalizedQuery,
+        string $rawQuery,
+        ?string $normalizedLocale,
+        bool $exactOnly,
+    ): ?string {
+        $canonicalSlug = $this->normalizeText($family->canonical_slug);
+        $titleEn = $this->normalizeText($family->title_en);
+        $titleZh = $this->normalizeRawText($family->title_zh);
+
+        if ($canonicalSlug === $normalizedQuery
+            || $titleEn === $normalizedQuery
+            || ($titleZh !== null && $titleZh === $rawQuery)
+            || $this->matchesExplicitFamilyAlias($family, $normalizedQuery, $normalizedLocale, exact: true)
+        ) {
+            return 'exact';
+        }
+
+        if ($exactOnly) {
+            return null;
+        }
+
+        if (($canonicalSlug !== null && str_starts_with($canonicalSlug, $normalizedQuery))
+            || ($titleEn !== null && str_starts_with($titleEn, $normalizedQuery))
+            || ($titleZh !== null && str_starts_with($titleZh, $rawQuery))
+            || $this->matchesExplicitFamilyAlias($family, $normalizedQuery, $normalizedLocale, exact: false)
+        ) {
+            return 'prefix';
+        }
+
+        return null;
+    }
+
+    private function matchesExplicitFamilyAlias(
+        OccupationFamily $family,
+        string $normalizedQuery,
+        ?string $normalizedLocale,
+        bool $exact,
+    ): bool {
+        $aliases = $family->aliases instanceof Collection ? $family->aliases : collect();
+
+        foreach ($aliases as $alias) {
+            if (! $alias instanceof OccupationAlias) {
+                continue;
+            }
+
+            $targetKind = strtolower(trim((string) $alias->target_kind));
+            if ($alias->occupation_id !== null && $targetKind !== 'family') {
+                continue;
+            }
+
+            if ($normalizedLocale !== null && ! str_starts_with(strtolower((string) $alias->lang), $normalizedLocale)) {
+                continue;
+            }
+
+            $aliasNormalized = $this->normalizeText($alias->normalized);
+            if ($aliasNormalized === null) {
+                continue;
+            }
+
+            if ($exact && $aliasNormalized === $normalizedQuery) {
+                return true;
+            }
+
+            if (! $exact && str_starts_with($aliasNormalized, $normalizedQuery)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidates
+     * @return list<array<string, mixed>>
+     */
+    private function filterBestTier(array $candidates): array
+    {
+        if ($candidates === []) {
+            return [];
+        }
+
+        $bestTier = collect($candidates)
+            ->pluck('match_tier')
+            ->filter(static fn (mixed $value): bool => is_string($value) && $value !== '')
+            ->map(static fn (string $tier): int => $tier === 'exact' ? 0 : 1)
+            ->min();
+
+        $bestTierValue = $bestTier === 0 ? 'exact' : 'prefix';
+
+        return array_values(array_filter(
+            $candidates,
+            static fn (array $candidate): bool => (string) ($candidate['match_tier'] ?? '') === $bestTierValue
+        ));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidates
+     * @return list<array<string, mixed>>
+     */
+    private function dedupeCandidates(array $candidates): array
+    {
+        $deduped = [];
+        foreach ($candidates as $candidate) {
+            $key = (string) ($candidate['candidate_key'] ?? '');
+            if ($key === '') {
+                continue;
+            }
+
+            $deduped[$key] = $candidate;
+        }
+
+        $values = array_values($deduped);
+        usort($values, function (array $left, array $right): int {
+            $kindCompare = strcmp((string) ($left['candidate_kind'] ?? ''), (string) ($right['candidate_kind'] ?? ''));
+            if ($kindCompare !== 0) {
+                return $kindCompare;
+            }
+
+            $leftTitle = strtolower((string) ($left['canonical_title_en'] ?? $left['title_en'] ?? ''));
+            $rightTitle = strtolower((string) ($right['canonical_title_en'] ?? $right['title_en'] ?? ''));
+            if ($leftTitle !== $rightTitle) {
+                return strcmp($leftTitle, $rightTitle);
+            }
+
+            return strcmp(
+                strtolower((string) ($left['canonical_slug'] ?? '')),
+                strtolower((string) ($right['canonical_slug'] ?? ''))
+            );
+        });
+
+        return $values;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildOccupationSeoContract(Occupation $occupation, RecommendationSnapshot $snapshot): array
+    {
+        $indexState = $snapshot->indexState;
+        $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
+        $canonicalTarget = $indexState?->canonical_target;
+        $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_alias_resolution_occupation',
+            'canonical_url' => $canonicalTarget ?: $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $canonicalTarget,
+            'index_state' => $indexState?->index_state,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
+     * @return Collection<string, array<string, mixed>>
+     */
+    private function readinessRowsBySlug(): Collection
+    {
+        $summary = $this->readinessSummaryService->build();
+
+        return collect($summary->occupations)
+            ->filter(static fn (mixed $row): bool => is_array($row) && is_string($row['canonical_slug'] ?? null))
+            ->keyBy(static fn (array $row): string => (string) $row['canonical_slug']);
+    }
+
+    private function normalizeText(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = mb_strtolower(trim($value), 'UTF-8');
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeRawText(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeLocale(?string $locale): ?string
+    {
+        $normalized = strtolower(trim((string) $locale));
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T16:55:00Z",
+  "updated_at": "2026-04-11T17:00:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -473,10 +473,10 @@
     "PR-B24": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b24-career-alias-disambiguation-authority-api",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "1d56325aec05f20f885a5c636ede6e37385ae0d9",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/866",
       "checks": {
         "local": [
           {
@@ -496,9 +496,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24278993342/job/70897714342"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24278993342/job/70897716268"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately again and the MBTI matrix job was skipped; local B24 verification passed and the failure pattern matches the repository's current workflow-start issue rather than a locally reproducible alias-resolution regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T16:20:00Z",
+  "updated_at": "2026-04-11T16:55:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -465,6 +465,40 @@
         ]
       },
       "failure_reason": "GitHub hygiene failed immediately again and the MBTI matrix job was skipped; local B23 verification passed and the failure pattern matches the current repository workflow-start issue rather than a locally reproducible regression.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B24": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b24-career-alias-disambiguation-authority-api",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php app/DTO/Career/CareerAliasResolutionBundle.php app/Http/Resources/Career/CareerAliasResolutionResource.php app/Http/Controllers/API/V0_5/Career/CareerAliasResolutionController.php routes/api.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -338,6 +338,33 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B24
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b24-career-alias-disambiguation-authority-api
+    base: main
+    depends_on: ["PR-B23"]
+    mode: execute
+    scope: >
+      Career alias / disambiguation authority API.
+      Add a dedicated backend-owned alias resolution endpoint with explicit
+      occupation/family/ambiguous/none states, strict public-safety gating,
+      and no changes to existing career search semantics, frontend, or SEO surfaces.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php app/DTO/Career/CareerAliasResolutionBundle.php app/Http/Resources/Career/CareerAliasResolutionResource.php app/Http/Controllers/API/V0_5/Career/CareerAliasResolutionController.php routes/api.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2464,6 +2464,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/resolve": {
+            "get": {
+                "operationId": "get_api_v0_5_career_resolve",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerAliasResolutionController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/search": {
             "get": {
                 "operationId": "get_api_v0_5_career_search",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -29,6 +29,7 @@ use App\Http\Controllers\API\V0_4\BootController;
 use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
+use App\Http\Controllers\API\V0_5\Career\CareerAliasResolutionController;
 use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
 use App\Http\Controllers\API\V0_5\Career\CareerFamilyHubController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
@@ -404,6 +405,7 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
 Route::prefix('v0.5')->group(function () {
     Route::post('/career/attribution/events', [CareerAttributionEventController::class, 'store']);
     Route::get('/career/family/{slug}', [CareerFamilyHubController::class, 'show']);
+    Route::get('/career/resolve', [CareerAliasResolutionController::class, 'show']);
     Route::get('/career/first-wave/readiness', [CareerFirstWaveReadinessController::class, 'show']);
     Route::get('/career/jobs', [CareerJobListController::class, 'index']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerAliasResolutionApiTest.php
+++ b/backend/tests/Feature/Career/CareerAliasResolutionApiTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\OccupationAlias;
+use App\Models\OccupationFamily;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerAliasResolutionApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_an_occupation_resolution_for_a_public_safe_leaf_alias(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $occupation = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $occupation->id,
+            'family_id' => $occupation->family_id,
+            'alias' => 'Applied Data Scientist',
+            'normalized' => 'applied data scientist',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.96,
+        ]);
+
+        $this->getJson('/api/v0.5/career/resolve?q=applied%20data%20scientist&locale=en-US')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_alias_resolution')
+            ->assertJsonPath('bundle_version', 'career.protocol.alias_resolution.v1')
+            ->assertJsonPath('query.raw', 'applied data scientist')
+            ->assertJsonPath('query.normalized', 'applied data scientist')
+            ->assertJsonPath('query.locale', 'en-us')
+            ->assertJsonPath('resolution.resolved_kind', 'occupation')
+            ->assertJsonPath('resolution.occupation.canonical_slug', 'data-scientists')
+            ->assertJsonPath('resolution.occupation.seo_contract.index_eligible', true)
+            ->assertJsonPath('resolution.occupation.trust_summary.reviewer_status', 'approved')
+            ->assertJsonMissingPath('resolution.family')
+            ->assertJsonMissingPath('resolution.candidates');
+    }
+
+    public function test_it_returns_family_for_an_authority_backed_family_query(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $family = OccupationFamily::query()->where('canonical_slug', 'computer-and-information-technology')->firstOrFail();
+
+        $this->getJson('/api/v0.5/career/resolve?q=computer-and-information-technology&locale=en')
+            ->assertOk()
+            ->assertJsonPath('resolution.resolved_kind', 'family')
+            ->assertJsonPath('resolution.family.canonical_slug', 'computer-and-information-technology')
+            ->assertJsonPath('resolution.family.title_en', $family->title_en)
+            ->assertJsonMissingPath('resolution.occupation')
+            ->assertJsonMissingPath('resolution.candidates');
+    }
+
+    public function test_it_returns_ambiguous_with_public_safe_candidates_only(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $first = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $second = Occupation::query()->where('canonical_slug', 'management-analysts')->firstOrFail();
+
+        foreach ([$first, $second] as $chain) {
+            OccupationAlias::query()->create([
+                'occupation_id' => $chain->id,
+                'family_id' => $chain->family_id,
+                'alias' => 'Applied Analytics Architect',
+                'normalized' => 'applied analytics architect',
+                'lang' => 'en-US',
+                'register' => 'alias',
+                'intent_scope' => 'specialized',
+                'target_kind' => 'leaf_or_child',
+                'precision_score' => 0.92,
+                'confidence_score' => 0.93,
+            ]);
+        }
+
+        $response = $this->getJson('/api/v0.5/career/resolve?q=applied%20analytics%20architect&locale=en-US');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('resolution.resolved_kind', 'ambiguous')
+            ->assertJsonCount(2, 'resolution.candidates')
+            ->assertJsonMissingPath('resolution.occupation')
+            ->assertJsonMissingPath('resolution.family');
+
+        $candidateKinds = collect($response->json('resolution.candidates'))->pluck('candidate_kind')->all();
+        $candidateSlugs = collect($response->json('resolution.candidates'))->pluck('canonical_slug')->sort()->values()->all();
+
+        $this->assertSame(['occupation', 'occupation'], $candidateKinds);
+        $this->assertSame(['data-scientists', 'management-analysts'], $candidateSlugs);
+    }
+
+    public function test_it_returns_none_for_unknown_or_unsafe_queries(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $blocked = $this->compileJobChain(CareerFoundationFixture::seedTrustLimitedCrossMarketChain());
+        $blocked['occupation']->update([
+            'canonical_slug' => 'software-developers',
+            'canonical_title_en' => 'Software Developers',
+        ]);
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $blocked['occupation']->id,
+            'family_id' => $blocked['occupation']->family_id,
+            'alias' => 'Unsafe Resolve Target',
+            'normalized' => 'unsafe resolve target',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.9,
+            'confidence_score' => 0.9,
+        ]);
+
+        $this->getJson('/api/v0.5/career/resolve?q=unsafe%20resolve%20target&locale=en-US')
+            ->assertOk()
+            ->assertJsonPath('resolution.resolved_kind', 'none')
+            ->assertJsonMissingPath('resolution.occupation')
+            ->assertJsonMissingPath('resolution.family')
+            ->assertJsonMissingPath('resolution.candidates');
+    }
+
+    public function test_it_rejects_empty_query_conservatively(): void
+    {
+        $this->getJson('/api/v0.5/career/resolve?q=')
+            ->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'VALIDATION_FAILED');
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     * @return array<string, mixed>
+     */
+    private function compileJobChain(array $chain): array
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-resolve-api-'.$chain['occupation']->canonical_slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        return [
+            'importRun' => $importRun,
+            'compileRun' => $compileRun,
+        ] + $chain;
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\OccupationAlias;
+use App\Models\OccupationFamily;
+use App\Services\Career\Bundles\CareerAliasResolutionBundleBuilder;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerAliasResolutionBundleBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_an_unambiguous_public_safe_occupation_resolution(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $occupation = Occupation::query()
+            ->where('canonical_slug', 'data-scientists')
+            ->firstOrFail();
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $occupation->id,
+            'family_id' => $occupation->family_id,
+            'alias' => 'Applied Data Scientist',
+            'normalized' => 'applied data scientist',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.96,
+        ]);
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('applied data scientist', 'en-US')
+            ->toArray();
+
+        $this->assertSame('career_alias_resolution', $payload['bundle_kind']);
+        $this->assertSame('occupation', data_get($payload, 'resolution.resolved_kind'));
+        $this->assertSame($occupation->id, data_get($payload, 'resolution.occupation.occupation_uuid'));
+        $this->assertSame('data-scientists', data_get($payload, 'resolution.occupation.canonical_slug'));
+        $this->assertSame(true, data_get($payload, 'resolution.occupation.seo_contract.index_eligible'));
+        $this->assertSame('approved', data_get($payload, 'resolution.occupation.trust_summary.reviewer_status'));
+    }
+
+    public function test_it_returns_family_when_family_identity_matches_and_no_safe_leaf_is_selected(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('computer-and-information-technology', 'en')
+            ->toArray();
+
+        $this->assertSame('family', data_get($payload, 'resolution.resolved_kind'));
+        $this->assertSame(
+            'computer-and-information-technology',
+            data_get($payload, 'resolution.family.canonical_slug')
+        );
+        $family = OccupationFamily::query()->where('canonical_slug', 'computer-and-information-technology')->firstOrFail();
+        $this->assertSame($family->title_en, data_get($payload, 'resolution.family.title_en'));
+    }
+
+    public function test_it_returns_ambiguous_when_multiple_public_safe_leaf_candidates_share_the_same_alias(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $first = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $second = Occupation::query()->where('canonical_slug', 'management-analysts')->firstOrFail();
+
+        foreach ([$first, $second] as $chain) {
+            OccupationAlias::query()->create([
+                'occupation_id' => $chain->id,
+                'family_id' => $chain->family_id,
+                'alias' => 'Applied Analytics Architect',
+                'normalized' => 'applied analytics architect',
+                'lang' => 'en-US',
+                'register' => 'alias',
+                'intent_scope' => 'specialized',
+                'target_kind' => 'leaf_or_child',
+                'precision_score' => 0.92,
+                'confidence_score' => 0.93,
+            ]);
+        }
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('applied analytics architect', 'en-US')
+            ->toArray();
+
+        $this->assertSame('ambiguous', data_get($payload, 'resolution.resolved_kind'));
+        $this->assertCount(2, data_get($payload, 'resolution.candidates'));
+        $this->assertSame(
+            ['data-scientists', 'management-analysts'],
+            collect(data_get($payload, 'resolution.candidates'))
+                ->pluck('canonical_slug')
+                ->sort()
+                ->values()
+                ->all()
+        );
+        $this->assertSame(
+            ['occupation', 'occupation'],
+            collect(data_get($payload, 'resolution.candidates'))
+                ->pluck('candidate_kind')
+                ->all()
+        );
+    }
+
+    public function test_it_omits_blocked_leaf_matches_and_returns_none_when_no_other_public_safe_resolution_exists(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $blocked = $this->compileJobChain(CareerFoundationFixture::seedTrustLimitedCrossMarketChain());
+        $blocked['occupation']->update([
+            'canonical_slug' => 'software-developers',
+            'canonical_title_en' => 'Software Developers',
+        ]);
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $blocked['occupation']->id,
+            'family_id' => $blocked['occupation']->family_id,
+            'alias' => 'Blocked Resolve Target',
+            'normalized' => 'blocked resolve target',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.9,
+            'confidence_score' => 0.9,
+        ]);
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('blocked resolve target', 'en-US')
+            ->toArray();
+
+        $this->assertSame('none', data_get($payload, 'resolution.resolved_kind'));
+        $this->assertNull(data_get($payload, 'resolution.occupation'));
+        $this->assertNull(data_get($payload, 'resolution.family'));
+        $this->assertNull(data_get($payload, 'resolution.candidates'));
+    }
+
+    public function test_it_returns_none_for_queries_without_any_safe_resolution(): void
+    {
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('query-with-no-career-match', 'en')
+            ->toArray();
+
+        $this->assertSame('none', data_get($payload, 'resolution.resolved_kind'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $chain
+     * @return array<string, mixed>
+     */
+    private function compileJobChain(array $chain): array
+    {
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-resolve-'.$chain['occupation']->canonical_slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        return [
+            'importRun' => $importRun,
+            'compileRun' => $compileRun,
+        ] + $chain;
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated backend-owned alias resolution authority endpoint at `GET /api/v0.5/career/resolve`
- introduce an explicit resolution bundle with `occupation`, `family`, `ambiguous`, and `none` states instead of mutating the existing career search contract
- enforce strict public-safety gating so only publish-ready, index-eligible, public-safe leaf occupations can resolve directly and blocked leafs are omitted entirely
- allow authority-backed family fallback and public-safe ambiguous candidate sets without exposing blocked counts, family narrative, or search-style fallback copy
- add focused builder and API coverage and update the OpenAPI route snapshot for the new endpoint
- register B24 in the PR train manifest/state with local verification results

## Why
- the backend already had alias, family, and readiness primitives, but no dedicated authority surface for occupation-vs-family resolution
- extending `/api/v0.5/career/search` would have mixed search semantics with disambiguation semantics and weakened the truth boundary
- this PR creates the minimal backend substrate needed for later explorer and disambiguation UI work while keeping current search behavior unchanged

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php app/DTO/Career/CareerAliasResolutionBundle.php app/Http/Resources/Career/CareerAliasResolutionResource.php app/Http/Controllers/API/V0_5/Career/CareerAliasResolutionController.php routes/api.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no frontend work
- no explorer UI or alias search redesign
- no family narrative or disambiguation prose
- no SEO rollout
- no schema or scoring changes
