### PR TITLE
PR-B31: Career non-self transition target materialization under stable_upside

### DIFF
--- a/backend/app/Services/Career/Transition/CareerTransitionPathWriter.php
+++ b/backend/app/Services/Career/Transition/CareerTransitionPathWriter.php
@@ -17,6 +17,7 @@ final class CareerTransitionPathWriter
     public function __construct(
         private readonly CareerTransitionPreviewReadinessLookup $readinessLookup,
         private readonly CareerTransitionStepAuthor $stepAuthor,
+        private readonly CareerTransitionTargetSelector $targetSelector,
     ) {}
 
     public function rewriteForSnapshot(RecommendationSnapshot $snapshot): int
@@ -44,6 +45,11 @@ final class CareerTransitionPathWriter
                 return 0;
             }
 
+            $targetOccupation = $this->targetSelector->selectForSnapshot($snapshot);
+            if (! $targetOccupation instanceof Occupation) {
+                return 0;
+            }
+
             $pathPayload = TransitionPathPayload::from([
                 'steps' => $this->stepAuthor->authorForOccupation($sourceOccupation),
             ]);
@@ -51,7 +57,7 @@ final class CareerTransitionPathWriter
             TransitionPath::query()->create([
                 'recommendation_snapshot_id' => $snapshot->id,
                 'from_occupation_id' => $sourceOccupation->id,
-                'to_occupation_id' => $sourceOccupation->id,
+                'to_occupation_id' => $targetOccupation->id,
                 'path_type' => TransitionPathType::StableUpside->value,
                 'path_payload' => $pathPayload->toArray(),
             ]);

