### PR TITLE
PR-B30: Career strain radar authority contract hardening

### DIFF
--- a/backend/app/DTO/Career/CareerExplainabilitySummary.php
+++ b/backend/app/DTO/Career/CareerExplainabilitySummary.php
@@ -9,6 +9,7 @@ final class CareerExplainabilitySummary
     /**
      * @param  array<string, mixed>  $subjectIdentity
      * @param  array<string, array<string, mixed>>  $scoreBundle
+     * @param  array<string, mixed>|null  $strainRadar
      * @param  array<string, mixed>  $warnings
      * @param  array<string, mixed>  $claimPermissions
      * @param  array<string, mixed>  $integritySummary
@@ -17,6 +18,7 @@ final class CareerExplainabilitySummary
         public readonly string $subjectKind,
         public readonly array $subjectIdentity,
         public readonly array $scoreBundle,
+        public readonly ?array $strainRadar,
         public readonly array $warnings,
         public readonly array $claimPermissions,
         public readonly array $integritySummary = [],
@@ -33,6 +35,7 @@ final class CareerExplainabilitySummary
             'subject_kind' => $this->subjectKind,
             'subject_identity' => $this->subjectIdentity,
             'score_bundle' => $this->scoreBundle,
+            'strain_radar' => $this->strainRadar,
             'warnings' => $this->warnings,
             'claim_permissions' => $this->claimPermissions,
             'integrity_summary' => $this->integritySummary,

--- a/backend/app/Services/Career/Explainability/CareerExplainabilitySummaryBuilder.php
+++ b/backend/app/Services/Career/Explainability/CareerExplainabilitySummaryBuilder.php
@@ -15,6 +15,7 @@ final class CareerExplainabilitySummaryBuilder
     public function __construct(
         private readonly CareerJobDetailBundleBuilder $jobDetailBundleBuilder,
         private readonly CareerRecommendationDetailBundleBuilder $recommendationDetailBundleBuilder,
+        private readonly StrainRadarBuilder $strainRadarBuilder,
     ) {}
 
     public function buildForJobSlug(string $slug): ?CareerExplainabilitySummary
@@ -33,6 +34,9 @@ final class CareerExplainabilitySummaryBuilder
                 'canonical_title_en' => $bundle->titles['canonical_en'] ?? null,
             ],
             scoreBundle: $this->normalizeScoreBundle($bundle->scoreBundle),
+            strainRadar: $this->strainRadarBuilder->build(
+                is_array($bundle->scoreBundle['strain_score'] ?? null) ? $bundle->scoreBundle['strain_score'] : []
+            ),
             warnings: $this->normalizeArray($bundle->warnings),
             claimPermissions: $this->normalizeArray($bundle->claimPermissions),
             integritySummary: $this->normalizeArray($bundle->integritySummary),
@@ -61,6 +65,9 @@ final class CareerExplainabilitySummaryBuilder
                 'canonical_title_en' => $bundle->identity['canonical_title_en'] ?? null,
             ],
             scoreBundle: $this->normalizeScoreBundle($bundle->scoreBundle),
+            strainRadar: $this->strainRadarBuilder->build(
+                is_array($bundle->scoreBundle['strain_score'] ?? null) ? $bundle->scoreBundle['strain_score'] : []
+            ),
             warnings: $this->normalizeArray($bundle->warnings),
             claimPermissions: $this->normalizeArray($bundle->claimPermissions),
             integritySummary: $this->normalizeArray($bundle->integritySummary),

--- a/backend/app/Services/Career/Explainability/StrainRadarBuilder.php
+++ b/backend/app/Services/Career/Explainability/StrainRadarBuilder.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Explainability;
+
+final class StrainRadarBuilder
+{
+    /**
+     * @var list<string>
+     */
+    private const PUBLIC_AXES = [
+        'people_friction',
+        'context_switch_load',
+        'political_load',
+        'uncertainty_load',
+        'low_autonomy_trap',
+        'repetition_mismatch',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $strainScore
+     * @return array<string, mixed>|null
+     */
+    public function build(array $strainScore): ?array
+    {
+        $integrityState = is_scalar($strainScore['integrity_state'] ?? null)
+            ? (string) $strainScore['integrity_state']
+            : null;
+
+        if ($integrityState === 'blocked') {
+            return null;
+        }
+
+        $inputs = $strainScore['component_breakdown']['inputs'] ?? null;
+        if (! is_array($inputs)) {
+            return null;
+        }
+
+        $axes = [];
+
+        foreach (self::PUBLIC_AXES as $axis) {
+            if (! array_key_exists($axis, $inputs)) {
+                continue;
+            }
+
+            $axes[$axis] = [
+                'value' => round((float) $inputs[$axis], 4),
+            ];
+        }
+
+        if ($axes === []) {
+            return null;
+        }
+
+        return [
+            'integrity_state' => $integrityState,
+            'confidence_cap' => (int) ($strainScore['confidence_cap'] ?? 0),
+            'degradation_factor' => (float) ($strainScore['degradation_factor'] ?? 0.0),
+            'formula_version' => is_scalar($strainScore['formula_ref'] ?? null) ? (string) $strainScore['formula_ref'] : null,
+            'axes' => $axes,
+        ];
+    }
+}

