### PR TITLE
PR-B33: Career transition preview additive delta public extension

### DIFF
--- a/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
+++ b/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
@@ -18,6 +18,7 @@ final class CareerTransitionPreviewBundle
         'bundle_version',
         'path_type',
         'steps',
+        'delta',
         'target_job',
         'score_summary',
         'trust_summary',
@@ -32,10 +33,12 @@ final class CareerTransitionPreviewBundle
      * @param  array<string, mixed>  $seoContract
      * @param  array<string, mixed>  $provenanceMeta
      * @param  list<string>|null  $steps
+     * @param  array<string, array{source_value:string,target_value:string,direction:string}>|null  $delta
      */
     public function __construct(
         public readonly string $pathType,
         public readonly ?array $steps,
+        public readonly ?array $delta,
         public readonly array $targetJob,
         public readonly array $scoreSummary,
         public readonly array $trustSummary,
@@ -53,6 +56,7 @@ final class CareerTransitionPreviewBundle
             'bundle_version' => self::BUNDLE_VERSION,
             'path_type' => $this->pathType,
             'steps' => $this->steps,
+            'delta' => $this->delta,
             'target_job' => $this->targetJob,
             'score_summary' => $this->scoreSummary,
             'trust_summary' => $this->trustSummary,
@@ -62,6 +66,10 @@ final class CareerTransitionPreviewBundle
 
         if ($payload['steps'] === null) {
             unset($payload['steps']);
+        }
+
+        if ($payload['delta'] === null) {
+            unset($payload['delta']);
         }
 
         /** @var array<string, mixed> $publicPayload */

--- a/backend/app/Http/Resources/Career/CareerTransitionPreviewResource.php
+++ b/backend/app/Http/Resources/Career/CareerTransitionPreviewResource.php
@@ -23,9 +23,10 @@ final class CareerTransitionPreviewResource extends JsonResource
         /** @var CareerTransitionPreviewBundle $bundle */
         $bundle = $this->resource;
         $publicKeys = CareerTransitionPreviewBundle::publicTopLevelKeys();
+        $payload = $bundle->toArray();
 
         return array_intersect_key(
-            $bundle->toArray(),
+            $payload,
             array_flip($publicKeys),
         );
     }

--- a/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
@@ -118,6 +118,7 @@ final class CareerTransitionPreviewBundleBuilder
         $publicSteps = $normalizedPathPayload->steps === []
             ? null
             : array_values($normalizedPathPayload->steps);
+        $publicDelta = $this->publicDelta($normalizedPathPayload->delta);
 
         $scoreBundle = is_array($payload['score_bundle'] ?? null) ? $payload['score_bundle'] : [];
         $reasonCodes = is_array($claimPermissions['reason_codes'] ?? null) ? array_values($claimPermissions['reason_codes']) : [];
