### PR TITLE
[P1-B] Guard public media URLs in public CMS APIs

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -13,6 +13,7 @@ use App\Services\Cms\ArticleService;
 use App\Services\PublicSurface\AnswerSurfaceContractService;
 use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -127,7 +128,9 @@ class ArticleController extends Controller
 
         $article->loadMissing($this->articleRelations());
 
-        $meta = $this->articleSeoService->buildSeoPayload($article);
+        $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
+            $this->articleSeoService->buildSeoPayload($article)
+        );
         $jsonLd = $this->articleSeoService->generateJsonLd($article);
 
         return response()->json([
@@ -176,7 +179,9 @@ class ArticleController extends Controller
             return response()->json(['error' => 'not found'], 404);
         }
 
-        $meta = $this->articleSeoService->buildSeoPayload($article);
+        $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
+            $this->articleSeoService->buildSeoPayload($article)
+        );
         $jsonLd = $this->articleSeoService->generateJsonLd($article);
 
         return response()->json([
@@ -778,7 +783,7 @@ class ArticleController extends Controller
             'excerpt' => $article->excerpt,
             'content_md' => (string) $article->content_md,
             'content_html' => $article->content_html,
-            'cover_image_url' => $article->cover_image_url,
+            'cover_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($article->cover_image_url),
             'status' => (string) $article->status,
             'is_public' => (bool) $article->is_public,
             'is_indexable' => (bool) $article->is_indexable,
@@ -788,7 +793,9 @@ class ArticleController extends Controller
             'updated_at' => $article->updated_at?->toISOString(),
             'category' => $article->relationLoaded('category') ? $article->category : null,
             'tags' => $article->relationLoaded('tags') ? $article->tags : [],
-            'seo_meta' => $article->relationLoaded('seoMeta') ? $article->seoMeta : null,
+            'seo_meta' => $article->relationLoaded('seoMeta')
+                ? PublicMediaUrlGuard::sanitizeArrayFields($article->seoMeta?->toArray(), ['og_image_url', 'twitter_image_url'])
+                : null,
         ];
     }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
@@ -13,6 +13,7 @@ use App\Services\Cms\CareerJobService;
 use App\Services\PublicSurface\AnswerSurfaceContractService;
 use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -81,7 +82,9 @@ final class CareerJobController extends Controller
             return $this->notFoundResponse('career job not found.');
         }
 
-        $meta = $this->careerJobSeoService->buildMeta($job, $validated['locale']);
+        $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
+            $this->careerJobSeoService->buildMeta($job, $validated['locale'])
+        );
         $jsonLd = $this->careerJobSeoService->buildJsonLd($job, $validated['locale']);
         $sections = array_map(
             fn (CareerJobSection $section): array => $this->careerJobService->sectionPayload($section),
@@ -118,7 +121,9 @@ final class CareerJobController extends Controller
             return response()->json(['error' => 'not found'], 404);
         }
 