--- a/backend/tests/Feature/Career/CareerExplainabilityApiTest.php
+++ b/backend/tests/Feature/Career/CareerExplainabilityApiTest.php
@@ -42,16 +42,38 @@ final class CareerExplainabilityApiTest extends TestCase
                         'degradation_factor',
                     ],
                 ],
+                'strain_radar' => [
+                    'integrity_state',
+                    'confidence_cap',
+                    'degradation_factor',
+                    'formula_version',
+                    'axes' => [
+                        'people_friction' => ['value'],
+                        'context_switch_load' => ['value'],
+                        'political_load' => ['value'],
+                        'uncertainty_load' => ['value'],
+                        'low_autonomy_trap' => ['value'],
+                        'repetition_mismatch' => ['value'],
+                    ],
+                ],
                 'warnings',
                 'claim_permissions',
                 'integrity_summary',
             ]);
 
-        $this->assertArrayNotHasKey('strain_radar', $response->json());
+        $this->assertSame([
+            'people_friction',
+            'context_switch_load',
+            'political_load',
+            'uncertainty_load',
+            'low_autonomy_trap',
+            'repetition_mismatch',
+        ], array_keys((array) data_get($response->json(), 'strain_radar.axes')));
+        $this->assertNull(data_get($response->json(), 'strain_radar.axes.environment_fit'));
         $this->assertArrayNotHasKey('why_this_is_right_for_you', $response->json());
     }
 
