### PR TITLE
PR-B39A: Career tests/topic canonical route registry + recommendation-subject linkage truth layer

### DIFF
--- a/backend/app/Domain/Career/Links/CareerCanonicalSupportRouteRegistry.php
+++ b/backend/app/Domain/Career/Links/CareerCanonicalSupportRouteRegistry.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Links;
+
+use App\Models\ScaleRegistry;
+use App\Models\TopicProfile;
+use App\Services\Cms\TopicProfileSeoService;
+
+final class CareerCanonicalSupportRouteRegistry
+{
+    public function __construct(
+        private readonly TopicProfileSeoService $topicProfileSeoService,
+    ) {}
+
+    /**
+     * @return list<array{
+     *     route_kind:string,
+     *     canonical_path:string,
+     *     canonical_slug:string,
+     *     metadata:array<string, string>,
+     *     is_active:bool,
+     *     source_of_truth:string
+     * }>
+     */
+    public function list(string $locale = 'en'): array
+    {
+        $routes = array_merge(
+            $this->listCanonicalTestLandingRoutes($locale),
+            $this->listCanonicalTopicDetailRoutes($locale),
+        );
+
+        return array_values(array_map(
+            static fn (array $row): array => $row,
+            collect($routes)
+                ->unique(static fn (array $row): string => sprintf(
+                    '%s|%s|%s',
+                    $row['route_kind'] ?? '',
+                    $row['canonical_path'] ?? '',
+                    $row['canonical_slug'] ?? '',
+                ))
+                ->values()
+                ->all()
+        ));
+    }
+
+    /**
+     * @return list<array{
+     *     route_kind:string,
+     *     canonical_path:string,
+     *     canonical_slug:string,
+     *     metadata:array<string, string>,
+     *     is_active:bool,
+     *     source_of_truth:string
+     * }>
+     */
+    private function listCanonicalTestLandingRoutes(string $locale): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+
+        return ScaleRegistry::queryByOrgWhitelist([0])
+            ->where('org_id', 0)
+            ->where('is_public', true)
+            ->where('is_active', true)
+            ->whereNotNull('primary_slug')
+            ->orderBy('code')
+            ->get()
+            ->map(function (ScaleRegistry $row) use ($segment): ?array {
+                $primarySlug = strtolower(trim((string) $row->primary_slug));
+                $scaleCode = strtoupper(trim((string) $row->code));
+
+                if ($primarySlug === '' || $scaleCode === '') {
+                    return null;
+                }
+
+                return [
+                    'route_kind' => 'test_landing',
+                    'canonical_path' => '/'.$segment.'/tests/'.rawurlencode($primarySlug),
+                    'canonical_slug' => $primarySlug,
+                    'metadata' => [
+                        'scale_code' => $scaleCode,
+                        'primary_slug' => $primarySlug,
+                    ],
+                    'is_active' => true,
+                    'source_of_truth' => 'scales_registry.primary_slug',
+                ];
+            })
+            ->filter(static fn (mixed $row): bool => is_array($row))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array{
+     *     route_kind:string,
+     *     canonical_path:string,
+     *     canonical_slug:string,
+     *     metadata:array<string, string>,
+     *     is_active:bool,
+     *     source_of_truth:string
+     * }>
+     */
+    private function listCanonicalTopicDetailRoutes(string $locale): array
+    {
+        $resolvedLocale = $this->normalizeLocale($locale);
+        $segment = $this->frontendLocaleSegment($resolvedLocale);
+
+        return TopicProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->forLocale($resolvedLocale)
+            ->publishedPublic()
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->orderBy('topic_code')
+            ->orderBy('id')
+            ->get()
+            ->map(function (TopicProfile $profile) use ($segment): ?array {
+                $topicCode = strtolower(trim((string) $profile->topic_code));
+                $slug = strtolower(trim((string) $profile->slug));
+
+                if ($topicCode === '' || $slug === '') {
+                    return null;
+                }
+
+                return [
+                    'route_kind' => 'topic_detail',
+                    'canonical_path' => '/'.$segment.'/topics/'.rawurlencode($slug),
+                    'canonical_slug' => $slug,
+                    'metadata' => [
+                        'topic_code' => $topicCode,
+                        'slug' => $slug,
+                    ],
+                    'is_active' => true,
+                    'source_of_truth' => 'topic_profiles.slug',
+                ];
+            })
+            ->filter(static fn (mixed $row): bool => is_array($row))
+            ->values()
+            ->all();
+    }
+
+    private function frontendLocaleSegment(string $locale): string
+    {
+        return $this->topicProfileSeoService->mapBackendLocaleToFrontendSegment($locale);
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+}

--- a/backend/app/Domain/Career/Links/CareerRecommendationSupportLinkageBuilder.php
+++ b/backend/app/Domain/Career/Links/CareerRecommendationSupportLinkageBuilder.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Links;
+
+use App\Models\PersonalityProfile;
+use App\Services\Career\Bundles\CareerRecommendationDetailBundleBuilder;
+
+final class CareerRecommendationSupportLinkageBuilder
+{
+    public function __construct(
+        private readonly CareerRecommendationDetailBundleBuilder $recommendationDetailBundleBuilder,
+        private readonly CareerCanonicalSupportRouteRegistry $canonicalSupportRouteRegistry,
+    ) {}
+
+    /**
+     * @return array{
+     *     subject_kind:string,
+     *     subject_identity:array{
+     *         type_code:?string,
+     *         canonical_type_code:?string,
+     *         public_route_slug:?string,
+     *         display_title:?string
+     *     },
+     *     support_links:list<array{
+     *         subject_kind:string,
+     *         subject_identity:array<string, ?string>,
+     *         route_kind:string,
+     *         canonical_path:string,
+     *         canonical_slug:string,
+     *         link_reason_code:string
+     *     }>
+     * }|null
+     */
+    public function buildByType(string $type, string $locale = 'en'): ?array
+    {
+        $normalizedType = trim($type);
+        if ($normalizedType === '') {
+            return null;
+        }
+
+        $bundle = $this->recommendationDetailBundleBuilder->buildByType($normalizedType);
+        if ($bundle === null) {
+            return null;
+        }
+
+        $bundlePayload = $bundle->toArray();
+        $subjectMeta = is_array($bundlePayload['recommendation_subject_meta'] ?? null)
+            ? $bundlePayload['recommendation_subject_meta']
+            : [];
+
+        $subjectIdentity = [
+            'type_code' => $this->normalizeNullableString($subjectMeta['type_code'] ?? null),
+            'canonical_type_code' => $this->normalizeNullableString($subjectMeta['canonical_type_code'] ?? null),
+            'public_route_slug' => $this->normalizeNullableString($subjectMeta['public_route_slug'] ?? null),
+            'display_title' => $this->normalizeNullableString($subjectMeta['display_title'] ?? null),
+        ];
+
+        if (! $this->isMbtiRecommendationSubject($subjectIdentity)) {
+            return null;
+        }
+
+        $registryRows = collect($this->canonicalSupportRouteRegistry->list($locale))
+            ->filter(static fn (mixed $row): bool => is_array($row))
+            ->keyBy(static fn (array $row): string => sprintf(
+                '%s|%s',
+                (string) ($row['route_kind'] ?? ''),
+                strtolower(trim((string) data_get($row, 'metadata.scale_code', data_get($row, 'metadata.topic_code', ''))))
+            ));
+
+        $supportLinks = [];
+
+        $testLandingRoute = $registryRows->get('test_landing|'.strtolower(PersonalityProfile::SCALE_CODE_MBTI));
+        if (is_array($testLandingRoute)) {
+            $supportLinks[] = $this->buildLinkageRow($subjectIdentity, $testLandingRoute, 'canonical_test_landing');
+        }
+
+        $topicRoute = $registryRows->get('topic_detail|mbti');
+        if (is_array($topicRoute)) {
+            $supportLinks[] = $this->buildLinkageRow($subjectIdentity, $topicRoute, 'canonical_topic_detail');
+        }
+
+        return [
+            'subject_kind' => 'recommendation_subject',
+            'subject_identity' => $subjectIdentity,
+            'support_links' => array_values(collect($supportLinks)
+                ->unique(static fn (array $row): string => sprintf(
+                    '%s|%s|%s',
+                    (string) ($row['route_kind'] ?? ''),
+                    (string) ($row['canonical_path'] ?? ''),
+                    (string) ($row['canonical_slug'] ?? ''),
+                ))
+                ->all()),
+        ];
+    }
+
+    /**
+     * @param  array<string, ?string>  $subjectIdentity
+     * @param  array<string, mixed>  $registryRow
+     * @return array{
+     *     subject_kind:string,
+     *     subject_identity:array<string, ?string>,
+     *     route_kind:string,
+     *     canonical_path:string,
+     *     canonical_slug:string,
+     *     link_reason_code:string
+     * }
+     */
+    private function buildLinkageRow(array $subjectIdentity, array $registryRow, string $reasonCode): array
+    {
+        return [
+            'subject_kind' => 'recommendation_subject',
+            'subject_identity' => $subjectIdentity,
+            'route_kind' => (string) ($registryRow['route_kind'] ?? ''),
+            'canonical_path' => (string) ($registryRow['canonical_path'] ?? ''),
+            'canonical_slug' => (string) ($registryRow['canonical_slug'] ?? ''),
+            'link_reason_code' => $reasonCode,
+        ];
+    }
+
+    /**
+     * @param  array<string, ?string>  $subjectIdentity
+     */
+    private function isMbtiRecommendationSubject(array $subjectIdentity): bool
+    {
+        $canonicalTypeCode = strtoupper(trim((string) ($subjectIdentity['canonical_type_code'] ?? '')));
+        if ($canonicalTypeCode !== '' && in_array($canonicalTypeCode, PersonalityProfile::BASE_TYPE_CODES, true)) {
+            return true;
+        }
+
+        $runtimeTypeCode = strtoupper(trim((string) ($subjectIdentity['type_code'] ?? '')));
+        if ($runtimeTypeCode !== '') {
+            $runtimeBaseType = strtoupper(trim(strtok($runtimeTypeCode, '-') ?: $runtimeTypeCode));
+
+            return in_array($runtimeBaseType, PersonalityProfile::BASE_TYPE_CODES, true);
+        }
+
+        return false;
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Links/CareerCanonicalSupportRouteRegistryTest.php
+++ b/backend/tests/Unit/Domain/Career/Links/CareerCanonicalSupportRouteRegistryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Links;
+
+use App\Domain\Career\Links\CareerCanonicalSupportRouteRegistry;
+use App\Models\TopicProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerCanonicalSupportRouteRegistryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_emits_only_canonical_test_landing_and_topic_detail_routes(): void
+    {
+        $this->seedCanonicalMbtiScale();
+        $this->createTopicProfile(topicCode: 'mbti', slug: 'mbti', status: TopicProfile::STATUS_PUBLISHED, isPublic: true);
+        $this->createTopicProfile(topicCode: 'draft-topic', slug: 'draft-topic', status: TopicProfile::STATUS_DRAFT, isPublic: true);
+
+        $routes = app(CareerCanonicalSupportRouteRegistry::class)->list('en');
+
+        $this->assertNotEmpty($routes);
+        $this->assertSame(
+            ['test_landing', 'topic_detail'],
+            collect($routes)->pluck('route_kind')->unique()->sort()->values()->all()
+        );
+
+        $testLanding = collect($routes)->first(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'test_landing'
+            && data_get($row, 'metadata.scale_code') === 'MBTI');
+        $topicDetail = collect($routes)->first(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'topic_detail'
+            && data_get($row, 'metadata.topic_code') === 'mbti');
+
+        $this->assertSame('/en/tests/mbti-personality-test-16-personality-types', $testLanding['canonical_path']);
+        $this->assertSame('scales_registry.primary_slug', $testLanding['source_of_truth']);
+        $this->assertSame('/en/topics/mbti', $topicDetail['canonical_path']);
+        $this->assertSame('topic_profiles.slug', $topicDetail['source_of_truth']);
+
+        $this->assertFalse(collect($routes)->contains(static fn (array $row): bool => str_ends_with((string) ($row['canonical_path'] ?? ''), '/take')));
+        $this->assertFalse(collect($routes)->contains(static fn (array $row): bool => ($row['canonical_path'] ?? null) === '/en/tests'));
+        $this->assertFalse(collect($routes)->contains(static fn (array $row): bool => data_get($row, 'metadata.topic_code') === 'draft-topic'));
+    }
+
+    public function test_it_excludes_invalid_or_unpublished_topic_identity_rows(): void
+    {
+        $this->seedCanonicalMbtiScale();
+        $this->createTopicProfile(topicCode: 'mbti', slug: '', status: TopicProfile::STATUS_PUBLISHED, isPublic: true);
+        $this->createTopicProfile(topicCode: 'mbti-private', slug: 'mbti-private', status: TopicProfile::STATUS_PUBLISHED, isPublic: false);
+
+        $routes = app(CareerCanonicalSupportRouteRegistry::class)->list('en');
+
+        $this->assertFalse(collect($routes)->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'topic_detail'));
+        $this->assertTrue(collect($routes)->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'test_landing'));
+    }
+
+    private function seedCanonicalMbtiScale(): void
+    {
+        Artisan::call('fap:scales:seed-default');
+        Artisan::call('fap:scales:sync-slugs');
+    }
+
+    private function createTopicProfile(string $topicCode, string $slug, string $status, bool $isPublic): void
+    {
+        TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => $topicCode,
+            'slug' => $slug,
+            'locale' => 'en',
+            'title' => strtoupper($topicCode).' Topic',
+            'status' => $status,
+            'is_public' => $isPublic,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => 'v1',
+        ]);
+    }
+}