-        $meta = $this->careerJobSeoService->buildMeta($job, $validated['locale']);
+        $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
+            $this->careerJobSeoService->buildMeta($job, $validated['locale'])
+        );
         $jsonLd = $this->careerJobSeoService->buildJsonLd($job, $validated['locale']);
 
         return response()->json([

--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -17,6 +17,7 @@ use App\Services\Cms\PersonalityProfileService;
 use App\Services\PublicSurface\AnswerSurfaceContractService;
 use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -93,7 +94,9 @@ class PersonalityController extends Controller
         /** @var PersonalityProfileVariant|null $variant */
         $variant = $routeProfile['variant'];
         $projection = $this->personalityProfileService->buildPublicProjection($profile, $variant);
-        $meta = $this->personalityProfileSeoService->buildMeta($profile, $variant);
+        $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
+            $this->personalityProfileSeoService->buildMeta($profile, $variant)
+        );
         $jsonLd = $this->personalityProfileSeoService->buildJsonLd($profile, $variant);
         $sections = $this->publicSectionPayloads($profile, $variant);
         $seoSurface = $this->buildSeoSurface($meta, $jsonLd, 'mbti_personality_public_detail');
@@ -141,7 +144,9 @@ class PersonalityController extends Controller
         $profile = $routeProfile['profile'];
         /** @var PersonalityProfileVariant|null $variant */
         $variant = $routeProfile['variant'];
-        $meta = $this->personalityProfileSeoService->buildMeta($profile, $variant);
+        $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
+            $this->personalityProfileSeoService->buildMeta($profile, $variant)
+        );
         $jsonLd = $this->personalityProfileSeoService->buildJsonLd($profile, $variant);
 
         return response()->json([
@@ -489,7 +494,7 @@ class PersonalityController extends Controller
             'excerpt' => $profile->excerpt,
             'hero_kicker' => $profile->hero_kicker,
             'hero_quote' => $profile->hero_quote,
-            'hero_image_url' => $profile->hero_image_url,
+            'hero_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($profile->hero_image_url),
             'status' => (string) $profile->status,
             'is_public' => (bool) $profile->is_public,
             'is_indexable' => (bool) $profile->is_indexable,
@@ -532,10 +537,10 @@ class PersonalityController extends Controller
             'canonical_url' => $this->personalityProfileSeoService->buildCanonicalUrl($profile, (string) $profile->locale, $variant),
             'og_title' => $seoMeta?->og_title,
             'og_description' => $seoMeta?->og_description,
-            'og_image_url' => $seoMeta?->og_image_url,
+            'og_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta?->og_image_url),
             'twitter_title' => $seoMeta?->twitter_title,
             'twitter_description' => $seoMeta?->twitter_description,
-            'twitter_image_url' => $seoMeta?->twitter_image_url,
+            'twitter_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta?->twitter_image_url),
             'robots' => $seoMeta?->robots,
             'jsonld_overrides_json' => $seoMeta?->jsonld_overrides_json,
         ];
@@ -554,7 +559,9 @@ class PersonalityController extends Controller
                 'robots',
             ] as $field) {
                 if ($variantSeoMeta->{$field} !== null) {
-                    $meta[$field] = $variantSeoMeta->{$field};
+                    $meta[$field] = in_array($field, ['og_image_url', 'twitter_image_url'], true)
+                        ? PublicMediaUrlGuard::sanitizeNullableUrl($variantSeoMeta->{$field})
+                        : $variantSeoMeta->{$field};
                 }
             }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
@@ -15,6 +15,7 @@ use App\Services\Cms\TopicProfileService;
 use App\Services\PublicSurface\AnswerSurfaceContractService;
 use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -85,7 +86,9 @@ final class TopicController extends Controller
             return $this->notFoundResponse('topic not found.');
         }
 
-        $meta = $this->topicProfileSeoService->buildMeta($profile, $validated['locale']);
+        $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
+            $this->topicProfileSeoService->buildMeta($profile, $validated['locale'])
+        );
         $jsonLd = $this->topicProfileSeoService->buildJsonLd($profile, $validated['locale']);
         $entryGroups = $this->topicEntryResolverService->resolveGroupedEntries($profile, $validated['locale']);
         $sections = array_map(
@@ -131,7 +134,9 @@ final class TopicController extends Controller
             return response()->json(['error' => 'not found'], 404);
         }
 
