### PR TITLE
PR-B32: Career transition rationale / delta authority layer

### DIFF
--- a/backend/app/Domain/Career/Transition/TransitionPathPayload.php
+++ b/backend/app/Domain/Career/Transition/TransitionPathPayload.php
@@ -12,17 +12,51 @@ final class TransitionPathPayload
 
     public const STEP_TOOL_OVERLAP = 'tool_overlap';
 
+    public const RATIONALE_SAME_FAMILY_TARGET = 'same_family_target';
+
+    public const RATIONALE_PUBLISH_READY_TARGET = 'publish_ready_target';
+
+    public const RATIONALE_INDEX_ELIGIBLE_TARGET = 'index_eligible_target';
+
+    public const RATIONALE_APPROVED_REVIEWER_TARGET = 'approved_reviewer_target';
+
+    public const RATIONALE_SAFE_CROSSWALK_TARGET = 'safe_crosswalk_target';
+
+    public const TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED = 'higher_entry_education_required';
+
+    public const TRADEOFF_HIGHER_WORK_EXPERIENCE_REQUIRED = 'higher_work_experience_required';
+
+    public const TRADEOFF_HIGHER_TRAINING_REQUIRED = 'higher_training_required';
+
+    public const DELTA_ENTRY_EDUCATION = 'entry_education_delta';
+
+    public const DELTA_WORK_EXPERIENCE = 'work_experience_delta';
+
+    public const DELTA_TRAINING = 'training_delta';
+
+    public const DELTA_DIRECTION_SAME = 'same';
+
+    public const DELTA_DIRECTION_HIGHER = 'higher';
+
+    public const DELTA_DIRECTION_LOWER = 'lower';
+
     /**
      * @param  list<string>  $steps
+     * @param  list<string>  $rationaleCodes
+     * @param  list<string>  $tradeoffCodes
+     * @param  array<string, array{source_value:string,target_value:string,direction:string}>  $delta
      */
     private function __construct(
         public readonly array $steps,
+        public readonly array $rationaleCodes,
+        public readonly array $tradeoffCodes,
+        public readonly array $delta,
     ) {}
 
     public static function from(mixed $payload): self
     {
         if (! is_array($payload)) {
-            return new self([]);
+            return new self([], [], [], []);
         }
 
         $steps = [];
@@ -39,7 +73,61 @@ final class TransitionPathPayload
             $steps[] = $normalized;
         }
 
