### PR TITLE
PR-B27: Career first-wave lifecycle summary read-model + API

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveLifecycleSummary.php
+++ b/backend/app/DTO/Career/CareerFirstWaveLifecycleSummary.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveLifecycleSummary
+{
+    /**
+     * @param  array<string, int>  $counts
+     * @param  list<array<string, mixed>>  $occupations
+     */
+    public function __construct(
+        public readonly string $summaryVersion,
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $occupations,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'summary_kind' => 'career_first_wave_lifecycle',
+            'summary_version' => $this->summaryVersion,
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'occupations' => $this->occupations,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Domain\Career\IndexStateValue;
+use App\DTO\Career\CareerFirstWaveLifecycleSummary;
+
+final class CareerFirstWaveLifecycleSummaryService
+{
+    public const SUMMARY_VERSION = 'career.lifecycle.first_wave.v1';
+
+    public const SCOPE = 'career_first_wave_10';
+
+    public function __construct(
+        private readonly FirstWaveManifestReader $manifestReader,
+        private readonly FirstWavePublishReadyValidator $validator,
+    ) {}
+
+    public function build(): CareerFirstWaveLifecycleSummary
+    {
+        $manifest = $this->manifestReader->read();
+        $report = $this->validator->validate();
+
+        $rowsBySlug = [];
+        foreach ((array) ($report['occupations'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = (string) ($row['canonical_slug'] ?? '');
+            if ($slug === '') {
+                continue;
+            }
+
+            $rowsBySlug[$slug] = $row;
+        }
+
+        $counts = [
+            'total' => 0,
+            CareerIndexLifecycleState::NOINDEX => 0,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE => 0,
+            CareerIndexLifecycleState::INDEXED => 0,
+            CareerIndexLifecycleState::DEMOTED => 0,
+        ];
+        $occupations = [];
+
+        foreach ((array) ($manifest['occupations'] ?? []) as $occupation) {
+            if (! is_array($occupation)) {
+                continue;
+            }
+
+            $slug = (string) ($occupation['canonical_slug'] ?? '');
+            if ($slug === '') {
+                continue;
+            }
+
+            $row = $rowsBySlug[$slug] ?? [];
+            $lifecycleState = $this->normalizeLifecycleState((string) ($row['index_state'] ?? ''));
+            $indexEligible = (bool) ($row['index_eligible'] ?? false);
+            $publicIndexState = IndexStateValue::publicFacing((string) ($row['index_state'] ?? ''), $indexEligible);
+            $reviewerStatus = $this->normalizeNullableString($row['reviewer_status'] ?? null);
+            $trustStatus = strtolower(trim((string) ($row['trust_status'] ?? '')));
+
+            $counts['total']++;
+            $counts[$lifecycleState]++;
+
+            $occupations[] = [
+                'occupation_uuid' => (string) ($occupation['occupation_uuid'] ?? ''),
+                'canonical_slug' => $slug,
+                'canonical_title_en' => (string) ($occupation['canonical_title_en'] ?? ''),
+                'lifecycle_state' => $lifecycleState,
+                'public_index_state' => $publicIndexState,
+                'index_eligible' => $indexEligible,
+                'reviewer_status' => $reviewerStatus,
+                'reason_codes' => $this->curateReasonCodes(
+                    lifecycleState: $lifecycleState,
+                    publicIndexState: $publicIndexState,
+                    indexEligible: $indexEligible,
+                    reviewerStatus: $reviewerStatus,
+                    trustStatus: $trustStatus,
+                ),
+            ];
+        }
+
+        return new CareerFirstWaveLifecycleSummary(
+            summaryVersion: self::SUMMARY_VERSION,
+            scope: self::SCOPE,
+            counts: $counts,
+            occupations: $occupations,
+        );
+    }
+
+    private function normalizeLifecycleState(string $state): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match ($normalized) {
+            CareerIndexLifecycleState::NOINDEX,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE,
+            CareerIndexLifecycleState::INDEXED,
+            CareerIndexLifecycleState::DEMOTED => $normalized,
+            default => CareerIndexLifecycleState::NOINDEX,
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function curateReasonCodes(
+        string $lifecycleState,
+        string $publicIndexState,
+        bool $indexEligible,
+        ?string $reviewerStatus,
+        string $trustStatus,
+    ): array {
+        $reasonCodes = [];
+        $reviewApproved = in_array($reviewerStatus, ['approved', 'reviewed'], true);
+
+        switch ($lifecycleState) {
+            case CareerIndexLifecycleState::INDEXED:
+                $reasonCodes[] = 'indexed_ready';
+                break;
+
+            case CareerIndexLifecycleState::PROMOTION_CANDIDATE:
+                $reasonCodes[] = 'publish_gate_candidate';
+                if (! $reviewApproved) {
+                    $reasonCodes[] = 'review_pending';
+                }
+                break;
+
+            case CareerIndexLifecycleState::DEMOTED:
+                if (! $reviewApproved) {
+                    $reasonCodes[] = 'demoted_review_regression';
+                }
+                if (! $indexEligible || $publicIndexState !== IndexStateValue::INDEXABLE) {
+                    $reasonCodes[] = 'demoted_trust_regression';
+                }
+                break;
+
+            default:
+                if ($trustStatus === WaveClassification::HOLD) {
+                    $reasonCodes[] = 'publish_gate_hold';
+                }
+                break;
+        }
+
+        if (! $indexEligible && $lifecycleState !== CareerIndexLifecycleState::INDEXED) {
+            $reasonCodes[] = 'not_index_eligible';
+        }
+
+        if ($publicIndexState === IndexStateValue::TRUST_LIMITED) {
+            $reasonCodes[] = 'trust_limited';
+        }
+
+        if ($reasonCodes === [] && $lifecycleState === CareerIndexLifecycleState::NOINDEX) {
+            $reasonCodes[] = 'not_index_eligible';
+        }
+
+        return array_values(array_unique($reasonCodes));
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLifecycleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLifecycleController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveLifecycleSummaryService;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerFirstWaveLifecycleSummaryResource;
+
+final class CareerFirstWaveLifecycleController extends Controller
+{
+    public function __construct(
+        private readonly CareerFirstWaveLifecycleSummaryService $summaryService,
+    ) {}
+
+    public function show(): CareerFirstWaveLifecycleSummaryResource
+    {
+        return new CareerFirstWaveLifecycleSummaryResource(
+            $this->summaryService->build()
+        );
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerFirstWaveLifecycleSummaryResource.php
+++ b/backend/app/Http/Resources/Career/CareerFirstWaveLifecycleSummaryResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerFirstWaveLifecycleSummary;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerFirstWaveLifecycleSummary
+ */
+final class CareerFirstWaveLifecycleSummaryResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerFirstWaveLifecycleSummary $summary */
+        $summary = $this->resource;
+
+        return $summary->toArray();
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-12T01:46:00Z",
+  "updated_at": "2026-04-12T02:05:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -627,21 +627,26 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295685724/job/70940197295"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295699853/job/70940236283"
           },
           {
             "name": "hygiene",
-            "status": "pending",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295690614/job/70940211184"
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295700608/job/70940237961"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295685724/job/70940199502"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295699853/job/70940238560"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295700608/job/70940239700"
           }
         ]
       },
-      "failure_reason": "GitHub hygiene failed immediately on the initial run and a newer rerun is still pending; local B27 verification passed and the failure pattern matches the repository's current workflow-start issue rather than a locally reproducible lifecycle-summary regression.",
+      "failure_reason": "GitHub Actions jobs were not started successfully because account payments failed or the spending limit needs to be increased; both hygiene runs failed immediately and MBTI verification was skipped, while local B27 verification passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-12T00:49:00Z",
+  "updated_at": "2026-04-12T01:30:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -592,6 +592,40 @@
         ]
       },
       "failure_reason": "GitHub hygiene failed immediately again and the MBTI matrix job was skipped; local B26 verification passed and the failure pattern matches the current repository workflow-start issue rather than a locally reproducible regression.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B27": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b27-career-first-wave-lifecycle-summary-read-model-api",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/DTO/Career/CareerFirstWaveLifecycleSummary.php app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php app/Http/Resources/Career/CareerFirstWaveLifecycleSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLifecycleController.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-12T01:30:00Z",
+  "updated_at": "2026-04-12T01:46:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -600,10 +600,10 @@
     "PR-B27": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b27-career-first-wave-lifecycle-summary-read-model-api",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "34767bd256862592b42022d6bd2d024828b6a275",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/869",
       "checks": {
         "local": [
           {
@@ -623,9 +623,25 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295685724/job/70940197295"
+          },
+          {
+            "name": "hygiene",
+            "status": "pending",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295690614/job/70940211184"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24295685724/job/70940199502"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately on the initial run and a newer rerun is still pending; local B27 verification passed and the failure pattern matches the repository's current workflow-start issue rather than a locally reproducible lifecycle-summary regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -417,6 +417,33 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B27
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b27-career-first-wave-lifecycle-summary-read-model-api
+    base: main
+    depends_on: ["PR-B26"]
+    mode: execute
+    scope: >
+      Career first-wave lifecycle summary read-model + API.
+      Add a dedicated first-wave-scoped lifecycle summary endpoint that exposes
+      counts and per-occupation lifecycle rows from persisted B26 lifecycle truth
+      without changing existing public bundle shapes, frontend, schema, or scoring.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/DTO/Career/CareerFirstWaveLifecycleSummary.php app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php app/Http/Resources/Career/CareerFirstWaveLifecycleSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLifecycleController.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2379,6 +2379,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/first-wave/lifecycle": {
+            "get": {
+                "operationId": "get_api_v0_5_career_first_wave_lifecycle",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerFirstWaveLifecycleController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/first-wave/readiness": {
             "get": {
                 "operationId": "get_api_v0_5_career_first_wave_readiness",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -32,6 +32,7 @@ use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Career\CareerAliasResolutionController;
 use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
 use App\Http\Controllers\API\V0_5\Career\CareerFamilyHubController;
+use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLifecycleController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobListController;
@@ -406,6 +407,7 @@ Route::prefix('v0.5')->group(function () {
     Route::post('/career/attribution/events', [CareerAttributionEventController::class, 'store']);
     Route::get('/career/family/{slug}', [CareerFamilyHubController::class, 'show']);
     Route::get('/career/resolve', [CareerAliasResolutionController::class, 'show']);
+    Route::get('/career/first-wave/lifecycle', [CareerFirstWaveLifecycleController::class, 'show']);
     Route::get('/career/first-wave/readiness', [CareerFirstWaveReadinessController::class, 'show']);
     Route::get('/career/jobs', [CareerJobListController::class, 'index']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveLifecycleApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_exposes_a_machine_readable_first_wave_lifecycle_summary(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/lifecycle');
+
+        $response->assertOk()
+            ->assertJsonPath('summary_kind', 'career_first_wave_lifecycle')
+            ->assertJsonPath('summary_version', 'career.lifecycle.first_wave.v1')
+            ->assertJsonPath('scope', 'career_first_wave_10')
+            ->assertJsonPath('counts.total', 10)
+            ->assertJsonPath('counts.noindex', 4)
+            ->assertJsonPath('counts.promotion_candidate', 0)
+            ->assertJsonPath('counts.indexed', 6)
+            ->assertJsonPath('counts.demoted', 0)
+            ->assertJsonStructure([
+                'summary_kind',
+                'summary_version',
+                'scope',
+                'counts' => [
+                    'total',
+                    'noindex',
+                    'promotion_candidate',
+                    'indexed',
+                    'demoted',
+                ],
+                'occupations' => [[
+                    'occupation_uuid',
+                    'canonical_slug',
+                    'canonical_title_en',
+                    'lifecycle_state',
+                    'public_index_state',
+                    'index_eligible',
+                    'reviewer_status',
+                    'reason_codes',
+                ]],
+            ]);
+
+        $occupations = collect($response->json('occupations'))->keyBy('canonical_slug');
+
+        $this->assertSame('indexed', $occupations['registered-nurses']['lifecycle_state']);
+        $this->assertSame('indexable', $occupations['registered-nurses']['public_index_state']);
+        $this->assertSame(['indexed_ready'], $occupations['registered-nurses']['reason_codes']);
+
+        $this->assertSame('noindex', $occupations['software-developers']['lifecycle_state']);
+        $this->assertContains('publish_gate_hold', $occupations['software-developers']['reason_codes']);
+        $this->assertContains('not_index_eligible', $occupations['software-developers']['reason_codes']);
+    }
+
+    public function test_it_exposes_curated_candidate_and_demoted_states_without_raw_internal_tags(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $demoted = Occupation::query()->where('canonical_slug', 'management-analysts')->firstOrFail();
+
+        $candidate->indexStates()->orderByDesc('changed_at')->orderByDesc('updated_at')->firstOrFail()->update([
+            'index_state' => 'promotion_candidate',
+            'index_eligible' => false,
+            'reason_codes' => ['career_index_lifecycle_promotion_candidate'],
+        ]);
+
+        $demoted->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewer_status' => 'changes_required',
+        ]);
+        $demoted->indexStates()->orderByDesc('changed_at')->orderByDesc('updated_at')->firstOrFail()->update([
+            'index_state' => 'demoted',
+            'index_eligible' => false,
+            'reason_codes' => ['career_index_lifecycle_demoted', 'career_index_lifecycle_regressed'],
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/lifecycle');
+
+        $response->assertOk()
+            ->assertJsonPath('counts.promotion_candidate', 1)
+            ->assertJsonPath('counts.demoted', 1);
+
+        $occupations = collect($response->json('occupations'))->keyBy('canonical_slug');
+        $candidateRow = $occupations['data-scientists'];
+        $demotedRow = $occupations['management-analysts'];
+
+        $this->assertSame('promotion_candidate', $candidateRow['lifecycle_state']);
+        $this->assertSame(['publish_gate_candidate', 'not_index_eligible', 'trust_limited'], $candidateRow['reason_codes']);
+
+        $this->assertSame('demoted', $demotedRow['lifecycle_state']);
+        $this->assertContains('demoted_review_regression', $demotedRow['reason_codes']);
+        $this->assertContains('demoted_trust_regression', $demotedRow['reason_codes']);
+        $this->assertNotContains('career_index_lifecycle_demoted', $demotedRow['reason_codes']);
+        $this->assertNotContains('career_index_lifecycle_regressed', $demotedRow['reason_codes']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveLifecycleSummaryService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveLifecycleSummaryServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_stable_first_wave_lifecycle_summary_from_persisted_truth(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $summary = app(CareerFirstWaveLifecycleSummaryService::class)->build()->toArray();
+        $occupations = collect($summary['occupations'])->keyBy('canonical_slug');
+
+        $this->assertSame('career_first_wave_lifecycle', $summary['summary_kind']);
+        $this->assertSame(CareerFirstWaveLifecycleSummaryService::SUMMARY_VERSION, $summary['summary_version']);
+        $this->assertSame(CareerFirstWaveLifecycleSummaryService::SCOPE, $summary['scope']);
+        $this->assertSame(10, $summary['counts']['total']);
+        $this->assertSame(4, $summary['counts']['noindex']);
+        $this->assertSame(0, $summary['counts']['promotion_candidate']);
+        $this->assertSame(6, $summary['counts']['indexed']);
+        $this->assertSame(0, $summary['counts']['demoted']);
+        $this->assertSame('software-developers', $summary['occupations'][0]['canonical_slug']);
+        $this->assertSame('management-analysts', $summary['occupations'][9]['canonical_slug']);
+
+        $dataScientists = $occupations->get('data-scientists');
+        $software = $occupations->get('software-developers');
+
+        $this->assertIsArray($dataScientists);
+        $this->assertSame('indexed', $dataScientists['lifecycle_state']);
+        $this->assertSame('indexable', $dataScientists['public_index_state']);
+        $this->assertTrue($dataScientists['index_eligible']);
+        $this->assertSame('approved', $dataScientists['reviewer_status']);
+        $this->assertSame(['indexed_ready'], $dataScientists['reason_codes']);
+
+        $this->assertIsArray($software);
+        $this->assertSame('noindex', $software['lifecycle_state']);
+        $this->assertSame('noindex', $software['public_index_state']);
+        $this->assertFalse($software['index_eligible']);
+        $this->assertNull($software['reviewer_status']);
+        $this->assertContains('publish_gate_hold', $software['reason_codes']);
+        $this->assertContains('not_index_eligible', $software['reason_codes']);
+    }
+
+    public function test_it_curates_candidate_and_demoted_reason_codes_without_leaking_internal_compiler_tags(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $demoted = Occupation::query()->where('canonical_slug', 'management-analysts')->firstOrFail();
+
+        $candidate->indexStates()->orderByDesc('changed_at')->orderByDesc('updated_at')->firstOrFail()->update([
+            'index_state' => 'promotion_candidate',
+            'index_eligible' => false,
+            'reason_codes' => ['career_index_lifecycle_promotion_candidate', 'debug_candidate_tag'],
+        ]);
+
+        $demoted->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewer_status' => 'changes_required',
+        ]);
+        $demoted->indexStates()->orderByDesc('changed_at')->orderByDesc('updated_at')->firstOrFail()->update([
+            'index_state' => 'demoted',
+            'index_eligible' => false,
+            'reason_codes' => ['career_index_lifecycle_demoted', 'career_index_lifecycle_regressed'],
+        ]);
+
+        $summary = app(CareerFirstWaveLifecycleSummaryService::class)->build()->toArray();
+        $occupations = collect($summary['occupations'])->keyBy('canonical_slug');
+
+        $this->assertSame(4, $summary['counts']['indexed']);
+        $this->assertSame(1, $summary['counts']['promotion_candidate']);
+        $this->assertSame(1, $summary['counts']['demoted']);
+
+        $candidateRow = $occupations->get('data-scientists');
+        $demotedRow = $occupations->get('management-analysts');
+
+        $this->assertIsArray($candidateRow);
+        $this->assertSame('promotion_candidate', $candidateRow['lifecycle_state']);
+        $this->assertSame('trust_limited', $candidateRow['public_index_state']);
+        $this->assertSame(['publish_gate_candidate', 'not_index_eligible', 'trust_limited'], $candidateRow['reason_codes']);
+
+        $this->assertIsArray($demotedRow);
+        $this->assertSame('demoted', $demotedRow['lifecycle_state']);
+        $this->assertContains('demoted_review_regression', $demotedRow['reason_codes']);
+        $this->assertContains('demoted_trust_regression', $demotedRow['reason_codes']);
+        $this->assertNotContains('career_index_lifecycle_demoted', $demotedRow['reason_codes']);
+        $this->assertNotContains('career_index_lifecycle_regressed', $demotedRow['reason_codes']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated first-wave lifecycle summary service, DTO, resource, and controller backed by the persisted B26 lifecycle truth
- add `GET /api/v0.5/career/first-wave/lifecycle` with summary counts and per-occupation lifecycle rows
- expose raw lifecycle state alongside compatibility-mapped `public_index_state`, `index_eligible`, `reviewer_status`, and curated machine-safe `reason_codes`
- keep B14 readiness unchanged and leave jobs, search, family, resolve, recommendation, and transition public bundle shapes untouched
- update the OpenAPI snapshot and PR train ledger for B27

## Why
- B26 made lifecycle truth real and durable, but it was still internal-only
- downstream rollout and governance work needs a dedicated authority surface for lifecycle counts and per-occupation posture
- the safest next step is a first-wave scoped endpoint that complements B14 instead of overloading existing bundle contracts

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/DTO/Career/CareerFirstWaveLifecycleSummary.php app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php app/Http/Resources/Career/CareerFirstWaveLifecycleSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLifecycleController.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no frontend changes
- no new public lifecycle write path
- no B14 readiness contract changes
- no lifecycle fields added to existing public bundles
- no schema or scoring changes
