### PR TITLE
PR-B25: Career family-target alias hardening + family fallback authority strengthening

### DIFF
--- a/backend/app/Domain/Career/Import/FirstWaveAliasHardeningService.php
+++ b/backend/app/Domain/Career/Import/FirstWaveAliasHardeningService.php
@@ -17,13 +17,15 @@ final class FirstWaveAliasHardeningService
 
     public function __construct(
         private readonly FirstWaveAliasCatalogReader $catalogReader,
+        private readonly FirstWaveFamilyAliasPolicy $familyAliasPolicy,
     ) {}
 
     /**
      * @return array{
      *   in_scope:bool,
      *   blocked_aliases:list<string>,
-     *   alias_payloads:list<array<string,mixed>>
+     *   alias_payloads:list<array<string,mixed>>,
+     *   family_alias_payloads:list<array<string,mixed>>
      * }
      */
     public function resolveAliasPayloads(
@@ -38,6 +40,7 @@ final class FirstWaveAliasHardeningService
                 'in_scope' => false,
                 'blocked_aliases' => [],
                 'alias_payloads' => [],
+                'family_alias_payloads' => [],
             ];
         }
 
@@ -89,10 +92,13 @@ final class FirstWaveAliasHardeningService
             $seen[$dedupeKey] = true;
         }
 
+        $familyAliases = $this->familyAliasPolicy->resolveFamilyAliasPayloads($family, $importRun);
+
         return [
             'in_scope' => true,
             'blocked_aliases' => $blockedAliases,
             'alias_payloads' => $payloads,
+            'family_alias_payloads' => $familyAliases['alias_payloads'],
         ];
     }
 