-        return new self(array_values(array_unique($steps)));
+        $rationaleCodes = [];
+        foreach ((array) ($payload['rationale_codes'] ?? []) as $code) {
+            if (! is_string($code)) {
+                continue;
+            }
+
+            $normalized = trim($code);
+            if ($normalized === '' || ! in_array($normalized, self::allowedRationaleCodes(), true)) {
+                continue;
+            }
+
+            $rationaleCodes[] = $normalized;
+        }
+
+        $tradeoffCodes = [];
+        foreach ((array) ($payload['tradeoff_codes'] ?? []) as $code) {
+            if (! is_string($code)) {
+                continue;
+            }
+
+            $normalized = trim($code);
+            if ($normalized === '' || ! in_array($normalized, self::allowedTradeoffCodes(), true)) {
+                continue;
+            }
+
+            $tradeoffCodes[] = $normalized;
+        }
+
+        $delta = [];
+        foreach ((array) ($payload['delta'] ?? []) as $key => $entry) {
+            if (! is_string($key) || ! in_array($key, self::allowedDeltaKeys(), true) || ! is_array($entry)) {
+                continue;
+            }
+
+            $sourceValue = is_scalar($entry['source_value'] ?? null) ? trim((string) $entry['source_value']) : '';
+            $targetValue = is_scalar($entry['target_value'] ?? null) ? trim((string) $entry['target_value']) : '';
+            $direction = is_scalar($entry['direction'] ?? null) ? trim((string) $entry['direction']) : '';
+
+            if ($sourceValue === '' || $targetValue === '' || ! in_array($direction, self::allowedDeltaDirections(), true)) {
+                continue;
+            }
+
+            $delta[$key] = [
+                'source_value' => $sourceValue,
+                'target_value' => $targetValue,
+                'direction' => $direction,
+            ];
+        }
+
+        return new self(
+            array_values(array_unique($steps)),
+            array_values(array_unique($rationaleCodes)),
+            array_values(array_unique($tradeoffCodes)),
+            $delta,
+        );
     }
 
     /**
@@ -48,12 +136,26 @@ final class TransitionPathPayload
     public function toArray(): array
     {
         if ($this->steps === []) {
-            return [];
+            $payload = [];
+        } else {
+            $payload = [
+                'steps' => $this->steps,
+            ];
         }
 
-        return [
-            'steps' => $this->steps,
-        ];
+        if ($this->rationaleCodes !== []) {
+            $payload['rationale_codes'] = $this->rationaleCodes;
+        }
+
+        if ($this->tradeoffCodes !== []) {
+            $payload['tradeoff_codes'] = $this->tradeoffCodes;
+        }
+
+        if ($this->delta !== []) {
+            $payload['delta'] = $this->delta;
+        }
+
+        return $payload;
     }
 
     /**
@@ -65,6 +167,59 @@ final class TransitionPathPayload
             self::STEP_SKILL_OVERLAP,
             self::STEP_TASK_OVERLAP,
             self::STEP_TOOL_OVERLAP,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedRationaleCodes(): array
+    {
+        return [
+            self::STEP_SKILL_OVERLAP,
+            self::STEP_TASK_OVERLAP,
+            self::STEP_TOOL_OVERLAP,
+            self::RATIONALE_SAME_FAMILY_TARGET,
+            self::RATIONALE_PUBLISH_READY_TARGET,
+            self::RATIONALE_INDEX_ELIGIBLE_TARGET,
+            self::RATIONALE_APPROVED_REVIEWER_TARGET,
+            self::RATIONALE_SAFE_CROSSWALK_TARGET,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedTradeoffCodes(): array
+    {
+        return [
+            self::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED,
+            self::TRADEOFF_HIGHER_WORK_EXPERIENCE_REQUIRED,
+            self::TRADEOFF_HIGHER_TRAINING_REQUIRED,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedDeltaKeys(): array
+    {
+        return [
+            self::DELTA_ENTRY_EDUCATION,
+            self::DELTA_WORK_EXPERIENCE,
+            self::DELTA_TRAINING,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedDeltaDirections(): array
+    {
+        return [
+            self::DELTA_DIRECTION_SAME,
+            self::DELTA_DIRECTION_HIGHER,
+            self::DELTA_DIRECTION_LOWER,
         ];
     }
 }

--- a/backend/app/Services/Career/Transition/CareerTransitionPathWriter.php
+++ b/backend/app/Services/Career/Transition/CareerTransitionPathWriter.php
@@ -18,6 +18,7 @@ final class CareerTransitionPathWriter
         private readonly CareerTransitionPreviewReadinessLookup $readinessLookup,
         private readonly CareerTransitionStepAuthor $stepAuthor,
         private readonly CareerTransitionTargetSelector $targetSelector,
+        private readonly CareerTransitionRationaleBuilder $rationaleBuilder,
     ) {}
 
     public function rewriteForSnapshot(RecommendationSnapshot $snapshot): int
@@ -50,9 +51,18 @@ final class CareerTransitionPathWriter
                 return 0;
             }
 
-            $pathPayload = TransitionPathPayload::from([
-                'steps' => $this->stepAuthor->authorForOccupation($sourceOccupation),
-            ]);
+            $steps = $this->stepAuthor->authorForOccupation($sourceOccupation);
+            $targetReadiness = $this->readinessLookup->bySlug($targetOccupation->canonical_slug);
+
+            $pathPayload = TransitionPathPayload::from(array_merge(
+                ['steps' => $steps],
+                $this->rationaleBuilder->build(
+                    $sourceOccupation,
+                    $targetOccupation,
+                    $steps,
+                    is_array($targetReadiness) ? $targetReadiness : [],
+                ),
+            ));
 
             TransitionPath::query()->create([
                 'recommendation_snapshot_id' => $snapshot->id,

--- a/backend/app/Services/Career/Transition/CareerTransitionRationaleBuilder.php
+++ b/backend/app/Services/Career/Transition/CareerTransitionRationaleBuilder.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Transition;
+
+use App\Domain\Career\Transition\TransitionPathPayload;
+use App\Models\Occupation;
+use App\Models\OccupationTruthMetric;
+
+final class CareerTransitionRationaleBuilder
+{
+    /**
+     * @var list<string>
+     */
+    private const SAFE_CROSSWALK_MODES = [
+        'exact',
+        'direct_match',
+        'trust_inheritance',
+    ];
+
+    /**
+     * @param  list<string>  $steps
+     * @param  array<string, mixed>  $targetReadiness
+     * @return array<string, mixed>
+     */
+    public function build(Occupation $sourceOccupation, Occupation $targetOccupation, array $steps, array $targetReadiness = []): array
+    {
+        $normalizedSteps = TransitionPathPayload::from(['steps' => $steps])->steps;
+
+        $rationaleCodes = [];
+        foreach (TransitionPathPayload::allowedRationaleCodes() as $code) {
+            if (in_array($code, $normalizedSteps, true)) {
+                $rationaleCodes[] = $code;
+            }
+        }
+
+        if ($sourceOccupation->family_id !== null && $sourceOccupation->family_id === $targetOccupation->family_id) {
+            $rationaleCodes[] = TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET;
+        }
+
+        if (($targetReadiness['status'] ?? null) === 'publish_ready') {
+            $rationaleCodes[] = TransitionPathPayload::RATIONALE_PUBLISH_READY_TARGET;
+        }
+
+        if (($targetReadiness['index_eligible'] ?? false) === true) {
+            $rationaleCodes[] = TransitionPathPayload::RATIONALE_INDEX_ELIGIBLE_TARGET;
+        }
+
+        if (($targetReadiness['reviewer_status'] ?? null) === 'approved') {
+            $rationaleCodes[] = TransitionPathPayload::RATIONALE_APPROVED_REVIEWER_TARGET;
+        }
+
+        $crosswalkMode = is_scalar($targetReadiness['crosswalk_mode'] ?? null)
+            ? trim((string) $targetReadiness['crosswalk_mode'])
+            : trim((string) ($targetOccupation->crosswalk_mode ?? ''));
+        if (in_array($crosswalkMode, self::SAFE_CROSSWALK_MODES, true)) {
+            $rationaleCodes[] = TransitionPathPayload::RATIONALE_SAFE_CROSSWALK_TARGET;
+        }
+
+        $delta = [];
+        $sourceTruthMetric = $this->latestTruthMetric($sourceOccupation);
+        $targetTruthMetric = $this->latestTruthMetric($targetOccupation);
+
+        if ($sourceTruthMetric instanceof OccupationTruthMetric && $targetTruthMetric instanceof OccupationTruthMetric) {
+            $delta = array_filter([
+                TransitionPathPayload::DELTA_ENTRY_EDUCATION => $this->compareRankedField(
+                    $sourceTruthMetric->entry_education,
+                    $targetTruthMetric->entry_education,
+                    $this->educationRank(...),
+                ),
+                TransitionPathPayload::DELTA_WORK_EXPERIENCE => $this->compareRankedField(
+                    $sourceTruthMetric->work_experience,
+                    $targetTruthMetric->work_experience,
+                    $this->workExperienceRank(...),
+                ),
+                TransitionPathPayload::DELTA_TRAINING => $this->compareRankedField(
+                    $sourceTruthMetric->on_the_job_training,
+                    $targetTruthMetric->on_the_job_training,
+                    $this->trainingRank(...),
+                ),
+            ], static fn (mixed $value): bool => is_array($value));
+        }
+
+        $tradeoffCodes = [];
+        if (($delta[TransitionPathPayload::DELTA_ENTRY_EDUCATION]['direction'] ?? null) === TransitionPathPayload::DELTA_DIRECTION_HIGHER) {
+            $tradeoffCodes[] = TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED;
+        }
+        if (($delta[TransitionPathPayload::DELTA_WORK_EXPERIENCE]['direction'] ?? null) === TransitionPathPayload::DELTA_DIRECTION_HIGHER) {
+            $tradeoffCodes[] = TransitionPathPayload::TRADEOFF_HIGHER_WORK_EXPERIENCE_REQUIRED;
+        }
+        if (($delta[TransitionPathPayload::DELTA_TRAINING]['direction'] ?? null) === TransitionPathPayload::DELTA_DIRECTION_HIGHER) {
+            $tradeoffCodes[] = TransitionPathPayload::TRADEOFF_HIGHER_TRAINING_REQUIRED;
+        }
+
+        $payload = [];
+        if ($rationaleCodes !== []) {
+            $payload['rationale_codes'] = array_values(array_unique($rationaleCodes));
+        }
+        if ($tradeoffCodes !== []) {
+            $payload['tradeoff_codes'] = array_values(array_unique($tradeoffCodes));
+        }
+        if ($delta !== []) {
+            $payload['delta'] = $delta;
+        }
+
+        return $payload;
+    }
+
+    private function latestTruthMetric(Occupation $occupation): ?OccupationTruthMetric
+    {
+        $truthMetric = $occupation->truthMetrics()
+            ->orderByDesc('reviewed_at')
+            ->orderByDesc('effective_at')
+            ->orderByDesc('updated_at')
+            ->orderByDesc('id')
+            ->first();
+
+        return $truthMetric instanceof OccupationTruthMetric ? $truthMetric : null;
+    }
+
+    /**
+     * @param  callable(string): ?int  $rankResolver
+     * @return array{source_value:string,target_value:string,direction:string}|null
+     */
+    private function compareRankedField(?string $sourceValue, ?string $targetValue, callable $rankResolver): ?array
+    {
+        $source = trim((string) $sourceValue);
+        $target = trim((string) $targetValue);
+        if ($source === '' || $target === '') {
+            return null;
+        }
+
+        $sourceRank = $rankResolver($source);
+        $targetRank = $rankResolver($target);
+        if (! is_int($sourceRank) || ! is_int($targetRank)) {
+            return null;
+        }
+
+        $direction = match (true) {
+            $targetRank > $sourceRank => TransitionPathPayload::DELTA_DIRECTION_HIGHER,
+            $targetRank < $sourceRank => TransitionPathPayload::DELTA_DIRECTION_LOWER,
+            default => TransitionPathPayload::DELTA_DIRECTION_SAME,
+        };
+
+        return [
+            'source_value' => $source,
+            'target_value' => $target,
+            'direction' => $direction,
+        ];
+    }
+
+    private function educationRank(string $value): ?int
+    {
+        $normalized = strtolower(trim($value));
+
+        return match (true) {
+            $normalized === 'none' => 0,
+            str_contains($normalized, 'high school') => 1,
+            str_contains($normalized, 'postsecondary nondegree') || str_contains($normalized, 'some college') => 2,
+            str_contains($normalized, 'associate') => 3,
+            str_contains($normalized, 'bachelor') => 4,
+            str_contains($normalized, 'master') => 5,
+            str_contains($normalized, 'doctoral') || str_contains($normalized, 'professional degree') => 6,
+            default => null,
+        };
+    }
+
+    private function workExperienceRank(string $value): ?int
+    {
+        $normalized = strtolower(trim($value));
+
+        return match (true) {
+            $normalized === 'none' => 0,
+            str_contains($normalized, 'less than 5 years') => 1,
+            str_contains($normalized, '5 years or more') => 2,
+            default => null,
+        };
+    }
+
+    private function trainingRank(string $value): ?int
+    {
+        $normalized = strtolower(trim($value));
+
+        return match (true) {
+            $normalized === 'none' => 0,
+            str_contains($normalized, 'short-term') => 1,
+            str_contains($normalized, 'moderate-term') => 2,
+            str_contains($normalized, 'long-term') => 3,
+            str_contains($normalized, 'apprenticeship') => 4,
+            default => null,
+        };
+    }
+}

