### PR TITLE
PR-B39: Career recommendation support-links public extension (test_landing only)

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php
+++ b/backend/app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php
@@ -9,7 +9,17 @@ final class CareerFirstWaveRecommendationCompanionLinksSummary
     /**
      * @param  array<string, mixed>  $subjectIdentity
      * @param  array<string, int>  $counts
-     * @param  list<array<string, mixed>>  $companionLinks
+     * @param  list<array{
+     *     route_kind:'career_job_detail'|'career_family_hub'|'test_landing',
+     *     canonical_path:string,
+     *     canonical_slug:string,
+     *     link_reason_code:string,
+     *     occupation_uuid?:string,
+     *     canonical_title_en?:string,
+     *     family_uuid?:string,
+     *     title_en?:string,
+     *     scale_code?:string
+     * }>  $companionLinks
      */
     public function __construct(
         public readonly string $summaryVersion,

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Career\Publish;
 
+use App\Domain\Career\Links\CareerRecommendationSupportLinkageBuilder;
 use App\DTO\Career\CareerFirstWaveRecommendationCompanionLinksSummary;
 use App\Models\Occupation;
 use App\Models\OccupationFamily;
@@ -18,9 +19,10 @@ final class CareerFirstWaveRecommendationCompanionLinksService
     public function __construct(
         private readonly CareerRecommendationDetailBundleBuilder $recommendationDetailBundleBuilder,
         private readonly CareerFirstWaveDiscoverabilityManifestService $discoverabilityManifestService,
+        private readonly CareerRecommendationSupportLinkageBuilder $recommendationSupportLinkageBuilder,
     ) {}
 
-    public function buildByType(string $type): ?CareerFirstWaveRecommendationCompanionLinksSummary
+    public function buildByType(string $type, string $locale = 'en'): ?CareerFirstWaveRecommendationCompanionLinksSummary
     {
         $normalizedType = trim($type);
         if ($normalizedType === '') {
@@ -121,6 +123,28 @@ final class CareerFirstWaveRecommendationCompanionLinksService
             ];
         }
 
+        $supportLinkage = $this->recommendationSupportLinkageBuilder->buildByType($normalizedType, $locale);
+        $supportLinks = collect((array) data_get($supportLinkage, 'support_links', []))
+            ->filter(static fn (mixed $row): bool => is_array($row))
+            ->filter(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'test_landing');
+
+        foreach ($supportLinks as $supportLink) {
+            $canonicalPath = trim((string) ($supportLink['canonical_path'] ?? ''));
+            $canonicalSlug = trim((string) ($supportLink['canonical_slug'] ?? ''));
+
+            if ($canonicalPath === '' || $canonicalSlug === '') {
+                continue;
+            }
+
+            $companionLinks[] = [
+                'route_kind' => 'test_landing',
+                'canonical_path' => $canonicalPath,
+                'canonical_slug' => $canonicalSlug,
+                'link_reason_code' => 'recommendation_test_support',
+                'scale_code' => 'MBTI',
+            ];
+        }
+
         $dedupedLinks = collect($companionLinks)
             ->unique(static fn (array $row): string => sprintf(
                 '%s|%s|%s',
@@ -135,6 +159,7 @@ final class CareerFirstWaveRecommendationCompanionLinksService
             'total' => count($dedupedLinks),
             'job_detail' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_job_detail')),
             'family_hub' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub')),
+            'test_landing' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'test_landing')),
         ];
 
         return new CareerFirstWaveRecommendationCompanionLinksSummary(

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Concerns\RespondsWithNotFound;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Career\CareerFirstWaveRecommendationCompanionLinksSummaryResource;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 final class CareerFirstWaveRecommendationCompanionLinksController extends Controller
 {
@@ -18,14 +19,30 @@ final class CareerFirstWaveRecommendationCompanionLinksController extends Contro
         private readonly CareerFirstWaveRecommendationCompanionLinksService $summaryService,
     ) {}
 
-    public function show(string $type): JsonResponse|CareerFirstWaveRecommendationCompanionLinksSummaryResource
+    /**
+     * Existing B38 endpoint, additively extended for public-safe recommendation support links.
+     */
+    public function show(Request $request, string $type): JsonResponse|CareerFirstWaveRecommendationCompanionLinksSummaryResource
     {
-        $summary = $this->summaryService->buildByType($type);
+        $summary = $this->summaryService->buildByType($type, $this->resolveLocale($request));
 
         if ($summary === null) {
             return $this->notFoundResponse('career recommendation companion links unavailable.');
         }
 
         return new CareerFirstWaveRecommendationCompanionLinksSummaryResource($summary);
+    }
+
+    private function resolveLocale(Request $request): string
+    {
+        $raw = trim((string) (
+            $request->query('locale')
+            ?? $request->header('X-FAP-Locale')
+            ?? 'en'
+        ));
+
+        $normalized = strtolower(str_replace('_', '-', $raw));
+
+        return str_starts_with($normalized, 'zh') ? 'zh-CN' : 'en';
     }
 }