@@ -126,6 +127,7 @@ final class CareerTransitionPreviewBundleBuilder
         return new CareerTransitionPreviewBundle(
             pathType: $pathType->value,
             steps: $publicSteps,
+            delta: $publicDelta,
             targetJob: [
                 'occupation_uuid' => $targetOccupation->id,
                 'canonical_slug' => $targetOccupation->canonical_slug,
@@ -184,5 +186,43 @@ final class CareerTransitionPreviewBundleBuilder
     private function isPublicPathTypeAllowed(TransitionPathType $pathType): bool
     {
         return $pathType === TransitionPathType::StableUpside;
+    }
+
+    /**
+     * @param  array<string, array{source_value:string,target_value:string,direction:string}>  $delta
+     * @return array<string, array{source_value:string,target_value:string,direction:string}>|null
+     */
+    private function publicDelta(array $delta): ?array
+    {
+        if ($delta === []) {
+            return null;
+        }
+
+        $publicDelta = [];
+        foreach ($delta as $key => $value) {
+            if (! in_array($key, \App\Domain\Career\Transition\TransitionPathPayload::allowedDeltaKeys(), true)) {
+                continue;
+            }
+
+            $sourceValue = is_scalar($value['source_value'] ?? null) ? trim((string) $value['source_value']) : '';
+            $targetValue = is_scalar($value['target_value'] ?? null) ? trim((string) $value['target_value']) : '';
+            $direction = is_scalar($value['direction'] ?? null) ? trim((string) $value['direction']) : '';
+
+            if (
+                $sourceValue === ''
+                || $targetValue === ''
+                || ! in_array($direction, \App\Domain\Career\Transition\TransitionPathPayload::allowedDeltaDirections(), true)
+            ) {
+                continue;
+            }
+
+            $publicDelta[$key] = [
+                'source_value' => $sourceValue,
+                'target_value' => $targetValue,
+                'direction' => $direction,
+            ];
+        }
+
+        return $publicDelta === [] ? null : $publicDelta;
     }
 }

--- a/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
+++ b/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
@@ -69,9 +69,15 @@ final class CareerTransitionPreviewApiTest extends TestCase
             ->assertJsonPath('target_job.canonical_slug', 'registered-nurses')
             ->assertJsonPath('trust_summary.allow_transition_recommendation', true)
             ->assertJsonPath('seo_contract.index_eligible', true)
+            ->assertJsonPath('delta.entry_education_delta.source_value', "Bachelor's degree")
+            ->assertJsonPath('delta.entry_education_delta.target_value', "Master's degree")
+            ->assertJsonPath('delta.entry_education_delta.direction', TransitionPathPayload::DELTA_DIRECTION_HIGHER)
             ->assertJsonStructure([
                 'path_type',
                 'steps',
+                'delta' => [
+                    'entry_education_delta' => ['source_value', 'target_value', 'direction'],
+                ],
                 'target_job' => ['occupation_uuid', 'canonical_slug', 'title'],
                 'score_summary' => [
                     'mobility_score' => ['value', 'integrity_state', 'band'],
@@ -85,13 +91,16 @@ final class CareerTransitionPreviewApiTest extends TestCase
             ->assertJsonMissingPath('what_is_lost')
             ->assertJsonMissingPath('bridge_steps_90d')
             ->assertJsonMissingPath('rationale_codes')
-            ->assertJsonMissingPath('tradeoff_codes')
-            ->assertJsonMissingPath('delta');
+            ->assertJsonMissingPath('tradeoff_codes');
 
         /** @var array<string, mixed> $payload */
         $payload = $response->json();
         $this->assertSame(CareerTransitionPreviewBundle::publicTopLevelKeys(), array_keys($payload));
         $this->assertSame(TransitionPathPayload::allowedStepLabels(), $payload['steps']);
+        $this->assertContains(
+            data_get($payload, 'delta.entry_education_delta.direction'),
+            TransitionPathPayload::allowedDeltaDirections(),
+        );
     }
 
     public function test_it_returns_not_found_when_no_safe_preview_exists(): void

--- a/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
@@ -47,7 +47,13 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
 
         $payload = app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
 
-        $this->assertSame(CareerTransitionPreviewBundle::publicTopLevelKeys(), array_keys($payload));
+        $this->assertSame(
+            array_values(array_filter(
+                CareerTransitionPreviewBundle::publicTopLevelKeys(),
+                static fn (string $key): bool => $key !== 'delta'
+            )),
+            array_keys($payload)
+        );
         $this->assertSame('career_transition_preview', $payload['bundle_kind']);
         $this->assertSame('career.protocol.transition_preview.v1', $payload['bundle_version']);
         $this->assertSame('stable_upside', $payload['path_type']);
@@ -57,6 +63,7 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
         $this->assertSame(true, data_get($payload, 'seo_contract.index_eligible'));
         $this->assertSame($snapshot->id, data_get($payload, 'provenance_meta.recommendation_snapshot_id'));
         $this->assertNotNull(data_get($payload, 'score_summary.mobility_score.value'));
+        $this->assertNull(data_get($payload, 'delta'));
         $this->assertNull(data_get($payload, 'why_this_path'));
         $this->assertNull(data_get($payload, 'what_is_lost'));
         $this->assertNull(data_get($payload, 'bridge_steps_90d'));
@@ -142,7 +149,7 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
         $this->assertNull(app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj'));
     }
 
-    public function test_it_sanitizes_internal_path_payload_without_expanding_public_preview_fields(): void
+    public function test_it_exposes_only_allowlisted_delta_fields_without_expanding_other_public_preview_fields(): void
     {
         $snapshot = $this->compileRecommendationChain('transition-source-sanitized-payload');
         $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
@@ -186,12 +193,60 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
         $this->assertSame($expectedKeys, array_keys($payload));
         $this->assertSame('stable_upside', $payload['path_type'] ?? null);
         $this->assertArrayNotHasKey('steps', $payload);
+        $this->assertSame([
+            'entry_education_delta' => [
+                'source_value' => "Bachelor's degree",
+                'target_value' => "Master's degree",
+                'direction' => 'higher',
+            ],
+        ], $payload['delta'] ?? null);
         $this->assertArrayNotHasKey('why_this_path', $payload);
         $this->assertArrayNotHasKey('what_is_lost', $payload);
         $this->assertArrayNotHasKey('bridge_steps_90d', $payload);
         $this->assertArrayNotHasKey('rationale_codes', $payload);
         $this->assertArrayNotHasKey('tradeoff_codes', $payload);
+    }
+
+    public function test_it_omits_delta_when_internal_truth_is_missing_or_unrankable(): void
+    {
+        $snapshot = $this->compileRecommendationChain('transition-source-thin-delta');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => [
+                'delta' => [
+                    TransitionPathPayload::DELTA_ENTRY_EDUCATION => [
+                        'source_value' => '',
+                        'target_value' => "Master's degree",
+                        'direction' => TransitionPathPayload::DELTA_DIRECTION_HIGHER,
+                    ],
+                    TransitionPathPayload::DELTA_WORK_EXPERIENCE => [
+                        'source_value' => 'None',
+                        'target_value' => '5 years or more',
+                        'direction' => 'unsafe',
+                    ],
+                ],
+                'rationale_codes' => [
+                    TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET,
+                ],
+                'tradeoff_codes' => [
+                    TransitionPathPayload::TRADEOFF_HIGHER_WORK_EXPERIENCE_REQUIRED,
+                ],
+            ],
+        ]);
+
+        $payload = app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
+
         $this->assertArrayNotHasKey('delta', $payload);
+        $this->assertArrayNotHasKey('rationale_codes', $payload);
+        $this->assertArrayNotHasKey('tradeoff_codes', $payload);
     }
 
     public function test_it_excludes_paths_with_invalid_non_array_payload_shape(): void


### PR DESCRIPTION
## What changed
- extend the existing transition preview public contract with an additive optional `delta` field sourced from B32 internal transition rationale/delta truth
- expose only the allowlisted structural delta keys:
  - `entry_education_delta`
  - `work_experience_delta`
  - `training_delta`
- keep `rationale_codes` and `tradeoff_codes` internal-only while hardening builder and API tests to prevent accidental public leakage
- preserve the current single-target `stable_upside` preview shape, route ownership, and omission behavior when delta truth is missing or unrankable

## Why
- B32 already made transition delta truth real internally, but the public preview still exposed none of that machine-safe structural comparison data
- the safest public extension is a narrow additive `delta`, not broader rationale/tradeoff fields and not any prose guidance
- this keeps the preview compact, non-narrative, and backend-owned without turning it into a strategy surface

## Validation
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php app/DTO/Career/CareerTransitionPreviewBundle.php app/Http/Resources/Career/CareerTransitionPreviewResource.php tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/FirstWaveTransitionPathMaterializationTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerRecommendationCompilerTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no public `rationale_codes`
- no public `tradeoff_codes`
- no prose fields such as `why_this_path`, `what_is_lost`, or `bridge_steps_90d`
- no strategy guidance or bridge-plan semantics
- no new endpoint
- no taxonomy expansion beyond `stable_upside`
- no frontend changes