--- a/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
+++ b/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
@@ -41,6 +41,20 @@ final class CareerTransitionPreviewApiTest extends TestCase
                     TransitionPathPayload::STEP_TASK_OVERLAP,
                     TransitionPathPayload::STEP_TOOL_OVERLAP,
                 ],
+                'rationale_codes' => [
+                    TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET,
+                    TransitionPathPayload::RATIONALE_PUBLISH_READY_TARGET,
+                ],
+                'tradeoff_codes' => [
+                    TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED,
+                ],
+                'delta' => [
+                    TransitionPathPayload::DELTA_ENTRY_EDUCATION => [
+                        'source_value' => "Bachelor's degree",
+                        'target_value' => "Master's degree",
+                        'direction' => TransitionPathPayload::DELTA_DIRECTION_HIGHER,
+                    ],
+                ],
             ],
         ]);
 
@@ -69,7 +83,10 @@ final class CareerTransitionPreviewApiTest extends TestCase
             ])
             ->assertJsonMissingPath('why_this_path')
             ->assertJsonMissingPath('what_is_lost')
-            ->assertJsonMissingPath('bridge_steps_90d');
+            ->assertJsonMissingPath('bridge_steps_90d')
+            ->assertJsonMissingPath('rationale_codes')
+            ->assertJsonMissingPath('tradeoff_codes')
+            ->assertJsonMissingPath('delta');
 
         /** @var array<string, mixed> $payload */
         $payload = $response->json();