--- a/backend/app/Domain/Career/Import/FirstWaveFamilyAliasPolicy.php
+++ b/backend/app/Domain/Career/Import/FirstWaveFamilyAliasPolicy.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Import;
+
+use App\Models\CareerImportRun;
+use App\Models\OccupationFamily;
+use RuntimeException;
+
+final class FirstWaveFamilyAliasPolicy
+{
+    /**
+     * @var array<string, array{
+     *   family_slug:string,
+     *   approved_family_alias_rows:list<array<string,mixed>>,
+     *   blocked_aliases:list<string>
+     * }>|null
+     */
+    private ?array $catalog = null;
+
+    public function defaultPath(): string
+    {
+        return base_path('docs/career/first_wave_family_aliases.json');
+    }
+
+    /**
+     * @return array{
+     *   version:string,
+     *   wave_name:string,
+     *   scope_source:string,
+     *   count_expected:int,
+     *   count_actual:int,
+     *   policy:array<string,mixed>,
+     *   items:list<array<string,mixed>>
+     * }
+     */
+    public function read(?string $path = null): array
+    {
+        $resolved = $path === null || trim($path) === ''
+            ? $this->defaultPath()
+            : (str_starts_with($path, '/') ? $path : base_path($path));
+
+        if (! is_file($resolved)) {
+            throw new RuntimeException(sprintf('First-wave family alias catalog not found at [%s].', $resolved));
+        }
+
+        $decoded = json_decode((string) file_get_contents($resolved), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException(sprintf('First-wave family alias catalog is not valid JSON: [%s].', $resolved));
+        }
+
+        foreach (['version', 'wave_name', 'scope_source', 'count_expected', 'count_actual', 'policy', 'items'] as $field) {
+            if (! array_key_exists($field, $decoded)) {
+                throw new RuntimeException(sprintf('First-wave family alias catalog missing field [%s].', $field));
+            }
+        }
+
+        if (! is_array($decoded['policy']) || ! is_array($decoded['items'])) {
+            throw new RuntimeException('First-wave family alias catalog policy and items must be arrays.');
+        }
+
+        $expected = (int) $decoded['count_expected'];
+        $actual = (int) $decoded['count_actual'];
+        if ($expected !== $actual || count($decoded['items']) !== $actual) {
+            throw new RuntimeException('First-wave family alias catalog count metadata must match items length.');
+        }
+
+        $seenFamilySlugs = [];
+        foreach ($decoded['items'] as $index => $item) {
+            if (! is_array($item)) {
+                throw new RuntimeException(sprintf('First-wave family alias catalog item at index [%d] is invalid.', $index));
+            }
+
+            foreach (['family_slug', 'approved_family_alias_rows', 'blocked_aliases'] as $field) {
+                if (! array_key_exists($field, $item)) {
+                    throw new RuntimeException(sprintf('First-wave family alias catalog item [%d] missing [%s].', $index, $field));
+                }
+            }
+
+            $familySlug = trim((string) $item['family_slug']);
+            if ($familySlug === '') {
+                throw new RuntimeException(sprintf('First-wave family alias catalog item [%d] contains blank family_slug.', $index));
+            }
+            if (isset($seenFamilySlugs[$familySlug])) {
+                throw new RuntimeException(sprintf('First-wave family alias catalog contains duplicate family slug [%s].', $familySlug));
+            }
+            $seenFamilySlugs[$familySlug] = true;
+
+            if (! is_array($item['approved_family_alias_rows']) || ! is_array($item['blocked_aliases'])) {
+                throw new RuntimeException(sprintf('First-wave family alias catalog item [%s] must contain alias arrays.', $familySlug));
+            }
+
+            foreach ($item['approved_family_alias_rows'] as $aliasIndex => $aliasRow) {
+                if (! is_array($aliasRow)) {
+                    throw new RuntimeException(sprintf('First-wave family alias row [%s:%d] is invalid.', $familySlug, $aliasIndex));
+                }
+
+                foreach (['alias', 'normalized', 'lang', 'register', 'precision', 'confidence'] as $field) {
+                    if (! array_key_exists($field, $aliasRow)) {
+                        throw new RuntimeException(sprintf('First-wave family alias row [%s:%d] missing [%s].', $familySlug, $aliasIndex, $field));
+                    }
+                }
+
+                if (trim((string) $aliasRow['alias']) === '' || trim((string) $aliasRow['normalized']) === '') {
+                    throw new RuntimeException(sprintf('First-wave family alias row [%s:%d] contains blank alias fields.', $familySlug, $aliasIndex));
+                }
+            }
+
+            foreach ($item['blocked_aliases'] as $blockedIndex => $blockedAlias) {
+                if (trim((string) $blockedAlias) === '') {
+                    throw new RuntimeException(sprintf('First-wave family blocked alias [%s:%d] must not be blank.', $familySlug, $blockedIndex));
+                }
+            }
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, array{
+     *   family_slug:string,
+     *   approved_family_alias_rows:list<array<string,mixed>>,
+     *   blocked_aliases:list<string>
+     * }>
+     */
+    public function byFamilySlug(?string $path = null): array
+    {
+        $catalog = $this->read($path);
+
+        $indexed = [];
+        foreach ($catalog['items'] as $item) {
+            $indexed[(string) $item['family_slug']] = $item;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @return array{
+     *   in_scope:bool,
+     *   blocked_aliases:list<string>,
+     *   alias_payloads:list<array<string,mixed>>
+     * }
+     */
+    public function resolveFamilyAliasPayloads(
+        OccupationFamily $family,
+        CareerImportRun $importRun,
+    ): array {
+        $entry = $this->catalog()[$family->canonical_slug] ?? null;
+        if (! is_array($entry)) {
+            return [
+                'in_scope' => false,
+                'blocked_aliases' => [],
+                'alias_payloads' => [],
+            ];
+        }
+
+        $blockedAliases = array_values(array_filter(array_map(
+            fn (mixed $alias): string => $this->normalizeText($alias),
+            $entry['blocked_aliases'] ?? [],
+        )));
+        $blockedSet = array_fill_keys($blockedAliases, true);
+
+        $payloads = [];
+        $seen = [];
+
+        foreach ($entry['approved_family_alias_rows'] as $row) {
+            $alias = trim((string) ($row['alias'] ?? ''));
+            $normalized = trim((string) ($row['normalized'] ?? ''));
+            $lang = trim((string) ($row['lang'] ?? ''));
+
+            if ($alias === '' || $normalized === '' || $lang === '') {
+                continue;
+            }
+
+            $aliasKey = $this->normalizeText($alias);
+            if ($aliasKey === '' || isset($blockedSet[$aliasKey])) {
+                continue;
+            }
+
+            $dedupeKey = sprintf('%s|%s', strtolower($lang), $this->normalizeText($normalized));
+            if (isset($seen[$dedupeKey])) {
+                continue;
+            }
+
+            $payloads[] = [
+                'occupation_id' => null,
+                'family_id' => $family->id,
+                'alias' => $alias,
+                'normalized' => $this->normalizeText($normalized),
+                'lang' => $lang,
+                'register' => (string) ($row['register'] ?? 'family_alias'),
+                'intent_scope' => 'exact',
+                'target_kind' => 'family',
+                'precision_score' => (float) ($row['precision'] ?? 1.0),
+                'confidence_score' => (float) ($row['confidence'] ?? 1.0),
+                'seniority_hint' => null,
+                'function_hint' => null,
+                'import_run_id' => $importRun->id,
+                'row_fingerprint' => null,
+            ];
+
+            $seen[$dedupeKey] = true;
+        }
+
+        return [
+            'in_scope' => true,
+            'blocked_aliases' => $blockedAliases,
+            'alias_payloads' => $payloads,
+        ];
+    }
+
+    /**
+     * @return array<string, array{
+     *   family_slug:string,
+     *   approved_family_alias_rows:list<array<string,mixed>>,
+     *   blocked_aliases:list<string>
+     * }>
+     */
+    private function catalog(): array
+    {
+        if ($this->catalog === null) {
+            $this->catalog = $this->byFamilySlug();
+        }
+
+        return $this->catalog;
+    }
+
+    private function normalizeText(mixed $value): string
+    {
+        return mb_strtolower(trim((string) $value), 'UTF-8');
+    }
+}

--- a/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
@@ -20,6 +20,7 @@ final class CareerAliasResolutionBundleBuilder
     public function __construct(
         private readonly FirstWaveReadinessSummaryService $readinessSummaryService,
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
+        private readonly CareerFamilyHubBundleBuilder $familyHubBundleBuilder,
     ) {}
 
     public function build(string $query, ?string $locale = null): CareerAliasResolutionBundle
@@ -319,6 +320,10 @@ final class CareerAliasResolutionBundleBuilder
                 continue;
             }
 
+            if (! $this->familyHasVisibleChildren($family)) {
+                continue;
+            }
+
             $matchTier = $this->resolveFamilyMatchTier($family, $normalizedQuery, $rawQuery, $normalizedLocale, $exactOnly);
             if ($matchTier === null) {
                 continue;
@@ -409,6 +414,16 @@ final class CareerAliasResolutionBundleBuilder
         }
 
         return false;
+    }
+
+    private function familyHasVisibleChildren(OccupationFamily $family): bool
+    {
+        $bundle = $this->familyHubBundleBuilder->buildBySlug((string) $family->canonical_slug);
+        if ($bundle === null) {
+            return false;
+        }
+
+        return count($bundle->visibleChildren) > 0;
     }
 
     /**

--- a/backend/app/Services/Career/Import/CareerAuthorityMaterializer.php
+++ b/backend/app/Services/Career/Import/CareerAuthorityMaterializer.php
@@ -512,7 +512,11 @@ final class CareerAuthorityMaterializer
             ];
         }
 
-        $payloads = [...$payloads, ...$hardening['alias_payloads']];
+        $payloads = [
+            ...$payloads,
+            ...$hardening['alias_payloads'],
+            ...((array) ($hardening['family_alias_payloads'] ?? [])),
+        ];
 
         $deduped = [];
         $seen = [];

--- a/backend/docs/career/first_wave_family_aliases.json
+++ b/backend/docs/career/first_wave_family_aliases.json
@@ -1,0 +1,79 @@
+{
+  "version": "first_wave_family_aliases_v1",
+  "wave_name": "career_first_wave_10",
+  "scope_source": "backend/docs/career/first_wave_manifest.json",
+  "count_expected": 2,
+  "count_actual": 2,
+  "policy": {
+    "allowed_match_scope": [
+      "explicit_family_slug_variant",
+      "explicit_family_title_variant",
+      "explicit_family_market_title"
+    ],
+    "disallowed_scope": [
+      "broad_slang_family_alias",
+      "crosswalk_derived_family_alias",
+      "leaf_title_promotion",
+      "short_ambiguous_umbrella"
+    ],
+    "rules": [
+      "Only aliases explicitly listed here may be authored as target_kind=family.",
+      "Do not promote nearby-professional or leaf job titles into family-target aliases.",
+      "Do not author family-target aliases for families without stable public-safe intent.",
+      "Chinese family aliases must remain narrow umbrella titles, not broad generic shorthand."
+    ]
+  },
+  "items": [
+    {
+      "family_slug": "computer-and-information-technology",
+      "approved_family_alias_rows": [
+        {
+          "alias": "Computer and Information Technology Careers",
+          "normalized": "computer and information technology careers",
+          "lang": "en",
+          "register": "family_title_variant",
+          "precision": 0.98,
+          "confidence": 0.98
+        },
+        {
+          "alias": "Information Technology Careers",
+          "normalized": "information technology careers",
+          "lang": "en",
+          "register": "family_market_title",
+          "precision": 0.9,
+          "confidence": 0.88
+        },
+        {
+          "alias": "信息技术职业",
+          "normalized": "信息技术职业",
+          "lang": "zh-CN",
+          "register": "family_market_title",
+          "precision": 0.92,
+          "confidence": 0.9
+        }
+      ],
+      "blocked_aliases": [
+        "technology",
+        "tech",
+        "it"
+      ]
+    },
+    {
+      "family_slug": "business-and-financial-operations",
+      "approved_family_alias_rows": [
+        {
+          "alias": "Business and Financial Operations Careers",
+          "normalized": "business and financial operations careers",
+          "lang": "en",
+          "register": "family_title_variant",
+          "precision": 0.97,
+          "confidence": 0.96
+        }
+      ],
+      "blocked_aliases": [
+        "business",
+        "finance"
+      ]
+    }
+  ]
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T17:24:00Z",
+  "updated_at": "2026-04-11T23:46:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -518,10 +518,10 @@
     "PR-B25": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b25-career-family-target-alias-hardening-family-fallback-authority",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "7eedb2b0a3d27cd580c5c7522b1871d1a1a420a6",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/867",
       "checks": {
         "local": [
           {
@@ -537,9 +537,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24285913530/job/70915119095"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24285913530/job/70915121673"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions jobs failed immediately on hygiene, matching the current repository workflow-start failure pattern rather than a locally reproducible B25 regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T23:46:00Z",
+  "updated_at": "2026-04-11T23:47:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -520,7 +520,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "github_checks_failed",
       "branch": "codex/pr-b25-career-family-target-alias-hardening-family-fallback-authority",
-      "commit_sha": "7eedb2b0a3d27cd580c5c7522b1871d1a1a420a6",
+      "commit_sha": "9359b10472bb0d31e5e5cda5d34941cb8c721083",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/867",
       "checks": {
         "local": [
@@ -541,12 +541,12 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24285913530/job/70915119095"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24285926777/job/70915150031"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24285913530/job/70915121673"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24285926777/job/70915152259"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T17:00:00Z",
+  "updated_at": "2026-04-11T17:24:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -510,6 +510,36 @@
         ]
       },
       "failure_reason": "GitHub hygiene failed immediately again and the MBTI matrix job was skipped; local B24 verification passed and the failure pattern matches the repository's current workflow-start issue rather than a locally reproducible alias-resolution regression.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B25": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b25-career-family-target-alias-hardening-family-fallback-authority",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Import/FirstWaveFamilyAliasPolicy.php app/Domain/Career/Import/FirstWaveAliasHardeningService.php app/Services/Career/Import/CareerAuthorityMaterializer.php app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php tests/Unit/Services/Career/FirstWaveFamilyAliasPolicyTest.php tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/FirstWaveFamilyAliasPolicyTest.php tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -365,6 +365,32 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B25
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b25-career-family-target-alias-hardening-family-fallback-authority
+    base: main
+    depends_on: ["PR-B24"]
+    mode: execute
+    scope: >
+      Career family-target alias hardening + family fallback authority strengthening.
+      Add an explicit curated family-target alias policy, production-write a small
+      family-target alias subset, and strengthen B24 family resolution semantics
+      without changing B24 public contract shape, frontend, schema, or scoring.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Import/FirstWaveFamilyAliasPolicy.php app/Domain/Career/Import/FirstWaveAliasHardeningService.php app/Services/Career/Import/CareerAuthorityMaterializer.php app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php tests/Unit/Services/Career/FirstWaveFamilyAliasPolicyTest.php tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php"
+      - "php artisan test tests/Unit/Services/Career/FirstWaveFamilyAliasPolicyTest.php tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerAliasResolutionApiTest.php
+++ b/backend/tests/Feature/Career/CareerAliasResolutionApiTest.php
@@ -66,6 +66,18 @@ final class CareerAliasResolutionApiTest extends TestCase
             ->assertJsonMissingPath('resolution.candidates');
     }
 
+    public function test_it_returns_family_for_a_curated_family_target_alias(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $this->getJson('/api/v0.5/career/resolve?q=information%20technology%20careers&locale=en')
+            ->assertOk()
+            ->assertJsonPath('resolution.resolved_kind', 'family')
+            ->assertJsonPath('resolution.family.canonical_slug', 'computer-and-information-technology')
+            ->assertJsonMissingPath('resolution.occupation')
+            ->assertJsonMissingPath('resolution.candidates');
+    }
+
     public function test_it_returns_ambiguous_with_public_safe_candidates_only(): void
     {
         $this->materializeCurrentFirstWaveFixture();
@@ -139,6 +151,35 @@ final class CareerAliasResolutionApiTest extends TestCase
             ->assertStatus(422)
             ->assertJsonPath('ok', false)
             ->assertJsonPath('error_code', 'VALIDATION_FAILED');
+    }
+
+    public function test_it_does_not_return_family_for_explicit_family_aliases_when_the_family_has_no_visible_children(): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'empty-family-api-resolution',
+            'title_en' => 'Empty Family Api Resolution',
+            'title_zh' => '空家族接口解析',
+        ]);
+
+        OccupationAlias::query()->create([
+            'occupation_id' => null,
+            'family_id' => $family->id,
+            'alias' => 'Empty Family Api Careers',
+            'normalized' => 'empty family api careers',
+            'lang' => 'en',
+            'register' => 'family_market_title',
+            'intent_scope' => 'exact',
+            'target_kind' => 'family',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.95,
+        ]);
+
+        $this->getJson('/api/v0.5/career/resolve?q=empty%20family%20api%20careers&locale=en')
+            ->assertOk()
+            ->assertJsonPath('resolution.resolved_kind', 'none')
+            ->assertJsonMissingPath('resolution.occupation')
+            ->assertJsonMissingPath('resolution.family')
+            ->assertJsonMissingPath('resolution.candidates');
     }
 
     /**

--- a/backend/tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
@@ -69,6 +69,21 @@ final class CareerAliasResolutionBundleBuilderTest extends TestCase
         $this->assertSame($family->title_en, data_get($payload, 'resolution.family.title_en'));
     }
 
+    public function test_it_returns_family_for_explicit_family_target_aliases_when_the_family_has_visible_children(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('information technology careers', 'en')
+            ->toArray();
+
+        $this->assertSame('family', data_get($payload, 'resolution.resolved_kind'));
+        $this->assertSame(
+            'computer-and-information-technology',
+            data_get($payload, 'resolution.family.canonical_slug')
+        );
+    }
+
     public function test_it_returns_ambiguous_when_multiple_public_safe_leaf_candidates_share_the_same_alias(): void
     {
         $this->materializeCurrentFirstWaveFixture();
@@ -148,6 +163,34 @@ final class CareerAliasResolutionBundleBuilderTest extends TestCase
     {
         $payload = app(CareerAliasResolutionBundleBuilder::class)
             ->build('query-with-no-career-match', 'en')
+            ->toArray();
+
+        $this->assertSame('none', data_get($payload, 'resolution.resolved_kind'));
+    }
+
+    public function test_it_omits_family_target_aliases_when_the_family_has_no_visible_public_safe_children(): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'empty-family-resolution',
+            'title_en' => 'Empty Family Resolution',
+            'title_zh' => '空家族解析',
+        ]);
+
+        OccupationAlias::query()->create([
+            'occupation_id' => null,
+            'family_id' => $family->id,
+            'alias' => 'Empty Family Careers',
+            'normalized' => 'empty family careers',
+            'lang' => 'en',
+            'register' => 'family_market_title',
+            'intent_scope' => 'exact',
+            'target_kind' => 'family',
+            'precision_score' => 0.95,
+            'confidence_score' => 0.95,
+        ]);
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('empty family careers', 'en')
             ->toArray();
 
         $this->assertSame('none', data_get($payload, 'resolution.resolved_kind'));

--- a/backend/tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php
@@ -6,6 +6,8 @@ namespace Tests\Unit\Services\Career;
 
 use App\Models\CareerImportRun;
 use App\Models\Occupation;
+use App\Models\OccupationAlias;
+use App\Models\OccupationFamily;
 use App\Services\Career\Import\CareerAuthorityMaterializer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -60,17 +62,75 @@ final class CareerAuthorityMaterializerAliasHardeningTest extends TestCase
         $this->assertSame(['marketing managers', 'marketing managers 中文'], $normalizedAliases);
     }
 
+    public function test_it_materializes_explicit_family_target_alias_rows_without_promoting_leaf_aliases(): void
+    {
+        $run = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b25-family-materializer',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+
+        app(CareerAuthorityMaterializer::class)->materializeImportRow(
+            $this->normalizedRow(
+                'data-scientists',
+                'Data Scientists',
+                'computer-and-information-technology',
+                'Computer and Information Technology',
+                '计算机与信息技术',
+            ),
+            $run
+        );
+
+        $family = OccupationFamily::query()->where('canonical_slug', 'computer-and-information-technology')->firstOrFail();
+        $familyAliases = OccupationAlias::query()
+            ->where('family_id', $family->id)
+            ->where('target_kind', 'family')
+            ->orderBy('normalized')
+            ->get();
+
+        $this->assertSame(
+            [
+                'computer and information technology careers',
+                'information technology careers',
+                '信息技术职业',
+            ],
+            $familyAliases->pluck('normalized')->all()
+        );
+        $this->assertSame([null, null, null], $familyAliases->pluck('occupation_id')->all());
+
+        $leafAliases = OccupationAlias::query()
+            ->where('family_id', $family->id)
+            ->whereNotNull('occupation_id')
+            ->pluck('target_kind')
+            ->unique()
+            ->values()
+            ->all();
+
+        $this->assertContains('occupation', $leafAliases);
+        $this->assertNotContains('family', $leafAliases);
+    }
+
     /**
      * @return array<string, mixed>
      */
-    private function normalizedRow(string $slug, string $title): array
-    {
+    private function normalizedRow(
+        string $slug,
+        string $title,
+        ?string $familySlug = null,
+        ?string $familyTitleEn = null,
+        ?string $familyTitleZh = null,
+    ): array {
         $titleZh = $title.' 中文';
 
         return [
-            'family_slug' => 'test-family-'.$slug,
-            'family_title_en' => 'Test Family',
-            'family_title_zh' => '测试家族',
+            'family_slug' => $familySlug ?? 'test-family-'.$slug,
+            'family_title_en' => $familyTitleEn ?? 'Test Family',
+            'family_title_zh' => $familyTitleZh ?? '测试家族',
             'canonical_slug' => $slug,
             'truth_market' => 'US',
             'display_market' => 'US',

--- a/backend/tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php
+++ b/backend/tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php
@@ -44,6 +44,7 @@ final class FirstWaveAliasHardeningServiceTest extends TestCase
             ['software developer', 'software developers', 'application developer', '软件开发工程师', '软件工程师'],
             array_values(array_map(static fn (array $payload): string => (string) $payload['normalized'], $resolved['alias_payloads']))
         );
+        $this->assertSame([], $resolved['family_alias_payloads']);
     }
 
     public function test_it_returns_no_alias_payloads_for_first_wave_entries_without_approved_alias_rows(): void
@@ -73,6 +74,7 @@ final class FirstWaveAliasHardeningServiceTest extends TestCase
         $this->assertTrue($resolved['in_scope']);
         $this->assertSame([], $resolved['alias_payloads']);
         $this->assertSame([], $resolved['blocked_aliases']);
+        $this->assertSame([], $resolved['family_alias_payloads']);
     }
 
     public function test_it_leaves_non_first_wave_occupations_out_of_scope(): void
@@ -101,5 +103,50 @@ final class FirstWaveAliasHardeningServiceTest extends TestCase
 
         $this->assertFalse($resolved['in_scope']);
         $this->assertSame([], $resolved['alias_payloads']);
+        $this->assertSame([], $resolved['family_alias_payloads']);
+    }
+
+    public function test_it_returns_curated_family_target_aliases_alongside_leaf_aliases_for_supported_families(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'data-scientists',
+            'crosswalk_mode' => 'exact',
+        ]);
+        $chain['family']->update([
+            'canonical_slug' => 'computer-and-information-technology',
+            'title_en' => 'Computer and Information Technology',
+            'title_zh' => '计算机与信息技术',
+        ]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b25-data-scientists',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+
+        $resolved = app(FirstWaveAliasHardeningService::class)->resolveAliasPayloads(
+            'data-scientists',
+            $chain['occupation'],
+            $chain['family'],
+            $importRun,
+        );
+
+        $this->assertTrue($resolved['in_scope']);
+        $this->assertSame(
+            [
+                'computer and information technology careers',
+                'information technology careers',
+                '信息技术职业',
+            ],
+            array_values(array_map(static fn (array $payload): string => (string) $payload['normalized'], $resolved['family_alias_payloads']))
+        );
+        $this->assertSame(
+            ['family', 'family', 'family'],
+            array_values(array_map(static fn (array $payload): string => (string) $payload['target_kind'], $resolved['family_alias_payloads']))
+        );
     }
 }

