### PR TITLE
[P0-B api] Stop preferring Tencent asset bases for MBTI result clone assets

### DIFF
--- a/backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php
+++ b/backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php
@@ -116,6 +116,10 @@ final class PersonalityDesktopCloneAssetSlotSupport
         $alt = self::normalizeNullableText($slot['alt'] ?? null);
         $meta = is_array($slot['meta'] ?? null) ? $slot['meta'] : null;
 
+        if ($status === self::STATUS_READY && $assetRef === null) {
+            $status = self::STATUS_PLACEHOLDER;
+        }
+
         return [
             'slot_id' => $slotId,
             'label' => $label,
@@ -140,10 +144,13 @@ final class PersonalityDesktopCloneAssetSlotSupport
         $provider = self::normalizeNullableText($assetRef['provider'] ?? null);
         $path = self::normalizeNullableText($assetRef['path'] ?? null);
         $url = self::normalizeNullableText($assetRef['url'] ?? null);
+        if (self::isTencentAssetUrl($url)) {
+            $url = null;
+        }
         $version = self::normalizeNullableText($assetRef['version'] ?? null);
         $checksum = self::normalizeNullableText($assetRef['checksum'] ?? null);
 
-        if ($provider === null && $path === null && $url === null && $version === null && $checksum === null) {
+        if ($path === null && $url === null) {
             return null;
         }
 
@@ -154,6 +161,30 @@ final class PersonalityDesktopCloneAssetSlotSupport
             'version' => $version,
             'checksum' => $checksum,
         ];
+    }
+
+    public static function isTencentAssetUrl(?string $url): bool
+    {
+        $normalized = strtolower(trim((string) $url));
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach ([
+            'myqcloud.com',
+            '.qcloud.com',
+            'qcloud',
+            'cos.',
+            'ci-process',
+            'imagemogr2',
+            'watermark',
+        ] as $marker) {
+            if (str_contains($normalized, $marker)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static function normalizeSlotId(mixed $slotId): string

--- a/backend/app/Services/Assets/AssetUrlResolver.php
+++ b/backend/app/Services/Assets/AssetUrlResolver.php
@@ -35,18 +35,23 @@ final class AssetUrlResolver
         string $region
     ): string {
         $override = is_string($override) ? trim($override) : '';
-        if ($override !== '') {
+        if ($override !== '' && ! $this->isBlockedTencentBaseUrl($override)) {
             return $override;
         }
 
         $cdnBase = $this->resolveCdnBaseUrl($region);
-        if ($cdnBase !== '') {
+        if ($cdnBase !== '' && ! $this->isBlockedTencentBaseUrl($cdnBase)) {
             return $cdnBase;
         }
 
         $versionBase = $this->readAssetsBaseUrlFromVersion($packId, $dirVersion);
-        if ($versionBase !== '') {
+        if ($versionBase !== '' && ! $this->isBlockedTencentBaseUrl($versionBase)) {
             return $versionBase;
+        }
+
+        $fallbackBase = trim((string) config('cdn_map.fallback_assets_base_url', ''));
+        if ($fallbackBase !== '') {
+            return rtrim($fallbackBase, '/');
         }
 
         $appUrl = trim((string) config('app.url', ''));
@@ -142,6 +147,23 @@ final class AssetUrlResolver
         }
 
         return $baseUrl.'/'.implode('/', $clean);
+    }
+
+    private function isBlockedTencentBaseUrl(string $url): bool
+    {
+        $normalized = strtolower(trim($url));
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach ((array) config('cdn_map.blocked_asset_base_markers', []) as $marker) {
+            $marker = strtolower(trim((string) $marker));
+            if ($marker !== '' && str_contains($normalized, $marker)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function assertStrictAssetPath(string $path): void

--- a/backend/config/cdn_map.php
+++ b/backend/config/cdn_map.php
@@ -7,6 +7,16 @@ $localAssets = $appUrl.'/storage/content_assets';
 
 return [
     'default_region' => env('FAP_DEFAULT_REGION', 'CN_MAINLAND'),
+    'fallback_assets_base_url' => env('FAP_LOCAL_ASSETS_BASE_URL', $localAssets),
+    'blocked_asset_base_markers' => [
+        'myqcloud.com',
+        '.qcloud.com',
+        'qcloud',
+        'cos.',
+        'ci-process',
+        'imagemogr2',
+        'watermark',
+    ],
 
     'map' => [
         'CN_MAINLAND' => [

--- a/backend/tests/Unit/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupportTest.php
+++ b/backend/tests/Unit/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupportTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PersonalityCms\DesktopClone;
+
+use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
+use Tests\TestCase;
+
+class PersonalityDesktopCloneAssetSlotSupportTest extends TestCase
+{
+    public function test_ready_slot_degrades_to_placeholder_when_only_tencent_url_is_present(): void
+    {
+        $normalized = PersonalityDesktopCloneAssetSlotSupport::normalizeAssetSlot([
+            'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_HERO_ILLUSTRATION,
+            'label' => 'Hero illustration',
+            'aspect_ratio' => '236:160',
+            'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_READY,
+            'asset_ref' => [
+                'provider' => PersonalityDesktopCloneAssetSlotSupport::ASSET_PROVIDER_CDN,
+                'path' => null,
+                'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/assets/mbti/hero.webp',
+                'version' => 'v1',
+                'checksum' => 'sha256:test',
+            ],
+        ]);
+
+        $this->assertSame(PersonalityDesktopCloneAssetSlotSupport::STATUS_PLACEHOLDER, $normalized['status']);
+        $this->assertNull($normalized['asset_ref']);
+    }
+
+    public function test_ready_slot_keeps_local_path_when_tencent_url_has_non_tencent_fallback_path(): void
+    {
+        $normalized = PersonalityDesktopCloneAssetSlotSupport::normalizeAssetSlot([
+            'slot_id' => PersonalityDesktopCloneAssetSlotSupport::SLOT_ID_HERO_ILLUSTRATION,
+            'label' => 'Hero illustration',
+            'aspect_ratio' => '236:160',
+            'status' => PersonalityDesktopCloneAssetSlotSupport::STATUS_READY,
+            'asset_ref' => [
+                'provider' => PersonalityDesktopCloneAssetSlotSupport::ASSET_PROVIDER_INTERNAL,
+                'path' => 'storage/content_assets/mbti/desktop/hero.webp',
+                'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/assets/mbti/hero.webp',
+                'version' => 'v1',
+                'checksum' => 'sha256:test',
+            ],
+        ]);
+
+        $this->assertSame(PersonalityDesktopCloneAssetSlotSupport::STATUS_READY, $normalized['status']);
+        $this->assertSame('storage/content_assets/mbti/desktop/hero.webp', $normalized['asset_ref']['path']);
+        $this->assertNull($normalized['asset_ref']['url']);
+    }
+}

--- a/backend/tests/Unit/Services/Assets/AssetUrlResolverTest.php
+++ b/backend/tests/Unit/Services/Assets/AssetUrlResolverTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Assets;
+
+use App\Services\Assets\AssetUrlResolver;
+use App\Services\Content\ContentPacksIndex;
+use App\Support\RegionContext;
+use Tests\TestCase;
+
+class AssetUrlResolverTest extends TestCase
+{
+    public function test_it_ignores_tencent_override_and_falls_back_to_local_assets_base(): void
+    {
+        config([
+            'app.url' => 'https://fermatmind.com',
+            'cdn_map.fallback_assets_base_url' => 'https://fermatmind.com/storage/content_assets',
+            'cdn_map.map.CN_MAINLAND.assets_base_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com',
+        ]);
+
+        $resolver = new AssetUrlResolver(new ContentPacksIndex(), new RegionContext());
+
+        $resolved = $resolver->resolve(
+            'MBTI-CN-v0.2.1-TEST',
+            '2026-04-10',
+            'assets/hero/infj-a.webp',
+            'CN_MAINLAND',
+            'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/runtime-override'
+        );
+
+        $this->assertSame(
+            'https://fermatmind.com/storage/content_assets/MBTI-CN-v0.2.1-TEST/2026-04-10/assets/hero/infj-a.webp',
+            $resolved
+        );
+    }
+}


### PR DESCRIPTION
## What changed
- strip Tencent-hosted asset URLs from MBTI desktop clone asset slot normalization
- downgrade `ready` clone slots to `placeholder` when the remaining asset ref is unusable
- prevent `AssetUrlResolver` from preferring Tencent-like override/CDN/version asset bases
- add a config-backed local fallback asset base URL
- add unit tests for clone asset slot normalization and resolver fallback

## Why
The MBTI result path should not treat Tencent COS/CI as a hard runtime dependency. This PR ensures API-side clone asset metadata and resolved asset bases degrade toward local/non-Tencent paths so the frontend can keep rendering the core result content.

## Validation commands
- `php -l backend/app/Services/Assets/AssetUrlResolver.php`
- `php -l backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php`
- `php -l backend/config/cdn_map.php`
- `cd backend && php artisan test tests/Unit/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupportTest.php tests/Unit/Services/Assets/AssetUrlResolverTest.php`

## Intentionally deferred items
- no database cleanup of existing Tencent URLs
- no article/topic/personality/career media migration
- no frontend placeholder UX changes in this PR