--- a/backend/tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php
+++ b/backend/tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php
@@ -45,9 +45,10 @@ final class FirstWaveTransitionPathMaterializationTest extends TestCase
         $this->assertNotSame($path->from_occupation_id, $path->to_occupation_id);
         $this->assertSame($path->fromOccupation?->family_id, $path->toOccupation?->family_id);
         $this->assertSame($target->canonical_slug, $path->toOccupation?->canonical_slug);
-        $this->assertSame([
-            'steps' => TransitionPathPayload::allowedStepLabels(),
-        ], $path->normalizedPathPayload()->toArray());
+        $this->assertSame(TransitionPathPayload::allowedStepLabels(), $path->normalizedPathPayload()->steps);
+        $this->assertContains('same_family_target', $path->normalizedPathPayload()->rationaleCodes);
+        $this->assertArrayNotHasKey('why_this_path', $path->normalizedPathPayload()->toArray());
+        $this->assertArrayNotHasKey('bridge_steps_90d', $path->normalizedPathPayload()->toArray());
         $this->assertNotNull($path->recommendationSnapshot?->compile_run_id);
     }
 
@@ -83,16 +84,17 @@ final class FirstWaveTransitionPathMaterializationTest extends TestCase
             TransitionPath::query()->count(),
             TransitionPath::query()->distinct('recommendation_snapshot_id')->count('recommendation_snapshot_id')
         );