--- a/backend/tests/Unit/Services/Career/FirstWaveFamilyAliasPolicyTest.php
+++ b/backend/tests/Unit/Services/Career/FirstWaveFamilyAliasPolicyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Import\FirstWaveFamilyAliasPolicy;
+use App\Models\CareerImportRun;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class FirstWaveFamilyAliasPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_only_curated_family_target_aliases_for_supported_families(): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'computer-and-information-technology',
+            'title_en' => 'Computer and Information Technology',
+            'title_zh' => '计算机与信息技术',
+        ]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b25-family-policy',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+
+        $resolved = app(FirstWaveFamilyAliasPolicy::class)->resolveFamilyAliasPayloads($family, $importRun);
+
+        $this->assertTrue($resolved['in_scope']);
+        $this->assertContains('tech', $resolved['blocked_aliases']);
+        $this->assertSame(
+            [
+                'computer and information technology careers',
+                'information technology careers',
+                '信息技术职业',
+            ],
+            array_values(array_map(static fn (array $payload): string => (string) $payload['normalized'], $resolved['alias_payloads']))
+        );
+        $this->assertSame(
+            ['family', 'family', 'family'],
+            array_values(array_map(static fn (array $payload): string => (string) $payload['target_kind'], $resolved['alias_payloads']))
+        );
+    }
+
+    public function test_it_does_not_promote_out_of_scope_families(): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'custom-platform-roles',
+            'title_en' => 'Custom Platform Roles',
+            'title_zh' => '自定义平台岗位',
+        ]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b25-family-policy-custom',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+
+        $resolved = app(FirstWaveFamilyAliasPolicy::class)->resolveFamilyAliasPayloads($family, $importRun);
+
+        $this->assertFalse($resolved['in_scope']);
+        $this->assertSame([], $resolved['alias_payloads']);
+        $this->assertSame([], $resolved['blocked_aliases']);
+    }
+}