-    public function test_it_returns_a_recommendation_explainability_payload_without_narrative_or_radar_fields(): void
+    public function test_it_returns_a_recommendation_explainability_payload_with_public_safe_radar_only(): void
     {
         $chain = CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
         $this->compileChain($chain, [
@@ -74,9 +96,42 @@ final class CareerExplainabilityApiTest extends TestCase
 
         $payload = $response->json();
 
-        $this->assertArrayNotHasKey('strain_radar', $payload);
+        $this->assertSame([
+            'people_friction',
+            'context_switch_load',
+            'political_load',
+            'uncertainty_load',
+            'low_autonomy_trap',
+            'repetition_mismatch',
+        ], array_keys((array) data_get($payload, 'strain_radar.axes')));
         $this->assertArrayNotHasKey('people_friction', $payload);
         $this->assertArrayNotHasKey('bridge_steps_90d', $payload);
+    }
+
+    public function test_it_keeps_strain_radar_machine_safe_for_missing_truth_cases(): void
+    {
+        $chain = CareerFoundationFixture::seedMissingTruthChain();
+        $this->compileChain($chain, [
+            'materialization' => 'career_first_wave',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/jobs/backend-architect-missing-truth/explainability')
+            ->assertOk()
+            ->assertJsonPath('score_bundle.strain_score.integrity_state', 'restricted')
+            ->assertJsonPath('strain_radar.integrity_state', 'restricted');
+
+        $payload = $response->json();
+
+        $this->assertSame([
+            'people_friction',
+            'context_switch_load',
+            'political_load',
+            'uncertainty_load',
+            'low_autonomy_trap',
+            'repetition_mismatch',
+        ], array_keys((array) data_get($payload, 'strain_radar.axes')));
+        $this->assertNull(data_get($payload, 'strain_radar.axes.environment_fit'));
+        $this->assertNull(data_get($payload, 'strain_radar.axes.weights'));
     }
 
     /**

--- a/backend/tests/Unit/Services/Career/CareerExplainabilitySummaryBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerExplainabilitySummaryBuilderTest.php
@@ -46,7 +46,23 @@ final class CareerExplainabilitySummaryBuilderTest extends TestCase
         $this->assertArrayHasKey('warnings', $payload);
         $this->assertArrayHasKey('claim_permissions', $payload);
         $this->assertArrayHasKey('integrity_summary', $payload);
-        $this->assertArrayNotHasKey('strain_radar', $payload);
+        $this->assertSame([
+            'integrity_state',
+            'confidence_cap',
+            'degradation_factor',
+            'formula_version',
+            'axes',
+        ], array_keys((array) data_get($payload, 'strain_radar')));
+        $this->assertSame([
+            'people_friction',
+            'context_switch_load',
+            'political_load',
+            'uncertainty_load',
+            'low_autonomy_trap',
+            'repetition_mismatch',
+        ], array_keys((array) data_get($payload, 'strain_radar.axes')));
+        $this->assertNull(data_get($payload, 'strain_radar.axes.environment_fit'));
+        $this->assertNull(data_get($payload, 'strain_radar.axes.environment_mismatch'));
         $this->assertArrayNotHasKey('why_this_path', $payload);
     }
 
@@ -75,7 +91,11 @@ final class CareerExplainabilitySummaryBuilderTest extends TestCase
         $this->assertFalse((bool) data_get($payload, 'claim_permissions.allow_salary_comparison'));
         $this->assertContains('cross_market_mismatch', (array) data_get($payload, 'warnings.amber_flags'));
         $this->assertArrayHasKey('strain_score', (array) data_get($payload, 'score_bundle'));
-        $this->assertNull(data_get($payload, 'strain_radar'));
+        $this->assertSame('career.strain_v1.2', data_get($payload, 'strain_radar.formula_version'));
+        $this->assertSame(
+            ['people_friction', 'context_switch_load', 'political_load', 'uncertainty_load', 'low_autonomy_trap', 'repetition_mismatch'],
+            array_keys((array) data_get($payload, 'strain_radar.axes'))
+        );
         $this->assertNull(data_get($payload, 'bridge_steps_90d'));
     }
 

--- a/backend/tests/Unit/Services/Career/StrainRadarBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/StrainRadarBuilderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Explainability\StrainRadarBuilder;
+use Tests\TestCase;
+
+final class StrainRadarBuilderTest extends TestCase
+{
+    public function test_it_builds_a_deterministic_public_safe_strain_radar(): void
+    {
+        $radar = (new StrainRadarBuilder)->build([
+            'integrity_state' => 'provisional',
+            'confidence_cap' => 78,
+            'formula_ref' => 'career.strain_v1.2',
+            'degradation_factor' => 0.84,
+            'component_breakdown' => [
+                'inputs' => [
+                    'environment_fit' => 0.25,
+                    'people_friction' => 0.61,
+                    'context_switch_load' => 0.52,
+                    'political_load' => 0.47,
+                    'uncertainty_load' => 0.58,
+                    'repetition_mismatch' => 0.33,
+                    'low_autonomy_trap' => 0.41,
+                ],
+                'weights' => [
+                    'people_friction' => 0.16,
+                ],
+                'base_score' => 49.2,
+            ],
+        ]);
+
+        $this->assertSame([
+            'integrity_state',
+            'confidence_cap',
+            'degradation_factor',
+            'formula_version',
+            'axes',
+        ], array_keys((array) $radar));
+        $this->assertSame([
+            'people_friction',
+            'context_switch_load',
+            'political_load',
+            'uncertainty_load',
+            'low_autonomy_trap',
+            'repetition_mismatch',
+        ], array_keys((array) data_get($radar, 'axes')));
+        $this->assertSame('provisional', data_get($radar, 'integrity_state'));
+        $this->assertSame(78, data_get($radar, 'confidence_cap'));
+        $this->assertSame(0.84, data_get($radar, 'degradation_factor'));
+        $this->assertSame('career.strain_v1.2', data_get($radar, 'formula_version'));
+        $this->assertSame(0.61, data_get($radar, 'axes.people_friction.value'));
+        $this->assertNull(data_get($radar, 'axes.environment_fit'));
+        $this->assertNull(data_get($radar, 'axes.environment_mismatch'));
+        $this->assertNull(data_get($radar, 'weights'));
+        $this->assertNull(data_get($radar, 'base_score'));
+        $this->assertNull(data_get($radar, 'description'));
+    }
+
+    public function test_it_omits_strain_radar_when_integrity_is_blocked(): void
+    {
+        $radar = (new StrainRadarBuilder)->build([
+            'integrity_state' => 'blocked',
+            'confidence_cap' => 0,
+            'formula_ref' => 'career.strain_v1.2',
+            'degradation_factor' => 0.0,
+            'component_breakdown' => [
+                'inputs' => [
+                    'people_friction' => 0.9,
+                ],
+            ],
+        ]);
+
+        $this->assertNull($radar);
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated internal `StrainRadarBuilder` that projects the existing `strain_score` truth into a public-safe `strain_radar` object
- extend the existing B29 explainability payload with additive `strain_radar` data for job detail and recommendation detail explainability endpoints
- expose only the six approved strain axes and inherit `integrity_state`, `confidence_cap`, `degradation_factor`, and `formula_version` from the underlying `strain_score`
- add focused unit and feature coverage for the radar contract while keeping the existing explainability endpoints and detail APIs otherwise unchanged

## Why
- the backend already had real six-axis strain truth in `StrainScoreCalculator`, but B29 only exposed the generic `strain_score.components` shape
- B30 hardens that into a stable authority contract without changing scoring formulas, adding a new endpoint, or leaking extra raw internals
- this keeps the payload machine-safe and detail-grade while explicitly avoiding narrative explanation, strategy guidance, and radar product semantics

## Validation
- `vendor/bin/pint --test app/Services/Career/Explainability/StrainRadarBuilder.php app/Services/Career/Explainability/CareerExplainabilitySummaryBuilder.php app/DTO/Career/CareerExplainabilitySummary.php tests/Unit/Services/Career/StrainRadarBuilderTest.php tests/Unit/Services/Career/CareerExplainabilitySummaryBuilderTest.php tests/Feature/Career/CareerExplainabilityApiTest.php`
- `php artisan test tests/Unit/Services/Career/StrainRadarBuilderTest.php tests/Unit/Services/Career/CareerExplainabilitySummaryBuilderTest.php tests/Feature/Career/CareerExplainabilityApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/CareerRecommendationCompilerTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no scoring formula changes
- no new route or explainability endpoint
- no frontend changes
- no prose, strategy, or recommendation guidance
- no extra strain internals beyond the six approved axes
- no public strain chart or radar product semantics
