### PR TITLE
PR-B35: Career first-wave discoverability manifest authority API

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveDiscoverabilityManifest.php
+++ b/backend/app/DTO/Career/CareerFirstWaveDiscoverabilityManifest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveDiscoverabilityManifest
+{
+    /**
+     * @param  list<array<string, mixed>>  $routes
+     */
+    public function __construct(
+        public readonly string $manifestVersion,
+        public readonly string $scope,
+        public readonly array $routes,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'manifest_kind' => 'career_first_wave_discoverability_manifest',
+            'manifest_version' => $this->manifestVersion,
+            'scope' => $this->scope,
+            'routes' => $this->routes,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveDiscoverabilityManifestService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveDiscoverabilityManifestService.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveDiscoverabilityManifest;
+use App\Models\OccupationFamily;
+use App\Services\Career\Bundles\CareerFamilyHubBundleBuilder;
+
+final class CareerFirstWaveDiscoverabilityManifestService
+{
+    public const MANIFEST_VERSION = 'career.discoverability.first_wave.v1';
+
+    public const SCOPE = 'career_first_wave_10';
+
+    public function __construct(
+        private readonly FirstWaveManifestReader $manifestReader,
+        private readonly CareerFirstWaveLaunchTierSummaryService $launchTierSummaryService,
+        private readonly CareerFamilyHubBundleBuilder $familyHubBundleBuilder,
+    ) {}
+
+    public function build(): CareerFirstWaveDiscoverabilityManifest
+    {
+        $manifest = $this->manifestReader->read();
+        $launchTierSummary = $this->launchTierSummaryService->build()->toArray();
+
+        $routes = array_merge(
+            $this->buildJobDetailRoutes((array) ($manifest['occupations'] ?? []), (array) ($launchTierSummary['occupations'] ?? [])),
+            $this->buildFamilyHubRoutes((array) ($manifest['occupations'] ?? [])),
+        );
+
+        usort($routes, static function (array $left, array $right): int {
+            $leftKey = sprintf('%s|%s', (string) ($left['route_kind'] ?? ''), (string) ($left['canonical_path'] ?? ''));
+            $rightKey = sprintf('%s|%s', (string) ($right['route_kind'] ?? ''), (string) ($right['canonical_path'] ?? ''));
+
+            return strcmp($leftKey, $rightKey);
+        });
+
+        return new CareerFirstWaveDiscoverabilityManifest(
+            manifestVersion: self::MANIFEST_VERSION,
+            scope: self::SCOPE,
+            routes: $routes,
+        );
+    }
+
+    /**
+     * @param  list<mixed>  $manifestOccupations
+     * @param  list<mixed>  $launchTierRows
+     * @return list<array<string, mixed>>
+     */
+    private function buildJobDetailRoutes(array $manifestOccupations, array $launchTierRows): array
+    {
+        $manifestSlugs = [];
+        foreach ($manifestOccupations as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug !== '') {
+                $manifestSlugs[$slug] = true;
+            }
+        }
+
+        $routes = [];
+        foreach ($launchTierRows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug === '' || ! isset($manifestSlugs[$slug])) {
+                continue;
+            }
+
+            $discoverable = (string) ($row['launch_tier'] ?? '') === WaveClassification::STABLE;
+
+            $routes[] = [
+                'route_kind' => 'career_job_detail',
+                'canonical_path' => '/career/jobs/'.$slug,
+                'discoverability_state' => $discoverable ? 'discoverable' : 'excluded',
+                'reason_codes' => $this->curateJobDetailReasonCodes(
+                    launchTier: (string) ($row['launch_tier'] ?? ''),
+                    blockedGovernanceStatus: $this->normalizeNullableString($row['blocked_governance_status'] ?? null),
+                    indexEligible: (bool) ($row['index_eligible'] ?? false),
+                ),
+                'occupation_uuid' => (string) ($row['occupation_uuid'] ?? ''),
+                'canonical_slug' => $slug,
+                'canonical_title_en' => (string) ($row['canonical_title_en'] ?? ''),
+                'launch_tier' => (string) ($row['launch_tier'] ?? WaveClassification::HOLD),
+                'readiness_status' => (string) ($row['readiness_status'] ?? ''),
+                'public_index_state' => (string) ($row['public_index_state'] ?? 'noindex'),
+                'index_eligible' => (bool) ($row['index_eligible'] ?? false),
+                'reviewer_status' => $this->normalizeNullableString($row['reviewer_status'] ?? null),
+                'crosswalk_mode' => $this->normalizeNullableString($row['crosswalk_mode'] ?? null),
+                'blocked_governance_status' => $this->normalizeNullableString($row['blocked_governance_status'] ?? null),
+            ];
+        }
+
+        return $routes;
+    }
+
+    /**
+     * @param  list<mixed>  $manifestOccupations
+     * @return list<array<string, mixed>>
+     */
+    private function buildFamilyHubRoutes(array $manifestOccupations): array
+    {
+        $manifestSlugs = [];
+        foreach ($manifestOccupations as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug !== '') {
+                $manifestSlugs[] = $slug;
+            }
+        }
+
+        if ($manifestSlugs === []) {
+            return [];
+        }
+
+        $families = OccupationFamily::query()
+            ->with('occupations')
+            ->whereHas('occupations', static function ($query) use ($manifestSlugs): void {
+                $query->whereIn('canonical_slug', $manifestSlugs);
+            })
+            ->orderBy('canonical_slug')
+            ->get();
+
+        $routes = [];
+        foreach ($families as $family) {
+            $bundle = $this->familyHubBundleBuilder->buildBySlug((string) $family->canonical_slug);
+            if ($bundle === null) {
+                continue;
+            }
+
+            $visibleChildrenCount = (int) ($bundle->counts['visible_children_count'] ?? 0);
+            $discoverable = $visibleChildrenCount > 0;
+
+            $routes[] = [
+                'route_kind' => 'career_family_hub',
+                'canonical_path' => '/career/family/'.$family->canonical_slug,
+                'discoverability_state' => $discoverable ? 'discoverable' : 'excluded',
+                'reason_codes' => $discoverable ? ['visible_children_present'] : ['excluded_zero_visible_children'],
+                'family_uuid' => (string) $family->id,
+                'canonical_slug' => (string) $family->canonical_slug,
+                'title_en' => (string) $family->title_en,
+                'visible_children_count' => $visibleChildrenCount,
+            ];
+        }
+
+        return $routes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function curateJobDetailReasonCodes(
+        string $launchTier,
+        ?string $blockedGovernanceStatus,
+        bool $indexEligible,
+    ): array {
+        if ($launchTier === WaveClassification::STABLE) {
+            return ['stable_launch_tier'];
+        }
+
+        $reasonCodes = [];
+        if ($blockedGovernanceStatus !== null) {
+            $reasonCodes[] = 'excluded_blocked_governance';
+        }
+
+        if (! $indexEligible) {
+            $reasonCodes[] = 'excluded_not_index_eligible';
+        }
+
+        if ($reasonCodes === []) {
+            $reasonCodes[] = 'excluded_non_stable_tier';
+        }
+
+        return array_values(array_unique($reasonCodes));
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveDiscoverabilityManifestController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveDiscoverabilityManifestController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveDiscoverabilityManifestService;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerFirstWaveDiscoverabilityManifestResource;
+
+final class CareerFirstWaveDiscoverabilityManifestController extends Controller
+{
+    public function __construct(
+        private readonly CareerFirstWaveDiscoverabilityManifestService $manifestService,
+    ) {}
+
+    public function show(): CareerFirstWaveDiscoverabilityManifestResource
+    {
+        return new CareerFirstWaveDiscoverabilityManifestResource(
+            $this->manifestService->build()
+        );
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerFirstWaveDiscoverabilityManifestResource.php
+++ b/backend/app/Http/Resources/Career/CareerFirstWaveDiscoverabilityManifestResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerFirstWaveDiscoverabilityManifest;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerFirstWaveDiscoverabilityManifest
+ */
+final class CareerFirstWaveDiscoverabilityManifestResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerFirstWaveDiscoverabilityManifest $manifest */
+        $manifest = $this->resource;
+
+        return $manifest->toArray();
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2379,6 +2379,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/first-wave/discoverability-manifest": {
+            "get": {
+                "operationId": "get_api_v0_5_career_first_wave_discoverability_manifest",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerFirstWaveDiscoverabilityManifestController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/first-wave/launch-tier": {
             "get": {
                 "operationId": "get_api_v0_5_career_first_wave_launch_tier",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -32,6 +32,7 @@ use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Career\CareerAliasResolutionController;
 use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
 use App\Http\Controllers\API\V0_5\Career\CareerFamilyHubController;
+use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveDiscoverabilityManifestController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLaunchTierController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLifecycleController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
@@ -410,6 +411,7 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
 Route::prefix('v0.5')->group(function () {
     Route::post('/career/attribution/events', [CareerAttributionEventController::class, 'store']);
     Route::get('/career/family/{slug}', [CareerFamilyHubController::class, 'show']);
+    Route::get('/career/first-wave/discoverability-manifest', [CareerFirstWaveDiscoverabilityManifestController::class, 'show']);
     Route::get('/career/first-wave/launch-tier', [CareerFirstWaveLaunchTierController::class, 'show']);
     Route::get('/career/resolve', [CareerAliasResolutionController::class, 'show']);
     Route::get('/career/first-wave/lifecycle', [CareerFirstWaveLifecycleController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveDiscoverabilityManifestApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_exposes_a_first_wave_discoverability_manifest_for_supported_route_kinds_only(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/discoverability-manifest');
+
+        $response->assertOk()
+            ->assertJsonPath('manifest_kind', 'career_first_wave_discoverability_manifest')
+            ->assertJsonPath('manifest_version', 'career.discoverability.first_wave.v1')
+            ->assertJsonPath('scope', 'career_first_wave_10')
+            ->assertJsonStructure([
+                'manifest_kind',
+                'manifest_version',
+                'scope',
+                'routes' => [[
+                    'route_kind',
+                    'canonical_path',
+                    'discoverability_state',
+                    'reason_codes',
+                ]],
+            ])
+            ->assertJsonMissingPath('recommended_action');
+
+        $routes = collect($response->json('routes'));
+
+        $this->assertSame(
+            ['career_family_hub', 'career_job_detail'],
+            $routes->pluck('route_kind')->unique()->sort()->values()->all()
+        );
+        $this->assertFalse($routes->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/recommendations')));
+        $this->assertFalse($routes->contains(static fn (array $row): bool => (string) ($row['canonical_path'] ?? '') === '/career/jobs'));
+        $this->assertContains(
+            'discoverable',
+            $routes->pluck('discoverability_state')->unique()->values()->all()
+        );
+        $this->assertContains(
+            'excluded',
+            $routes->pluck('discoverability_state')->unique()->values()->all()
+        );
+
+        $jobRoutes = $routes->where('route_kind', 'career_job_detail')->keyBy('canonical_slug');
+        $familyRoutes = $routes->where('route_kind', 'career_family_hub')->keyBy('canonical_slug');
+
+        $this->assertSame('discoverable', $jobRoutes['registered-nurses']['discoverability_state']);
+        $this->assertSame('stable', $jobRoutes['registered-nurses']['launch_tier']);
+        $this->assertSame(['stable_launch_tier'], $jobRoutes['registered-nurses']['reason_codes']);
+
+        $this->assertSame('excluded', $jobRoutes['software-developers']['discoverability_state']);
+        $this->assertContains('excluded_blocked_governance', $jobRoutes['software-developers']['reason_codes']);
+        $this->assertSame('discoverable', $familyRoutes['computer-and-information-technology']['discoverability_state']);
+        $this->assertSame(1, $familyRoutes['computer-and-information-technology']['visible_children_count']);
+        $this->assertSame(['visible_children_present'], $familyRoutes['computer-and-information-technology']['reason_codes']);
+    }
+
+    public function test_it_keeps_candidate_jobs_and_zero_visible_families_explicitly_excluded(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'blocked-tech-family-api',
+            'title_en' => 'Blocked Tech Family API',
+            'title_zh' => '受限技术家族 API',
+        ]);
+
+        $familyExcludedOccupation = Occupation::query()->where('canonical_slug', 'registered-nurses')->firstOrFail();
+        $familyExcludedOccupation->update([
+            'family_id' => $family->id,
+            'crosswalk_mode' => 'family_proxy',
+        ]);
+
+        $routes = collect($this->getJson('/api/v0.5/career/first-wave/discoverability-manifest')->json('routes'));
+        $jobRoutes = $routes->where('route_kind', 'career_job_detail')->keyBy('canonical_slug');
+        $familyRoutes = $routes->where('route_kind', 'career_family_hub')->keyBy('canonical_slug');
+
+        $this->assertSame('candidate', $jobRoutes['data-scientists']['launch_tier']);
+        $this->assertSame('excluded', $jobRoutes['data-scientists']['discoverability_state']);
+        $this->assertSame(['excluded_non_stable_tier'], $jobRoutes['data-scientists']['reason_codes']);
+
+        $this->assertSame('excluded', $familyRoutes['blocked-tech-family-api']['discoverability_state']);
+        $this->assertSame(0, $familyRoutes['blocked-tech-family-api']['visible_children_count']);
+        $this->assertSame(['excluded_zero_visible_children'], $familyRoutes['blocked-tech-family-api']['reason_codes']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveDiscoverabilityManifestServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveDiscoverabilityManifestServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveDiscoverabilityManifestService;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveDiscoverabilityManifestServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_mixed_route_discoverability_manifest_from_current_backend_truth(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $manifest = app(CareerFirstWaveDiscoverabilityManifestService::class)->build()->toArray();
+        $routes = collect($manifest['routes']);
+        $jobRoutes = $routes->where('route_kind', 'career_job_detail')->keyBy('canonical_slug');
+        $familyRoutes = $routes->where('route_kind', 'career_family_hub')->keyBy('canonical_slug');
+
+        $this->assertSame('career_first_wave_discoverability_manifest', $manifest['manifest_kind']);
+        $this->assertSame(CareerFirstWaveDiscoverabilityManifestService::MANIFEST_VERSION, $manifest['manifest_version']);
+        $this->assertSame(CareerFirstWaveDiscoverabilityManifestService::SCOPE, $manifest['scope']);
+        $this->assertNotEmpty($manifest['routes']);
+        $this->assertContainsOnly('array', $manifest['routes']);
+        $this->assertSame(
+            ['career_family_hub', 'career_job_detail'],
+            $routes->pluck('route_kind')->unique()->sort()->values()->all()
+        );
+        $this->assertFalse($routes->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/recommendations')));
+        $this->assertFalse($routes->contains(static fn (array $row): bool => (string) ($row['canonical_path'] ?? '') === '/career/jobs'));
+
+        $registeredNurses = $jobRoutes->get('registered-nurses');
+        $softwareDevelopers = $jobRoutes->get('software-developers');
+        $technologyFamily = $familyRoutes->get('computer-and-information-technology');
+
+        $this->assertIsArray($registeredNurses);
+        $this->assertSame('/career/jobs/registered-nurses', $registeredNurses['canonical_path']);
+        $this->assertSame('discoverable', $registeredNurses['discoverability_state']);
+        $this->assertSame('stable', $registeredNurses['launch_tier']);
+        $this->assertSame(['stable_launch_tier'], $registeredNurses['reason_codes']);
+
+        $this->assertIsArray($softwareDevelopers);
+        $this->assertSame('excluded', $softwareDevelopers['discoverability_state']);
+        $this->assertSame('hold', $softwareDevelopers['launch_tier']);
+        $this->assertContains('excluded_blocked_governance', $softwareDevelopers['reason_codes']);
+        $this->assertContains('excluded_not_index_eligible', $softwareDevelopers['reason_codes']);
+
+        $this->assertIsArray($technologyFamily);
+        $this->assertSame('/career/family/computer-and-information-technology', $technologyFamily['canonical_path']);
+        $this->assertSame('discoverable', $technologyFamily['discoverability_state']);
+        $this->assertSame(1, $technologyFamily['visible_children_count']);
+        $this->assertSame(['visible_children_present'], $technologyFamily['reason_codes']);
+    }
+
+    public function test_it_excludes_non_stable_jobs_and_zero_visible_families_with_explicit_states(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'blocked-tech-family',
+            'title_en' => 'Blocked Tech Family',
+            'title_zh' => '受限技术家族',
+        ]);
+
+        $familyExcludedOccupation = Occupation::query()->where('canonical_slug', 'registered-nurses')->firstOrFail();
+        $familyExcludedOccupation->update([
+            'family_id' => $family->id,
+            'crosswalk_mode' => 'family_proxy',
+        ]);
+
+        $manifest = app(CareerFirstWaveDiscoverabilityManifestService::class)->build()->toArray();
+        $routes = collect($manifest['routes']);
+        $jobRoutes = $routes->where('route_kind', 'career_job_detail')->keyBy('canonical_slug');
+        $familyRoutes = $routes->where('route_kind', 'career_family_hub')->keyBy('canonical_slug');
+
+        $candidateRow = $jobRoutes->get('data-scientists');
+        $excludedFamily = $familyRoutes->get('blocked-tech-family');
+
+        $this->assertIsArray($candidateRow);
+        $this->assertSame('candidate', $candidateRow['launch_tier']);
+        $this->assertSame('excluded', $candidateRow['discoverability_state']);
+        $this->assertSame(['excluded_non_stable_tier'], $candidateRow['reason_codes']);
+
+        $this->assertIsArray($excludedFamily);
+        $this->assertSame('excluded', $excludedFamily['discoverability_state']);
+        $this->assertSame(0, $excludedFamily['visible_children_count']);
+        $this->assertSame(['excluded_zero_visible_children'], $excludedFamily['reason_codes']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated first-wave discoverability manifest authority service that projects backend-owned route inventory for `career_job_detail` and `career_family_hub`
- add a read-only v0.5 API surface for the discoverability manifest with explicit `discoverability_state` and curated machine-safe reason codes
- add focused unit and feature coverage for mixed-route inclusion, family visible-child gating, job-detail stable-only discoverability, and unsupported-route exclusion

## Why
- backend already had the underlying first-wave truth split across readiness, launch tier, and family hub visibility, but no single authority surface for discoverability inventory
- downstream consumers need one backend-owned manifest for sitemap and llms inventory alignment without conflating launch tier, lifecycle, or family rules
- this keeps the scope conservative: first-wave only, read-only, mixed-route but explicit, and limited to route kinds the backend can actually justify

## Validation
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveDiscoverabilityManifestService.php app/DTO/Career/CareerFirstWaveDiscoverabilityManifest.php app/Http/Resources/Career/CareerFirstWaveDiscoverabilityManifestResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveDiscoverabilityManifestController.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveDiscoverabilityManifestServiceTest.php tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveDiscoverabilityManifestServiceTest.php tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no frontend changes
- no SEO rollout implementation
- no action semantics or operator workflow
- no unsupported route classes beyond `career_job_detail` and `career_family_hub`
- no changes to existing B14, B23, or B34 contracts