-        $meta = $this->topicProfileSeoService->buildMeta($profile, $validated['locale']);
+        $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
+            $this->topicProfileSeoService->buildMeta($profile, $validated['locale'])
+        );
         $jsonLd = $this->topicProfileSeoService->buildJsonLd($profile, $validated['locale']);
 
         return response()->json([
@@ -485,7 +490,7 @@ final class TopicController extends Controller
             'excerpt' => $profile->excerpt,
             'hero_kicker' => $profile->hero_kicker,
             'hero_quote' => $profile->hero_quote,
-            'cover_image_url' => $profile->cover_image_url,
+            'cover_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($profile->cover_image_url),
             'status' => (string) $profile->status,
             'is_public' => (bool) $profile->is_public,
             'is_indexable' => (bool) $profile->is_indexable,
@@ -526,10 +531,10 @@ final class TopicController extends Controller
             'canonical_url' => $seoMeta->canonical_url,
             'og_title' => $seoMeta->og_title,
             'og_description' => $seoMeta->og_description,
-            'og_image_url' => $seoMeta->og_image_url,
+            'og_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta->og_image_url),
             'twitter_title' => $seoMeta->twitter_title,
             'twitter_description' => $seoMeta->twitter_description,
-            'twitter_image_url' => $seoMeta->twitter_image_url,
+            'twitter_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta->twitter_image_url),
             'robots' => $seoMeta->robots,
             'jsonld_overrides_json' => $seoMeta->jsonld_overrides_json,
         ];

--- a/backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php
+++ b/backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\PersonalityCms\DesktopClone;
 
+use App\Support\PublicMediaUrlGuard;
+
 final class PersonalityDesktopCloneAssetSlotSupport
 {
     public const SLOT_ID_HERO_ILLUSTRATION = 'hero-illustration';
@@ -165,26 +167,7 @@ final class PersonalityDesktopCloneAssetSlotSupport
 
     public static function isTencentAssetUrl(?string $url): bool
     {
-        $normalized = strtolower(trim((string) $url));
-        if ($normalized === '') {
-            return false;
-        }
-
-        foreach ([
-            'myqcloud.com',
-            '.qcloud.com',
-            'qcloud',
-            'cos.',
-            'ci-process',
-            'imagemogr2',
-            'watermark',
-        ] as $marker) {
-            if (str_contains($normalized, $marker)) {
-                return true;
-            }
-        }
-
-        return false;
+        return PublicMediaUrlGuard::isBlockedUrl($url);
     }
 
     public static function normalizeSlotId(mixed $slotId): string

--- a/backend/app/Services/Cms/CareerJobService.php
+++ b/backend/app/Services/Cms/CareerJobService.php
@@ -8,6 +8,7 @@ use App\Models\CareerJob;
 use App\Models\CareerJobSection;
 use App\Models\CareerJobSeoMeta;
 use App\Models\Scopes\TenantScope;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -139,7 +140,7 @@ final class CareerJobService
             'excerpt' => $job->excerpt,
             'hero_kicker' => $job->hero_kicker,
             'hero_quote' => $job->hero_quote,
-            'cover_image_url' => $job->cover_image_url,
+            'cover_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($job->cover_image_url),
             'industry_slug' => $job->industry_slug,
             'industry_label' => $job->industry_label,
             'body_md' => $job->body_md,
@@ -184,10 +185,10 @@ final class CareerJobService
             'canonical_url' => $seoMeta->canonical_url,
             'og_title' => $seoMeta->og_title,
             'og_description' => $seoMeta->og_description,
-            'og_image_url' => $seoMeta->og_image_url,
+            'og_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta->og_image_url),
             'twitter_title' => $seoMeta->twitter_title,
             'twitter_description' => $seoMeta->twitter_description,
-            'twitter_image_url' => $seoMeta->twitter_image_url,
+            'twitter_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta->twitter_image_url),
             'robots' => $seoMeta->robots,
             'jsonld_overrides_json' => $seoMeta->jsonld_overrides_json,
         ];

--- a/backend/app/Services/Cms/TopicEntryResolverService.php
+++ b/backend/app/Services/Cms/TopicEntryResolverService.php
@@ -8,6 +8,7 @@ use App\Models\Article;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
 use App\Models\TopicProfileEntry;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Support\Facades\DB;
 
 final class TopicEntryResolverService
@@ -219,7 +220,7 @@ final class TopicEntryResolverService
                 $entry->cta_label,
                 $this->defaultCtaLabel((string) $entry->entry_type, $resolvedLocale)
             ),
-            'image_url' => $imageUrl,
+            'image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($imageUrl),
             'is_featured' => (bool) $entry->is_featured,
         ];
     }