-        $this->assertSame(
-            array_fill(0, TransitionPath::query()->count(), [
-                'steps' => TransitionPathPayload::allowedStepLabels(),
-            ]),
-            TransitionPath::query()
-                ->orderBy('recommendation_snapshot_id')
-                ->get()
-                ->map(static fn (TransitionPath $path): array => $path->normalizedPathPayload()->toArray())
-                ->all()
-        );
+        TransitionPath::query()
+            ->orderBy('recommendation_snapshot_id')
+            ->get()
+            ->each(function (TransitionPath $path): void {
+                $payload = $path->normalizedPathPayload()->toArray();
+                $this->assertSame(TransitionPathPayload::allowedStepLabels(), $path->normalizedPathPayload()->steps);
+                $this->assertContains('same_family_target', $path->normalizedPathPayload()->rationaleCodes);
+                $this->assertArrayNotHasKey('why_this_path', $payload);
+                $this->assertArrayNotHasKey('what_is_lost', $payload);
+                $this->assertArrayNotHasKey('bridge_steps_90d', $payload);
+            });
         $this->assertSame(
             $firstFingerprints,
             TransitionPath::query()

--- a/backend/tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php
+++ b/backend/tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php
@@ -20,6 +20,15 @@ final class TransitionPathPayloadTest extends TestCase
     {
         $payload = TransitionPathPayload::from([
             'steps' => [' skill_overlap ', 'task_overlap', 'tool_overlap'],
+            'rationale_codes' => ['skill_overlap', 'same_family_target'],
+            'tradeoff_codes' => ['higher_entry_education_required'],
+            'delta' => [
+                'entry_education_delta' => [
+                    'source_value' => "Bachelor's degree",
+                    'target_value' => "Master's degree",
+                    'direction' => 'higher',
+                ],
+            ],
         ]);
 
         $this->assertSame([
@@ -28,13 +37,41 @@ final class TransitionPathPayloadTest extends TestCase
                 'task_overlap',
                 'tool_overlap',
             ],
+            'rationale_codes' => [
+                'skill_overlap',
+                'same_family_target',
+            ],
+            'tradeoff_codes' => [
+                'higher_entry_education_required',
+            ],
+            'delta' => [
+                'entry_education_delta' => [
+                    'source_value' => "Bachelor's degree",
+                    'target_value' => "Master's degree",
+                    'direction' => 'higher',
+                ],
+            ],
         ], $payload->toArray());
     }
 
-    public function test_it_strips_invalid_steps_and_ignores_richer_narrative_fields(): void
+    public function test_it_strips_invalid_steps_and_ignores_unsupported_or_narrative_fields(): void
     {
         $payload = TransitionPathPayload::from([
             'steps' => ['skill_overlap', 'deepen system design', 42, '', null, ' task_overlap ', 'skill_overlap'],
+            'rationale_codes' => ['same_family_target', 'best_next_move', null],
+            'tradeoff_codes' => ['higher_entry_education_required', 'sacrifice_salary'],
+            'delta' => [
+                'entry_education_delta' => [
+                    'source_value' => "Bachelor's degree",
+                    'target_value' => "Master's degree",
+                    'direction' => 'higher',
+                ],
+                'salary_delta' => [
+                    'source_value' => '100000',
+                    'target_value' => '90000',
+                    'direction' => 'lower',
+                ],
+            ],
             'why_this_path' => 'fixture-only narrative',
             'what_is_lost' => 'fixture-only tradeoff copy',
             'bridge_steps_90d' => ['not authoritative'],
@@ -44,6 +81,19 @@ final class TransitionPathPayloadTest extends TestCase
             'steps' => [
                 'skill_overlap',
                 'task_overlap',
+            ],
+            'rationale_codes' => [
+                'same_family_target',
+            ],
+            'tradeoff_codes' => [
+                'higher_entry_education_required',
+            ],
+            'delta' => [
+                'entry_education_delta' => [
+                    'source_value' => "Bachelor's degree",
+                    'target_value' => "Master's degree",
+                    'direction' => 'higher',
+                ],
             ],
         ], $payload->toArray());
     }

--- a/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career;
 
+use App\Domain\Career\Transition\TransitionPathPayload;
 use App\DTO\Career\CareerTransitionPreviewBundle;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
@@ -156,6 +157,20 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
             'path_type' => 'stable_upside',
             'path_payload' => [
                 'steps' => ['first valid step', 99, ' second valid step '],
+                'rationale_codes' => [
+                    TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET,
+                    TransitionPathPayload::RATIONALE_PUBLISH_READY_TARGET,
+                ],
+                'tradeoff_codes' => [
+                    TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED,
+                ],
+                'delta' => [
+                    TransitionPathPayload::DELTA_ENTRY_EDUCATION => [
+                        'source_value' => "Bachelor's degree",
+                        'target_value' => "Master's degree",
+                        'direction' => TransitionPathPayload::DELTA_DIRECTION_HIGHER,
+                    ],
+                ],
                 'why_this_path' => 'fixture-only narrative',
                 'what_is_lost' => 'fixture-only tradeoff',
                 'bridge_steps_90d' => ['not authoritative'],
@@ -174,6 +189,9 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
         $this->assertArrayNotHasKey('why_this_path', $payload);
         $this->assertArrayNotHasKey('what_is_lost', $payload);
         $this->assertArrayNotHasKey('bridge_steps_90d', $payload);
+        $this->assertArrayNotHasKey('rationale_codes', $payload);
+        $this->assertArrayNotHasKey('tradeoff_codes', $payload);
+        $this->assertArrayNotHasKey('delta', $payload);
     }
 
     public function test_it_excludes_paths_with_invalid_non_array_payload_shape(): void

--- a/backend/tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php
+++ b/backend/tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php
@@ -7,7 +7,9 @@ namespace Tests\Unit\Services\Career\Transition;
 use App\Domain\Career\Transition\TransitionPathPayload;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
+use App\Models\OccupationTruthMetric;
 use App\Models\RecommendationSnapshot;
+use App\Models\SourceTrace;
 use App\Models\TransitionPath;
 use App\Services\Career\CareerRecommendationCompiler;
 use App\Services\Career\CareerTransitionPreviewReadinessLookup;
