### PR TITLE
PR-B26: Career internal index lifecycle compiler

### DIFF
--- a/backend/app/Domain/Career/IndexStateValue.php
+++ b/backend/app/Domain/Career/IndexStateValue.php
@@ -13,4 +13,62 @@ final class IndexStateValue
     public const NOINDEX = 'noindex';
 
     public const INDEXABLE = 'indexable';
+
+    public const PROMOTION_CANDIDATE = 'promotion_candidate';
+
+    public const INDEXED = 'indexed';
+
+    public const DEMOTED = 'demoted';
+
+    public static function publicFacing(string $state, bool $indexEligible): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match ($normalized) {
+            self::INDEXED => self::INDEXABLE,
+            self::PROMOTION_CANDIDATE => self::TRUST_LIMITED,
+            self::DEMOTED => self::NOINDEX,
+            default => $indexEligible && $normalized === '' ? self::INDEXABLE : ($normalized !== '' ? $normalized : self::NOINDEX),
+        };
+    }
+
+    public static function isIndexedLike(string $state, bool $indexEligible): bool
+    {
+        if (! $indexEligible) {
+            return false;
+        }
+
+        return in_array(strtolower(trim($state)), [self::INDEXABLE, self::INDEXED], true);
+    }
+
+    public static function isIndexRestricted(string $state, bool $indexEligible): bool
+    {
+        if (! $indexEligible) {
+            return true;
+        }
+
+        return in_array(
+            self::publicFacing($state, $indexEligible),
+            [self::TRUST_LIMITED, self::NOINDEX, self::UNAVAILABLE],
+            true,
+        );
+    }
+
+    public static function isIndexBlocked(string $state, bool $indexEligible): bool
+    {
+        return in_array(
+            self::publicFacing($state, $indexEligible),
+            [self::NOINDEX, self::UNAVAILABLE],
+            true,
+        );
+    }
+
+    public static function wasIndexedOrCandidate(string $state): bool
+    {
+        return in_array(
+            strtolower(trim($state)),
+            [self::INDEXABLE, self::INDEXED, self::PROMOTION_CANDIDATE],
+            true,
+        );
+    }
 }