--- a/backend/app/Services/Career/Transition/CareerTransitionTargetSelector.php
+++ b/backend/app/Services/Career/Transition/CareerTransitionTargetSelector.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Transition;
+
+use App\Domain\Career\ReviewerStatus;
+use App\Models\Occupation;
+use App\Models\RecommendationSnapshot;
+use App\Services\Career\CareerTransitionPreviewReadinessLookup;
+use Illuminate\Support\Collection;
+
+final class CareerTransitionTargetSelector
+{
+    /**
+     * @var list<string>
+     */
+    private const SAFE_CROSSWALK_MODES = ['exact', 'direct_match', 'trust_inheritance'];
+
+    public function __construct(
+        private readonly CareerTransitionPreviewReadinessLookup $readinessLookup,
+    ) {}
+
+    public function selectForSnapshot(RecommendationSnapshot $snapshot): ?Occupation
+    {
+        $sourceOccupation = $snapshot->occupation;
+        if (! $sourceOccupation instanceof Occupation) {
+            return null;
+        }
+
+        /** @var Collection<int, Occupation> $candidates */
+        $candidates = Occupation::query()
+            ->where('family_id', $sourceOccupation->family_id)
+            ->where('entity_level', $sourceOccupation->entity_level)
+            ->whereKeyNot($sourceOccupation->id)
+            ->get();
+
+        /** @var Collection<int, Occupation> $eligible */
+        $eligible = $candidates
+            ->filter(function (Occupation $candidate): bool {
+                return $this->targetReadinessRow($candidate) !== null;
+            })
+            ->sort(function (Occupation $left, Occupation $right): int {
+                return $this->compareCandidates($left, $right);
+            })
+            ->values();
+
+        /** @var Occupation|null $selected */
+        $selected = $eligible->first();
+
+        return $selected;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function targetReadinessRow(Occupation $candidate): ?array
+    {
+        $readiness = $this->readinessLookup->bySlug((string) $candidate->canonical_slug);
+        if (! is_array($readiness)) {
+            return null;
+        }
+
+        if (($readiness['status'] ?? null) !== 'publish_ready') {
+            return null;
+        }
+
+        if (($readiness['index_eligible'] ?? false) !== true) {
+            return null;
+        }
+
+        $reviewerStatus = strtolower(trim((string) ($readiness['reviewer_status'] ?? '')));
+        if ($reviewerStatus !== ReviewerStatus::APPROVED) {
+            return null;
+        }
+
+        $crosswalkMode = strtolower(trim((string) ($readiness['crosswalk_mode'] ?? $candidate->crosswalk_mode ?? '')));
+        if (! in_array($crosswalkMode, self::SAFE_CROSSWALK_MODES, true)) {
+            return null;
+        }
+
+        return $readiness;
+    }
+
+    private function compareCandidates(Occupation $left, Occupation $right): int
+    {
+        $leftCrosswalkRank = $this->crosswalkRank($left);
+        $rightCrosswalkRank = $this->crosswalkRank($right);
+        if ($leftCrosswalkRank !== $rightCrosswalkRank) {
+            return $leftCrosswalkRank <=> $rightCrosswalkRank;
+        }
+
+        $leftTitle = strtolower(trim((string) $left->canonical_title_en));
+        $rightTitle = strtolower(trim((string) $right->canonical_title_en));
+        if ($leftTitle !== $rightTitle) {
+            return $leftTitle <=> $rightTitle;
+        }
+
+        $leftSlug = strtolower(trim((string) $left->canonical_slug));
+        $rightSlug = strtolower(trim((string) $right->canonical_slug));
+        if ($leftSlug !== $rightSlug) {
+            return $leftSlug <=> $rightSlug;
+        }
+
+        return strcmp((string) $left->id, (string) $right->id);
+    }
+
+    private function crosswalkRank(Occupation $candidate): int
+    {
+        $row = $this->targetReadinessRow($candidate);
+        $mode = strtolower(trim((string) ($row['crosswalk_mode'] ?? $candidate->crosswalk_mode ?? '')));
+
+        return match ($mode) {
+            'exact' => 0,
+            'direct_match' => 1,
+            'trust_inheritance' => 2,
+            default => 9,
+        };
+    }
+}

--- a/backend/tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php
+++ b/backend/tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php
@@ -5,10 +5,19 @@ declare(strict_types=1);
 namespace Tests\Feature\Career;
 
 use App\Domain\Career\Transition\TransitionPathPayload;
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
 use App\Models\ProfileProjection;
+use App\Models\RecommendationSnapshot;
 use App\Models\TransitionPath;
+use App\Services\Career\CareerRecommendationCompiler;
+use App\Services\Career\CareerTransitionPreviewReadinessLookup;
+use App\Services\Career\Transition\CareerTransitionPathWriter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use Mockery;
+use Tests\Fixtures\Career\CareerFoundationFixture;
 use Tests\TestCase;
 
 final class FirstWaveTransitionPathMaterializationTest extends TestCase
@@ -17,23 +26,25 @@ final class FirstWaveTransitionPathMaterializationTest extends TestCase
 
     public function test_it_materializes_publish_ready_transition_paths_from_the_first_wave_pipeline(): void
     {
-        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
-            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_publish_subset.csv'),
-            '--materialize-missing' => true,
-            '--compile-missing' => true,
-            '--json' => true,
+        $snapshot = $this->compileRecommendationChain('transition-materialization-source');
+        $target = $this->createSameFamilyTarget($snapshot, 'transition-materialization-target', 'Transition Materialization Target');
+        $this->mockReadinessSummary([
+            $this->readinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
+            $this->readinessRow($target->canonical_slug, 'publish_ready', true, 'indexable', 'approved'),
         ]);
 
-        $this->assertSame(0, $exitCode);
-        $this->assertGreaterThan(0, TransitionPath::query()->count());
-        $this->assertSame(
-            TransitionPath::query()->count(),
-            TransitionPath::query()->distinct('recommendation_snapshot_id')->count('recommendation_snapshot_id')
-        );
+        $written = app(CareerTransitionPathWriter::class)->rewriteForSnapshot($snapshot);
 
-        $path = TransitionPath::query()->with(['recommendationSnapshot', 'fromOccupation', 'toOccupation'])->latest('created_at')->firstOrFail();
+        $this->assertSame(1, $written);
+        $this->assertSame(1, TransitionPath::query()->where('recommendation_snapshot_id', $snapshot->id)->count());
+        $path = TransitionPath::query()
+            ->with(['recommendationSnapshot', 'fromOccupation', 'toOccupation'])
+            ->where('recommendation_snapshot_id', $snapshot->id)
+            ->sole();
         $this->assertSame('stable_upside', $path->path_type);
-        $this->assertSame($path->from_occupation_id, $path->to_occupation_id);
+        $this->assertNotSame($path->from_occupation_id, $path->to_occupation_id);
+        $this->assertSame($path->fromOccupation?->family_id, $path->toOccupation?->family_id);
+        $this->assertSame($target->canonical_slug, $path->toOccupation?->canonical_slug);
         $this->assertSame([
             'steps' => TransitionPathPayload::allowedStepLabels(),
         ], $path->normalizedPathPayload()->toArray());
@@ -52,13 +63,14 @@ final class FirstWaveTransitionPathMaterializationTest extends TestCase
         $firstExitCode = Artisan::call('career:validate-first-wave-publish-ready', $command);
         $firstCount = TransitionPath::query()->count();
         $firstFingerprints = TransitionPath::query()
+            ->with(['fromOccupation', 'toOccupation'])
             ->orderBy('recommendation_snapshot_id')
             ->get()
             ->map(static fn (TransitionPath $path): array => [
-                'snapshot_id' => $path->recommendation_snapshot_id,
+                'from_slug' => $path->fromOccupation?->canonical_slug,
+                'to_slug' => $path->toOccupation?->canonical_slug,
                 'path_type' => $path->path_type,
-                'from' => $path->from_occupation_id,
-                'to' => $path->to_occupation_id,
+                'same_family' => $path->fromOccupation?->family_id === $path->toOccupation?->family_id,
             ])
             ->all();
 
@@ -81,30 +93,38 @@ final class FirstWaveTransitionPathMaterializationTest extends TestCase
                 ->map(static fn (TransitionPath $path): array => $path->normalizedPathPayload()->toArray())
                 ->all()
         );
-        $this->assertNotSame($firstFingerprints, TransitionPath::query()
-            ->orderBy('recommendation_snapshot_id')
-            ->get()
-            ->map(static fn (TransitionPath $path): array => [
-                'snapshot_id' => $path->recommendation_snapshot_id,
-                'path_type' => $path->path_type,
-                'from' => $path->from_occupation_id,
-                'to' => $path->to_occupation_id,
-            ])
-            ->all());
+        $this->assertSame(
+            $firstFingerprints,
+            TransitionPath::query()
+                ->with(['fromOccupation', 'toOccupation'])
+                ->orderBy('recommendation_snapshot_id')
+                ->get()
+                ->map(static fn (TransitionPath $path): array => [
+                    'from_slug' => $path->fromOccupation?->canonical_slug,
+                    'to_slug' => $path->toOccupation?->canonical_slug,
+                    'path_type' => $path->path_type,
+                    'same_family' => $path->fromOccupation?->family_id === $path->toOccupation?->family_id,
+                ])
+                ->all()
+        );
     }
 
     public function test_preview_api_can_read_production_written_transition_rows_without_expanding_public_contract(): void
     {
-        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
-            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_publish_subset.csv'),
-            '--materialize-missing' => true,
-            '--compile-missing' => true,
-            '--json' => true,
+        $snapshot = $this->compileRecommendationChain('transition-preview-source');
+        $target = $this->createSameFamilyTarget($snapshot, 'registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
+            $this->readinessRow($target->canonical_slug, 'publish_ready', true, 'indexable', 'approved'),
         ]);
 
