### PR TITLE
PR-B37: Career occupation companion-links authority API

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveOccupationCompanionLinksSummary.php
+++ b/backend/app/DTO/Career/CareerFirstWaveOccupationCompanionLinksSummary.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveOccupationCompanionLinksSummary
+{
+    /**
+     * @param  array<string, mixed>  $subjectIdentity
+     * @param  array<string, int>  $counts
+     * @param  list<array<string, mixed>>  $companionLinks
+     */
+    public function __construct(
+        public readonly string $summaryVersion,
+        public readonly string $scope,
+        public readonly array $subjectIdentity,
+        public readonly array $counts,
+        public readonly array $companionLinks,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'summary_kind' => 'career_first_wave_companion_links',
+            'summary_version' => $this->summaryVersion,
+            'scope' => $this->scope,
+            'subject_kind' => 'occupation',
+            'subject_identity' => $this->subjectIdentity,
+            'counts' => $this->counts,
+            'companion_links' => $this->companionLinks,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveOccupationCompanionLinksService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveOccupationCompanionLinksService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveOccupationCompanionLinksSummary;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+
+final class CareerFirstWaveOccupationCompanionLinksService
+{
+    public const SUMMARY_VERSION = 'career.companion.first_wave.v1';
+
+    public const SCOPE = 'career_first_wave_10';
+
+    public function __construct(
+        private readonly CareerFirstWaveDiscoverabilityManifestService $discoverabilityManifestService,
+    ) {}
+
+    public function buildBySlug(string $slug): ?CareerFirstWaveOccupationCompanionLinksSummary
+    {
+        $normalizedSlug = trim($slug);
+        if ($normalizedSlug === '') {
+            return null;
+        }
+
+        $subject = Occupation::query()
+            ->with('family')
+            ->where('canonical_slug', $normalizedSlug)
+            ->first();
+
+        if (! $subject instanceof Occupation) {
+            return null;
+        }
+
+        $manifest = $this->discoverabilityManifestService->build()->toArray();
+        $routes = collect((array) ($manifest['routes'] ?? []))
+            ->filter(static fn (mixed $row): bool => is_array($row));
+
+        $jobRoutes = $routes
+            ->where('route_kind', 'career_job_detail')
+            ->keyBy(static fn (array $row): string => (string) ($row['canonical_slug'] ?? ''));
+
+        if (! $jobRoutes->has($subject->canonical_slug)) {
+            return null;
+        }
+
+        $companionLinks = [];
+
+        $family = $subject->family;
+        if ($family instanceof OccupationFamily) {
+            $familyRoute = $routes
+                ->first(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub'
+                    && ($row['canonical_slug'] ?? null) === $family->canonical_slug
+                    && ($row['discoverability_state'] ?? null) === 'discoverable');
+
+            if (is_array($familyRoute)) {
+                $companionLinks[] = [
+                    'route_kind' => 'career_family_hub',
+                    'canonical_path' => (string) ($familyRoute['canonical_path'] ?? '/career/family/'.$family->canonical_slug),
+                    'canonical_slug' => (string) $family->canonical_slug,
+                    'link_reason_code' => 'family_hub_companion',
+                    'family_uuid' => (string) $family->id,
+                    'title_en' => (string) $family->title_en,
+                ];
+            }
+
+            $siblings = Occupation::query()
+                ->where('family_id', $family->id)
+                ->whereKeyNot($subject->id)
+                ->orderBy('canonical_title_en')
+                ->orderBy('canonical_slug')
+                ->get();
+
+            foreach ($siblings as $sibling) {
+                $route = $jobRoutes->get((string) $sibling->canonical_slug);
+                if (! is_array($route) || ($route['discoverability_state'] ?? null) !== 'discoverable') {
+                    continue;
+                }
+
+                $companionLinks[] = [
+                    'route_kind' => 'career_job_detail',
+                    'canonical_path' => (string) ($route['canonical_path'] ?? '/career/jobs/'.$sibling->canonical_slug),
+                    'canonical_slug' => (string) $sibling->canonical_slug,
+                    'link_reason_code' => 'same_family_job_companion',
+                    'occupation_uuid' => (string) $sibling->id,
+                    'canonical_title_en' => (string) $sibling->canonical_title_en,
+                ];
+            }
+        }
+
+        $dedupedLinks = collect($companionLinks)
+            ->unique(static fn (array $row): string => sprintf(
+                '%s|%s|%s',
+                (string) ($row['route_kind'] ?? ''),
+                (string) ($row['canonical_path'] ?? ''),
+                (string) ($row['canonical_slug'] ?? '')
+            ))
+            ->sortBy(static fn (array $row): array => [
+                strtolower((string) ($row['route_kind'] ?? '')),
+                strtolower((string) ($row['canonical_path'] ?? '')),
+            ])
+            ->values()
+            ->all();
+
+        $counts = [
+            'total' => count($dedupedLinks),
+            'job_detail' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_job_detail')),
+            'family_hub' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub')),
+        ];
+
+        return new CareerFirstWaveOccupationCompanionLinksSummary(
+            summaryVersion: self::SUMMARY_VERSION,
+            scope: self::SCOPE,
+            subjectIdentity: [
+                'occupation_uuid' => (string) $subject->id,
+                'canonical_slug' => (string) $subject->canonical_slug,
+                'canonical_title_en' => (string) $subject->canonical_title_en,
+            ],
+            counts: $counts,
+            companionLinks: $dedupedLinks,
+        );
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveOccupationCompanionLinksController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveOccupationCompanionLinksController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveOccupationCompanionLinksService;
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerFirstWaveOccupationCompanionLinksSummaryResource;
+use Illuminate\Http\JsonResponse;
+
+final class CareerFirstWaveOccupationCompanionLinksController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerFirstWaveOccupationCompanionLinksService $summaryService,
+    ) {}
+
+    public function show(string $slug): JsonResponse|CareerFirstWaveOccupationCompanionLinksSummaryResource
+    {
+        $summary = $this->summaryService->buildBySlug($slug);
+
+        if ($summary === null) {
+            return $this->notFoundResponse('career companion links unavailable.');
+        }
+
+        return new CareerFirstWaveOccupationCompanionLinksSummaryResource($summary);
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerFirstWaveOccupationCompanionLinksSummaryResource.php
+++ b/backend/app/Http/Resources/Career/CareerFirstWaveOccupationCompanionLinksSummaryResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerFirstWaveOccupationCompanionLinksSummary;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerFirstWaveOccupationCompanionLinksSummary
+ */
+final class CareerFirstWaveOccupationCompanionLinksSummaryResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerFirstWaveOccupationCompanionLinksSummary $summary */
+        $summary = $this->resource;
+
+        return $summary->toArray();
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2396,6 +2396,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/first-wave/jobs/{slug}/companion-links": {
+            "get": {
+                "operationId": "get_api_v0_5_career_first_wave_jobs_slug_companion_links",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerFirstWaveOccupationCompanionLinksController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/first-wave/jobs/{slug}/next-step-links": {
             "get": {
                 "operationId": "get_api_v0_5_career_first_wave_jobs_slug_next_step_links",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -36,6 +36,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveDiscoverabilityManifestC
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLaunchTierController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLifecycleController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveNextStepLinksController;
+use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveOccupationCompanionLinksController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveRolloutQueueController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
@@ -414,6 +415,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/family/{slug}', [CareerFamilyHubController::class, 'show']);
     Route::get('/career/first-wave/discoverability-manifest', [CareerFirstWaveDiscoverabilityManifestController::class, 'show']);
     Route::get('/career/first-wave/jobs/{slug}/next-step-links', [CareerFirstWaveNextStepLinksController::class, 'show']);
+    Route::get('/career/first-wave/jobs/{slug}/companion-links', [CareerFirstWaveOccupationCompanionLinksController::class, 'show']);
     Route::get('/career/first-wave/launch-tier', [CareerFirstWaveLaunchTierController::class, 'show']);
     Route::get('/career/resolve', [CareerAliasResolutionController::class, 'show']);
     Route::get('/career/first-wave/lifecycle', [CareerFirstWaveLifecycleController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerFirstWaveOccupationCompanionLinksApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveOccupationCompanionLinksApiTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveOccupationCompanionLinksService;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerFirstWaveOccupationCompanionLinksApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_exposes_a_first_wave_occupation_companion_links_summary_for_supported_route_kinds_only(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/jobs/accountants-and-auditors/companion-links');
+
+        $response->assertOk()
+            ->assertJsonPath('summary_kind', 'career_first_wave_companion_links')
+            ->assertJsonPath('summary_version', CareerFirstWaveOccupationCompanionLinksService::SUMMARY_VERSION)
+            ->assertJsonPath('scope', CareerFirstWaveOccupationCompanionLinksService::SCOPE)
+            ->assertJsonPath('subject_kind', 'occupation')
+            ->assertJsonPath('subject_identity.canonical_slug', 'accountants-and-auditors')
+            ->assertJsonPath('counts.total', 3)
+            ->assertJsonPath('counts.job_detail', 2)
+            ->assertJsonPath('counts.family_hub', 1)
+            ->assertJsonStructure([
+                'summary_kind',
+                'summary_version',
+                'scope',
+                'subject_kind',
+                'subject_identity' => ['occupation_uuid', 'canonical_slug', 'canonical_title_en'],
+                'counts' => ['total', 'job_detail', 'family_hub'],
+                'companion_links' => [[
+                    'route_kind',
+                    'canonical_path',
+                    'canonical_slug',
+                    'link_reason_code',
+                ]],
+            ])
+            ->assertJsonMissingPath('recommended_action')
+            ->assertJsonMissingPath('why_this_path');
+
+        $links = collect($response->json('companion_links'));
+
+        $this->assertSame(
+            ['career_family_hub', 'career_job_detail'],
+            $links->pluck('route_kind')->unique()->sort()->values()->all()
+        );
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/recommendations')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/search')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/career/tests/')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/topics/')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => (string) ($row['canonical_path'] ?? '') === '/career/jobs/accountants-and-auditors'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'software-developers'));
+    }
+
+    public function test_it_returns_not_found_for_unknown_or_out_of_scope_occupation_slugs(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'non-first-wave-occupation-companion-api',
+        ]);
+
+        $this->getJson('/api/v0.5/career/first-wave/jobs/unknown-occupation/companion-links')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/career/first-wave/jobs/non-first-wave-occupation-companion-api/companion-links')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_it_excludes_undiscoverable_family_hubs_from_the_companion_counts(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $blockedFamily = OccupationFamily::query()->create([
+            'canonical_slug' => 'blocked-companion-family-api',
+            'title_en' => 'Blocked Companion Family API',
+            'title_zh' => '受限 companion 家族 API',
+        ]);
+
+        $subject = Occupation::query()->where('canonical_slug', 'registered-nurses')->firstOrFail();
+        $subject->update([
+            'family_id' => $blockedFamily->id,
+            'crosswalk_mode' => 'family_proxy',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/jobs/registered-nurses/companion-links')
+            ->assertOk()
+            ->assertJsonPath('counts.family_hub', 0);
+
+        $links = collect($response->json('companion_links'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveOccupationCompanionLinksServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveOccupationCompanionLinksServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveOccupationCompanionLinksService;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerFirstWaveOccupationCompanionLinksServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_machine_safe_companion_links_for_a_first_wave_occupation(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $summary = app(CareerFirstWaveOccupationCompanionLinksService::class)->buildBySlug('accountants-and-auditors')?->toArray();
+
+        $this->assertIsArray($summary);
+        $this->assertSame('career_first_wave_companion_links', $summary['summary_kind']);
+        $this->assertSame(CareerFirstWaveOccupationCompanionLinksService::SUMMARY_VERSION, $summary['summary_version']);
+        $this->assertSame(CareerFirstWaveOccupationCompanionLinksService::SCOPE, $summary['scope']);
+        $this->assertSame('occupation', $summary['subject_kind']);
+        $this->assertSame('accountants-and-auditors', data_get($summary, 'subject_identity.canonical_slug'));
+        $this->assertSame(3, data_get($summary, 'counts.total'));
+        $this->assertSame(2, data_get($summary, 'counts.job_detail'));
+        $this->assertSame(1, data_get($summary, 'counts.family_hub'));
+
+        $links = collect($summary['companion_links']);
+        $familyLink = $links->firstWhere('route_kind', 'career_family_hub');
+        $jobLinks = $links->where('route_kind', 'career_job_detail')->values();
+
+        $this->assertSame('/career/family/business-and-financial-37ec69bd', $familyLink['canonical_path']);
+        $this->assertSame('business-and-financial-37ec69bd', $familyLink['canonical_slug']);
+        $this->assertSame('family_hub_companion', $familyLink['link_reason_code']);
+
+        $this->assertCount(2, $jobLinks);
+        $this->assertSame(
+            ['human-resources-specialists', 'project-management-specialists'],
+            $jobLinks->pluck('canonical_slug')->sort()->values()->all()
+        );
+        $this->assertTrue($jobLinks->every(static fn (array $row): bool => ($row['link_reason_code'] ?? null) === 'same_family_job_companion'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/recommendations')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/search')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'software-developers'));
+    }
+
+    public function test_it_excludes_self_and_undiscoverable_family_routes(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $blockedFamily = OccupationFamily::query()->create([
+            'canonical_slug' => 'blocked-companion-family',
+            'title_en' => 'Blocked Companion Family',
+            'title_zh' => '受限 companion 家族',
+        ]);
+
+        $subject = Occupation::query()->where('canonical_slug', 'registered-nurses')->firstOrFail();
+        $subject->update([
+            'family_id' => $blockedFamily->id,
+            'crosswalk_mode' => 'family_proxy',
+        ]);
+
+        $summary = app(CareerFirstWaveOccupationCompanionLinksService::class)->buildBySlug('registered-nurses')?->toArray();
+
+        $this->assertIsArray($summary);
+
+        $links = collect($summary['companion_links']);
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'registered-nurses'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'blocked-companion-family'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'software-developers'));
+        $this->assertSame(0, data_get($summary, 'counts.family_hub'));
+    }
+
+    public function test_it_returns_null_for_unknown_or_out_of_scope_occupation_slugs(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'non-first-wave-occupation-companion',
+        ]);
+
+        $service = app(CareerFirstWaveOccupationCompanionLinksService::class);
+
+        $this->assertNull($service->buildBySlug('unknown-occupation'));
+        $this->assertNull($service->buildBySlug('non-first-wave-occupation-companion'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated first-wave occupation companion-links authority service that projects a machine-safe per-occupation cross-surface graph from backend-owned discoverability truth
- add a read-only v0.5 API for occupation companion links with explicit counts and route rows limited to `career_family_hub` and `career_job_detail`
- add focused unit and feature coverage for family companion inclusion, same-family discoverable job companions, self exclusion, unsupported route exclusion, and regression safety against existing family hub, transition preview, discoverability manifest, and next-step contracts

## Why
- backend already had the authority ingredients for a narrow occupation companion-links graph, but no dedicated surface to expose it
- downstream consumers need a backend-owned answer to cross-surface companion routes without conflating it with discoverability manifest, next-step links, transition preview, or recommendation guidance
- this keeps the graph deliberately narrow and machine-safe by only counting discoverable family hubs and discoverable same-family sibling job routes for occupation subjects

## Validation
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveOccupationCompanionLinksService.php app/DTO/Career/CareerFirstWaveOccupationCompanionLinksSummary.php app/Http/Resources/Career/CareerFirstWaveOccupationCompanionLinksSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveOccupationCompanionLinksController.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveOccupationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveOccupationCompanionLinksApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveOccupationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveOccupationCompanionLinksApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php tests/Feature/Career/CareerFirstWaveNextStepLinksApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no recommendation-subject support
- no transition-preview-derived companion links
- no tests/topic/search/alias/editorial route kinds
- no frontend changes
- no broader-than-first-wave companion graph