--- a/backend/app/Domain/Career/Publish/CareerIndexLifecycleCompiler.php
+++ b/backend/app/Domain/Career/Publish/CareerIndexLifecycleCompiler.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Domain\Career\IndexStateValue;
+use App\Domain\Career\ReviewerStatus;
+
+final class CareerIndexLifecycleCompiler
+{
+    public function __construct(
+        private readonly FirstWavePublishGate $publishGate,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $subject
+     * @return array{index_state:string,index_eligible:bool,reason_codes:list<string>}
+     */
+    public function compile(array $subject): array
+    {
+        $rawIndexState = strtolower(trim((string) ($subject['raw_index_state'] ?? $subject['index_state'] ?? '')));
+        $indexEligible = (bool) ($subject['index_eligible'] ?? false);
+        $previousState = strtolower(trim((string) ($subject['previous_index_state'] ?? '')));
+        $crosswalkMode = strtolower(trim((string) ($subject['crosswalk_mode'] ?? '')));
+        $reviewerStatus = strtolower(trim((string) ($subject['reviewer_status'] ?? '')));
+        $allowStrongClaim = (bool) ($subject['allow_strong_claim'] ?? false);
+        $reasonCodes = array_values(array_filter(
+            array_map(
+                static fn (mixed $code): string => is_string($code) ? trim($code) : '',
+                (array) ($subject['reason_codes'] ?? [])
+            ),
+            static fn (string $code): bool => $code !== ''
+        ));
+
+        $gate = $this->publishGate->evaluate([
+            'crosswalk_mode' => $crosswalkMode,
+            'confidence_score' => $subject['confidence_score'] ?? 0,
+            'reviewer_status' => $reviewerStatus,
+            'index_state' => $rawIndexState,
+            'index_eligible' => $indexEligible,
+            'allow_strong_claim' => $allowStrongClaim,
+        ]);
+
+        $stable = (bool) $gate['publishable']
+            && IndexStateValue::isIndexedLike($rawIndexState, $indexEligible)
+            && in_array($crosswalkMode, ['exact', 'trust_inheritance'], true)
+            && in_array($reviewerStatus, [ReviewerStatus::APPROVED, 'reviewed'], true)
+            && $allowStrongClaim;
+
+        if ($stable) {
+            return [
+                'index_state' => CareerIndexLifecycleState::INDEXED,
+                'index_eligible' => true,
+                'reason_codes' => $this->withLifecycleReason($reasonCodes, CareerIndexLifecycleState::INDEXED),
+            ];
+        }
+
+        if ($this->shouldDemote($previousState, $rawIndexState, $indexEligible, $gate['classification'] ?? null, $reviewerStatus, $allowStrongClaim)) {
+            return [
+                'index_state' => CareerIndexLifecycleState::DEMOTED,
+                'index_eligible' => false,
+                'reason_codes' => $this->withLifecycleReason($reasonCodes, CareerIndexLifecycleState::DEMOTED, 'career_index_lifecycle_regressed'),
+            ];
+        }
+
+        if (($gate['classification'] ?? null) === WaveClassification::CANDIDATE) {
+            return [
+                'index_state' => CareerIndexLifecycleState::PROMOTION_CANDIDATE,
+                'index_eligible' => false,
+                'reason_codes' => $this->withLifecycleReason($reasonCodes, CareerIndexLifecycleState::PROMOTION_CANDIDATE),
+            ];
+        }
+
+        return [
+            'index_state' => CareerIndexLifecycleState::NOINDEX,
+            'index_eligible' => false,
+            'reason_codes' => $this->withLifecycleReason($reasonCodes, CareerIndexLifecycleState::NOINDEX),
+        ];
+    }
+
+    private function shouldDemote(
+        string $previousState,
+        string $rawIndexState,
+        bool $indexEligible,
+        mixed $gateClassification,
+        string $reviewerStatus,
+        bool $allowStrongClaim,
+    ): bool {
+        $priorIndexed = in_array($previousState, [IndexStateValue::INDEXABLE, CareerIndexLifecycleState::INDEXED], true);
+        $priorCandidate = $previousState === CareerIndexLifecycleState::PROMOTION_CANDIDATE;
+
+        $regressed = ! $indexEligible
+            || in_array($rawIndexState, [IndexStateValue::TRUST_LIMITED, IndexStateValue::NOINDEX, IndexStateValue::UNAVAILABLE], true)
+            || $gateClassification === WaveClassification::HOLD
+            || ! in_array($reviewerStatus, [ReviewerStatus::APPROVED, 'reviewed'], true)
+            || ! $allowStrongClaim;
+
+        if ($priorIndexed && $regressed) {
+            return true;
+        }
+
+        return $priorCandidate && (
+            $gateClassification === WaveClassification::HOLD
+            || in_array($rawIndexState, [IndexStateValue::NOINDEX, IndexStateValue::UNAVAILABLE], true)
+            || ! $indexEligible
+        );
+    }
+
+    /**
+     * @param  list<string>  $reasonCodes
+     * @return list<string>
+     */
+    private function withLifecycleReason(array $reasonCodes, string $state, ?string $extra = null): array
+    {
+        $reasonCodes[] = 'career_index_lifecycle_'.$state;
+        if (is_string($extra) && $extra !== '') {
+            $reasonCodes[] = $extra;
+        }
+
+        return array_values(array_unique($reasonCodes));
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerIndexLifecycleState.php
+++ b/backend/app/Domain/Career/Publish/CareerIndexLifecycleState.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+final class CareerIndexLifecycleState
+{
+    public const NOINDEX = 'noindex';
+
+    public const PROMOTION_CANDIDATE = 'promotion_candidate';
+
+    public const INDEXED = 'indexed';
+
+    public const DEMOTED = 'demoted';
+}

--- a/backend/app/Domain/Career/Publish/FirstWavePublishGate.php
+++ b/backend/app/Domain/Career/Publish/FirstWavePublishGate.php
@@ -57,7 +57,7 @@ final class FirstWavePublishGate
             $reasons[] = PublishReasonCode::REVIEWER_BLOCKED;
         }
 
-        if ($indexEligible && $indexState === IndexStateValue::INDEXABLE) {
+        if (IndexStateValue::isIndexedLike($indexState, $indexEligible)) {
             $reasons[] = PublishReasonCode::INDEX_ELIGIBLE;
         } else {
             $reasons[] = PublishReasonCode::INDEX_INELIGIBLE;
@@ -73,8 +73,7 @@ final class FirstWavePublishGate
             in_array($crosswalkMode, ['exact', 'trust_inheritance'], true)
             && $confidenceScore >= 75
             && $reviewerStatus === ReviewerStatus::APPROVED
-            && $indexEligible
-            && $indexState === IndexStateValue::INDEXABLE
+            && IndexStateValue::isIndexedLike($indexState, $indexEligible)
             && $allowStrongClaim
         ) {
             $reasons[] = PublishReasonCode::STABLE_PUBLISH_READY;
@@ -89,7 +88,7 @@ final class FirstWavePublishGate
         if (
             $confidenceScore < 60
             || $reviewerStatus === ReviewerStatus::CHANGES_REQUIRED
-            || $indexState === IndexStateValue::UNAVAILABLE
+            || in_array($indexState, [IndexStateValue::UNAVAILABLE, IndexStateValue::DEMOTED], true)
         ) {
             $reasons[] = PublishReasonCode::HOLD_SCOPE_RESTRICTED;
 

--- a/backend/app/Domain/Career/Publish/FirstWavePublishSeedMaterializer.php
+++ b/backend/app/Domain/Career/Publish/FirstWavePublishSeedMaterializer.php
@@ -13,6 +13,10 @@ use App\Services\Career\CareerRecommendationCompiler;
 
 final class FirstWavePublishSeedMaterializer
 {
+    public function __construct(
+        private readonly CareerIndexLifecycleCompiler $indexLifecycleCompiler,
+    ) {}
+
     /**
      * @param  list<array<string, mixed>>  $occupations
      * @return array{applied:int,skipped:int,issues_by_slug:array<string,list<string>>}
@@ -71,8 +75,8 @@ final class FirstWavePublishSeedMaterializer
             $confidenceScore = (int) round((float) ($trustSeed['confidence_score'] ?? 0));
             $reviewerStatus = strtolower(trim((string) ($reviewerSeed['status'] ?? 'pending')));
             $reviewedAt = in_array($reviewerStatus, ['approved', 'reviewed'], true) ? now() : null;
-            $indexState = strtolower(trim((string) ($indexSeed['state'] ?? IndexStateValue::NOINDEX)));
-            $indexEligible = (bool) ($indexSeed['index_eligible'] ?? false);
+            $rawIndexState = strtolower(trim((string) ($indexSeed['state'] ?? IndexStateValue::NOINDEX)));
+            $rawIndexEligible = (bool) ($indexSeed['index_eligible'] ?? false);
             $reasonCodes = array_values(array_unique(array_filter([
                 ...((array) ($manifestOccupation['publish_reason_codes'] ?? [])),
                 ...((array) ($indexSeed['reason_codes'] ?? [])),
@@ -124,20 +128,35 @@ final class FirstWavePublishSeedMaterializer
                 $trustPayload,
             );
 
+            $previousIndexState = $occupation->indexStates()
+                ->orderByDesc('changed_at')
+                ->orderByDesc('updated_at')
+                ->first();
+            $lifecycle = $this->indexLifecycleCompiler->compile([
+                'crosswalk_mode' => $occupation->crosswalk_mode,
+                'confidence_score' => $confidenceScore,
+                'reviewer_status' => $reviewerStatus,
+                'raw_index_state' => $rawIndexState,
+                'index_eligible' => $rawIndexEligible,
+                'allow_strong_claim' => (bool) ($claimSeed['allow_strong_claim'] ?? false),
+                'previous_index_state' => $previousIndexState?->index_state,
+                'reason_codes' => $reasonCodes,
+            ]);
+
             $indexPayload = [
                 'occupation_id' => $occupation->id,
-                'index_state' => $indexState,
-                'index_eligible' => $indexEligible,
+                'index_state' => $lifecycle['index_state'],
+                'index_eligible' => $lifecycle['index_eligible'],
                 'canonical_path' => '/career/jobs/'.$occupation->canonical_slug,
                 'canonical_target' => null,
-                'reason_codes' => $reasonCodes,
+                'reason_codes' => $lifecycle['reason_codes'],
                 'changed_at' => now(),
                 'import_run_id' => $importRun->id,
                 'row_fingerprint' => $this->fingerprint([
                     'occupation_id' => $occupation->id,
-                    'index_state' => $indexState,
-                    'index_eligible' => $indexEligible,
-                    'reason_codes' => $reasonCodes,
+                    'index_state' => $lifecycle['index_state'],
+                    'index_eligible' => $lifecycle['index_eligible'],
+                    'reason_codes' => $lifecycle['reason_codes'],
                 ]),
             ];
 

--- a/backend/app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php
+++ b/backend/app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Career\Publish;
 
+use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\FirstWaveReadinessSummary;
 
 final class FirstWaveReadinessSummaryService
@@ -73,7 +74,10 @@ final class FirstWaveReadinessSummaryService
                 'review_required' => (bool) ($row['review_required'] ?? false),
                 'crosswalk_mode' => $row['crosswalk_mode'] ?? null,
                 'reviewer_status' => $row['reviewer_status'] ?? null,
-                'index_state' => $row['index_state'] ?? null,
+                'index_state' => IndexStateValue::publicFacing(
+                    (string) ($row['index_state'] ?? ''),
+                    (bool) ($row['index_eligible'] ?? false),
+                ),
                 'index_eligible' => (bool) ($row['index_eligible'] ?? false),
                 'reason_codes' => $this->reasonCodesFor($row, $normalizedStatus),
             ];

--- a/backend/app/Domain/Career/Scoring/ClaimPermissionsCompiler.php
+++ b/backend/app/Domain/Career/Scoring/ClaimPermissionsCompiler.php
@@ -22,8 +22,8 @@ final class ClaimPermissionsCompiler
         $mobilityScore = $scoreBundle['mobility_score'] ?? null;
         $indexState = (string) ($context['index_state'] ?? '');
         $indexEligible = (bool) ($context['index_eligible'] ?? false);
-        $indexRestricted = ! $indexEligible || in_array($indexState, [IndexStateValue::TRUST_LIMITED, IndexStateValue::NOINDEX, IndexStateValue::UNAVAILABLE], true);
-        $indexBlocked = in_array($indexState, [IndexStateValue::NOINDEX, IndexStateValue::UNAVAILABLE], true);
+        $indexRestricted = IndexStateValue::isIndexRestricted($indexState, $indexEligible);
+        $indexBlocked = IndexStateValue::isIndexBlocked($indexState, $indexEligible);
 
         $allowStrongClaim = ! isset($blocked['strong_claim'])
             && ! $indexRestricted

--- a/backend/app/Domain/Career/Scoring/WarningMatrix.php
+++ b/backend/app/Domain/Career/Scoring/WarningMatrix.php
@@ -59,14 +59,14 @@ final class WarningMatrix
             $blockedClaims[] = 'transition_recommendation';
         }
 
-        if (in_array($indexState, [IndexStateValue::NOINDEX, IndexStateValue::UNAVAILABLE], true)) {
+        if (IndexStateValue::isIndexBlocked($indexState, $indexEligible)) {
             $redFlags[] = ClaimReasonCode::INDEX_STATE_RESTRICTED;
             $blockedClaims[] = 'strong_claim';
             $blockedClaims[] = 'salary_comparison';
             $blockedClaims[] = 'ai_strategy';
             $blockedClaims[] = 'transition_recommendation';
             $blockedClaims[] = 'cross_market_pay_copy';
-        } elseif ($indexState === IndexStateValue::TRUST_LIMITED || ! $indexEligible) {
+        } elseif (IndexStateValue::isIndexRestricted($indexState, $indexEligible)) {
             $amberFlags[] = ClaimReasonCode::INDEX_STATE_RESTRICTED;
             $blockedClaims[] = 'strong_claim';
         }

--- a/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\IndexStateValue;
 use App\Domain\Career\Publish\FirstWaveReadinessSummaryService;
 use App\DTO\Career\CareerAliasResolutionBundle;
 use App\Models\Occupation;
@@ -497,6 +498,7 @@ final class CareerAliasResolutionBundleBuilder
         $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
         $canonicalTarget = $indexState?->canonical_target;
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => 'career_protocol_bundle',
@@ -505,14 +507,14 @@ final class CareerAliasResolutionBundleBuilder
             'robots_policy' => $robotsPolicy,
             'title' => $occupation->canonical_title_en,
             'description' => $occupation->canonical_title_en,
-            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'indexability_state' => $publicIndexState,
             'sitemap_state' => $indexEligible ? 'included' : 'excluded',
         ]);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $canonicalTarget,
-            'index_state' => $indexState?->index_state,
+            'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
             'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,

--- a/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\IndexStateValue;
 use App\Domain\Career\Publish\FirstWaveReadinessSummaryService;
 use App\DTO\Career\CareerFamilyHubBundle;
 use App\Models\Occupation;
@@ -213,6 +214,7 @@ final class CareerFamilyHubBundleBuilder
         $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
         $canonicalTarget = $indexState?->canonical_target;
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => 'career_protocol_bundle',
@@ -221,14 +223,14 @@ final class CareerFamilyHubBundleBuilder
             'robots_policy' => $robotsPolicy,
             'title' => $occupation->canonical_title_en,
             'description' => $occupation->canonical_title_en,
-            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'indexability_state' => $publicIndexState,
             'sitemap_state' => $indexEligible ? 'included' : 'excluded',
         ]);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $canonicalTarget,
-            'index_state' => $indexState?->index_state,
+            'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
             'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerJobDetailBundle;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
@@ -209,6 +210,7 @@ final class CareerJobDetailBundleBuilder
         $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
         $canonicalTarget = $indexState?->canonical_target;
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => 'career_protocol_bundle',
@@ -217,14 +219,14 @@ final class CareerJobDetailBundleBuilder
             'robots_policy' => $robotsPolicy,
             'title' => $occupation->canonical_title_en,
             'description' => $occupation->canonical_title_en,
-            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'indexability_state' => $publicIndexState,
             'sitemap_state' => $indexEligible ? 'included' : 'excluded',
         ]);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $canonicalTarget,
-            'index_state' => $indexState?->index_state,
+            'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
             'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerJobListItemBundle;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
@@ -185,6 +186,7 @@ final class CareerJobListBundleBuilder
         $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
         $canonicalTarget = $indexState?->canonical_target;
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => 'career_protocol_bundle',
@@ -193,14 +195,14 @@ final class CareerJobListBundleBuilder
             'robots_policy' => $robotsPolicy,
             'title' => $occupation->canonical_title_en,
             'description' => $occupation->canonical_title_en,
-            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'indexability_state' => $publicIndexState,
             'sitemap_state' => $indexEligible ? 'included' : 'excluded',
         ]);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $canonicalTarget,
-            'index_state' => $indexState?->index_state,
+            'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
             'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerRecommendationDetailBundle;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
@@ -215,6 +216,7 @@ final class CareerRecommendationDetailBundleBuilder
         $routeSubject = $this->routeSubject($subjectMeta, $requestedType);
         $canonicalPath = '/career/recommendations/mbti/'.$routeSubject;
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => 'career_protocol_bundle',
@@ -223,14 +225,14 @@ final class CareerRecommendationDetailBundleBuilder
             'robots_policy' => $robotsPolicy,
             'title' => (string) ($subjectMeta['display_title'] ?? $subjectMeta['type_code'] ?? $snapshot->occupation?->canonical_title_en ?? ''),
             'description' => (string) ($snapshot->occupation?->canonical_title_en ?? ''),
-            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'indexability_state' => $publicIndexState,
             'sitemap_state' => $indexEligible ? 'included' : 'excluded',
         ]);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $indexState?->canonical_target,
-            'index_state' => $indexState?->index_state,
+            'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
             'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
@@ -247,12 +249,14 @@ final class CareerRecommendationDetailBundleBuilder
     {
         $indexState = $snapshot->indexState;
         $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
+        $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $indexState?->canonical_target,
-            'index_state' => $indexState?->index_state,
-            'index_eligible' => (bool) ($indexState?->index_eligible ?? false),
+            'index_state' => $publicIndexState,
+            'index_eligible' => $indexEligible,
             'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
         ];
     }

--- a/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerRecommendationIndexItemBundle;
 use App\Models\RecommendationSnapshot;
 use App\Services\PublicSurface\SeoSurfaceContractService;
@@ -177,6 +178,7 @@ final class CareerRecommendationIndexBundleBuilder
         $routeSubject = $this->routeSubject($subjectMeta) ?? 'unknown';
         $canonicalPath = '/career/recommendations/mbti/'.$routeSubject;
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => 'career_protocol_bundle',
@@ -185,14 +187,14 @@ final class CareerRecommendationIndexBundleBuilder
             'robots_policy' => $robotsPolicy,
             'title' => (string) ($subjectMeta['display_title'] ?? $subjectMeta['type_code'] ?? $routeSubject),
             'description' => (string) ($subjectMeta['display_title'] ?? $routeSubject),
-            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'indexability_state' => $publicIndexState,
             'sitemap_state' => $indexEligible ? 'included' : 'excluded',
         ]);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $indexState?->canonical_target,
-            'index_state' => $indexState?->index_state,
+            'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
             'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,

--- a/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerSearchResultBundle;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
@@ -267,6 +268,7 @@ final class CareerSearchBundleBuilder
         $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
         $canonicalTarget = $indexState?->canonical_target;
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+        $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => 'career_protocol_bundle',
@@ -275,14 +277,14 @@ final class CareerSearchBundleBuilder
             'robots_policy' => $robotsPolicy,
             'title' => $occupation->canonical_title_en,
             'description' => $occupation->canonical_title_en,
-            'indexability_state' => $indexEligible ? 'indexable' : ((string) ($indexState?->index_state ?? 'noindex')),
+            'indexability_state' => $publicIndexState,
             'sitemap_state' => $indexEligible ? 'included' : 'excluded',
         ]);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $canonicalTarget,
-            'index_state' => $indexState?->index_state,
+            'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
             'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,

--- a/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\IndexStateValue;
 use App\Domain\Career\Transition\TransitionPathType;
 use App\DTO\Career\CareerTransitionPreviewBundle;
 use App\Models\RecommendationSnapshot;
@@ -142,7 +143,10 @@ final class CareerTransitionPreviewBundleBuilder
             seoContract: [
                 'canonical_path' => '/career/jobs/'.$targetOccupation->canonical_slug,
                 'canonical_target' => null,
-                'index_state' => $readiness['index_state'] ?? null,
+                'index_state' => IndexStateValue::publicFacing(
+                    (string) ($readiness['index_state'] ?? ''),
+                    true,
+                ),
                 'index_eligible' => true,
                 'reason_codes' => $seoReasonCodes,
             ],

--- a/backend/app/Services/Career/Import/CareerAuthorityMaterializer.php
+++ b/backend/app/Services/Career/Import/CareerAuthorityMaterializer.php
@@ -6,6 +6,7 @@ namespace App\Services\Career\Import;
 
 use App\Domain\Career\Import\CrosswalkSeedPolicy;
 use App\Domain\Career\Import\FirstWaveAliasHardeningService;
+use App\Domain\Career\Publish\CareerIndexLifecycleCompiler;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\ContextSnapshot;
@@ -35,6 +36,7 @@ final class CareerAuthorityMaterializer
         private readonly CareerRecommendationCompiler $compiler,
         private readonly FirstWaveAliasHardeningService $firstWaveAliasHardeningService,
         private readonly CareerTransitionPathWriter $transitionPathWriter,
+        private readonly CareerIndexLifecycleCompiler $indexLifecycleCompiler,
     ) {}
 
     /**
@@ -236,6 +238,20 @@ final class CareerAuthorityMaterializer
             $counts['skill_graphs_created'] += $skillGraph->wasRecentlyCreated ? 1 : 0;
 
             $seed = $this->crosswalkSeedPolicy->seed($normalized);
+            $previousIndexState = $occupation->indexStates()
+                ->orderByDesc('changed_at')
+                ->orderByDesc('updated_at')
+                ->first();
+            $lifecycle = $this->indexLifecycleCompiler->compile([
+                'crosswalk_mode' => $occupation->crosswalk_mode,
+                'confidence_score' => (string) $normalized['mapping_mode'] === 'exact' ? 74 : 58,
+                'reviewer_status' => 'pending',
+                'raw_index_state' => $seed['index_state'],
+                'index_eligible' => $seed['index_eligible'],
+                'allow_strong_claim' => false,
+                'previous_index_state' => $previousIndexState?->index_state,
+                'reason_codes' => $seed['reason_codes'],
+            ]);
 
             $trustManifestPayload = [
                 'occupation_id' => $occupation->id,
@@ -310,19 +326,19 @@ final class CareerAuthorityMaterializer
 
             $indexStatePayload = [
                 'occupation_id' => $occupation->id,
-                'index_state' => $seed['index_state'],
-                'index_eligible' => $seed['index_eligible'],
+                'index_state' => $lifecycle['index_state'],
+                'index_eligible' => $lifecycle['index_eligible'],
                 'canonical_path' => (string) $normalized['canonical_path'],
                 'canonical_target' => null,
-                'reason_codes' => $seed['reason_codes'],
+                'reason_codes' => $lifecycle['reason_codes'],
                 'changed_at' => $importRun->started_at,
                 'import_run_id' => $importRun->id,
                 'row_fingerprint' => $this->fingerprint([
                     'occupation_slug' => $occupation->canonical_slug,
-                    'index_state' => $seed['index_state'],
-                    'index_eligible' => $seed['index_eligible'],
+                    'index_state' => $lifecycle['index_state'],
+                    'index_eligible' => $lifecycle['index_eligible'],
                     'canonical_path' => $normalized['canonical_path'],
-                    'reason_codes' => $seed['reason_codes'],
+                    'reason_codes' => $lifecycle['reason_codes'],
                 ]),
             ];
             $indexState = IndexState::query()->firstOrCreate(

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-12T00:42:00Z",
+  "updated_at": "2026-04-12T00:49:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -559,10 +559,10 @@
     "PR-B26": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b26-career-internal-index-lifecycle-compiler",
-      "commit_sha": "ef67853a247b7d60ca17887a47c3de8c030f78bc",
-      "pr_url": "",
+      "commit_sha": "b404b7e42e90d4f48c5ae6990b1d1be5b9a06c93",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/868",
       "checks": {
         "local": [
           {
@@ -578,9 +578,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24286387352/job/70916344383"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24286387352/job/70916347815"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately again and the MBTI matrix job was skipped; local B26 verification passed and the failure pattern matches the current repository workflow-start issue rather than a locally reproducible regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-11T23:47:00Z",
+  "updated_at": "2026-04-12T00:30:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -551,6 +551,36 @@
         ]
       },
       "failure_reason": "GitHub Actions jobs failed immediately on hygiene, matching the current repository workflow-start failure pattern rather than a locally reproducible B25 regression.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B26": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b26-career-internal-index-lifecycle-compiler",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/IndexStateValue.php app/Domain/Career/Publish/CareerIndexLifecycleState.php app/Domain/Career/Publish/CareerIndexLifecycleCompiler.php app/Domain/Career/Publish/FirstWavePublishGate.php app/Domain/Career/Publish/FirstWavePublishSeedMaterializer.php app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php app/Domain/Career/Scoring/ClaimPermissionsCompiler.php app/Domain/Career/Scoring/WarningMatrix.php app/Services/Career/Import/CareerAuthorityMaterializer.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php app/Services/Career/Bundles/CareerJobListBundleBuilder.php app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php app/Services/Career/Bundles/CareerSearchBundleBuilder.php app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php tests/Unit/Services/Career/CareerIndexLifecycleCompilerTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Feature/Career/CareerAuthorityImportCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerIndexLifecycleCompilerTest.php tests/Feature/Career/CareerAuthorityImportCommandTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationIndexApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-12T00:30:00Z",
+  "updated_at": "2026-04-12T00:42:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -561,7 +561,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "local_verified",
       "branch": "codex/pr-b26-career-internal-index-lifecycle-compiler",
-      "commit_sha": "",
+      "commit_sha": "ef67853a247b7d60ca17887a47c3de8c030f78bc",
       "pr_url": "",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -391,6 +391,32 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B26
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b26-career-internal-index-lifecycle-compiler
+    base: main
+    depends_on: ["PR-B25"]
+    mode: execute
+    scope: >
+      Career internal index lifecycle compiler.
+      Formalize internal backend-owned lifecycle states for noindex,
+      promotion-candidate, indexed, and demoted using existing index-state
+      persistence while keeping public API contracts unchanged.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/IndexStateValue.php app/Domain/Career/Publish/CareerIndexLifecycleState.php app/Domain/Career/Publish/CareerIndexLifecycleCompiler.php app/Domain/Career/Publish/FirstWavePublishGate.php app/Domain/Career/Publish/FirstWavePublishSeedMaterializer.php app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php app/Domain/Career/Scoring/ClaimPermissionsCompiler.php app/Domain/Career/Scoring/WarningMatrix.php app/Services/Career/Import/CareerAuthorityMaterializer.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php app/Services/Career/Bundles/CareerJobListBundleBuilder.php app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php app/Services/Career/Bundles/CareerSearchBundleBuilder.php app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php tests/Unit/Services/Career/CareerIndexLifecycleCompilerTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Feature/Career/CareerAuthorityImportCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerIndexLifecycleCompilerTest.php tests/Feature/Career/CareerAuthorityImportCommandTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationIndexApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerAuthorityImportCommandTest.php
+++ b/backend/tests/Feature/Career/CareerAuthorityImportCommandTest.php
@@ -56,6 +56,6 @@ final class CareerAuthorityImportCommandTest extends TestCase
         $this->assertDatabaseHas('occupation_truth_metrics', ['import_run_id' => $run->id]);
         $this->assertDatabaseHas('trust_manifests', ['import_run_id' => $run->id]);
         $this->assertDatabaseHas('index_states', ['import_run_id' => $run->id, 'index_state' => 'noindex']);
-        $this->assertDatabaseHas('index_states', ['import_run_id' => $run->id, 'index_state' => 'trust_limited']);
+        $this->assertDatabaseHas('index_states', ['import_run_id' => $run->id, 'index_state' => 'promotion_candidate']);
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerIndexLifecycleCompilerTest.php
+++ b/backend/tests/Unit/Services/Career/CareerIndexLifecycleCompilerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\IndexStateValue;
+use App\Domain\Career\Publish\CareerIndexLifecycleCompiler;
+use App\Domain\Career\Publish\CareerIndexLifecycleState;
+use App\Domain\Career\ReviewerStatus;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerIndexLifecycleCompilerTest extends TestCase
+{
+    #[Test]
+    public function it_marks_stable_public_safe_rows_as_indexed(): void
+    {
+        $payload = app(CareerIndexLifecycleCompiler::class)->compile([
+            'crosswalk_mode' => 'exact',
+            'confidence_score' => 82,
+            'reviewer_status' => ReviewerStatus::APPROVED,
+            'raw_index_state' => IndexStateValue::INDEXABLE,
+            'index_eligible' => true,
+            'allow_strong_claim' => true,
+            'reason_codes' => ['publish_ready'],
+        ]);
+
+        $this->assertSame(CareerIndexLifecycleState::INDEXED, $payload['index_state']);
+        $this->assertTrue($payload['index_eligible']);
+        $this->assertContains('career_index_lifecycle_indexed', $payload['reason_codes']);
+    }
+
+    #[Test]
+    public function it_marks_candidate_grade_rows_as_promotion_candidates(): void
+    {
+        $payload = app(CareerIndexLifecycleCompiler::class)->compile([
+            'crosswalk_mode' => 'functional_equivalent',
+            'confidence_score' => 68,
+            'reviewer_status' => ReviewerStatus::IN_REVIEW,
+            'raw_index_state' => IndexStateValue::NOINDEX,
+            'index_eligible' => false,
+            'allow_strong_claim' => false,
+            'reason_codes' => ['candidate_review_required'],
+        ]);
+
+        $this->assertSame(CareerIndexLifecycleState::PROMOTION_CANDIDATE, $payload['index_state']);
+        $this->assertFalse($payload['index_eligible']);
+        $this->assertContains('career_index_lifecycle_promotion_candidate', $payload['reason_codes']);
+    }
+
+    #[Test]
+    public function it_marks_regressed_previously_indexed_rows_as_demoted(): void
+    {
+        $payload = app(CareerIndexLifecycleCompiler::class)->compile([
+            'crosswalk_mode' => 'exact',
+            'confidence_score' => 74,
+            'reviewer_status' => ReviewerStatus::PENDING,
+            'raw_index_state' => IndexStateValue::TRUST_LIMITED,
+            'index_eligible' => false,
+            'allow_strong_claim' => false,
+            'previous_index_state' => CareerIndexLifecycleState::INDEXED,
+            'reason_codes' => ['index_state_restricted'],
+        ]);
+
+        $this->assertSame(CareerIndexLifecycleState::DEMOTED, $payload['index_state']);
+        $this->assertFalse($payload['index_eligible']);
+        $this->assertContains('career_index_lifecycle_demoted', $payload['reason_codes']);
+        $this->assertContains('career_index_lifecycle_regressed', $payload['reason_codes']);
+    }
+
+    #[Test]
+    public function it_marks_non_promotable_hold_rows_as_noindex(): void
+    {
+        $payload = app(CareerIndexLifecycleCompiler::class)->compile([
+            'crosswalk_mode' => 'unmapped',
+            'confidence_score' => 52,
+            'reviewer_status' => ReviewerStatus::CHANGES_REQUIRED,
+            'raw_index_state' => IndexStateValue::UNAVAILABLE,
+            'index_eligible' => false,
+            'allow_strong_claim' => false,
+            'reason_codes' => ['hold_scope_restricted'],
+        ]);
+
+        $this->assertSame(CareerIndexLifecycleState::NOINDEX, $payload['index_state']);
+        $this->assertFalse($payload['index_eligible']);
+        $this->assertContains('career_index_lifecycle_noindex', $payload['reason_codes']);
+    }
+}

--- a/backend/tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php
+++ b/backend/tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Services\Career;
 
 use App\Domain\Career\Publish\FirstWaveReadinessSummaryService;
+use App\Models\Occupation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;
@@ -60,6 +61,11 @@ final class FirstWaveReadinessSummaryServiceTest extends TestCase
         $this->assertSame('approved', $dataScientists['reviewer_status']);
         $this->assertSame('indexable', $dataScientists['index_state']);
         $this->assertTrue($dataScientists['index_eligible']);
+
+        $occupation = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $latestIndexState = $occupation->indexStates()->orderByDesc('changed_at')->orderByDesc('updated_at')->firstOrFail();
+        $this->assertSame('indexed', $latestIndexState->index_state);
+        $this->assertTrue($latestIndexState->index_eligible);
     }
 
     public function test_it_keeps_partial_only_as_a_raw_summary_count_when_present(): void


### PR DESCRIPTION
## What changed
- add an internal career index lifecycle compiler and formal lifecycle states for `noindex`, `promotion_candidate`, `indexed`, and `demoted`
- reuse the existing `index_states` persistence path so lifecycle truth is stored durably without adding schema or public API surface
- wire both authority import and first-wave publish-seed materialization through the lifecycle compiler
- keep existing public career bundles unchanged in shape by mapping internal lifecycle values back to legacy-compatible public `index_state` values at read time
- harden internal claim/warning logic to interpret lifecycle-backed index states conservatively
- add focused lifecycle compiler coverage plus import/readiness regression tests and update the PR train ledger

## Why
- current backend truth for index exposure is spread across readiness, publish gate, reviewer/trust state, and `index_eligible`, but durable lifecycle state did not exist yet
- this PR turns that dispersed truth into an internal backend-owned lifecycle compiler without conflating frontend launch state with backend authority
- the result is a stable substrate for future promotion/demotion control while preserving current public contracts

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/IndexStateValue.php app/Domain/Career/Publish/CareerIndexLifecycleState.php app/Domain/Career/Publish/CareerIndexLifecycleCompiler.php app/Domain/Career/Publish/FirstWavePublishGate.php app/Domain/Career/Publish/FirstWavePublishSeedMaterializer.php app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php app/Domain/Career/Scoring/ClaimPermissionsCompiler.php app/Domain/Career/Scoring/WarningMatrix.php app/Services/Career/Import/CareerAuthorityMaterializer.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php app/Services/Career/Bundles/CareerJobListBundleBuilder.php app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php app/Services/Career/Bundles/CareerSearchBundleBuilder.php app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php tests/Unit/Services/Career/CareerIndexLifecycleCompilerTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Feature/Career/CareerAuthorityImportCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Unit/Services/Career/CareerIndexLifecycleCompilerTest.php tests/Feature/Career/CareerAuthorityImportCommandTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationIndexApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`

## Intentionally deferred
- no public lifecycle API or OpenAPI change
- no frontend changes
- no SEO rollout semantics
- no scoring changes
- no schema migration