-        $this->assertSame(0, $exitCode);
+        $written = app(CareerTransitionPathWriter::class)->rewriteForSnapshot($snapshot);
+        $this->assertSame(1, $written);
 
-        $path = TransitionPath::query()->with(['recommendationSnapshot.profileProjection', 'toOccupation'])->latest('created_at')->firstOrFail();
+        $path = TransitionPath::query()
+            ->with(['recommendationSnapshot.profileProjection', 'toOccupation'])
+            ->where('recommendation_snapshot_id', $snapshot->id)
+            ->sole();
         $projection = $path->recommendationSnapshot?->profileProjection;
         $this->assertInstanceOf(ProfileProjection::class, $projection);
 
@@ -130,5 +150,117 @@ final class FirstWaveTransitionPathMaterializationTest extends TestCase
             ->assertJsonMissingPath('why_this_path')
             ->assertJsonMissingPath('what_is_lost')
             ->assertJsonMissingPath('bridge_steps_90d');
+
+        $this->assertNotSame($path->from_occupation_id, $path->to_occupation_id);
+    }
+
+    private function compileRecommendationChain(string $slug): RecommendationSnapshot
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-transition-materialization-'.$slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave'],
+            ),
+        ]);
+
+        return app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+    }
+
+    private function createSameFamilyTarget(RecommendationSnapshot $snapshot, string $slug, string $title): Occupation
+    {
+        $source = $snapshot->occupation()->firstOrFail();
+
+        return Occupation::query()->create([
+            'family_id' => $source->family_id,
+            'parent_id' => null,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => $source->truth_market,
+            'display_market' => $source->display_market,
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+            'search_h1_zh' => $title,
+            'structural_stability' => $source->structural_stability,
+            'task_prototype_signature' => $source->task_prototype_signature,
+            'market_semantics_gap' => $source->market_semantics_gap,
+            'regulatory_divergence' => $source->regulatory_divergence,
+            'toolchain_divergence' => $source->toolchain_divergence,
+            'skill_gap_threshold' => $source->skill_gap_threshold,
+            'trust_inheritance_scope' => $source->trust_inheritance_scope,
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $occupations
+     */
+    private function mockReadinessSummary(array $occupations): void
+    {
+        $lookup = Mockery::mock(CareerTransitionPreviewReadinessLookup::class);
+        foreach ($occupations as $row) {
+            $lookup->shouldReceive('bySlug')
+                ->with((string) ($row['canonical_slug'] ?? ''))
+                ->andReturn($row);
+        }
+        $lookup->shouldReceive('bySlug')->andReturn(null);
+
+        $this->app->instance(CareerTransitionPreviewReadinessLookup::class, $lookup);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readinessRow(
+        string $canonicalSlug,
+        string $status,
+        bool $indexEligible,
+        string $indexState,
+        string $reviewerStatus,
+    ): array {
+        return [
+            'occupation_uuid' => 'uuid-'.$canonicalSlug,
+            'canonical_slug' => $canonicalSlug,
+            'canonical_title_en' => $canonicalSlug,
+            'status' => $status,
+            'blocker_type' => null,
+            'remediation_class' => null,
+            'authority_override_supplied' => false,
+            'review_required' => false,
+            'crosswalk_mode' => 'exact',
+            'reviewer_status' => $reviewerStatus,
+            'index_state' => $indexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => [$status],
+        ];
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
@@ -35,7 +35,13 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
             'from_occupation_id' => $snapshot->occupation_id,
             'to_occupation_id' => $target->id,
             'path_type' => 'stable_upside',
-            'path_payload' => ['steps' => ['fixture-only transition evidence']],
+            'path_payload' => [
+                'steps' => [
+                    \App\Domain\Career\Transition\TransitionPathPayload::STEP_SKILL_OVERLAP,
+                    \App\Domain\Career\Transition\TransitionPathPayload::STEP_TASK_OVERLAP,
+                    \App\Domain\Career\Transition\TransitionPathPayload::STEP_TOOL_OVERLAP,
+                ],
+            ],
         ]);
 
         $payload = app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
@@ -158,7 +164,11 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
 
         $payload = app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
 
-        $this->assertSame(CareerTransitionPreviewBundle::publicTopLevelKeys(), array_keys($payload));
+        $expectedKeys = array_values(array_filter(
+            CareerTransitionPreviewBundle::publicTopLevelKeys(),
+            static fn (string $key): bool => $key !== 'steps'
+        ));
+        $this->assertSame($expectedKeys, array_keys($payload));
         $this->assertSame('stable_upside', $payload['path_type'] ?? null);
         $this->assertArrayNotHasKey('steps', $payload);
         $this->assertArrayNotHasKey('why_this_path', $payload);

--- a/backend/tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php
+++ b/backend/tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php
@@ -24,14 +24,19 @@ final class CareerTransitionPathWriterTest extends TestCase
     public function test_it_materializes_a_minimal_stable_upside_path_for_a_publish_ready_first_wave_snapshot(): void
     {
         $snapshot = $this->compiledFirstWaveSnapshot();
-        $this->mockReadinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved');
+        $target = $this->createSameFamilyTarget($snapshot, 'backend-platform-engineer', 'Backend Platform Engineer');
+        $this->mockReadinessRows([
+            $this->readinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
+            $this->readinessRow($target->canonical_slug, 'publish_ready', true, 'indexable', 'approved'),
+        ]);
 
         $written = app(CareerTransitionPathWriter::class)->rewriteForSnapshot($snapshot);
 
         $this->assertSame(1, $written);
         $path = TransitionPath::query()->where('recommendation_snapshot_id', $snapshot->id)->sole();
         $this->assertSame($snapshot->occupation_id, $path->from_occupation_id);
-        $this->assertSame($snapshot->occupation_id, $path->to_occupation_id);
+        $this->assertSame($target->id, $path->to_occupation_id);
+        $this->assertNotSame($path->from_occupation_id, $path->to_occupation_id);
         $this->assertSame('stable_upside', $path->path_type);
         $this->assertSame([
             'steps' => TransitionPathPayload::allowedStepLabels(),
@@ -41,7 +46,11 @@ final class CareerTransitionPathWriterTest extends TestCase
     public function test_it_rewrites_stale_rows_for_the_same_snapshot_without_duplicates(): void
     {
         $snapshot = $this->compiledFirstWaveSnapshot();
-        $this->mockReadinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved');
+        $target = $this->createSameFamilyTarget($snapshot, 'backend-site-reliability-engineer', 'Backend Site Reliability Engineer');
+        $this->mockReadinessRows([
+            $this->readinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
+            $this->readinessRow($target->canonical_slug, 'publish_ready', true, 'indexable', 'approved'),
+        ]);
 
         TransitionPath::query()->create([
             'recommendation_snapshot_id' => $snapshot->id,
@@ -57,6 +66,8 @@ final class CareerTransitionPathWriterTest extends TestCase
         $this->assertSame(1, TransitionPath::query()->where('recommendation_snapshot_id', $snapshot->id)->count());
         $path = TransitionPath::query()->where('recommendation_snapshot_id', $snapshot->id)->sole();
         $this->assertSame('stable_upside', $path->path_type);
+        $this->assertSame($target->id, $path->to_occupation_id);
+        $this->assertNotSame($path->from_occupation_id, $path->to_occupation_id);
         $this->assertSame([
             'steps' => TransitionPathPayload::allowedStepLabels(),
         ], $path->normalizedPathPayload()->toArray());
@@ -68,7 +79,11 @@ final class CareerTransitionPathWriterTest extends TestCase
         $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
         $payload['claim_permissions']['allow_transition_recommendation'] = false;
         $snapshot->forceFill(['snapshot_payload' => $payload])->save();
-        $this->mockReadinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved');
+        $target = $this->createSameFamilyTarget($snapshot, 'backend-analytics-engineer', 'Backend Analytics Engineer');
+        $this->mockReadinessRows([
+            $this->readinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
+            $this->readinessRow($target->canonical_slug, 'publish_ready', true, 'indexable', 'approved'),
+        ]);
 
         $written = app(CareerTransitionPathWriter::class)->rewriteForSnapshot($snapshot);
 
@@ -76,10 +91,22 @@ final class CareerTransitionPathWriterTest extends TestCase
         $this->assertSame(0, TransitionPath::query()->where('recommendation_snapshot_id', $snapshot->id)->count());
     }
 
-    public function test_it_rejects_non_publish_ready_targets(): void
+    public function test_it_writes_zero_rows_when_no_safe_non_self_target_exists(): void
     {
         $snapshot = $this->compiledFirstWaveSnapshot();
-        $this->mockReadinessRow($snapshot->occupation?->canonical_slug ?? '', 'partial_raw', false, 'noindex', 'pending');
+        $target = $this->createSameFamilyTarget($snapshot, 'backend-ops-engineer', 'Backend Ops Engineer');
+        $this->mockReadinessRows([
+            $this->readinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
+            $this->readinessRow($target->canonical_slug, 'partial_raw', false, 'noindex', 'pending'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $snapshot->occupation_id,
+            'path_type' => 'stable_upside',
+            'path_payload' => ['steps' => ['legacy self row']],
+        ]);
 
         $written = app(CareerTransitionPathWriter::class)->rewriteForSnapshot($snapshot);
 
@@ -90,7 +117,11 @@ final class CareerTransitionPathWriterTest extends TestCase
     public function test_it_rejects_blocked_targets_including_override_eligible_and_not_safely_remediable(): void
     {
         $overrideSnapshot = $this->compiledFirstWaveSnapshot(['slug' => 'software-developers']);
-        $this->mockReadinessRow($overrideSnapshot->occupation?->canonical_slug ?? '', 'blocked_override_eligible', false, 'noindex', 'approved');
+        $overrideTarget = $this->createSameFamilyTarget($overrideSnapshot, 'software-developers-staff', 'Software Developers Staff');
+        $this->mockReadinessRows([
+            $this->readinessRow($overrideSnapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
+            $this->readinessRow($overrideTarget->canonical_slug, 'blocked_override_eligible', false, 'noindex', 'approved'),
+        ]);
 
         $overrideWritten = app(CareerTransitionPathWriter::class)->rewriteForSnapshot($overrideSnapshot);
 
@@ -98,12 +129,40 @@ final class CareerTransitionPathWriterTest extends TestCase
         $this->assertSame(0, TransitionPath::query()->where('recommendation_snapshot_id', $overrideSnapshot->id)->count());
 
         $blockedSnapshot = $this->compiledFirstWaveSnapshot(['slug' => 'marketing-managers']);
-        $this->mockReadinessRow($blockedSnapshot->occupation?->canonical_slug ?? '', 'blocked_not_safely_remediable', false, 'noindex', 'pending');
+        $blockedTarget = $this->createSameFamilyTarget($blockedSnapshot, 'marketing-managers-staff', 'Marketing Managers Staff');
+        $this->mockReadinessRows([
+            $this->readinessRow($blockedSnapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
+            $this->readinessRow($blockedTarget->canonical_slug, 'blocked_not_safely_remediable', false, 'noindex', 'pending'),
+        ]);
 
         $blockedWritten = app(CareerTransitionPathWriter::class)->rewriteForSnapshot($blockedSnapshot);
 
         $this->assertSame(0, $blockedWritten);
         $this->assertSame(0, TransitionPath::query()->where('recommendation_snapshot_id', $blockedSnapshot->id)->count());
+    }
+
+    public function test_it_selects_the_same_non_self_target_deterministically_on_rewrite(): void
+    {
+        $snapshot = $this->compiledFirstWaveSnapshot(['slug' => 'backend-architect-deterministic']);
+        $alpha = $this->createSameFamilyTarget($snapshot, 'backend-alpha', 'Backend Alpha');
+        $omega = $this->createSameFamilyTarget($snapshot, 'backend-omega', 'Backend Omega');
+
+        $this->mockReadinessRows([
+            $this->readinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
+            $this->readinessRow($alpha->canonical_slug, 'publish_ready', true, 'indexable', 'approved', 'exact'),
+            $this->readinessRow($omega->canonical_slug, 'publish_ready', true, 'indexable', 'approved', 'trust_inheritance'),
+        ]);
+
+        $firstWritten = app(CareerTransitionPathWriter::class)->rewriteForSnapshot($snapshot);
+        $firstTarget = TransitionPath::query()->where('recommendation_snapshot_id', $snapshot->id)->sole()->to_occupation_id;
+
+        $secondWritten = app(CareerTransitionPathWriter::class)->rewriteForSnapshot($snapshot);
+        $secondTarget = TransitionPath::query()->where('recommendation_snapshot_id', $snapshot->id)->sole()->to_occupation_id;
+
+        $this->assertSame(1, $firstWritten);
+        $this->assertSame(1, $secondWritten);
+        $this->assertSame($alpha->id, $firstTarget);
+        $this->assertSame($alpha->id, $secondTarget);
     }
 
     /**
@@ -151,33 +210,72 @@ final class CareerTransitionPathWriterTest extends TestCase
         ]);
     }
 
-    private function mockReadinessRow(
+    private function createSameFamilyTarget(RecommendationSnapshot $snapshot, string $slug, string $title): \App\Models\Occupation
+    {
+        $source = $snapshot->occupation()->firstOrFail();
+
+        return \App\Models\Occupation::query()->create([
+            'family_id' => $source->family_id,
+            'parent_id' => null,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => $source->truth_market,
+            'display_market' => $source->display_market,
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+            'search_h1_zh' => $title,
+            'structural_stability' => $source->structural_stability,
+            'task_prototype_signature' => $source->task_prototype_signature,
+            'market_semantics_gap' => $source->market_semantics_gap,
+            'regulatory_divergence' => $source->regulatory_divergence,
+            'toolchain_divergence' => $source->toolchain_divergence,
+            'skill_gap_threshold' => $source->skill_gap_threshold,
+            'trust_inheritance_scope' => $source->trust_inheritance_scope,
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function mockReadinessRows(array $rows): void
+    {
+        $lookup = Mockery::mock(CareerTransitionPreviewReadinessLookup::class);
+        foreach ($rows as $row) {
+            $lookup->shouldReceive('bySlug')
+                ->with((string) ($row['canonical_slug'] ?? ''))
+                ->andReturn($row);
+        }
+        $lookup->shouldReceive('bySlug')->andReturn(null);
+
+        $this->app->instance(CareerTransitionPreviewReadinessLookup::class, $lookup);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readinessRow(
         string $canonicalSlug,
         string $status,
         bool $indexEligible,
         string $indexState,
         string $reviewerStatus,
-    ): void {
-        $lookup = Mockery::mock(CareerTransitionPreviewReadinessLookup::class);
-        $lookup->shouldReceive('bySlug')
-            ->with($canonicalSlug)
-            ->andReturn([
-                'occupation_uuid' => 'uuid-'.$canonicalSlug,
-                'canonical_slug' => $canonicalSlug,
-                'canonical_title_en' => $canonicalSlug,
-                'status' => $status,
-                'blocker_type' => null,
-                'remediation_class' => null,
-                'authority_override_supplied' => false,
-                'review_required' => false,
-                'crosswalk_mode' => 'exact',
-                'reviewer_status' => $reviewerStatus,
-                'index_state' => $indexState,
-                'index_eligible' => $indexEligible,
-                'reason_codes' => [$status],
-            ]);
-        $lookup->shouldReceive('bySlug')->andReturn(null);
-
-        $this->app->instance(CareerTransitionPreviewReadinessLookup::class, $lookup);
+        string $crosswalkMode = 'exact',
+    ): array {
+        return [
+            'occupation_uuid' => 'uuid-'.$canonicalSlug,
+            'canonical_slug' => $canonicalSlug,
+            'canonical_title_en' => $canonicalSlug,
+            'status' => $status,
+            'blocker_type' => null,
+            'remediation_class' => null,
+            'authority_override_supplied' => false,
+            'review_required' => false,
+            'crosswalk_mode' => $crosswalkMode,
+            'reviewer_status' => $reviewerStatus,
+            'index_state' => $indexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => [$status],
+        ];
     }
 }

--- a/backend/tests/Unit/Services/Career/Transition/CareerTransitionTargetSelectorTest.php
+++ b/backend/tests/Unit/Services/Career/Transition/CareerTransitionTargetSelectorTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career\Transition;
+
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use App\Models\RecommendationSnapshot;
+use App\Services\Career\CareerTransitionPreviewReadinessLookup;
+use App\Services\Career\Transition\CareerTransitionTargetSelector;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerTransitionTargetSelectorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_selects_a_same_family_publish_ready_non_self_target(): void
+    {
+        $snapshot = $this->sourceSnapshot();
+        $source = $snapshot->occupation()->firstOrFail();
+        $candidate = $this->sameFamilyOccupation($source, 'backend-platform-engineer', 'Backend Platform Engineer');
+
+        $this->mockReadiness([
+            (string) $candidate->canonical_slug => $this->readinessRow($candidate->canonical_slug),
+        ]);
+
+        $selected = app(CareerTransitionTargetSelector::class)->selectForSnapshot($snapshot);
+
+        $this->assertInstanceOf(Occupation::class, $selected);
+        $this->assertSame($candidate->id, $selected?->id);
+        $this->assertNotSame($source->id, $selected?->id);
+        $this->assertSame($source->family_id, $selected?->family_id);
+    }
+
+    public function test_it_returns_null_when_only_self_or_unsafe_targets_exist(): void
+    {
+        $snapshot = $this->sourceSnapshot();
+        $source = $snapshot->occupation()->firstOrFail();
+        $unsafeSameFamily = $this->sameFamilyOccupation($source, 'backend-architect-unsafe', 'Backend Architect Unsafe');
+        $otherFamily = $this->otherFamilyOccupation('registered-nurses', 'Registered Nurses');
+
+        $this->mockReadiness([
+            (string) $unsafeSameFamily->canonical_slug => $this->readinessRow($unsafeSameFamily->canonical_slug, status: 'blocked_override_eligible', indexEligible: false),
+            (string) $otherFamily->canonical_slug => $this->readinessRow($otherFamily->canonical_slug),
+        ]);
+
+        $selected = app(CareerTransitionTargetSelector::class)->selectForSnapshot($snapshot);
+
+        $this->assertNull($selected);
+    }
+
+    public function test_it_filters_by_index_eligibility_reviewer_status_and_crosswalk_mode(): void
+    {
+        $snapshot = $this->sourceSnapshot();
+        $source = $snapshot->occupation()->firstOrFail();
+
+        $indexBlocked = $this->sameFamilyOccupation($source, 'backend-index-blocked', 'Backend Index Blocked');
+        $reviewBlocked = $this->sameFamilyOccupation($source, 'backend-review-blocked', 'Backend Review Blocked');
+        $crosswalkBlocked = $this->sameFamilyOccupation($source, 'backend-crosswalk-blocked', 'Backend Crosswalk Blocked');
+
+        $this->mockReadiness([
+            (string) $indexBlocked->canonical_slug => $this->readinessRow($indexBlocked->canonical_slug, indexEligible: false),
+            (string) $reviewBlocked->canonical_slug => $this->readinessRow($reviewBlocked->canonical_slug, reviewerStatus: 'pending'),
+            (string) $crosswalkBlocked->canonical_slug => $this->readinessRow($crosswalkBlocked->canonical_slug, crosswalkMode: 'family_proxy'),
+        ]);
+
+        $this->assertNull(app(CareerTransitionTargetSelector::class)->selectForSnapshot($snapshot));
+    }
+
+    public function test_it_breaks_ties_deterministically_by_crosswalk_safety_then_canonical_order(): void
+    {
+        $snapshot = $this->sourceSnapshot();
+        $source = $snapshot->occupation()->firstOrFail();
+
+        $trustInherited = $this->sameFamilyOccupation($source, 'backend-zeta', 'Backend Zeta');
+        $exactAlpha = $this->sameFamilyOccupation($source, 'backend-alpha', 'Backend Alpha');
+        $exactOmega = $this->sameFamilyOccupation($source, 'backend-omega', 'Backend Omega');
+
+        $this->mockReadiness([
+            (string) $trustInherited->canonical_slug => $this->readinessRow($trustInherited->canonical_slug, crosswalkMode: 'trust_inheritance'),
+            (string) $exactAlpha->canonical_slug => $this->readinessRow($exactAlpha->canonical_slug, crosswalkMode: 'exact'),
+            (string) $exactOmega->canonical_slug => $this->readinessRow($exactOmega->canonical_slug, crosswalkMode: 'exact'),
+        ]);
+
+        $selected = app(CareerTransitionTargetSelector::class)->selectForSnapshot($snapshot);
+
+        $this->assertInstanceOf(Occupation::class, $selected);
+        $this->assertSame($exactAlpha->id, $selected?->id);
+    }
+
+    private function sourceSnapshot(): RecommendationSnapshot
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'backend-architect-source',
+        ]);
+
+        return $chain['recommendationSnapshot'];
+    }
+
+    private function sameFamilyOccupation(Occupation $source, string $slug, string $title): Occupation
+    {
+        return Occupation::query()->create([
+            'family_id' => $source->family_id,
+            'parent_id' => null,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => $source->truth_market,
+            'display_market' => $source->display_market,
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+            'search_h1_zh' => $title,
+            'structural_stability' => $source->structural_stability,
+            'task_prototype_signature' => $source->task_prototype_signature,
+            'market_semantics_gap' => $source->market_semantics_gap,
+            'regulatory_divergence' => $source->regulatory_divergence,
+            'toolchain_divergence' => $source->toolchain_divergence,
+            'skill_gap_threshold' => $source->skill_gap_threshold,
+            'trust_inheritance_scope' => $source->trust_inheritance_scope,
+        ]);
+    }
+
+    private function otherFamilyOccupation(string $slug, string $title): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'healthcare-'.$slug,
+            'title_en' => 'Healthcare',
+            'title_zh' => '医疗',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'parent_id' => null,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+            'search_h1_zh' => $title,
+            'structural_stability' => 0.82,
+            'task_prototype_signature' => ['analysis' => 0.5],
+            'market_semantics_gap' => 0.12,
+            'regulatory_divergence' => 0.11,
+            'toolchain_divergence' => 0.17,
+            'skill_gap_threshold' => 0.35,
+            'trust_inheritance_scope' => ['allow_task_truth' => true],
+        ]);
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $rowsBySlug
+     */
+    private function mockReadiness(array $rowsBySlug): void
+    {
+        $lookup = Mockery::mock(CareerTransitionPreviewReadinessLookup::class);
+        foreach ($rowsBySlug as $slug => $row) {
+            $lookup->shouldReceive('bySlug')->with($slug)->andReturn($row);
+        }
+        $lookup->shouldReceive('bySlug')->andReturn(null);
+
+        $this->app->instance(CareerTransitionPreviewReadinessLookup::class, $lookup);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readinessRow(
+        string $canonicalSlug,
+        string $status = 'publish_ready',
+        bool $indexEligible = true,
+        string $reviewerStatus = 'approved',
+        string $crosswalkMode = 'exact',
+    ): array {
+        return [
+            'occupation_uuid' => 'uuid-'.$canonicalSlug,
+            'canonical_slug' => $canonicalSlug,
+            'canonical_title_en' => $canonicalSlug,
+            'status' => $status,
+            'blocker_type' => null,
+            'remediation_class' => null,
+            'authority_override_supplied' => false,
+            'review_required' => false,
+            'crosswalk_mode' => $crosswalkMode,
+            'reviewer_status' => $reviewerStatus,
+            'index_state' => $indexEligible ? 'indexable' : 'noindex',
+            'index_eligible' => $indexEligible,
+            'reason_codes' => [$status],
+        ];
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated `CareerTransitionTargetSelector` to choose one safe non-self same-family target using existing readiness, reviewer, index, and crosswalk truth
- upgrade `CareerTransitionPathWriter` to stop writing self-baseline rows and instead write exactly one `stable_upside` row only when a safe non-self target exists
- keep the transition preview contract shape unchanged while updating writer, materialization, and preview regression tests for non-self targets and zero-row fallback

## Why
- production transition writing was still self-baseline only, even though the preview contract and typed transition payloads already supported a real target
- the safest next step is to make backend writer truth real under conservative gates rather than expand taxonomy, routes, or frontend semantics
- this preserves first-wave safety, same-family conservatism, single-target semantics, and deterministic replay without turning transitions into a strategy system

## Validation
- `vendor/bin/pint --test app/Services/Career/Transition/CareerTransitionTargetSelector.php app/Services/Career/Transition/CareerTransitionPathWriter.php tests/Unit/Services/Career/Transition/CareerTransitionTargetSelectorTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php`
- `php artisan test tests/Unit/Services/Career/Transition/CareerTransitionTargetSelectorTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerRecommendationCompilerTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no taxonomy expansion beyond `stable_upside`
- no multi-target writing
- no cross-family transitions
- no new routes or public contract shape changes
- no narrative or strategy semantics
- no frontend changes