### PR DESCRIPTION
## What changed
- add an explicit first-wave family-target alias policy/catalog with a conservative curated subset of family aliases
- extend first-wave alias hardening and authority materialization to production-write explicit `target_kind = family` alias rows without reinterpreting existing family-linked leaf aliases
- strengthen the alias resolution builder so explicit family-target aliases resolve to `family` only when the family hub is actually public-safe
- keep B24 public response shape unchanged while improving the authority behind `family` resolution
- add focused policy, materialization, resolver, family-hub-safety, and API regression coverage
- register B25 in the PR train manifest/state with local verification results

## Why
- the schema and resolver already supported family-target semantics structurally, but production alias authoring was still occupation-first
- this PR adds a small, auditable family-target alias truth layer instead of promoting all family-linked aliases or inventing fallback semantics
- the result is a more stable backend substrate for family resolution while preserving strict leaf public-safety gating and keeping the public contract unchanged

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Import/FirstWaveFamilyAliasPolicy.php app/Domain/Career/Import/FirstWaveAliasHardeningService.php app/Services/Career/Import/CareerAuthorityMaterializer.php app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php tests/Unit/Services/Career/FirstWaveFamilyAliasPolicyTest.php tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php`
- `php artisan test tests/Unit/Services/Career/FirstWaveFamilyAliasPolicyTest.php tests/Unit/Services/Career/FirstWaveAliasHardeningServiceTest.php tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php`

## Intentionally deferred
- no B24 DTO/resource/controller public contract change
- no frontend work
- no explorer/search redesign
- no broad family alias promotion beyond the curated subset
- no schema or scoring changes