@@ -24,7 +26,14 @@ final class CareerTransitionPathWriterTest extends TestCase
     public function test_it_materializes_a_minimal_stable_upside_path_for_a_publish_ready_first_wave_snapshot(): void
     {
         $snapshot = $this->compiledFirstWaveSnapshot();
-        $target = $this->createSameFamilyTarget($snapshot, 'backend-platform-engineer', 'Backend Platform Engineer');
+        $target = $this->createSameFamilyTarget(
+            $snapshot,
+            'backend-platform-engineer',
+            'Backend Platform Engineer',
+            "Master's degree",
+            '5 years or more',
+            'Moderate-term on-the-job training',
+        );
         $this->mockReadinessRows([
             $this->readinessRow($snapshot->occupation?->canonical_slug ?? '', 'publish_ready', true, 'indexable', 'approved'),
             $this->readinessRow($target->canonical_slug, 'publish_ready', true, 'indexable', 'approved'),
@@ -38,8 +47,56 @@ final class CareerTransitionPathWriterTest extends TestCase
         $this->assertSame($target->id, $path->to_occupation_id);
         $this->assertNotSame($path->from_occupation_id, $path->to_occupation_id);
         $this->assertSame('stable_upside', $path->path_type);
+        $this->assertSame(TransitionPathPayload::allowedStepLabels(), $path->normalizedPathPayload()->steps);
+        $this->assertSame([
+            'skill_overlap',
+            'task_overlap',
+            'tool_overlap',
+            'same_family_target',
+            'publish_ready_target',
+            'index_eligible_target',
+            'approved_reviewer_target',
+            'safe_crosswalk_target',
+        ], $path->normalizedPathPayload()->rationaleCodes);
+        $this->assertSame([
+            'higher_entry_education_required',
+            'higher_work_experience_required',
+            'higher_training_required',
+        ], $path->normalizedPathPayload()->tradeoffCodes);
         $this->assertSame([
             'steps' => TransitionPathPayload::allowedStepLabels(),
+            'rationale_codes' => [
+                'skill_overlap',
+                'task_overlap',
+                'tool_overlap',
+                'same_family_target',
+                'publish_ready_target',
+                'index_eligible_target',
+                'approved_reviewer_target',
+                'safe_crosswalk_target',
+            ],
+            'tradeoff_codes' => [
+                'higher_entry_education_required',
+                'higher_work_experience_required',
+                'higher_training_required',
+            ],
+            'delta' => [
+                'entry_education_delta' => [
+                    'source_value' => "Bachelor's degree",
+                    'target_value' => "Master's degree",
+                    'direction' => 'higher',
+                ],
+                'work_experience_delta' => [
+                    'source_value' => 'None',
+                    'target_value' => '5 years or more',
+                    'direction' => 'higher',
+                ],
+                'training_delta' => [
+                    'source_value' => 'None',
+                    'target_value' => 'Moderate-term on-the-job training',
+                    'direction' => 'higher',
+                ],
+            ],
         ], $path->normalizedPathPayload()->toArray());
     }
 
@@ -68,9 +125,8 @@ final class CareerTransitionPathWriterTest extends TestCase
         $this->assertSame('stable_upside', $path->path_type);
         $this->assertSame($target->id, $path->to_occupation_id);
         $this->assertNotSame($path->from_occupation_id, $path->to_occupation_id);
-        $this->assertSame([
-            'steps' => TransitionPathPayload::allowedStepLabels(),
-        ], $path->normalizedPathPayload()->toArray());
+        $this->assertSame(TransitionPathPayload::allowedStepLabels(), $path->normalizedPathPayload()->steps);
+        $this->assertContains('same_family_target', $path->normalizedPathPayload()->rationaleCodes);
     }
 
     public function test_it_rejects_snapshots_without_transition_claim_permission(): void
@@ -210,11 +266,17 @@ final class CareerTransitionPathWriterTest extends TestCase
         ]);
     }
 