--- a/backend/app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php
+++ b/backend/app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php
@@ -16,7 +16,15 @@ final class CareerFirstWaveRecommendationCompanionLinksSummaryResource extends J
     public static $wrap = null;
 
     /**
-     * @return array<string, mixed>
+     * @return array{
+     *     summary_kind:string,
+     *     summary_version:string,
+     *     scope:string,
+     *     subject_kind:string,
+     *     subject_identity:array<string, mixed>,
+     *     counts:array<string, int>,
+     *     companion_links:list<array<string, mixed>>
+     * }
      */
     public function toArray(Request $request): array
     {

--- a/backend/tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php
@@ -47,16 +47,17 @@ final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
             ->assertJsonPath('subject_identity.type_code', 'INTJ-A')
             ->assertJsonPath('subject_identity.canonical_type_code', 'INTJ')
             ->assertJsonPath('subject_identity.public_route_slug', 'intj')
-            ->assertJsonPath('counts.total', 3)
+            ->assertJsonPath('counts.total', 4)
             ->assertJsonPath('counts.job_detail', 2)
             ->assertJsonPath('counts.family_hub', 1)
+            ->assertJsonPath('counts.test_landing', 1)
             ->assertJsonStructure([
                 'summary_kind',
                 'summary_version',
                 'scope',
                 'subject_kind',
                 'subject_identity' => ['type_code', 'canonical_type_code', 'public_route_slug', 'display_title'],
-                'counts' => ['total', 'job_detail', 'family_hub'],
+                'counts' => ['total', 'job_detail', 'family_hub', 'test_landing'],
                 'companion_links' => [[
                     'route_kind',
                     'canonical_path',
@@ -70,13 +71,20 @@ final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
         $links = collect($response->json('companion_links'));
 
         $this->assertSame(
-            ['career_family_hub', 'career_job_detail'],
+            ['career_family_hub', 'career_job_detail', 'test_landing'],
             $links->pluck('route_kind')->unique()->sort()->values()->all()
         );
+        $testLanding = $links->firstWhere('route_kind', 'test_landing');
+        $this->assertSame('/en/tests/mbti-personality-test-16-personality-types', $testLanding['canonical_path']);
+        $this->assertSame('recommendation_test_support', $testLanding['link_reason_code']);
+        $this->assertSame('MBTI', $testLanding['scale_code']);
+        $this->assertArrayNotHasKey('source_of_truth', $testLanding);
+        $this->assertArrayNotHasKey('is_active', $testLanding);
         $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/recommendations')));
         $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/search')));
         $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/career/tests/')));
         $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/topics/')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_ends_with((string) ($row['canonical_path'] ?? ''), '/take')));
         $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'backend-architect-cn-market'));
         $this->assertSame(1, $links->where('canonical_slug', 'accountants-and-auditors')->count());
     }
@@ -89,6 +97,31 @@ final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
             ->assertStatus(404)
             ->assertJsonPath('ok', false)
             ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_it_resolves_test_landing_paths_with_request_locale(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $subjectMeta = [
+            'type_code' => 'INTJ-A',
+            'canonical_type_code' => 'INTJ',
+            'display_title' => 'INTJ-A Career Match',
+            'public_route_slug' => 'intj',
+        ];
+
+        CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+
+        $this->compileRecommendationSnapshotForOccupation('accountants-and-auditors', $subjectMeta, 1);
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/recommendations/mbti/intj/companion-links?locale=zh-CN');
+
+        $response->assertOk();
+
+        $links = collect($response->json('companion_links'));
+        $testLanding = $links->firstWhere('route_kind', 'test_landing');
+
+        $this->assertSame('/zh/tests/mbti-personality-test-16-personality-types', $testLanding['canonical_path']);
     }
 
     private function materializeCurrentFirstWaveFixture(): void

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php
@@ -47,24 +47,31 @@ final class CareerFirstWaveRecommendationCompanionLinksServiceTest extends TestC
         $this->assertSame('INTJ-A', data_get($summary, 'subject_identity.type_code'));
         $this->assertSame('INTJ', data_get($summary, 'subject_identity.canonical_type_code'));
         $this->assertSame('intj', data_get($summary, 'subject_identity.public_route_slug'));
-        $this->assertSame(3, data_get($summary, 'counts.total'));
+        $this->assertSame(4, data_get($summary, 'counts.total'));
         $this->assertSame(2, data_get($summary, 'counts.job_detail'));
         $this->assertSame(1, data_get($summary, 'counts.family_hub'));
+        $this->assertSame(1, data_get($summary, 'counts.test_landing'));
 
         $links = collect($summary['companion_links']);
         $this->assertSame(
-            ['career_family_hub', 'career_job_detail'],
+            ['career_family_hub', 'career_job_detail', 'test_landing'],
             $links->pluck('route_kind')->unique()->sort()->values()->all()
         );
 
         $targetJob = $links->first(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'accountants-and-auditors');
         $familyLink = $links->firstWhere('route_kind', 'career_family_hub');
         $jobLinks = $links->where('route_kind', 'career_job_detail')->values();
+        $testLanding = $links->firstWhere('route_kind', 'test_landing');
 
         $this->assertSame('target_job_detail_companion', $targetJob['link_reason_code']);
         $this->assertSame('/career/jobs/accountants-and-auditors', $targetJob['canonical_path']);
         $this->assertSame('/career/family/business-and-financial-37ec69bd', $familyLink['canonical_path']);
         $this->assertSame('target_family_hub_companion', $familyLink['link_reason_code']);
+        $this->assertSame('/en/tests/mbti-personality-test-16-personality-types', $testLanding['canonical_path']);
+        $this->assertSame('recommendation_test_support', $testLanding['link_reason_code']);
+        $this->assertSame('MBTI', $testLanding['scale_code']);
+        $this->assertArrayNotHasKey('source_of_truth', $testLanding);
+        $this->assertArrayNotHasKey('is_active', $testLanding);
         $this->assertSame(
             ['accountants-and-auditors', 'human-resources-specialists'],
             $jobLinks->pluck('canonical_slug')->sort()->values()->all()
@@ -72,6 +79,7 @@ final class CareerFirstWaveRecommendationCompanionLinksServiceTest extends TestC
         $this->assertTrue($jobLinks->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'human-resources-specialists'
             && ($row['link_reason_code'] ?? null) === 'matched_job_detail_companion'));
         $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'backend-architect-cn-market'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'topic_detail'));
         $this->assertSame(1, $jobLinks->where('canonical_slug', 'accountants-and-auditors')->count());
     }
 


### PR DESCRIPTION
## What changed
- extend the existing B38 recommendation companion-links authority surface with one additive public-safe route kind: `test_landing`
- keep the endpoint, subject kind, and existing job/family companion behavior unchanged while remapping internal support-linkage truth to a curated public reason code
- add focused regression coverage for additive `test_landing` rows, locale-aware canonical paths, internal-field exclusion, and continued exclusion of `topic_detail` and other unsupported route kinds

## Why
- B39A established internal canonical support-route registry and recommendation-subject linkage truth, but only `test_landing` is strong enough to publicize safely right now
- extending B38 is the narrowest path because it preserves the existing recommendation companion surface and avoids a second endpoint for the same subject
- this keeps support-link publicization machine-safe without leaking internal registry metadata, CTA heuristics, or content-heavy topic semantics

## Validation
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php tests/Feature/Career/CareerFirstWaveNextStepLinksApiTest.php tests/Feature/Career/CareerFirstWaveOccupationCompanionLinksApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no `topic_detail` publicization
- no occupation-subject support-link changes
- no new endpoint
- no `tests_index` or `test_take`
- no search/alias/editorial/article URLs
- no frontend changes