--- a/backend/tests/Unit/Domain/Career/Links/CareerRecommendationSupportLinkageBuilderTest.php
+++ b/backend/tests/Unit/Domain/Career/Links/CareerRecommendationSupportLinkageBuilderTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Career\Links;
+
+use App\Domain\Career\Links\CareerRecommendationSupportLinkageBuilder;
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\ContextSnapshot;
+use App\Models\Occupation;
+use App\Models\ProfileProjection;
+use App\Models\TopicProfile;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerRecommendationSupportLinkageBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_internal_support_linkage_for_recommendation_subjects(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $this->seedCanonicalMbtiScale();
+        $this->createPublishedTopicProfile('mbti', 'mbti');
+
+        $subjectMeta = [
+            'type_code' => 'INTJ-A',
+            'canonical_type_code' => 'INTJ',
+            'display_title' => 'INTJ-A Career Match',
+            'public_route_slug' => 'intj',
+        ];
+
+        CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+        $this->compileRecommendationSnapshotForOccupation('accountants-and-auditors', $subjectMeta, 1);
+
+        $payload = app(CareerRecommendationSupportLinkageBuilder::class)->buildByType('intj', 'en');
+
+        $this->assertIsArray($payload);
+        $this->assertSame('recommendation_subject', $payload['subject_kind']);
+        $this->assertSame('INTJ-A', data_get($payload, 'subject_identity.type_code'));
+        $this->assertSame('INTJ', data_get($payload, 'subject_identity.canonical_type_code'));
+        $this->assertSame('intj', data_get($payload, 'subject_identity.public_route_slug'));
+
+        $links = collect((array) ($payload['support_links'] ?? []));
+        $this->assertSame(
+            ['test_landing', 'topic_detail'],
+            $links->pluck('route_kind')->unique()->sort()->values()->all()
+        );
+        $this->assertTrue($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'test_landing'
+            && ($row['canonical_path'] ?? null) === '/en/tests/mbti-personality-test-16-personality-types'
+            && ($row['link_reason_code'] ?? null) === 'canonical_test_landing'));
+        $this->assertTrue($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'topic_detail'
+            && ($row['canonical_path'] ?? null) === '/en/topics/mbti'
+            && ($row['link_reason_code'] ?? null) === 'canonical_topic_detail'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['subject_kind'] ?? null) === 'occupation'));
+    }
+
+    public function test_it_does_not_promote_controller_cta_fallbacks_into_topic_truth_when_topic_registry_rows_are_missing(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $subjectMeta = [
+            'type_code' => 'INTJ-A',
+            'canonical_type_code' => 'INTJ',
+            'display_title' => 'INTJ-A Career Match',
+            'public_route_slug' => 'intj',
+        ];
+
+        CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+        $this->compileRecommendationSnapshotForOccupation('accountants-and-auditors', $subjectMeta, 1);
+
+        $payload = app(CareerRecommendationSupportLinkageBuilder::class)->buildByType('intj', 'en');
+
+        $this->assertIsArray($payload);
+        $links = collect((array) ($payload['support_links'] ?? []));
+
+        $this->assertTrue($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'test_landing'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'topic_detail'));
+    }
+
+    public function test_it_rejects_non_mbti_recommendation_subject_identity_even_if_snapshot_shape_matches(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $this->seedCanonicalMbtiScale();
+        $this->createPublishedTopicProfile('mbti', 'mbti');
+
+        $subjectMeta = [
+            'type_code' => 'DISC-A',
+            'canonical_type_code' => 'DISC',
+            'display_title' => 'DISC-A Career Match',
+            'public_route_slug' => 'disc',
+        ];
+
+        CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+        $this->compileRecommendationSnapshotForOccupation('accountants-and-auditors', $subjectMeta, 1);
+
+        $payload = app(CareerRecommendationSupportLinkageBuilder::class)->buildByType('disc', 'en');
+
+        $this->assertNull($payload);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    private function seedCanonicalMbtiScale(): void
+    {
+        Artisan::call('fap:scales:seed-default');
+        Artisan::call('fap:scales:sync-slugs');
+    }
+
+    private function createPublishedTopicProfile(string $topicCode, string $slug): void
+    {
+        TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => $topicCode,
+            'slug' => $slug,
+            'locale' => 'en',
+            'title' => strtoupper($topicCode).' Topic',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => 'v1',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $subjectMeta
+     */
+    private function compileRecommendationSnapshotForOccupation(string $occupationSlug, array $subjectMeta, int $compiledAtOffsetMinutes): void
+    {
+        $occupation = Occupation::query()->where('canonical_slug', $occupationSlug)->firstOrFail();
+
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b39a-'.$occupationSlug.'-'.strtolower((string) ($subjectMeta['canonical_type_code'] ?? 'unknown')),
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+
+        $contextSnapshot = ContextSnapshot::query()->create([
+            'identity_id' => 'identity-b39a-'.$occupationSlug,
+            'visitor_id' => 'visitor-b39a-'.$occupationSlug,
+            'captured_at' => now()->subMinutes(30),
+            'current_occupation_id' => $occupation->id,
+            'employment_status' => 'employed',
+            'monthly_comp_band' => '25k_40k',
+            'burnout_level' => 0.48,
+            'switch_urgency' => 0.54,
+            'risk_tolerance' => 0.45,
+            'geo_region' => 'cn-east',
+            'family_constraint_level' => 0.40,
+            'manager_track_preference' => 0.32,
+            'time_horizon_months' => 12,
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => [
+                'materialization' => 'career_first_wave',
+                'trigger' => 'career_refresh',
+            ],
+        ]);
+
+        $profileProjection = ProfileProjection::query()->create([
+            'identity_id' => 'identity-b39a-'.$occupationSlug,
+            'visitor_id' => 'visitor-b39a-'.$occupationSlug,
+            'context_snapshot_id' => $contextSnapshot->id,
+            'projection_version' => 'career_projection_v1',
+            'compile_run_id' => $compileRun->id,
+            'psychometric_axis_coverage' => 0.81,
+            'projection_payload' => [
+                'materialization' => 'career_first_wave',
+                'recommendation_subject_meta' => $subjectMeta,
+                'fit_axes' => [
+                    'abstraction' => 0.88,
+                    'autonomy' => 0.78,
+                    'collaboration' => 0.42,
+                    'variability' => 0.68,
+                    'variant_trigger_load' => 0.12,
+                ],
+            ],
+        ]);
+
+        $snapshot = app(CareerRecommendationCompiler::class)->compile($profileProjection, $occupation, [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        $snapshot->forceFill([
+            'compiled_at' => now()->subMinutes($compiledAtOffsetMinutes),
+            'created_at' => now()->subMinutes($compiledAtOffsetMinutes),
+        ])->save();
+    }
+}


### PR DESCRIPTION
## What changed
- add an internal canonical support-route registry for tests/topic route truth, limited to `test_landing` and `topic_detail`
- add an internal recommendation-subject support-linkage builder that maps only structurally valid MBTI recommendation subjects onto canonical support routes
- add focused unit coverage for canonical route inclusion/exclusion, CTA-fallback exclusion, and non-MBTI subject rejection while keeping B37/B38 public companion surfaces untouched

## Why
- public tests/topic companion authority is still not safe, but backend now needs an internal truth-prep layer that separates canonical route identity from subject linkage
- this establishes machine-safe internal truth without promoting CMS CTA links, tests index pages, take flows, or editorial URLs into authority
- recommendation-subject linkage is the safest first pass because it already has stronger structural identity than occupation-side tests/topic linkage

## Validation
- `vendor/bin/pint --test app/Domain/Career/Links/CareerCanonicalSupportRouteRegistry.php app/Domain/Career/Links/CareerRecommendationSupportLinkageBuilder.php tests/Unit/Domain/Career/Links/CareerCanonicalSupportRouteRegistryTest.php tests/Unit/Domain/Career/Links/CareerRecommendationSupportLinkageBuilderTest.php`
- `php artisan test tests/Unit/Domain/Career/Links/CareerCanonicalSupportRouteRegistryTest.php tests/Unit/Domain/Career/Links/CareerRecommendationSupportLinkageBuilderTest.php tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php tests/Unit/Services/Career/CareerFirstWaveOccupationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveOccupationCompanionLinksApiTest.php`

## Intentionally deferred
- no public API
- no frontend changes
- no occupation-subject linkage
- no `tests_index` or `test_take`
- no entry-group, article, editorial, alias, or search routes