--- a/backend/app/Support/PublicMediaUrlGuard.php
+++ b/backend/app/Support/PublicMediaUrlGuard.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class PublicMediaUrlGuard
+{
+    /**
+     * @var list<string>
+     */
+    private const BLOCKED_MARKERS = [
+        'myqcloud.com',
+        '.qcloud.com',
+        'qcloud',
+        'cos.',
+        'ci-process',
+        'imagemogr2',
+        'watermark',
+    ];
+
+    public static function sanitizeNullableUrl(mixed $url): ?string
+    {
+        $normalized = trim((string) $url);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        return self::isBlockedUrl($normalized) ? null : $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     * @param  list<string>  $keys
+     * @return array<string, mixed>|null
+     */
+    public static function sanitizeArrayFields(?array $payload, array $keys): ?array
+    {
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            if (! array_key_exists($key, $payload)) {
+                continue;
+            }
+
+            $payload[$key] = self::sanitizeNullableUrl($payload[$key]);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    public static function sanitizeSeoMeta(array $meta): array
+    {
+        if (is_array($meta['og'] ?? null)) {
+            $meta['og'] = self::sanitizeArrayFields($meta['og'], ['image']) ?? [];
+        }
+
+        if (is_array($meta['twitter'] ?? null)) {
+            $meta['twitter'] = self::sanitizeArrayFields($meta['twitter'], ['image']) ?? [];
+        }
+
+        return $meta;
+    }
+
+    public static function isBlockedUrl(?string $url): bool
+    {
+        $normalized = strtolower(trim((string) $url));
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach (self::BLOCKED_MARKERS as $marker) {
+            if (str_contains($normalized, $marker)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -174,6 +174,29 @@ final class ArticlePublicApiTest extends TestCase
         $this->assertNull(data_get($response->json(), 'meta.alternates.zh-CN'));
     }
 
+    public function test_detail_and_seo_null_blocked_media_urls(): void
+    {
+        $article = $this->createArticle([
+            'slug' => 'guarded-article',
+            'locale' => 'en',
+            'title' => 'Guarded article',
+            'cover_image_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/article.png',
+        ]);
+        $this->createSeoMeta($article, [
+            'og_image_url' => 'https://ci.example.test/article.png?ci-process=cover',
+        ]);
+
+        $this->getJson('/api/v0.5/articles/guarded-article?locale=en')
+            ->assertOk()
+            ->assertJsonPath('article.cover_image_url', null)
+            ->assertJsonPath('article.seo_meta.og_image_url', null);
+
+        $this->getJson('/api/v0.5/articles/guarded-article/seo?locale=en')
+            ->assertOk()
+            ->assertJsonPath('meta.og.image', null)
+            ->assertJsonPath('meta.twitter.image', null);
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */

--- a/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
@@ -310,6 +310,34 @@ final class CareerJobPublicApiTest extends TestCase
             ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
+    public function test_detail_and_seo_null_blocked_media_urls(): void
+    {
+        $job = $this->createJob([
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'title' => 'Product Manager',
+            'cover_image_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/job.png',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($job, [
+            'og_image_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/job-og.png',
+            'twitter_image_url' => 'https://ci.example.test/job.png?ci-process=thumb',
+        ]);
+
+        $this->getJson('/api/v0.5/career-jobs/product-manager?locale=en')
+            ->assertOk()
+            ->assertJsonPath('job.cover_image_url', null)
+            ->assertJsonPath('seo_meta.og_image_url', null)
+            ->assertJsonPath('seo_meta.twitter_image_url', null);
+
+        $this->getJson('/api/v0.5/career-jobs/product-manager/seo?locale=en')
+            ->assertOk()
+            ->assertJsonPath('meta.og.image', null)
+            ->assertJsonPath('meta.twitter.image', null);
+    }
+
     public function test_imported_local_baseline_publishes_family_jobs_for_en_and_zh_cn(): void
     {
         $this->artisan('career-jobs:import-local-baseline', [

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -259,6 +259,34 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
+    public function test_detail_and_seo_null_blocked_media_urls(): void
+    {
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ - Architect',
+            'hero_image_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/profile.png',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($profile, [
+            'og_image_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/og.png',
+            'twitter_image_url' => 'https://ci.example.test/image.png?ci-process=cover',
+        ]);
+
+        $this->getJson('/api/v0.5/personality/intj?locale=en')
+            ->assertOk()
+            ->assertJsonPath('profile.hero_image_url', null)
+            ->assertJsonPath('seo_meta.og_image_url', null)
+            ->assertJsonPath('seo_meta.twitter_image_url', null);
+
+        $this->getJson('/api/v0.5/personality/intj/seo?locale=en')
+            ->assertOk()
+            ->assertJsonPath('meta.og.image', null)
+            ->assertJsonPath('meta.twitter.image', null);
+    }
+
     public function test_seo_endpoint_returns_locale_aware_meta_and_jsonld(): void
     {
         config(['app.frontend_url' => 'https://staging.fermatmind.com']);

--- a/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
@@ -298,6 +298,72 @@ final class TopicsPublicApiTest extends TestCase
             ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
+    public function test_detail_and_seo_null_blocked_media_urls_and_entry_images(): void
+    {
+        $topic = $this->createTopicProfile([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'title' => 'MBTI',
+            'cover_image_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/topic.png',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createTopicSeoMeta($topic, [
+            'og_image_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/og.png',
+            'twitter_image_url' => 'https://ci.example.test/card.png?ci-process=thumb',
+        ]);
+
+        $article = $this->createArticle([
+            'slug' => 'mbti-article',
+            'locale' => 'en',
+            'title' => 'MBTI article',
+            'excerpt' => 'Excerpt',
+            'cover_image_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/article.png',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $personality = $this->createPersonalityProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ',
+            'hero_image_url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/personality.png',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'article',
+            'group_key' => 'articles',
+            'target_key' => (string) $article->slug,
+            'target_locale' => 'en',
+            'sort_order' => 10,
+        ]);
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'personality_profile',
+            'group_key' => 'featured',
+            'target_key' => (string) $personality->type_code,
+            'target_locale' => 'en',
+            'sort_order' => 20,
+        ]);
+
+        $this->getJson('/api/v0.5/topics/mbti?locale=en')
+            ->assertOk()
+            ->assertJsonPath('profile.cover_image_url', null)
+            ->assertJsonPath('seo_meta.og_image_url', null)
+            ->assertJsonPath('seo_meta.twitter_image_url', null)
+            ->assertJsonPath('entry_groups.articles.0.image_url', null)
+            ->assertJsonPath('entry_groups.featured.0.image_url', null);
+
+        $this->getJson('/api/v0.5/topics/mbti/seo?locale=en')
+            ->assertOk()
+            ->assertJsonPath('meta.og.image', null)
+            ->assertJsonPath('meta.twitter.image', null);
+    }
+
     public function test_resolver_skips_invalid_targets_safely(): void
     {
         $topic = $this->createTopicProfile([

--- a/backend/tests/Unit/Support/PublicMediaUrlGuardTest.php
+++ b/backend/tests/Unit/Support/PublicMediaUrlGuardTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use App\Support\PublicMediaUrlGuard;
+use PHPUnit\Framework\TestCase;
+
+final class PublicMediaUrlGuardTest extends TestCase
+{
+    public function test_sanitize_nullable_url_blocks_tencent_markers_and_keeps_safe_urls(): void
+    {
+        $this->assertNull(
+            PublicMediaUrlGuard::sanitizeNullableUrl('https://bucket.cos.ap-shanghai.myqcloud.com/path.png')
+        );
+        $this->assertNull(
+            PublicMediaUrlGuard::sanitizeNullableUrl('https://example.test/image.png?ci-process=cover')
+        );
+        $this->assertSame(
+            '/images/local-cover.png',
+            PublicMediaUrlGuard::sanitizeNullableUrl('/images/local-cover.png')
+        );
+        $this->assertSame(
+            'https://cdn.example.test/cover.png',
+            PublicMediaUrlGuard::sanitizeNullableUrl('https://cdn.example.test/cover.png')
+        );
+    }
+
+    public function test_sanitize_array_fields_only_nulls_blocked_media_fields(): void
+    {
+        $payload = PublicMediaUrlGuard::sanitizeArrayFields([
+            'og_image_url' => 'https://bucket.cos.ap-shanghai.myqcloud.com/og.png',
+            'twitter_image_url' => 'https://cdn.example.test/twitter.png',
+            'title' => 'SEO',
+        ], ['og_image_url', 'twitter_image_url']);
+
+        $this->assertSame([
+            'og_image_url' => null,
+            'twitter_image_url' => 'https://cdn.example.test/twitter.png',
+            'title' => 'SEO',
+        ], $payload);
+    }
+}


### PR DESCRIPTION
## What changed
- add a small shared `PublicMediaUrlGuard` for public media fields
- guard `hero_image_url`, `cover_image_url`, `og_image_url`, `twitter_image_url`, and topic-entry `image_url` before they leave the public API
- apply the guard to personality, topics, articles, and career job public detail/seo responses
- reuse the same blocked-host logic in desktop-clone asset-slot filtering to avoid drift
- add focused unit and public API feature coverage for blocked Tencent-style media URLs

## Why
The current public responses are clean because the underlying DB values are currently clean or null, not because the API output layer was defensive. These surfaces were still largely passing media fields through from DB values. This change makes the public API resilient if CMS or database content reintroduces Tencent-style or other blocked media URLs later.

## Validation commands
- `php -l backend/app/Support/PublicMediaUrlGuard.php`
- `php -l backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php`
- `php -l backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php`
- `php -l backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php`
- `php -l backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php`
- `php -l backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php`
- `php -l backend/app/Services/Cms/CareerJobService.php`
- `php -l backend/app/Services/Cms/TopicEntryResolverService.php`
- `cd backend && php artisan test tests/Unit/Support/PublicMediaUrlGuardTest.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/V0_5/TopicsPublicApiTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/V0_5/CareerJobPublicApiTest.php`

## Intentionally deferred items
- no database or CMS data cleanup
- no provider/storage migration work
- no frontend placeholder or non-core media UX changes
- no broad allowlist policy for all external hosts beyond the blocked Tencent-style markers in this PR