-    private function createSameFamilyTarget(RecommendationSnapshot $snapshot, string $slug, string $title): \App\Models\Occupation
-    {
+    private function createSameFamilyTarget(
+        RecommendationSnapshot $snapshot,
+        string $slug,
+        string $title,
+        ?string $entryEducation = null,
+        ?string $workExperience = null,
+        ?string $training = null,
+    ): \App\Models\Occupation {
         $source = $snapshot->occupation()->firstOrFail();
 
-        return \App\Models\Occupation::query()->create([
+        $target = \App\Models\Occupation::query()->create([
             'family_id' => $source->family_id,
             'parent_id' => null,
             'canonical_slug' => $slug,
@@ -233,6 +295,40 @@ final class CareerTransitionPathWriterTest extends TestCase
             'skill_gap_threshold' => $source->skill_gap_threshold,
             'trust_inheritance_scope' => $source->trust_inheritance_scope,
         ]);
+
+        $sourceTruthMetric = $source->truthMetrics()->latest('id')->first();
+        if ($sourceTruthMetric instanceof OccupationTruthMetric) {
+            $sourceTrace = SourceTrace::query()->create([
+                'source_id' => 'source_'.$slug,
+                'source_type' => 'fixture_dataset',
+                'title' => 'Transition writer fixture source',
+                'url' => 'https://example.test/sources/'.$slug,
+                'fields_used' => ['entry_education', 'work_experience', 'on_the_job_training'],
+                'retrieved_at' => now()->subDay(),
+                'evidence_strength' => 0.93,
+            ]);
+
+            OccupationTruthMetric::query()->create([
+                'occupation_id' => $target->id,
+                'source_trace_id' => $sourceTrace->id,
+                'median_pay_usd_annual' => $sourceTruthMetric->median_pay_usd_annual,
+                'jobs_2024' => $sourceTruthMetric->jobs_2024,
+                'projected_jobs_2034' => $sourceTruthMetric->projected_jobs_2034,
+                'employment_change' => $sourceTruthMetric->employment_change,
+                'outlook_pct_2024_2034' => $sourceTruthMetric->outlook_pct_2024_2034,
+                'outlook_description' => $sourceTruthMetric->outlook_description,
+                'entry_education' => $entryEducation ?? $sourceTruthMetric->entry_education,
+                'work_experience' => $workExperience ?? $sourceTruthMetric->work_experience,
+                'on_the_job_training' => $training ?? $sourceTruthMetric->on_the_job_training,
+                'ai_exposure' => $sourceTruthMetric->ai_exposure,
+                'ai_rationale' => 'fixture',
+                'truth_market' => $sourceTruthMetric->truth_market,
+                'effective_at' => now()->subDays(5),
+                'reviewed_at' => now()->subDay(),
+            ]);
+        }
+
+        return $target;
     }
 
     /**

--- a/backend/tests/Unit/Services/Career/Transition/CareerTransitionRationaleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/Transition/CareerTransitionRationaleBuilderTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career\Transition;
+
+use App\Domain\Career\Transition\TransitionPathPayload;
+use App\Models\Occupation;
+use App\Models\OccupationTruthMetric;
+use App\Models\SourceTrace;
+use App\Services\Career\Transition\CareerTransitionRationaleBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerTransitionRationaleBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_machine_coded_rationale_and_tradeoff_fields_for_a_safe_target(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'transition-rationale-source']);
+        $source = $chain['occupation']->fresh();
+        $target = $this->createSameFamilyTargetWithTruth(
+            $source,
+            'transition-rationale-target',
+            "Master's degree",
+            '5 years or more',
+            'Moderate-term on-the-job training',
+        );
+
+        $payload = app(CareerTransitionRationaleBuilder::class)->build(
+            $source,
+            $target,
+            TransitionPathPayload::allowedStepLabels(),
+            [
+                'status' => 'publish_ready',
+                'index_eligible' => true,
+                'reviewer_status' => 'approved',
+                'crosswalk_mode' => 'exact',
+            ],
+        );
+
+        $this->assertSame([
+            'skill_overlap',
+            'task_overlap',
+            'tool_overlap',
+            'same_family_target',
+            'publish_ready_target',
+            'index_eligible_target',
+            'approved_reviewer_target',
+            'safe_crosswalk_target',
+        ], $payload['rationale_codes']);
+        $this->assertSame([
+            'higher_entry_education_required',
+            'higher_work_experience_required',
+            'higher_training_required',
+        ], $payload['tradeoff_codes']);
+        $this->assertSame([
+            'entry_education_delta' => [
+                'source_value' => "Bachelor's degree",
+                'target_value' => "Master's degree",
+                'direction' => 'higher',
+            ],
+            'work_experience_delta' => [
+                'source_value' => 'None',
+                'target_value' => '5 years or more',
+                'direction' => 'higher',
+            ],
+            'training_delta' => [
+                'source_value' => 'None',
+                'target_value' => 'Moderate-term on-the-job training',
+                'direction' => 'higher',
+            ],
+        ], $payload['delta']);
+        $this->assertArrayNotHasKey('why_this_path', $payload);
+        $this->assertArrayNotHasKey('what_is_lost', $payload);
+        $this->assertArrayNotHasKey('bridge_steps_90d', $payload);
+    }
+
+    public function test_it_omits_delta_and_tradeoff_when_truth_is_missing_or_not_rankable(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'transition-rationale-thin-source']);
+        $source = $chain['occupation']->fresh();
+        $target = Occupation::query()->create([
+            'family_id' => $source->family_id,
+            'canonical_slug' => 'transition-rationale-thin-target',
+            'entity_level' => $source->entity_level,
+            'truth_market' => $source->truth_market,
+            'display_market' => $source->display_market,
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => 'Thin Target',
+            'canonical_title_zh' => 'Thin Target',
+            'search_h1_zh' => 'Thin Target',
+            'structural_stability' => $source->structural_stability,
+            'task_prototype_signature' => $source->task_prototype_signature,
+            'market_semantics_gap' => $source->market_semantics_gap,
+            'regulatory_divergence' => $source->regulatory_divergence,
+            'toolchain_divergence' => $source->toolchain_divergence,
+            'skill_gap_threshold' => $source->skill_gap_threshold,
+            'trust_inheritance_scope' => $source->trust_inheritance_scope,
+        ]);
+
+        $payload = app(CareerTransitionRationaleBuilder::class)->build(
+            $source,
+            $target,
+            [TransitionPathPayload::STEP_SKILL_OVERLAP],
+            [
+                'status' => 'publish_ready',
+                'index_eligible' => true,
+                'reviewer_status' => 'approved',
+                'crosswalk_mode' => 'exact',
+            ],
+        );
+
+        $this->assertSame([
+            'skill_overlap',
+            'same_family_target',
+            'publish_ready_target',
+            'index_eligible_target',
+            'approved_reviewer_target',
+            'safe_crosswalk_target',
+        ], $payload['rationale_codes']);
+        $this->assertArrayNotHasKey('tradeoff_codes', $payload);
+        $this->assertArrayNotHasKey('delta', $payload);
+    }
+
+    private function createSameFamilyTargetWithTruth(
+        Occupation $source,
+        string $slug,
+        string $entryEducation,
+        string $workExperience,
+        string $training,
+    ): Occupation {
+        $target = Occupation::query()->create([
+            'family_id' => $source->family_id,
+            'canonical_slug' => $slug,
+            'entity_level' => $source->entity_level,
+            'truth_market' => $source->truth_market,
+            'display_market' => $source->display_market,
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => $slug,
+            'canonical_title_zh' => $slug,
+            'search_h1_zh' => $slug,
+            'structural_stability' => $source->structural_stability,
+            'task_prototype_signature' => $source->task_prototype_signature,
+            'market_semantics_gap' => $source->market_semantics_gap,
+            'regulatory_divergence' => $source->regulatory_divergence,
+            'toolchain_divergence' => $source->toolchain_divergence,
+            'skill_gap_threshold' => $source->skill_gap_threshold,
+            'trust_inheritance_scope' => $source->trust_inheritance_scope,
+        ]);
+
+        $sourceTrace = SourceTrace::query()->create([
+            'source_id' => 'source_'.$slug,
+            'source_type' => 'fixture_dataset',
+            'title' => 'Transition rationale fixture source',
+            'url' => 'https://example.test/sources/'.$slug,
+            'fields_used' => ['entry_education', 'work_experience', 'on_the_job_training'],
+            'retrieved_at' => now()->subDay(),
+            'evidence_strength' => 0.94,
+        ]);
+
+        OccupationTruthMetric::query()->create([
+            'occupation_id' => $target->id,
+            'source_trace_id' => $sourceTrace->id,
+            'median_pay_usd_annual' => 170000,
+            'jobs_2024' => 1000,
+            'projected_jobs_2034' => 1200,
+            'employment_change' => 200,
+            'outlook_pct_2024_2034' => 10.0,
+            'outlook_description' => 'Faster than average',
+            'entry_education' => $entryEducation,
+            'work_experience' => $workExperience,
+            'on_the_job_training' => $training,
+            'ai_exposure' => 3.5,
+            'ai_rationale' => 'fixture',
+            'truth_market' => $source->truth_market,
+            'effective_at' => now()->subDays(5),
+            'reviewed_at' => now()->subDay(),
+        ]);
+
+        return $target;
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated backend-owned `CareerTransitionRationaleBuilder` that derives machine-coded transition rationale and source-target delta truth from the selected B31 non-self target, current overlap steps, readiness posture, and authoritative occupation truth fields
- extend `TransitionPathPayload` to support internal-only `rationale_codes`, `tradeoff_codes`, and structured `delta` fields while preserving public-safe normalization rules
- update `CareerTransitionPathWriter` to persist the new internal rationale/delta authority payload alongside the existing `stable_upside` single-target transition row
- harden unit and feature coverage so richer internal transition payload fields remain machine-coded, deterministic, and omitted from the public transition preview contract

## Why
- B31 made the transition target real, but backend still lacked a formal source-to-target rationale/delta authority layer
- the safest next step is to make backend truth real first without introducing prose, strategy guidance, bridge-plan semantics, or new public surface area
- this PR keeps transition semantics conservative: `stable_upside` only, single target only, same-family only, and public preview shape unchanged

## Validation
- `vendor/bin/pint --test app/Domain/Career/Transition/TransitionPathPayload.php app/Services/Career/Transition/CareerTransitionRationaleBuilder.php app/Services/Career/Transition/CareerTransitionPathWriter.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Unit/Services/Career/Transition/CareerTransitionRationaleBuilderTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php`
- `php artisan test tests/Unit/Services/Career/Transition/CareerTransitionRationaleBuilderTest.php tests/Unit/Domain/Career/Transition/TransitionPathPayloadTest.php tests/Unit/Services/Career/Transition/CareerTransitionPathWriterTest.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerRecommendationCompilerTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no public additive preview extension
- no new route or dedicated rationale endpoint
- no prose fields such as `why_this_path`, `what_is_lost`, or `bridge_steps_90d`
- no strategy guidance or bridge-plan semantics
- no taxonomy expansion beyond `stable_upside`
- no frontend changes
