### PR TITLE
PR-B36: Career first-wave next-step links authority API

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveNextStepLinksSummary.php
+++ b/backend/app/DTO/Career/CareerFirstWaveNextStepLinksSummary.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveNextStepLinksSummary
+{
+    /**
+     * @param  array<string, mixed>  $subjectIdentity
+     * @param  array<string, int>  $counts
+     * @param  list<array<string, mixed>>  $nextStepLinks
+     */
+    public function __construct(
+        public readonly string $summaryVersion,
+        public readonly string $scope,
+        public readonly array $subjectIdentity,
+        public readonly array $counts,
+        public readonly array $nextStepLinks,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'summary_kind' => 'career_first_wave_next_step_links',
+            'summary_version' => $this->summaryVersion,
+            'scope' => $this->scope,
+            'subject_kind' => 'occupation',
+            'subject_identity' => $this->subjectIdentity,
+            'counts' => $this->counts,
+            'next_step_links' => $this->nextStepLinks,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveNextStepLinksSummary;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+
+final class CareerFirstWaveNextStepLinksService
+{
+    public const SUMMARY_VERSION = 'career.next_step.first_wave.v1';
+
+    public const SCOPE = 'career_first_wave_10';
+
+    public function __construct(
+        private readonly CareerFirstWaveDiscoverabilityManifestService $discoverabilityManifestService,
+    ) {}
+
+    public function buildBySlug(string $slug): ?CareerFirstWaveNextStepLinksSummary
+    {
+        $normalizedSlug = trim($slug);
+        if ($normalizedSlug === '') {
+            return null;
+        }
+
+        $subject = Occupation::query()
+            ->with('family')
+            ->where('canonical_slug', $normalizedSlug)
+            ->first();
+
+        if (! $subject instanceof Occupation) {
+            return null;
+        }
+
+        $manifest = $this->discoverabilityManifestService->build()->toArray();
+        $routes = collect((array) ($manifest['routes'] ?? []))
+            ->filter(static fn (mixed $row): bool => is_array($row));
+
+        $jobRoutes = $routes
+            ->where('route_kind', 'career_job_detail')
+            ->keyBy(static fn (array $row): string => (string) ($row['canonical_slug'] ?? ''));
+
+        if (! $jobRoutes->has($subject->canonical_slug)) {
+            return null;
+        }
+
+        $nextStepLinks = [];
+
+        $family = $subject->family;
+        if ($family instanceof OccupationFamily) {
+            $familyRoute = $routes
+                ->first(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub'
+                    && ($row['canonical_slug'] ?? null) === $family->canonical_slug
+                    && ($row['discoverability_state'] ?? null) === 'discoverable');
+
+            if (is_array($familyRoute)) {
+                $nextStepLinks[] = [
+                    'route_kind' => 'career_family_hub',
+                    'canonical_path' => (string) ($familyRoute['canonical_path'] ?? '/career/family/'.$family->canonical_slug),
+                    'canonical_slug' => (string) $family->canonical_slug,
+                    'link_reason_code' => 'family_hub_discoverable',
+                    'family_uuid' => (string) $family->id,
+                    'title_en' => (string) $family->title_en,
+                ];
+            }
+
+            $siblings = Occupation::query()
+                ->where('family_id', $family->id)
+                ->whereKeyNot($subject->id)
+                ->orderBy('canonical_title_en')
+                ->orderBy('canonical_slug')
+                ->get();
+
+            foreach ($siblings as $sibling) {
+                $route = $jobRoutes->get((string) $sibling->canonical_slug);
+                if (! is_array($route) || ($route['discoverability_state'] ?? null) !== 'discoverable') {
+                    continue;
+                }
+
+                $nextStepLinks[] = [
+                    'route_kind' => 'career_job_detail',
+                    'canonical_path' => (string) ($route['canonical_path'] ?? '/career/jobs/'.$sibling->canonical_slug),
+                    'canonical_slug' => (string) $sibling->canonical_slug,
+                    'link_reason_code' => 'same_family_sibling_discoverable',
+                    'occupation_uuid' => (string) $sibling->id,
+                    'canonical_title_en' => (string) $sibling->canonical_title_en,
+                ];
+            }
+        }
+
+        $dedupedLinks = collect($nextStepLinks)
+            ->unique(static fn (array $row): string => sprintf(
+                '%s|%s|%s',
+                (string) ($row['route_kind'] ?? ''),
+                (string) ($row['canonical_path'] ?? ''),
+                (string) ($row['canonical_slug'] ?? '')
+            ))
+            ->sortBy(static fn (array $row): array => [
+                strtolower((string) ($row['route_kind'] ?? '')),
+                strtolower((string) ($row['canonical_path'] ?? '')),
+            ])
+            ->values()
+            ->all();
+
+        $counts = [
+            'total' => count($dedupedLinks),
+            'job_detail' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_job_detail')),
+            'family_hub' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub')),
+        ];
+
+        return new CareerFirstWaveNextStepLinksSummary(
+            summaryVersion: self::SUMMARY_VERSION,
+            scope: self::SCOPE,
+            subjectIdentity: [
+                'occupation_uuid' => (string) $subject->id,
+                'canonical_slug' => (string) $subject->canonical_slug,
+                'canonical_title_en' => (string) $subject->canonical_title_en,
+            ],
+            counts: $counts,
+            nextStepLinks: $dedupedLinks,
+        );
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveNextStepLinksController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveNextStepLinksController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveNextStepLinksService;
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerFirstWaveNextStepLinksSummaryResource;
+use Illuminate\Http\JsonResponse;
+
+final class CareerFirstWaveNextStepLinksController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerFirstWaveNextStepLinksService $summaryService,
+    ) {}
+
+    public function show(string $slug): JsonResponse|CareerFirstWaveNextStepLinksSummaryResource
+    {
+        $summary = $this->summaryService->buildBySlug($slug);
+
+        if ($summary === null) {
+            return $this->notFoundResponse('career next-step links unavailable.');
+        }
+
+        return new CareerFirstWaveNextStepLinksSummaryResource($summary);
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerFirstWaveNextStepLinksSummaryResource.php
+++ b/backend/app/Http/Resources/Career/CareerFirstWaveNextStepLinksSummaryResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerFirstWaveNextStepLinksSummary;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerFirstWaveNextStepLinksSummary
+ */
+final class CareerFirstWaveNextStepLinksSummaryResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerFirstWaveNextStepLinksSummary $summary */
+        $summary = $this->resource;
+
+        return $summary->toArray();
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2396,6 +2396,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/first-wave/jobs/{slug}/next-step-links": {
+            "get": {
+                "operationId": "get_api_v0_5_career_first_wave_jobs_slug_next_step_links",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerFirstWaveNextStepLinksController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/first-wave/launch-tier": {
             "get": {
                 "operationId": "get_api_v0_5_career_first_wave_launch_tier",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -35,6 +35,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerFamilyHubController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveDiscoverabilityManifestController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLaunchTierController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLifecycleController;
+use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveNextStepLinksController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveRolloutQueueController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
@@ -412,6 +413,7 @@ Route::prefix('v0.5')->group(function () {
     Route::post('/career/attribution/events', [CareerAttributionEventController::class, 'store']);
     Route::get('/career/family/{slug}', [CareerFamilyHubController::class, 'show']);
     Route::get('/career/first-wave/discoverability-manifest', [CareerFirstWaveDiscoverabilityManifestController::class, 'show']);
+    Route::get('/career/first-wave/jobs/{slug}/next-step-links', [CareerFirstWaveNextStepLinksController::class, 'show']);
     Route::get('/career/first-wave/launch-tier', [CareerFirstWaveLaunchTierController::class, 'show']);
     Route::get('/career/resolve', [CareerAliasResolutionController::class, 'show']);
     Route::get('/career/first-wave/lifecycle', [CareerFirstWaveLifecycleController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerFirstWaveNextStepLinksApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveNextStepLinksApiTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveNextStepLinksService;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerFirstWaveNextStepLinksApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_exposes_a_first_wave_next_step_links_summary_for_supported_route_kinds_only(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/jobs/accountants-and-auditors/next-step-links');
+
+        $response->assertOk()
+            ->assertJsonPath('summary_kind', 'career_first_wave_next_step_links')
+            ->assertJsonPath('summary_version', CareerFirstWaveNextStepLinksService::SUMMARY_VERSION)
+            ->assertJsonPath('scope', CareerFirstWaveNextStepLinksService::SCOPE)
+            ->assertJsonPath('subject_kind', 'occupation')
+            ->assertJsonPath('subject_identity.canonical_slug', 'accountants-and-auditors')
+            ->assertJsonPath('counts.total', 3)
+            ->assertJsonPath('counts.job_detail', 2)
+            ->assertJsonPath('counts.family_hub', 1)
+            ->assertJsonStructure([
+                'summary_kind',
+                'summary_version',
+                'scope',
+                'subject_kind',
+                'subject_identity' => ['occupation_uuid', 'canonical_slug', 'canonical_title_en'],
+                'counts' => ['total', 'job_detail', 'family_hub'],
+                'next_step_links' => [[
+                    'route_kind',
+                    'canonical_path',
+                    'canonical_slug',
+                    'link_reason_code',
+                ]],
+            ])
+            ->assertJsonMissingPath('recommended_action')
+            ->assertJsonMissingPath('why_this_path');
+
+        $links = collect($response->json('next_step_links'));
+
+        $this->assertSame(
+            ['career_family_hub', 'career_job_detail'],
+            $links->pluck('route_kind')->unique()->sort()->values()->all()
+        );
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/recommendations')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => (string) ($row['canonical_path'] ?? '') === '/career/jobs/accountants-and-auditors'));
+    }
+
+    public function test_it_returns_not_found_for_unknown_or_out_of_scope_occupation_slugs(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'non-first-wave-occupation-api',
+        ]);
+
+        $this->getJson('/api/v0.5/career/first-wave/jobs/unknown-occupation/next-step-links')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/career/first-wave/jobs/non-first-wave-occupation-api/next-step-links')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_it_excludes_undiscoverable_family_hubs_from_the_next_step_counts(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $blockedFamily = OccupationFamily::query()->create([
+            'canonical_slug' => 'blocked-next-step-family-api',
+            'title_en' => 'Blocked Next Step Family API',
+            'title_zh' => '受限下一步家族 API',
+        ]);
+
+        $subject = Occupation::query()->where('canonical_slug', 'registered-nurses')->firstOrFail();
+        $subject->update([
+            'family_id' => $blockedFamily->id,
+            'crosswalk_mode' => 'family_proxy',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/jobs/registered-nurses/next-step-links')
+            ->assertOk()
+            ->assertJsonPath('counts.family_hub', 0);
+
+        $links = collect($response->json('next_step_links'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveNextStepLinksServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveNextStepLinksServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveNextStepLinksService;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerFirstWaveNextStepLinksServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_machine_safe_next_step_links_for_a_first_wave_occupation(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $summary = app(CareerFirstWaveNextStepLinksService::class)->buildBySlug('accountants-and-auditors')?->toArray();
+
+        $this->assertIsArray($summary);
+        $this->assertSame('career_first_wave_next_step_links', $summary['summary_kind']);
+        $this->assertSame(CareerFirstWaveNextStepLinksService::SUMMARY_VERSION, $summary['summary_version']);
+        $this->assertSame(CareerFirstWaveNextStepLinksService::SCOPE, $summary['scope']);
+        $this->assertSame('occupation', $summary['subject_kind']);
+        $this->assertSame('accountants-and-auditors', data_get($summary, 'subject_identity.canonical_slug'));
+        $this->assertSame(3, data_get($summary, 'counts.total'));
+        $this->assertSame(2, data_get($summary, 'counts.job_detail'));
+        $this->assertSame(1, data_get($summary, 'counts.family_hub'));
+
+        $links = collect($summary['next_step_links']);
+
+        $familyLink = $links->firstWhere('route_kind', 'career_family_hub');
+        $siblingLink = $links->firstWhere('route_kind', 'career_job_detail');
+
+        $this->assertSame('/career/family/business-and-financial-37ec69bd', $familyLink['canonical_path']);
+        $this->assertSame('business-and-financial-37ec69bd', $familyLink['canonical_slug']);
+        $this->assertSame('family_hub_discoverable', $familyLink['link_reason_code']);
+
+        $this->assertContains($siblingLink['canonical_slug'], ['human-resources-specialists', 'project-management-specialists']);
+        $this->assertSame('same_family_sibling_discoverable', $siblingLink['link_reason_code']);
+    }
+
+    public function test_it_excludes_self_transition_targets_and_undiscoverable_routes(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $blockedFamily = OccupationFamily::query()->create([
+            'canonical_slug' => 'blocked-next-step-family',
+            'title_en' => 'Blocked Next Step Family',
+            'title_zh' => '受限下一步家族',
+        ]);
+
+        $subject = Occupation::query()->where('canonical_slug', 'registered-nurses')->firstOrFail();
+        $subject->update([
+            'family_id' => $blockedFamily->id,
+            'crosswalk_mode' => 'family_proxy',
+        ]);
+
+        $summary = app(CareerFirstWaveNextStepLinksService::class)->buildBySlug('registered-nurses')?->toArray();
+
+        $this->assertIsArray($summary);
+
+        $links = collect($summary['next_step_links']);
+
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'registered-nurses'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'blocked-next-step-family'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'software-developers'));
+        $this->assertSame(0, data_get($summary, 'counts.family_hub'));
+    }
+
+    public function test_it_returns_null_for_unknown_or_out_of_scope_occupation_slugs(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'non-first-wave-occupation',
+        ]);
+
+        $service = app(CareerFirstWaveNextStepLinksService::class);
+
+        $this->assertNull($service->buildBySlug('unknown-occupation'));
+        $this->assertNull($service->buildBySlug('non-first-wave-occupation'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated first-wave next-step links summary service that builds a narrow, machine-safe per-occupation route graph from backend authority
- add a read-only v0.5 API for next-step links with explicit counts and route rows limited to `career_family_hub` and `career_job_detail`
- add focused unit and feature coverage for family hub discoverability links, discoverable same-family sibling job links, self exclusion, out-of-scope exclusion, and regression safety against existing family, transition preview, launch-tier, and discoverability contracts

## Why
- backend already had the authority ingredients for a conservative next-step graph, but no dedicated per-occupation surface to expose it
- downstream consumers need a backend-owned answer to “real next-step links” without conflating it with discoverability manifest, transition preview, or strategy guidance
- this keeps the graph narrow and machine-safe by only counting discoverable family hubs and discoverable same-family sibling job routes

## Validation
- `vendor/bin/pint --test app/DTO/Career/CareerFirstWaveNextStepLinksSummary.php app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveNextStepLinksController.php app/Http/Resources/Career/CareerFirstWaveNextStepLinksSummaryResource.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveNextStepLinksServiceTest.php tests/Feature/Career/CareerFirstWaveNextStepLinksApiTest.php docs/contracts/openapi.snapshot.json`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveNextStepLinksServiceTest.php tests/Feature/Career/CareerFirstWaveNextStepLinksApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no transition-preview-derived links
- no recommendation/search/alias/editorial route graph
- no action semantics
- no frontend changes
- no broader-than-first-wave route graph
