### PR TITLE
PR-B34: Career first-wave launch-tier authority API

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveLaunchTierSummary.php
+++ b/backend/app/DTO/Career/CareerFirstWaveLaunchTierSummary.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveLaunchTierSummary
+{
+    /**
+     * @param  array<string, int>  $counts
+     * @param  list<array<string, mixed>>  $occupations
+     */
+    public function __construct(
+        public readonly string $summaryVersion,
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $occupations,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'summary_kind' => 'career_first_wave_launch_tier',
+            'summary_version' => $this->summaryVersion,
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'occupations' => $this->occupations,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchTierSummaryService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchTierSummaryService.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveLaunchTierSummary;
+use App\Models\Occupation;
+
+final class CareerFirstWaveLaunchTierSummaryService
+{
+    public const SUMMARY_VERSION = 'career.launch_tier.first_wave.v1';
+
+    public const SCOPE = 'career_first_wave_10';
+
+    /**
+     * @var array<string, true>
+     */
+    private const HOLD_CROSSWALK_MODES = [
+        'local_heavy_interpretation' => true,
+        'family_proxy' => true,
+        'unmapped' => true,
+    ];
+
+    public function __construct(
+        private readonly FirstWaveManifestReader $manifestReader,
+        private readonly FirstWavePublishReadyValidator $validator,
+        private readonly CareerFirstWaveLifecycleSummaryService $lifecycleSummaryService,
+        private readonly FirstWavePublishGate $publishGate,
+    ) {}
+
+    public function build(): CareerFirstWaveLaunchTierSummary
+    {
+        $manifest = $this->manifestReader->read();
+        $report = $this->validator->validate();
+        $lifecycleSummary = $this->lifecycleSummaryService->build()->toArray();
+
+        $readinessBySlug = [];
+        foreach ((array) ($report['occupations'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = (string) ($row['canonical_slug'] ?? '');
+            if ($slug !== '') {
+                $readinessBySlug[$slug] = $row;
+            }
+        }
+
+        $lifecycleBySlug = [];
+        foreach ((array) ($lifecycleSummary['occupations'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = (string) ($row['canonical_slug'] ?? '');
+            if ($slug !== '') {
+                $lifecycleBySlug[$slug] = $row;
+            }
+        }
+
+        $counts = [
+            'total' => 0,
+            WaveClassification::STABLE => 0,
+            WaveClassification::CANDIDATE => 0,
+            WaveClassification::HOLD => 0,
+        ];
+        $occupations = [];
+
+        foreach ((array) ($manifest['occupations'] ?? []) as $occupation) {
+            if (! is_array($occupation)) {
+                continue;
+            }
+
+            $slug = (string) ($occupation['canonical_slug'] ?? '');
+            if ($slug === '') {
+                continue;
+            }
+
+            $readiness = $readinessBySlug[$slug] ?? [];
+            $lifecycle = $lifecycleBySlug[$slug] ?? [];
+            $seed = $this->loadSeedRow($slug);
+            $gate = $this->evaluateGate($readiness, $seed);
+            $launchTier = $this->resolveLaunchTier(
+                gateClassification: (string) ($gate['classification'] ?? WaveClassification::HOLD),
+                readinessStatus: $this->normalizeReadinessStatus((string) ($readiness['status'] ?? '')),
+                blockedGovernanceStatus: $this->normalizeNullableString($readiness['blocked_governance_status'] ?? null),
+            );
+
+            $counts['total']++;
+            $counts[$launchTier]++;
+
+            $occupations[] = [
+                'occupation_uuid' => (string) ($occupation['occupation_uuid'] ?? ''),
+                'canonical_slug' => $slug,
+                'canonical_title_en' => (string) ($occupation['canonical_title_en'] ?? ''),
+                'launch_tier' => $launchTier,
+                'readiness_status' => $this->normalizeReadinessStatus((string) ($readiness['status'] ?? '')),
+                'lifecycle_state' => (string) ($lifecycle['lifecycle_state'] ?? CareerIndexLifecycleState::NOINDEX),
+                'public_index_state' => (string) ($lifecycle['public_index_state'] ?? 'noindex'),
+                'index_eligible' => (bool) ($readiness['index_eligible'] ?? false),
+                'reviewer_status' => $this->normalizeNullableString($readiness['reviewer_status'] ?? null),
+                'crosswalk_mode' => $this->normalizeNullableString($readiness['crosswalk_mode'] ?? $seed['crosswalk_mode'] ?? null),
+                'allow_strong_claim' => (bool) ($seed['allow_strong_claim'] ?? false),
+                'confidence_score' => $seed['confidence_score'],
+                'blocked_governance_status' => $this->normalizeNullableString($readiness['blocked_governance_status'] ?? null),
+                'reason_codes' => $this->curateReasonCodes(
+                    launchTier: $launchTier,
+                    gateReasons: (array) ($gate['reasons'] ?? []),
+                    blockedGovernanceStatus: $this->normalizeNullableString($readiness['blocked_governance_status'] ?? null),
+                    reviewerStatus: $this->normalizeNullableString($readiness['reviewer_status'] ?? null),
+                    crosswalkMode: $this->normalizeNullableString($readiness['crosswalk_mode'] ?? $seed['crosswalk_mode'] ?? null),
+                    indexEligible: (bool) ($readiness['index_eligible'] ?? false),
+                    allowStrongClaim: (bool) ($seed['allow_strong_claim'] ?? false),
+                    confidenceScore: $seed['confidence_score'],
+                ),
+            ];
+        }
+
+        return new CareerFirstWaveLaunchTierSummary(
+            summaryVersion: self::SUMMARY_VERSION,
+            scope: self::SCOPE,
+            counts: $counts,
+            occupations: $occupations,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $readiness
+     * @param  array{crosswalk_mode:?string,confidence_score:?int,allow_strong_claim:bool,reviewer_status:?string,index_state:?string,index_eligible:bool}  $seed
+     * @return array{classification:string,reasons:list<string>,publishable:bool}
+     */
+    private function evaluateGate(array $readiness, array $seed): array
+    {
+        return $this->publishGate->evaluate([
+            'crosswalk_mode' => $readiness['crosswalk_mode'] ?? $seed['crosswalk_mode'],
+            'confidence_score' => $seed['confidence_score'] ?? 0,
+            'reviewer_status' => $readiness['reviewer_status'] ?? $seed['reviewer_status'],
+            'index_state' => $readiness['index_state'] ?? $seed['index_state'],
+            'index_eligible' => $readiness['index_eligible'] ?? $seed['index_eligible'],
+            'allow_strong_claim' => $seed['allow_strong_claim'],
+        ]);
+    }
+
+    private function resolveLaunchTier(
+        string $gateClassification,
+        string $readinessStatus,
+        ?string $blockedGovernanceStatus,
+    ): string {
+        if ($blockedGovernanceStatus !== null) {
+            return WaveClassification::HOLD;
+        }
+
+        if ($gateClassification === WaveClassification::STABLE && $readinessStatus === 'publish_ready') {
+            return WaveClassification::STABLE;
+        }
+
+        if ($gateClassification === WaveClassification::CANDIDATE) {
+            return WaveClassification::CANDIDATE;
+        }
+
+        return WaveClassification::HOLD;
+    }
+
+    /**
+     * @param  list<mixed>  $gateReasons
+     * @return list<string>
+     */
+    private function curateReasonCodes(
+        string $launchTier,
+        array $gateReasons,
+        ?string $blockedGovernanceStatus,
+        ?string $reviewerStatus,
+        ?string $crosswalkMode,
+        bool $indexEligible,
+        bool $allowStrongClaim,
+        ?int $confidenceScore,
+    ): array {
+        $reasonCodes = match ($launchTier) {
+            WaveClassification::STABLE => ['stable_launch_ready'],
+            WaveClassification::CANDIDATE => ['candidate_review_required'],
+            default => [],
+        };
+
+        $gateReasons = array_values(array_filter(array_map(
+            static fn (mixed $code): string => is_string($code) ? trim($code) : '',
+            $gateReasons,
+        )));
+
+        if ($launchTier === WaveClassification::HOLD) {
+            if ($blockedGovernanceStatus !== null) {
+                $reasonCodes[] = 'hold_blocked_governance';
+            }
+
+            if ($reviewerStatus !== null && ! in_array($reviewerStatus, ['approved', 'reviewed'], true)) {
+                $reasonCodes[] = 'hold_review_required';
+            }
+
+            if (! $indexEligible) {
+                $reasonCodes[] = 'hold_not_index_eligible';
+            }
+
+            if ($crosswalkMode !== null && isset(self::HOLD_CROSSWALK_MODES[strtolower($crosswalkMode)])) {
+                $reasonCodes[] = 'hold_crosswalk_restricted';
+            }
+
+            if (! $allowStrongClaim) {
+                $reasonCodes[] = 'hold_strong_claim_disallowed';
+            }
+
+            if (in_array(PublishReasonCode::CONFIDENCE_TOO_LOW, $gateReasons, true)
+                || ($confidenceScore !== null && $confidenceScore < 60)) {
+                $reasonCodes[] = 'hold_confidence_too_low';
+            }
+
+            if ($reasonCodes === []) {
+                $reasonCodes[] = 'hold_scope_restricted';
+            }
+        }
+
+        return array_values(array_unique($reasonCodes));
+    }
+
+    /**
+     * @return array{crosswalk_mode:?string,confidence_score:?int,allow_strong_claim:bool,reviewer_status:?string,index_state:?string,index_eligible:bool}
+     */
+    private function loadSeedRow(string $slug): array
+    {
+        $occupation = Occupation::query()->where('canonical_slug', $slug)->first();
+        if (! $occupation instanceof Occupation) {
+            return [
+                'crosswalk_mode' => null,
+                'confidence_score' => null,
+                'allow_strong_claim' => false,
+                'reviewer_status' => null,
+                'index_state' => null,
+                'index_eligible' => false,
+            ];
+        }
+
+        $trustManifest = $occupation->trustManifests()
+            ->orderByDesc('reviewed_at')
+            ->orderByDesc('created_at')
+            ->first();
+        $indexState = $occupation->indexStates()
+            ->orderByDesc('changed_at')
+            ->orderByDesc('updated_at')
+            ->first();
+        $snapshot = $occupation->recommendationSnapshots()
+            ->with(['contextSnapshot', 'profileProjection'])
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        $confidenceScore = data_get($trustManifest?->quality, 'confidence_score', data_get($trustManifest?->quality, 'confidence'));
+        $normalizedConfidence = is_numeric($confidenceScore) ? (int) round((float) $confidenceScore) : null;
+
+        return [
+            'crosswalk_mode' => $this->normalizeNullableString($occupation->crosswalk_mode),
+            'confidence_score' => $normalizedConfidence,
+            'allow_strong_claim' => (bool) data_get($snapshot?->snapshot_payload, 'claim_permissions.allow_strong_claim', false),
+            'reviewer_status' => $this->normalizeNullableString($trustManifest?->reviewer_status),
+            'index_state' => $this->normalizeNullableString($indexState?->index_state),
+            'index_eligible' => (bool) ($indexState?->index_eligible ?? false),
+        ];
+    }
+
+    private function normalizeReadinessStatus(string $status): string
+    {
+        $normalized = strtolower(trim($status));
+
+        return match ($normalized) {
+            'publish_ready', 'blocked_override_eligible', 'blocked_not_safely_remediable', 'partial', 'partial_raw' => $normalized === 'partial' ? 'partial_raw' : $normalized,
+            default => 'blocked_not_safely_remediable',
+        };
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLaunchTierController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLaunchTierController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveLaunchTierSummaryService;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerFirstWaveLaunchTierSummaryResource;
+
+final class CareerFirstWaveLaunchTierController extends Controller
+{
+    public function __construct(
+        private readonly CareerFirstWaveLaunchTierSummaryService $summaryService,
+    ) {}
+
+    public function show(): CareerFirstWaveLaunchTierSummaryResource
+    {
+        return new CareerFirstWaveLaunchTierSummaryResource(
+            $this->summaryService->build()
+        );
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerFirstWaveLaunchTierSummaryResource.php
+++ b/backend/app/Http/Resources/Career/CareerFirstWaveLaunchTierSummaryResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerFirstWaveLaunchTierSummary;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerFirstWaveLaunchTierSummary
+ */
+final class CareerFirstWaveLaunchTierSummaryResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerFirstWaveLaunchTierSummary $summary */
+        $summary = $this->resource;
+
+        return $summary->toArray();
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2379,6 +2379,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/first-wave/launch-tier": {
+            "get": {
+                "operationId": "get_api_v0_5_career_first_wave_launch_tier",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerFirstWaveLaunchTierController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/first-wave/lifecycle": {
             "get": {
                 "operationId": "get_api_v0_5_career_first_wave_lifecycle",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -32,6 +32,7 @@ use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Career\CareerAliasResolutionController;
 use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
 use App\Http\Controllers\API\V0_5\Career\CareerFamilyHubController;
+use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLaunchTierController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLifecycleController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveRolloutQueueController;
@@ -409,6 +410,7 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
 Route::prefix('v0.5')->group(function () {
     Route::post('/career/attribution/events', [CareerAttributionEventController::class, 'store']);
     Route::get('/career/family/{slug}', [CareerFamilyHubController::class, 'show']);
+    Route::get('/career/first-wave/launch-tier', [CareerFirstWaveLaunchTierController::class, 'show']);
     Route::get('/career/resolve', [CareerAliasResolutionController::class, 'show']);
     Route::get('/career/first-wave/lifecycle', [CareerFirstWaveLifecycleController::class, 'show']);
     Route::get('/career/first-wave/rollout-queue', [CareerFirstWaveRolloutQueueController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveLaunchTierApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_exposes_a_machine_readable_first_wave_launch_tier_summary(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/launch-tier');
+
+        $response->assertOk()
+            ->assertJsonPath('summary_kind', 'career_first_wave_launch_tier')
+            ->assertJsonPath('summary_version', 'career.launch_tier.first_wave.v1')
+            ->assertJsonPath('scope', 'career_first_wave_10')
+            ->assertJsonPath('counts.total', 10)
+            ->assertJsonPath('counts.stable', 6)
+            ->assertJsonPath('counts.candidate', 0)
+            ->assertJsonPath('counts.hold', 4)
+            ->assertJsonStructure([
+                'summary_kind',
+                'summary_version',
+                'scope',
+                'counts' => [
+                    'total',
+                    'stable',
+                    'candidate',
+                    'hold',
+                ],
+                'occupations' => [[
+                    'occupation_uuid',
+                    'canonical_slug',
+                    'canonical_title_en',
+                    'launch_tier',
+                    'readiness_status',
+                    'lifecycle_state',
+                    'public_index_state',
+                    'index_eligible',
+                    'reviewer_status',
+                    'crosswalk_mode',
+                    'allow_strong_claim',
+                    'confidence_score',
+                    'blocked_governance_status',
+                    'reason_codes',
+                ]],
+            ])
+            ->assertJsonMissingPath('recommended_action');
+
+        $occupations = collect($response->json('occupations'))->keyBy('canonical_slug');
+
+        $this->assertSame('stable', $occupations['registered-nurses']['launch_tier']);
+        $this->assertSame('hold', $occupations['software-developers']['launch_tier']);
+        $this->assertContains('hold_blocked_governance', $occupations['software-developers']['reason_codes']);
+        $this->assertNotContains('publish_gate_candidate', $occupations['software-developers']['reason_codes']);
+    }
+
+    public function test_it_exposes_candidate_rows_without_turning_them_into_rollout_queue_actions(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/launch-tier');
+
+        $response->assertOk()
+            ->assertJsonPath('counts.stable', 5)
+            ->assertJsonPath('counts.candidate', 1)
+            ->assertJsonPath('counts.hold', 4)
+            ->assertJsonMissingPath('occupations.0.recommended_action');
+
+        $occupations = collect($response->json('occupations'))->keyBy('canonical_slug');
+        $candidateRow = $occupations['data-scientists'];
+
+        $this->assertSame('candidate', $candidateRow['launch_tier']);
+        $this->assertSame('indexed', $candidateRow['lifecycle_state']);
+        $this->assertSame('direct_match', $candidateRow['crosswalk_mode']);
+        $this->assertSame(['candidate_review_required'], $candidateRow['reason_codes']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchTierSummaryServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchTierSummaryServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveLaunchTierSummaryService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveLaunchTierSummaryServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_machine_coded_first_wave_launch_tier_summary_from_current_truth(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $summary = app(CareerFirstWaveLaunchTierSummaryService::class)->build()->toArray();
+        $occupations = collect($summary['occupations'])->keyBy('canonical_slug');
+
+        $this->assertSame('career_first_wave_launch_tier', $summary['summary_kind']);
+        $this->assertSame(CareerFirstWaveLaunchTierSummaryService::SUMMARY_VERSION, $summary['summary_version']);
+        $this->assertSame(CareerFirstWaveLaunchTierSummaryService::SCOPE, $summary['scope']);
+        $this->assertSame(10, $summary['counts']['total']);
+        $this->assertSame(6, $summary['counts']['stable']);
+        $this->assertSame(0, $summary['counts']['candidate']);
+        $this->assertSame(4, $summary['counts']['hold']);
+        $this->assertSame('software-developers', $summary['occupations'][0]['canonical_slug']);
+        $this->assertSame('management-analysts', $summary['occupations'][9]['canonical_slug']);
+
+        $registeredNurses = $occupations->get('registered-nurses');
+        $softwareDevelopers = $occupations->get('software-developers');
+
+        $this->assertIsArray($registeredNurses);
+        $this->assertSame('stable', $registeredNurses['launch_tier']);
+        $this->assertSame('publish_ready', $registeredNurses['readiness_status']);
+        $this->assertSame('indexed', $registeredNurses['lifecycle_state']);
+        $this->assertSame('indexable', $registeredNurses['public_index_state']);
+        $this->assertTrue($registeredNurses['index_eligible']);
+        $this->assertSame('approved', $registeredNurses['reviewer_status']);
+        $this->assertContains('stable_launch_ready', $registeredNurses['reason_codes']);
+
+        $this->assertIsArray($softwareDevelopers);
+        $this->assertSame('hold', $softwareDevelopers['launch_tier']);
+        $this->assertSame('blocked_override_eligible', $softwareDevelopers['blocked_governance_status']);
+        $this->assertContains('hold_blocked_governance', $softwareDevelopers['reason_codes']);
+        $this->assertContains('hold_not_index_eligible', $softwareDevelopers['reason_codes']);
+    }
+
+    public function test_it_can_classify_candidate_without_conflating_lifecycle_state(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+
+        $summary = app(CareerFirstWaveLaunchTierSummaryService::class)->build()->toArray();
+        $occupations = collect($summary['occupations'])->keyBy('canonical_slug');
+        $candidateRow = $occupations->get('data-scientists');
+
+        $this->assertSame(5, $summary['counts']['stable']);
+        $this->assertSame(1, $summary['counts']['candidate']);
+        $this->assertSame(4, $summary['counts']['hold']);
+
+        $this->assertIsArray($candidateRow);
+        $this->assertSame('candidate', $candidateRow['launch_tier']);
+        $this->assertSame('indexed', $candidateRow['lifecycle_state']);
+        $this->assertSame('direct_match', $candidateRow['crosswalk_mode']);
+        $this->assertSame(['candidate_review_required'], $candidateRow['reason_codes']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated first-wave launch-tier summary service that projects backend-owned `stable`, `candidate`, and `hold` tiers from the existing publish gate, readiness, lifecycle, and trust seeds
- add a new read-only v0.5 API surface for first-wave launch tiers with machine-coded rows plus aggregate counts
- add focused unit and feature coverage for tier classification, curated reason codes, and route/resource shape while keeping the existing readiness, lifecycle, and rollout queue contracts unchanged

## Why
- first-wave launch-tier truth already existed in backend logic, but it was split across readiness, lifecycle, rollout queue, and publish-gate semantics with no dedicated authority read model
- a separate launch-tier API gives downstream governance, whitelist alignment, and rollout consumers one backend-owned source of truth without overloading B14, B27, or B28
- this keeps the surface first-wave only, read-only, and machine-coded without adding action semantics or frontend rollout assumptions

## Validation
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveLaunchTierSummaryService.php app/DTO/Career/CareerFirstWaveLaunchTierSummary.php app/Http/Resources/Career/CareerFirstWaveLaunchTierSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLaunchTierController.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveLaunchTierSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php docs/contracts/openapi.snapshot.json`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchTierSummaryServiceTest.php tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php tests/Feature/Career/CareerFirstWaveRolloutQueueApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no frontend changes
- no SEO rollout implementation
- no launch manifest or smoke semantics
- no action endpoints
- no changes to existing B14, B27, or B28 public contracts
