### PR TITLE
PR-B38: Career recommendation-detail companion-links authority API

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php
+++ b/backend/app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveRecommendationCompanionLinksSummary
+{
+    /**
+     * @param  array<string, mixed>  $subjectIdentity
+     * @param  array<string, int>  $counts
+     * @param  list<array<string, mixed>>  $companionLinks
+     */
+    public function __construct(
+        public readonly string $summaryVersion,
+        public readonly string $scope,
+        public readonly array $subjectIdentity,
+        public readonly array $counts,
+        public readonly array $companionLinks,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'summary_kind' => 'career_first_wave_recommendation_companion_links',
+            'summary_version' => $this->summaryVersion,
+            'scope' => $this->scope,
+            'subject_kind' => 'recommendation_subject',
+            'subject_identity' => $this->subjectIdentity,
+            'counts' => $this->counts,
+            'companion_links' => $this->companionLinks,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveRecommendationCompanionLinksSummary;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use App\Services\Career\Bundles\CareerRecommendationDetailBundleBuilder;
+
+final class CareerFirstWaveRecommendationCompanionLinksService
+{
+    public const SUMMARY_VERSION = 'career.companion.recommendation.first_wave.v1';
+
+    public const SCOPE = 'career_first_wave_10';
+
+    public function __construct(
+        private readonly CareerRecommendationDetailBundleBuilder $recommendationDetailBundleBuilder,
+        private readonly CareerFirstWaveDiscoverabilityManifestService $discoverabilityManifestService,
+    ) {}
+
+    public function buildByType(string $type): ?CareerFirstWaveRecommendationCompanionLinksSummary
+    {
+        $normalizedType = trim($type);
+        if ($normalizedType === '') {
+            return null;
+        }
+
+        $bundle = $this->recommendationDetailBundleBuilder->buildByType($normalizedType);
+        if ($bundle === null) {
+            return null;
+        }
+
+        $bundlePayload = $bundle->toArray();
+        $subjectMeta = is_array($bundlePayload['recommendation_subject_meta'] ?? null)
+            ? $bundlePayload['recommendation_subject_meta']
+            : [];
+
+        $publicRouteSlug = $this->normalizeRecommendationRouteSlug($subjectMeta);
+        if ($publicRouteSlug === null) {
+            return null;
+        }
+
+        $targetSlug = trim((string) data_get($bundlePayload, 'identity.canonical_slug', ''));
+        if ($targetSlug === '') {
+            return null;
+        }
+
+        $targetOccupation = Occupation::query()
+            ->with('family')
+            ->where('canonical_slug', $targetSlug)
+            ->first();
+
+        if (! $targetOccupation instanceof Occupation) {
+            return null;
+        }
+
+        $manifest = $this->discoverabilityManifestService->build()->toArray();
+        $routes = collect((array) ($manifest['routes'] ?? []))
+            ->filter(static fn (mixed $row): bool => is_array($row));
+
+        $discoverableJobRoutes = $routes
+            ->filter(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_job_detail'
+                && ($row['discoverability_state'] ?? null) === 'discoverable')
+            ->keyBy(static fn (array $row): string => (string) ($row['canonical_slug'] ?? ''));
+
+        $companionLinks = [];
+
+        $targetJobRoute = $discoverableJobRoutes->get($targetSlug);
+        if (is_array($targetJobRoute)) {
+            $companionLinks[] = [
+                'route_kind' => 'career_job_detail',
+                'canonical_path' => (string) ($targetJobRoute['canonical_path'] ?? '/career/jobs/'.$targetSlug),
+                'canonical_slug' => $targetSlug,
+                'link_reason_code' => 'target_job_detail_companion',
+                'occupation_uuid' => (string) $targetOccupation->id,
+                'canonical_title_en' => (string) $targetOccupation->canonical_title_en,
+            ];
+        }
+
+        $family = $targetOccupation->family;
+        if ($family instanceof OccupationFamily) {
+            $familyRoute = $routes->first(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub'
+                && ($row['canonical_slug'] ?? null) === $family->canonical_slug
+                && ($row['discoverability_state'] ?? null) === 'discoverable');
+
+            if (is_array($familyRoute)) {
+                $companionLinks[] = [
+                    'route_kind' => 'career_family_hub',
+                    'canonical_path' => (string) ($familyRoute['canonical_path'] ?? '/career/family/'.$family->canonical_slug),
+                    'canonical_slug' => (string) $family->canonical_slug,
+                    'link_reason_code' => 'target_family_hub_companion',
+                    'family_uuid' => (string) $family->id,
+                    'title_en' => (string) $family->title_en,
+                ];
+            }
+        }
+
+        $matchedJobs = collect((array) ($bundlePayload['matched_jobs'] ?? []))
+            ->filter(static fn (mixed $row): bool => is_array($row));
+
+        foreach ($matchedJobs as $matchedJob) {
+            $matchedSlug = trim((string) ($matchedJob['canonical_slug'] ?? ''));
+            if ($matchedSlug === '') {
+                continue;
+            }
+
+            $route = $discoverableJobRoutes->get($matchedSlug);
+            if (! is_array($route)) {
+                continue;
+            }
+
+            $companionLinks[] = [
+                'route_kind' => 'career_job_detail',
+                'canonical_path' => (string) ($route['canonical_path'] ?? '/career/jobs/'.$matchedSlug),
+                'canonical_slug' => $matchedSlug,
+                'link_reason_code' => 'matched_job_detail_companion',
+                'occupation_uuid' => (string) ($matchedJob['occupation_uuid'] ?? ''),
+                'canonical_title_en' => (string) ($matchedJob['title'] ?? ''),
+            ];
+        }
+
+        $dedupedLinks = collect($companionLinks)
+            ->unique(static fn (array $row): string => sprintf(
+                '%s|%s|%s',
+                (string) ($row['route_kind'] ?? ''),
+                (string) ($row['canonical_path'] ?? ''),
+                (string) ($row['canonical_slug'] ?? '')
+            ))
+            ->values()
+            ->all();
+
+        $counts = [
+            'total' => count($dedupedLinks),
+            'job_detail' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_job_detail')),
+            'family_hub' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub')),
+        ];
+
+        return new CareerFirstWaveRecommendationCompanionLinksSummary(
+            summaryVersion: self::SUMMARY_VERSION,
+            scope: self::SCOPE,
+            subjectIdentity: [
+                'type_code' => $this->normalizeNullableString($subjectMeta['type_code'] ?? null),
+                'canonical_type_code' => $this->normalizeNullableString($subjectMeta['canonical_type_code'] ?? null),
+                'public_route_slug' => $publicRouteSlug,
+                'display_title' => $this->normalizeNullableString($subjectMeta['display_title'] ?? null),
+            ],
+            counts: $counts,
+            companionLinks: $dedupedLinks,
+        );
+    }
+
+    private function normalizeRecommendationRouteSlug(array $subjectMeta): ?string
+    {
+        $candidates = [
+            $subjectMeta['public_route_slug'] ?? null,
+            $subjectMeta['route_type'] ?? null,
+            $subjectMeta['canonical_type_code'] ?? null,
+            $subjectMeta['type_code'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_scalar($candidate)) {
+                continue;
+            }
+
+            $normalized = strtolower(trim((string) $candidate));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRecommendationCompanionLinksService;
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerFirstWaveRecommendationCompanionLinksSummaryResource;
+use Illuminate\Http\JsonResponse;
+
+final class CareerFirstWaveRecommendationCompanionLinksController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerFirstWaveRecommendationCompanionLinksService $summaryService,
+    ) {}
+
+    public function show(string $type): JsonResponse|CareerFirstWaveRecommendationCompanionLinksSummaryResource
+    {
+        $summary = $this->summaryService->buildByType($type);
+
+        if ($summary === null) {
+            return $this->notFoundResponse('career recommendation companion links unavailable.');
+        }
+
+        return new CareerFirstWaveRecommendationCompanionLinksSummaryResource($summary);
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php
+++ b/backend/app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerFirstWaveRecommendationCompanionLinksSummary;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerFirstWaveRecommendationCompanionLinksSummary
+ */
+final class CareerFirstWaveRecommendationCompanionLinksSummaryResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerFirstWaveRecommendationCompanionLinksSummary $summary */
+        $summary = $this->resource;
+
+        return $summary->toArray();
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-12T02:05:00Z",
+  "updated_at": "2026-04-12T13:00:17Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -647,6 +647,36 @@
         ]
       },
       "failure_reason": "GitHub Actions jobs were not started successfully because account payments failed or the spending limit needs to be increased; both hygiene runs failed immediately and MBTI verification was skipped, while local B27 verification passed.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B38": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-b38-career-recommendation-detail-companion-links-authority-api",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php docs/contracts/openapi.snapshot.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php tests/Feature/Career/CareerFirstWaveNextStepLinksApiTest.php tests/Feature/Career/CareerFirstWaveOccupationCompanionLinksApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-12T13:00:17Z",
+  "updated_at": "2026-04-12T13:01:07Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -655,9 +655,9 @@
     "PR-B38": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "committed",
       "branch": "codex/pr-b38-career-recommendation-detail-companion-links-authority-api",
-      "commit_sha": "",
+      "commit_sha": "248a882ef7a97fda70a0a287acbee26d3e18df25",
       "pr_url": "",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-12T13:01:07Z",
+  "updated_at": "2026-04-12T13:02:05Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -655,10 +655,10 @@
     "PR-B38": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "committed",
+      "status": "pr_open",
       "branch": "codex/pr-b38-career-recommendation-detail-companion-links-authority-api",
       "commit_sha": "248a882ef7a97fda70a0a287acbee26d3e18df25",
-      "pr_url": "",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/883",
       "checks": {
         "local": [
           {

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2481,6 +2481,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/first-wave/recommendations/mbti/{type}/companion-links": {
+            "get": {
+                "operationId": "get_api_v0_5_career_first_wave_recommendations_mbti_type_companion_links",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerFirstWaveRecommendationCompanionLinksController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/first-wave/rollout-queue": {
             "get": {
                 "operationId": "get_api_v0_5_career_first_wave_rollout_queue",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -38,6 +38,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLifecycleController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveNextStepLinksController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveOccupationCompanionLinksController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveReadinessController;
+use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveRecommendationCompanionLinksController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveRolloutQueueController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobExplainabilityController;
@@ -416,6 +417,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/first-wave/discoverability-manifest', [CareerFirstWaveDiscoverabilityManifestController::class, 'show']);
     Route::get('/career/first-wave/jobs/{slug}/next-step-links', [CareerFirstWaveNextStepLinksController::class, 'show']);
     Route::get('/career/first-wave/jobs/{slug}/companion-links', [CareerFirstWaveOccupationCompanionLinksController::class, 'show']);
+    Route::get('/career/first-wave/recommendations/mbti/{type}/companion-links', [CareerFirstWaveRecommendationCompanionLinksController::class, 'show']);
     Route::get('/career/first-wave/launch-tier', [CareerFirstWaveLaunchTierController::class, 'show']);
     Route::get('/career/resolve', [CareerAliasResolutionController::class, 'show']);
     Route::get('/career/first-wave/lifecycle', [CareerFirstWaveLifecycleController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRecommendationCompanionLinksService;
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\ContextSnapshot;
+use App\Models\Occupation;
+use App\Models\ProfileProjection;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_exposes_a_first_wave_recommendation_companion_links_summary_for_supported_route_kinds_only(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $subjectMeta = [
+            'type_code' => 'INTJ-A',
+            'canonical_type_code' => 'INTJ',
+            'display_title' => 'INTJ-A Career Match',
+            'public_route_slug' => 'intj',
+        ];
+
+        CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+
+        $this->compileRecommendationSnapshotForOccupation('human-resources-specialists', $subjectMeta, 3);
+        $this->compileRecommendationSnapshotForOccupation('backend-architect-cn-market', $subjectMeta, 2);
+        $this->compileRecommendationSnapshotForOccupation('accountants-and-auditors', $subjectMeta, 1);
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/recommendations/mbti/intj/companion-links');
+
+        $response->assertOk()
+            ->assertJsonPath('summary_kind', 'career_first_wave_recommendation_companion_links')
+            ->assertJsonPath('summary_version', CareerFirstWaveRecommendationCompanionLinksService::SUMMARY_VERSION)
+            ->assertJsonPath('scope', CareerFirstWaveRecommendationCompanionLinksService::SCOPE)
+            ->assertJsonPath('subject_kind', 'recommendation_subject')
+            ->assertJsonPath('subject_identity.type_code', 'INTJ-A')
+            ->assertJsonPath('subject_identity.canonical_type_code', 'INTJ')
+            ->assertJsonPath('subject_identity.public_route_slug', 'intj')
+            ->assertJsonPath('counts.total', 3)
+            ->assertJsonPath('counts.job_detail', 2)
+            ->assertJsonPath('counts.family_hub', 1)
+            ->assertJsonStructure([
+                'summary_kind',
+                'summary_version',
+                'scope',
+                'subject_kind',
+                'subject_identity' => ['type_code', 'canonical_type_code', 'public_route_slug', 'display_title'],
+                'counts' => ['total', 'job_detail', 'family_hub'],
+                'companion_links' => [[
+                    'route_kind',
+                    'canonical_path',
+                    'canonical_slug',
+                    'link_reason_code',
+                ]],
+            ])
+            ->assertJsonMissingPath('recommended_action')
+            ->assertJsonMissingPath('why_this_path');
+
+        $links = collect($response->json('companion_links'));
+
+        $this->assertSame(
+            ['career_family_hub', 'career_job_detail'],
+            $links->pluck('route_kind')->unique()->sort()->values()->all()
+        );
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/recommendations')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/search')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/career/tests/')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/topics/')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'backend-architect-cn-market'));
+        $this->assertSame(1, $links->where('canonical_slug', 'accountants-and-auditors')->count());
+    }
+
+    public function test_it_returns_not_found_for_unknown_recommendation_subjects(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $this->getJson('/api/v0.5/career/first-wave/recommendations/mbti/unknown-type/companion-links')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    /**
+     * @param  array<string, mixed>  $subjectMeta
+     */
+    private function compileRecommendationSnapshotForOccupation(string $occupationSlug, array $subjectMeta, int $compiledAtOffsetMinutes): void
+    {
+        $occupation = Occupation::query()->where('canonical_slug', $occupationSlug)->firstOrFail();
+
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b38-api-'.$occupationSlug.'-'.strtolower((string) ($subjectMeta['canonical_type_code'] ?? 'unknown')),
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $contextSnapshot = ContextSnapshot::query()->create([
+            'identity_id' => 'identity-b38-api-'.$occupationSlug,
+            'visitor_id' => 'visitor-b38-api-'.$occupationSlug,
+            'captured_at' => now()->subMinutes(30),
+            'current_occupation_id' => $occupation->id,
+            'employment_status' => 'employed',
+            'monthly_comp_band' => '25k_40k',
+            'burnout_level' => 0.48,
+            'switch_urgency' => 0.54,
+            'risk_tolerance' => 0.45,
+            'geo_region' => 'cn-east',
+            'family_constraint_level' => 0.40,
+            'manager_track_preference' => 0.32,
+            'time_horizon_months' => 12,
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => [
+                'materialization' => 'career_first_wave',
+                'trigger' => 'career_refresh',
+            ],
+        ]);
+
+        $profileProjection = ProfileProjection::query()->create([
+            'identity_id' => 'identity-b38-api-'.$occupationSlug,
+            'visitor_id' => 'visitor-b38-api-'.$occupationSlug,
+            'context_snapshot_id' => $contextSnapshot->id,
+            'projection_version' => 'career_projection_v1',
+            'compile_run_id' => $compileRun->id,
+            'psychometric_axis_coverage' => 0.81,
+            'projection_payload' => [
+                'materialization' => 'career_first_wave',
+                'recommendation_subject_meta' => $subjectMeta,
+                'fit_axes' => [
+                    'abstraction' => 0.88,
+                    'autonomy' => 0.78,
+                    'collaboration' => 0.42,
+                    'variability' => 0.68,
+                    'variant_trigger_load' => 0.12,
+                ],
+            ],
+        ]);
+
+        $snapshot = app(CareerRecommendationCompiler::class)->compile($profileProjection, $occupation, [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        $snapshot->forceFill([
+            'compiled_at' => now()->subMinutes($compiledAtOffsetMinutes),
+            'created_at' => now()->subMinutes($compiledAtOffsetMinutes),
+        ])->save();
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRecommendationCompanionLinksService;
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\ContextSnapshot;
+use App\Models\Occupation;
+use App\Models\ProfileProjection;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerFirstWaveRecommendationCompanionLinksServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_machine_safe_companion_links_for_a_first_wave_recommendation_subject(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $subjectMeta = [
+            'type_code' => 'INTJ-A',
+            'canonical_type_code' => 'INTJ',
+            'display_title' => 'INTJ-A Career Match',
+            'public_route_slug' => 'intj',
+        ];
+
+        CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+
+        $this->compileRecommendationSnapshotForOccupation('human-resources-specialists', $subjectMeta, 3);
+        $this->compileRecommendationSnapshotForOccupation('backend-architect-cn-market', $subjectMeta, 2);
+        $this->compileRecommendationSnapshotForOccupation('accountants-and-auditors', $subjectMeta, 1);
+
+        $summary = app(CareerFirstWaveRecommendationCompanionLinksService::class)->buildByType('intj')?->toArray();
+
+        $this->assertIsArray($summary);
+        $this->assertSame('career_first_wave_recommendation_companion_links', $summary['summary_kind']);
+        $this->assertSame(CareerFirstWaveRecommendationCompanionLinksService::SUMMARY_VERSION, $summary['summary_version']);
+        $this->assertSame(CareerFirstWaveRecommendationCompanionLinksService::SCOPE, $summary['scope']);
+        $this->assertSame('recommendation_subject', $summary['subject_kind']);
+        $this->assertSame('INTJ-A', data_get($summary, 'subject_identity.type_code'));
+        $this->assertSame('INTJ', data_get($summary, 'subject_identity.canonical_type_code'));
+        $this->assertSame('intj', data_get($summary, 'subject_identity.public_route_slug'));
+        $this->assertSame(3, data_get($summary, 'counts.total'));
+        $this->assertSame(2, data_get($summary, 'counts.job_detail'));
+        $this->assertSame(1, data_get($summary, 'counts.family_hub'));
+
+        $links = collect($summary['companion_links']);
+        $this->assertSame(
+            ['career_family_hub', 'career_job_detail'],
+            $links->pluck('route_kind')->unique()->sort()->values()->all()
+        );
+
+        $targetJob = $links->first(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'accountants-and-auditors');
+        $familyLink = $links->firstWhere('route_kind', 'career_family_hub');
+        $jobLinks = $links->where('route_kind', 'career_job_detail')->values();
+
+        $this->assertSame('target_job_detail_companion', $targetJob['link_reason_code']);
+        $this->assertSame('/career/jobs/accountants-and-auditors', $targetJob['canonical_path']);
+        $this->assertSame('/career/family/business-and-financial-37ec69bd', $familyLink['canonical_path']);
+        $this->assertSame('target_family_hub_companion', $familyLink['link_reason_code']);
+        $this->assertSame(
+            ['accountants-and-auditors', 'human-resources-specialists'],
+            $jobLinks->pluck('canonical_slug')->sort()->values()->all()
+        );
+        $this->assertTrue($jobLinks->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'human-resources-specialists'
+            && ($row['link_reason_code'] ?? null) === 'matched_job_detail_companion'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'backend-architect-cn-market'));
+        $this->assertSame(1, $jobLinks->where('canonical_slug', 'accountants-and-auditors')->count());
+    }
+
+    public function test_it_returns_null_for_unknown_or_unavailable_recommendation_subjects(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $service = app(CareerFirstWaveRecommendationCompanionLinksService::class);
+
+        $this->assertNull($service->buildByType(''));
+        $this->assertNull($service->buildByType('unknown-type'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    /**
+     * @param  array<string, mixed>  $subjectMeta
+     */
+    private function compileRecommendationSnapshotForOccupation(string $occupationSlug, array $subjectMeta, int $compiledAtOffsetMinutes): void
+    {
+        $occupation = Occupation::query()->where('canonical_slug', $occupationSlug)->firstOrFail();
+
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b38-'.$occupationSlug.'-'.strtolower((string) ($subjectMeta['canonical_type_code'] ?? 'unknown')),
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $contextSnapshot = ContextSnapshot::query()->create([
+            'identity_id' => 'identity-b38-'.$occupationSlug,
+            'visitor_id' => 'visitor-b38-'.$occupationSlug,
+            'captured_at' => now()->subMinutes(30),
+            'current_occupation_id' => $occupation->id,
+            'employment_status' => 'employed',
+            'monthly_comp_band' => '25k_40k',
+            'burnout_level' => 0.48,
+            'switch_urgency' => 0.54,
+            'risk_tolerance' => 0.45,
+            'geo_region' => 'cn-east',
+            'family_constraint_level' => 0.40,
+            'manager_track_preference' => 0.32,
+            'time_horizon_months' => 12,
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => [
+                'materialization' => 'career_first_wave',
+                'trigger' => 'career_refresh',
+            ],
+        ]);
+
+        $profileProjection = ProfileProjection::query()->create([
+            'identity_id' => 'identity-b38-'.$occupationSlug,
+            'visitor_id' => 'visitor-b38-'.$occupationSlug,
+            'context_snapshot_id' => $contextSnapshot->id,
+            'projection_version' => 'career_projection_v1',
+            'compile_run_id' => $compileRun->id,
+            'psychometric_axis_coverage' => 0.81,
+            'projection_payload' => [
+                'materialization' => 'career_first_wave',
+                'recommendation_subject_meta' => $subjectMeta,
+                'fit_axes' => [
+                    'abstraction' => 0.88,
+                    'autonomy' => 0.78,
+                    'collaboration' => 0.42,
+                    'variability' => 0.68,
+                    'variant_trigger_load' => 0.12,
+                ],
+            ],
+        ]);
+
+        $snapshot = app(CareerRecommendationCompiler::class)->compile($profileProjection, $occupation, [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        $snapshot->forceFill([
+            'compiled_at' => now()->subMinutes($compiledAtOffsetMinutes),
+            'created_at' => now()->subMinutes($compiledAtOffsetMinutes),
+        ])->save();
+    }
+}


### PR DESCRIPTION
## What changed
- add a dedicated first-wave recommendation companion-links authority service that projects a machine-safe per-recommendation cross-surface graph from recommendation detail structural truth plus backend-owned discoverability truth
- add a read-only v0.5 API for recommendation companion links with explicit counts and route rows limited to `career_job_detail` and `career_family_hub`
- add focused unit and feature coverage for target job inclusion, target family inclusion, discoverable matched-job inclusion, duplicate target suppression, unsupported-route exclusion, and regression safety against existing recommendation detail, transition preview, discoverability, next-step, and occupation companion contracts

## Why
- backend already had the authority ingredients for a narrow recommendation-subject companion graph, but no dedicated surface to expose it
- downstream consumers need a backend-owned answer to recommendation-detail companion routes without conflating it with recommendation advice, transition preview, next-step links, or search/editorial convenience links
- this keeps the graph deliberately narrow and machine-safe by only counting discoverable target job routes, discoverable target family hubs, and discoverable matched job routes for recommendation subjects

## Validation
- `vendor/bin/pint --test app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php routes/api.php tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php docs/contracts/openapi.snapshot.json`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php tests/Feature/Career/CareerFirstWaveNextStepLinksApiTest.php tests/Feature/Career/CareerFirstWaveOccupationCompanionLinksApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no occupation subject changes
- no transition-preview-derived companion links
- no recommendation self route
- no search/alias/tests/topics/editorial route kinds
- no frontend changes
