### PR TITLE
PR-B28: Career first-wave rollout queue summary API

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveRolloutQueueSummary.php
+++ b/backend/app/DTO/Career/CareerFirstWaveRolloutQueueSummary.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveRolloutQueueSummary
+{
+    /**
+     * @param  array<string, int>  $counts
+     * @param  list<array<string, mixed>>  $queueItems
+     */
+    public function __construct(
+        public readonly string $summaryVersion,
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $queueItems,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'summary_kind' => 'career_first_wave_rollout_queue',
+            'summary_version' => $this->summaryVersion,
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'queue_items' => $this->queueItems,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveRolloutQueueSummaryService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveRolloutQueueSummaryService.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveRolloutQueueSummary;
+
+final class CareerFirstWaveRolloutQueueSummaryService
+{
+    public const SUMMARY_VERSION = 'career.rollout.first_wave.v1';
+
+    public const SCOPE = 'career_first_wave_10';
+
+    public const QUEUE_STATE_PROMOTION_CANDIDATE_REVIEW = 'promotion_candidate_review';
+
+    public const QUEUE_STATE_DEMOTION_REVIEW = 'demotion_review';
+
+    public function __construct(
+        private readonly CareerFirstWaveLifecycleSummaryService $lifecycleSummaryService,
+        private readonly FirstWaveReadinessSummaryService $readinessSummaryService,
+    ) {}
+
+    public function build(): CareerFirstWaveRolloutQueueSummary
+    {
+        $lifecycleSummary = $this->lifecycleSummaryService->build()->toArray();
+        $readinessSummary = $this->readinessSummaryService->build()->toArray();
+        $readinessBySlug = [];
+
+        foreach ((array) ($readinessSummary['occupations'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = (string) ($row['canonical_slug'] ?? '');
+            if ($slug === '') {
+                continue;
+            }
+
+            $readinessBySlug[$slug] = $row;
+        }
+
+        $counts = [
+            'total' => 0,
+            self::QUEUE_STATE_PROMOTION_CANDIDATE_REVIEW => 0,
+            self::QUEUE_STATE_DEMOTION_REVIEW => 0,
+        ];
+        $queueItems = [];
+
+        foreach ((array) ($lifecycleSummary['occupations'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = (string) ($row['canonical_slug'] ?? '');
+            if ($slug === '') {
+                continue;
+            }
+
+            $readinessRow = $readinessBySlug[$slug] ?? [];
+            $queueState = $this->determineQueueState((string) ($row['lifecycle_state'] ?? ''));
+            if ($queueState === null) {
+                continue;
+            }
+
+            $counts['total']++;
+            $counts[$queueState]++;
+
+            $queueItems[] = [
+                'occupation_uuid' => (string) ($row['occupation_uuid'] ?? ''),
+                'canonical_slug' => $slug,
+                'canonical_title_en' => (string) ($row['canonical_title_en'] ?? ''),
+                'lifecycle_state' => (string) ($row['lifecycle_state'] ?? CareerIndexLifecycleState::NOINDEX),
+                'readiness_status' => $this->normalizeNullableString($readinessRow['status'] ?? null),
+                'public_index_state' => (string) ($row['public_index_state'] ?? 'noindex'),
+                'index_eligible' => (bool) ($row['index_eligible'] ?? false),
+                'reviewer_status' => $this->normalizeNullableString($row['reviewer_status'] ?? null),
+                'blocked_governance_status' => $this->normalizeNullableString($readinessRow['blocked_governance_status'] ?? null),
+                'queue_state' => $queueState,
+                'reason_codes' => $this->curateReasonCodes(
+                    queueState: $queueState,
+                    lifecycleReasonCodes: (array) ($row['reason_codes'] ?? []),
+                    blockedGovernanceStatus: $this->normalizeNullableString($readinessRow['blocked_governance_status'] ?? null),
+                ),
+            ];
+        }
+
+        usort($queueItems, function (array $left, array $right): int {
+            $queueOrder = [
+                self::QUEUE_STATE_PROMOTION_CANDIDATE_REVIEW => 0,
+                self::QUEUE_STATE_DEMOTION_REVIEW => 1,
+            ];
+
+            $leftOrder = $queueOrder[(string) ($left['queue_state'] ?? '')] ?? 99;
+            $rightOrder = $queueOrder[(string) ($right['queue_state'] ?? '')] ?? 99;
+
+            if ($leftOrder !== $rightOrder) {
+                return $leftOrder <=> $rightOrder;
+            }
+
+            return strcmp((string) ($left['canonical_slug'] ?? ''), (string) ($right['canonical_slug'] ?? ''));
+        });
+
+        return new CareerFirstWaveRolloutQueueSummary(
+            summaryVersion: self::SUMMARY_VERSION,
+            scope: self::SCOPE,
+            counts: $counts,
+            queueItems: $queueItems,
+        );
+    }
+
+    private function determineQueueState(string $lifecycleState): ?string
+    {
+        $normalized = strtolower(trim($lifecycleState));
+
+        return match ($normalized) {
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE => self::QUEUE_STATE_PROMOTION_CANDIDATE_REVIEW,
+            CareerIndexLifecycleState::DEMOTED => self::QUEUE_STATE_DEMOTION_REVIEW,
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<int, mixed>  $lifecycleReasonCodes
+     * @return list<string>
+     */
+    private function curateReasonCodes(
+        string $queueState,
+        array $lifecycleReasonCodes,
+        ?string $blockedGovernanceStatus,
+    ): array {
+        $allowedLifecycleCodes = [
+            'publish_gate_candidate',
+            'review_pending',
+            'trust_limited',
+            'demoted_trust_regression',
+            'demoted_review_regression',
+            'not_index_eligible',
+        ];
+
+        $reasonCodes = match ($queueState) {
+            self::QUEUE_STATE_PROMOTION_CANDIDATE_REVIEW => ['promotion_candidate'],
+            self::QUEUE_STATE_DEMOTION_REVIEW => ['demoted_lifecycle'],
+            default => [],
+        };
+
+        foreach ($lifecycleReasonCodes as $code) {
+            if (! is_string($code)) {
+                continue;
+            }
+
+            $normalized = trim($code);
+            if ($normalized !== '' && in_array($normalized, $allowedLifecycleCodes, true)) {
+                $reasonCodes[] = $normalized;
+            }
+        }
+
+        if ($blockedGovernanceStatus !== null) {
+            $reasonCodes[] = 'blocked_governance';
+        }
+
+        return array_values(array_unique($reasonCodes));
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRolloutQueueController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRolloutQueueController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRolloutQueueSummaryService;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerFirstWaveRolloutQueueSummaryResource;
+
+final class CareerFirstWaveRolloutQueueController extends Controller
+{
+    public function __construct(
+        private readonly CareerFirstWaveRolloutQueueSummaryService $summaryService,
+    ) {}
+
+    public function show(): CareerFirstWaveRolloutQueueSummaryResource
+    {
+        return new CareerFirstWaveRolloutQueueSummaryResource(
+            $this->summaryService->build()
+        );
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerFirstWaveRolloutQueueSummaryResource.php
+++ b/backend/app/Http/Resources/Career/CareerFirstWaveRolloutQueueSummaryResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerFirstWaveRolloutQueueSummary;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerFirstWaveRolloutQueueSummary
+ */
+final class CareerFirstWaveRolloutQueueSummaryResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerFirstWaveRolloutQueueSummary $summary */
+        $summary = $this->resource;
+
+        return $summary->toArray();
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2413,6 +2413,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/first-wave/rollout-queue": {
+            "get": {
+                "operationId": "get_api_v0_5_career_first_wave_rollout_queue",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerFirstWaveRolloutQueueController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/jobs": {
             "get": {
                 "operationId": "get_api_v0_5_career_jobs",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -34,6 +34,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
 use App\Http\Controllers\API\V0_5\Career\CareerFamilyHubController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLifecycleController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
+use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveRolloutQueueController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobListController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationDetailController;
@@ -408,6 +409,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/family/{slug}', [CareerFamilyHubController::class, 'show']);
     Route::get('/career/resolve', [CareerAliasResolutionController::class, 'show']);
     Route::get('/career/first-wave/lifecycle', [CareerFirstWaveLifecycleController::class, 'show']);
+    Route::get('/career/first-wave/rollout-queue', [CareerFirstWaveRolloutQueueController::class, 'show']);
     Route::get('/career/first-wave/readiness', [CareerFirstWaveReadinessController::class, 'show']);
     Route::get('/career/jobs', [CareerJobListController::class, 'index']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerFirstWaveRolloutQueueApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveRolloutQueueApiTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveRolloutQueueApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_exposes_an_empty_first_wave_rollout_queue_when_no_rows_need_review(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/rollout-queue');
+
+        $response->assertOk()
+            ->assertJsonPath('summary_kind', 'career_first_wave_rollout_queue')
+            ->assertJsonPath('summary_version', 'career.rollout.first_wave.v1')
+            ->assertJsonPath('scope', 'career_first_wave_10')
+            ->assertJsonPath('counts.total', 0)
+            ->assertJsonPath('counts.promotion_candidate_review', 0)
+            ->assertJsonPath('counts.demotion_review', 0)
+            ->assertJsonPath('queue_items', [])
+            ->assertJsonMissingPath('recommended_action');
+    }
+
+    public function test_it_exposes_queue_worthy_candidate_and_demoted_rows_without_recommended_actions(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $demoted = Occupation::query()->where('canonical_slug', 'management-analysts')->firstOrFail();
+
+        $candidate->indexStates()->orderByDesc('changed_at')->orderByDesc('updated_at')->firstOrFail()->update([
+            'index_state' => 'promotion_candidate',
+            'index_eligible' => false,
+            'reason_codes' => ['career_index_lifecycle_promotion_candidate'],
+        ]);
+
+        $demoted->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewer_status' => 'changes_required',
+        ]);
+        $demoted->indexStates()->orderByDesc('changed_at')->orderByDesc('updated_at')->firstOrFail()->update([
+            'index_state' => 'demoted',
+            'index_eligible' => false,
+            'reason_codes' => ['career_index_lifecycle_demoted', 'career_index_lifecycle_regressed'],
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/rollout-queue');
+
+        $response->assertOk()
+            ->assertJsonPath('counts.total', 2)
+            ->assertJsonPath('counts.promotion_candidate_review', 1)
+            ->assertJsonPath('counts.demotion_review', 1)
+            ->assertJsonStructure([
+                'summary_kind',
+                'summary_version',
+                'scope',
+                'counts' => [
+                    'total',
+                    'promotion_candidate_review',
+                    'demotion_review',
+                ],
+                'queue_items' => [[
+                    'occupation_uuid',
+                    'canonical_slug',
+                    'canonical_title_en',
+                    'lifecycle_state',
+                    'readiness_status',
+                    'public_index_state',
+                    'index_eligible',
+                    'reviewer_status',
+                    'blocked_governance_status',
+                    'queue_state',
+                    'reason_codes',
+                ]],
+            ])
+            ->assertJsonMissingPath('queue_items.0.recommended_action');
+
+        $queueItems = collect($response->json('queue_items'))->keyBy('canonical_slug');
+        $candidateRow = $queueItems['data-scientists'];
+        $demotedRow = $queueItems['management-analysts'];
+
+        $this->assertSame('promotion_candidate_review', $candidateRow['queue_state']);
+        $this->assertSame(
+            ['promotion_candidate', 'publish_gate_candidate', 'not_index_eligible', 'trust_limited'],
+            $candidateRow['reason_codes']
+        );
+
+        $this->assertSame('demotion_review', $demotedRow['queue_state']);
+        $this->assertContains('demoted_lifecycle', $demotedRow['reason_codes']);
+        $this->assertContains('demoted_review_regression', $demotedRow['reason_codes']);
+        $this->assertContains('demoted_trust_regression', $demotedRow['reason_codes']);
+        $this->assertNotContains('career_index_lifecycle_demoted', $demotedRow['reason_codes']);
+        $this->assertNotContains('career_index_lifecycle_regressed', $demotedRow['reason_codes']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutQueueSummaryServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutQueueSummaryServiceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRolloutQueueSummaryService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveRolloutQueueSummaryServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_an_empty_rollout_queue_from_stable_first_wave_truth(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $summary = app(CareerFirstWaveRolloutQueueSummaryService::class)->build()->toArray();
+
+        $this->assertSame('career_first_wave_rollout_queue', $summary['summary_kind']);
+        $this->assertSame(CareerFirstWaveRolloutQueueSummaryService::SUMMARY_VERSION, $summary['summary_version']);
+        $this->assertSame(CareerFirstWaveRolloutQueueSummaryService::SCOPE, $summary['scope']);
+        $this->assertSame(0, $summary['counts']['total']);
+        $this->assertSame(0, $summary['counts']['promotion_candidate_review']);
+        $this->assertSame(0, $summary['counts']['demotion_review']);
+        $this->assertSame([], $summary['queue_items']);
+    }
+
+    public function test_it_projects_candidate_and_demoted_rows_into_review_buckets_with_curated_reason_codes(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $demoted = Occupation::query()->where('canonical_slug', 'management-analysts')->firstOrFail();
+        $candidate->indexStates()->orderByDesc('changed_at')->orderByDesc('updated_at')->firstOrFail()->update([
+            'index_state' => 'promotion_candidate',
+            'index_eligible' => false,
+            'reason_codes' => ['career_index_lifecycle_promotion_candidate', 'debug_candidate_tag'],
+        ]);
+
+        $demoted->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewer_status' => 'changes_required',
+        ]);
+        $demoted->indexStates()->orderByDesc('changed_at')->orderByDesc('updated_at')->firstOrFail()->update([
+            'index_state' => 'demoted',
+            'index_eligible' => false,
+            'reason_codes' => ['career_index_lifecycle_demoted', 'career_index_lifecycle_regressed'],
+        ]);
+
+        $summary = app(CareerFirstWaveRolloutQueueSummaryService::class)->build()->toArray();
+        $queueItems = collect($summary['queue_items'])->keyBy('canonical_slug');
+
+        $this->assertSame(2, $summary['counts']['total']);
+        $this->assertSame(1, $summary['counts']['promotion_candidate_review']);
+        $this->assertSame(1, $summary['counts']['demotion_review']);
+        $this->assertSame(['data-scientists', 'management-analysts'], array_column($summary['queue_items'], 'canonical_slug'));
+
+        $candidateRow = $queueItems->get('data-scientists');
+        $demotedRow = $queueItems->get('management-analysts');
+
+        $this->assertIsArray($candidateRow);
+        $this->assertSame('promotion_candidate_review', $candidateRow['queue_state']);
+        $this->assertSame('promotion_candidate', $candidateRow['lifecycle_state']);
+        $this->assertSame('partial_raw', $candidateRow['readiness_status']);
+        $this->assertNull($candidateRow['blocked_governance_status']);
+        $this->assertSame(
+            ['promotion_candidate', 'publish_gate_candidate', 'not_index_eligible', 'trust_limited'],
+            $candidateRow['reason_codes']
+        );
+
+        $this->assertIsArray($demotedRow);
+        $this->assertSame('demotion_review', $demotedRow['queue_state']);
+        $this->assertSame('demoted', $demotedRow['lifecycle_state']);
+        $this->assertContains('demoted_lifecycle', $demotedRow['reason_codes']);
+        $this->assertContains('demoted_review_regression', $demotedRow['reason_codes']);
+        $this->assertContains('demoted_trust_regression', $demotedRow['reason_codes']);
+
+        $this->assertNotContains('software-developers', array_column($summary['queue_items'], 'canonical_slug'));
+        $this->assertNotContains('career_index_lifecycle_promotion_candidate', $candidateRow['reason_codes']);
+        $this->assertNotContains('career_index_lifecycle_demoted', $demotedRow['reason_codes']);
+        $this->assertNotContains('career_index_lifecycle_regressed', $demotedRow['reason_codes']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated first-wave rollout queue summary service, DTO, resource, and controller backed by existing lifecycle, readiness, and governance truth
- add `GET /api/v0.5/career/first-wave/rollout-queue` with queue counts and queue-worthy rows only
- expose only two queue buckets, `promotion_candidate_review` and `demotion_review`, without introducing write actions or `recommended_action`
- curate queue reason codes so consumer-facing payloads do not leak raw internal lifecycle compiler/debug tags
- keep B14, B23, B24, and B27 public contracts unchanged while updating the OpenAPI snapshot and adding focused coverage

## Why
- B26 and B27 made lifecycle truth durable and readable, but downstream rollout governance still lacked a dedicated queue-shaped authority surface
- lifecycle summary alone is not the same thing as a rollout queue because `promotion_candidate` does not mean `promotion_ready`
- this PR adds the minimal read-only queue projection needed for rollout governance without turning the API into an action engine

## Validation
- `vendor/bin/pint --test app/DTO/Career/CareerFirstWaveRolloutQueueSummary.php app/Domain/Career/Publish/CareerFirstWaveRolloutQueueSummaryService.php app/Http/Resources/Career/CareerFirstWaveRolloutQueueSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRolloutQueueController.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveRolloutQueueSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveRolloutQueueApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutQueueSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveRolloutQueueApiTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no write actions such as promote/demote/approve
- no `recommended_action`
- no frontend changes
- no SEO rollout semantics
- no scoring or schema changes
