### PR TITLE
PR-B40: Career recommendation topic support-links public extension

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php
+++ b/backend/app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php
@@ -10,7 +10,7 @@ final class CareerFirstWaveRecommendationCompanionLinksSummary
      * @param  array<string, mixed>  $subjectIdentity
      * @param  array<string, int>  $counts
      * @param  list<array{
-     *     route_kind:'career_job_detail'|'career_family_hub'|'test_landing',
+     *     route_kind:'career_job_detail'|'career_family_hub'|'test_landing'|'topic_detail',
      *     canonical_path:string,
      *     canonical_slug:string,
      *     link_reason_code:string,
@@ -18,7 +18,8 @@ final class CareerFirstWaveRecommendationCompanionLinksSummary
      *     canonical_title_en?:string,
      *     family_uuid?:string,
      *     title_en?:string,
-     *     scale_code?:string
+     *     scale_code?:string,
+     *     topic_code?:string
      * }>  $companionLinks
      */
     public function __construct(

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php
@@ -125,24 +125,44 @@ final class CareerFirstWaveRecommendationCompanionLinksService
 
         $supportLinkage = $this->recommendationSupportLinkageBuilder->buildByType($normalizedType, $locale);
         $supportLinks = collect((array) data_get($supportLinkage, 'support_links', []))
-            ->filter(static fn (mixed $row): bool => is_array($row))
-            ->filter(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'test_landing');
+            ->filter(static fn (mixed $row): bool => is_array($row));
 
         foreach ($supportLinks as $supportLink) {
             $canonicalPath = trim((string) ($supportLink['canonical_path'] ?? ''));
             $canonicalSlug = trim((string) ($supportLink['canonical_slug'] ?? ''));
+            $routeKind = trim((string) ($supportLink['route_kind'] ?? ''));
 
             if ($canonicalPath === '' || $canonicalSlug === '') {
                 continue;
             }
 
-            $companionLinks[] = [
-                'route_kind' => 'test_landing',
-                'canonical_path' => $canonicalPath,
-                'canonical_slug' => $canonicalSlug,
-                'link_reason_code' => 'recommendation_test_support',
-                'scale_code' => 'MBTI',
-            ];
+            if ($routeKind === 'test_landing') {
+                $companionLinks[] = [
+                    'route_kind' => 'test_landing',
+                    'canonical_path' => $canonicalPath,
+                    'canonical_slug' => $canonicalSlug,
+                    'link_reason_code' => 'recommendation_test_support',
+                    'scale_code' => 'MBTI',
+                ];
+
+                continue;
+            }
+
+            if ($routeKind === 'topic_detail') {
+                $topicCode = trim((string) data_get($supportLink, 'topic_code', $canonicalSlug));
+
+                if ($topicCode === '') {
+                    $topicCode = $canonicalSlug;
+                }
+
+                $companionLinks[] = [
+                    'route_kind' => 'topic_detail',
+                    'canonical_path' => $canonicalPath,
+                    'canonical_slug' => $canonicalSlug,
+                    'link_reason_code' => 'recommendation_topic_support',
+                    'topic_code' => $topicCode,
+                ];
+            }
         }
 
         $dedupedLinks = collect($companionLinks)
@@ -160,6 +180,7 @@ final class CareerFirstWaveRecommendationCompanionLinksService
             'job_detail' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_job_detail')),
             'family_hub' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub')),
             'test_landing' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'test_landing')),
+            'topic_detail' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'topic_detail')),
         ];
 
         return new CareerFirstWaveRecommendationCompanionLinksSummary(

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php
@@ -20,7 +20,8 @@ final class CareerFirstWaveRecommendationCompanionLinksController extends Contro
     ) {}
 
     /**
-     * Existing B38 endpoint, additively extended for public-safe recommendation support links.
+     * Existing B38 endpoint, additively extended for public-safe recommendation support links,
+     * including canonical topic support rows for recommendation subjects only.
      */
     public function show(Request $request, string $type): JsonResponse|CareerFirstWaveRecommendationCompanionLinksSummaryResource
     {

--- a/backend/app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php
+++ b/backend/app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php
@@ -22,7 +22,7 @@ final class CareerFirstWaveRecommendationCompanionLinksSummaryResource extends J
      *     scope:string,
      *     subject_kind:string,
      *     subject_identity:array<string, mixed>,
-     *     counts:array<string, int>,
+     *     counts:array{total:int,job_detail:int,family_hub:int,test_landing:int,topic_detail:int},
      *     companion_links:list<array<string, mixed>>
      * }
      */

--- a/backend/tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php
@@ -10,6 +10,7 @@ use App\Models\CareerImportRun;
 use App\Models\ContextSnapshot;
 use App\Models\Occupation;
 use App\Models\ProfileProjection;
+use App\Models\TopicProfile;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -23,6 +24,7 @@ final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
     public function test_it_exposes_a_first_wave_recommendation_companion_links_summary_for_supported_route_kinds_only(): void
     {
         $this->materializeCurrentFirstWaveFixture();
+        $this->createPublishedTopicProfile('mbti', 'mbti', 'en');
 
         $subjectMeta = [
             'type_code' => 'INTJ-A',
@@ -47,17 +49,18 @@ final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
             ->assertJsonPath('subject_identity.type_code', 'INTJ-A')
             ->assertJsonPath('subject_identity.canonical_type_code', 'INTJ')
             ->assertJsonPath('subject_identity.public_route_slug', 'intj')
-            ->assertJsonPath('counts.total', 4)
+            ->assertJsonPath('counts.total', 5)
             ->assertJsonPath('counts.job_detail', 2)
             ->assertJsonPath('counts.family_hub', 1)
             ->assertJsonPath('counts.test_landing', 1)
+            ->assertJsonPath('counts.topic_detail', 1)
             ->assertJsonStructure([
                 'summary_kind',
                 'summary_version',
                 'scope',
                 'subject_kind',
                 'subject_identity' => ['type_code', 'canonical_type_code', 'public_route_slug', 'display_title'],
-                'counts' => ['total', 'job_detail', 'family_hub', 'test_landing'],
+                'counts' => ['total', 'job_detail', 'family_hub', 'test_landing', 'topic_detail'],
                 'companion_links' => [[
                     'route_kind',
                     'canonical_path',
@@ -71,22 +74,31 @@ final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
         $links = collect($response->json('companion_links'));
 
         $this->assertSame(
-            ['career_family_hub', 'career_job_detail', 'test_landing'],
+            ['career_family_hub', 'career_job_detail', 'test_landing', 'topic_detail'],
             $links->pluck('route_kind')->unique()->sort()->values()->all()
         );
         $testLanding = $links->firstWhere('route_kind', 'test_landing');
+        $topicDetail = $links->firstWhere('route_kind', 'topic_detail');
         $this->assertSame('/en/tests/mbti-personality-test-16-personality-types', $testLanding['canonical_path']);
         $this->assertSame('recommendation_test_support', $testLanding['link_reason_code']);
         $this->assertSame('MBTI', $testLanding['scale_code']);
+        $this->assertSame('/en/topics/mbti', $topicDetail['canonical_path']);
+        $this->assertSame('recommendation_topic_support', $topicDetail['link_reason_code']);
+        $this->assertSame('mbti', $topicDetail['topic_code']);
         $this->assertArrayNotHasKey('source_of_truth', $testLanding);
         $this->assertArrayNotHasKey('is_active', $testLanding);
+        $this->assertArrayNotHasKey('source_of_truth', $topicDetail);
+        $this->assertArrayNotHasKey('is_active', $topicDetail);
         $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/recommendations')));
         $this->assertFalse($links->contains(static fn (array $row): bool => str_starts_with((string) ($row['canonical_path'] ?? ''), '/career/search')));
         $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/career/tests/')));
-        $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/topics/')));
         $this->assertFalse($links->contains(static fn (array $row): bool => str_ends_with((string) ($row['canonical_path'] ?? ''), '/take')));
         $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'backend-architect-cn-market'));
         $this->assertSame(1, $links->where('canonical_slug', 'accountants-and-auditors')->count());
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/articles/')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => str_contains((string) ($row['canonical_path'] ?? ''), '/guides/')));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'mbti-personality-test-16-personality-types'
+            && ($row['route_kind'] ?? null) === 'topic_detail'));
     }
 
     public function test_it_returns_not_found_for_unknown_recommendation_subjects(): void
@@ -102,6 +114,7 @@ final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
     public function test_it_resolves_test_landing_paths_with_request_locale(): void
     {
         $this->materializeCurrentFirstWaveFixture();
+        $this->createPublishedTopicProfile('mbti', 'mbti', 'zh-CN');
 
         $subjectMeta = [
             'type_code' => 'INTJ-A',
@@ -124,6 +137,32 @@ final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
         $this->assertSame('/zh/tests/mbti-personality-test-16-personality-types', $testLanding['canonical_path']);
     }
 
+    public function test_it_resolves_topic_detail_paths_with_request_locale(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $this->createPublishedTopicProfile('mbti', 'mbti', 'zh-CN');
+
+        $subjectMeta = [
+            'type_code' => 'INTJ-A',
+            'canonical_type_code' => 'INTJ',
+            'display_title' => 'INTJ-A Career Match',
+            'public_route_slug' => 'intj',
+        ];
+
+        CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+
+        $this->compileRecommendationSnapshotForOccupation('accountants-and-auditors', $subjectMeta, 1);
+
+        $response = $this->getJson('/api/v0.5/career/first-wave/recommendations/mbti/intj/companion-links?locale=zh-CN');
+
+        $response->assertOk();
+
+        $links = collect($response->json('companion_links'));
+        $topicDetail = $links->firstWhere('route_kind', 'topic_detail');
+
+        $this->assertSame('/zh/topics/mbti', $topicDetail['canonical_path']);
+    }
+
     private function materializeCurrentFirstWaveFixture(): void
     {
         $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
@@ -135,6 +174,22 @@ final class CareerFirstWaveRecommendationCompanionLinksApiTest extends TestCase
         ]);
 
         $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    private function createPublishedTopicProfile(string $topicCode, string $slug, string $locale): void
+    {
+        TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => $topicCode,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => strtoupper($topicCode).' Topic',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => 'v1',
+        ]);
     }
 
     /**

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php
@@ -10,6 +10,7 @@ use App\Models\CareerImportRun;
 use App\Models\ContextSnapshot;
 use App\Models\Occupation;
 use App\Models\ProfileProjection;
+use App\Models\TopicProfile;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -23,6 +24,7 @@ final class CareerFirstWaveRecommendationCompanionLinksServiceTest extends TestC
     public function test_it_builds_machine_safe_companion_links_for_a_first_wave_recommendation_subject(): void
     {
         $this->materializeCurrentFirstWaveFixture();
+        $this->createPublishedTopicProfile('mbti', 'mbti', 'en');
 
         $subjectMeta = [
             'type_code' => 'INTJ-A',
@@ -47,14 +49,15 @@ final class CareerFirstWaveRecommendationCompanionLinksServiceTest extends TestC
         $this->assertSame('INTJ-A', data_get($summary, 'subject_identity.type_code'));
         $this->assertSame('INTJ', data_get($summary, 'subject_identity.canonical_type_code'));
         $this->assertSame('intj', data_get($summary, 'subject_identity.public_route_slug'));
-        $this->assertSame(4, data_get($summary, 'counts.total'));
+        $this->assertSame(5, data_get($summary, 'counts.total'));
         $this->assertSame(2, data_get($summary, 'counts.job_detail'));
         $this->assertSame(1, data_get($summary, 'counts.family_hub'));
         $this->assertSame(1, data_get($summary, 'counts.test_landing'));
+        $this->assertSame(1, data_get($summary, 'counts.topic_detail'));
 
         $links = collect($summary['companion_links']);
         $this->assertSame(
-            ['career_family_hub', 'career_job_detail', 'test_landing'],
+            ['career_family_hub', 'career_job_detail', 'test_landing', 'topic_detail'],
             $links->pluck('route_kind')->unique()->sort()->values()->all()
         );
 
@@ -62,6 +65,7 @@ final class CareerFirstWaveRecommendationCompanionLinksServiceTest extends TestC
         $familyLink = $links->firstWhere('route_kind', 'career_family_hub');
         $jobLinks = $links->where('route_kind', 'career_job_detail')->values();
         $testLanding = $links->firstWhere('route_kind', 'test_landing');
+        $topicDetail = $links->firstWhere('route_kind', 'topic_detail');
 
         $this->assertSame('target_job_detail_companion', $targetJob['link_reason_code']);
         $this->assertSame('/career/jobs/accountants-and-auditors', $targetJob['canonical_path']);
@@ -70,8 +74,13 @@ final class CareerFirstWaveRecommendationCompanionLinksServiceTest extends TestC
         $this->assertSame('/en/tests/mbti-personality-test-16-personality-types', $testLanding['canonical_path']);
         $this->assertSame('recommendation_test_support', $testLanding['link_reason_code']);
         $this->assertSame('MBTI', $testLanding['scale_code']);
+        $this->assertSame('/en/topics/mbti', $topicDetail['canonical_path']);
+        $this->assertSame('recommendation_topic_support', $topicDetail['link_reason_code']);
+        $this->assertSame('mbti', $topicDetail['topic_code']);
         $this->assertArrayNotHasKey('source_of_truth', $testLanding);
         $this->assertArrayNotHasKey('is_active', $testLanding);
+        $this->assertArrayNotHasKey('source_of_truth', $topicDetail);
+        $this->assertArrayNotHasKey('is_active', $topicDetail);
         $this->assertSame(
             ['accountants-and-auditors', 'human-resources-specialists'],
             $jobLinks->pluck('canonical_slug')->sort()->values()->all()
@@ -79,8 +88,37 @@ final class CareerFirstWaveRecommendationCompanionLinksServiceTest extends TestC
         $this->assertTrue($jobLinks->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'human-resources-specialists'
             && ($row['link_reason_code'] ?? null) === 'matched_job_detail_companion'));
         $this->assertFalse($links->contains(static fn (array $row): bool => ($row['canonical_slug'] ?? null) === 'backend-architect-cn-market'));
-        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'topic_detail'));
         $this->assertSame(1, $jobLinks->where('canonical_slug', 'accountants-and-auditors')->count());
+    }
+
+    public function test_it_excludes_support_links_for_non_mbti_recommendation_subjects_while_preserving_career_companions(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $this->createPublishedTopicProfile('mbti', 'mbti', 'en');
+
+        $subjectMeta = [
+            'type_code' => 'DISC-A',
+            'canonical_type_code' => 'DISC',
+            'display_title' => 'DISC-A Career Match',
+            'public_route_slug' => 'disc',
+        ];
+
+        CareerFoundationFixture::seedTrustLimitedCrossMarketChain();
+
+        $this->compileRecommendationSnapshotForOccupation('accountants-and-auditors', $subjectMeta, 1);
+
+        $summary = app(CareerFirstWaveRecommendationCompanionLinksService::class)->buildByType('disc')?->toArray();
+
+        $this->assertIsArray($summary);
+        $this->assertSame(2, data_get($summary, 'counts.total'));
+        $this->assertSame(1, data_get($summary, 'counts.job_detail'));
+        $this->assertSame(1, data_get($summary, 'counts.family_hub'));
+        $this->assertSame(0, data_get($summary, 'counts.test_landing'));
+        $this->assertSame(0, data_get($summary, 'counts.topic_detail'));
+
+        $links = collect($summary['companion_links']);
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'test_landing'));
+        $this->assertFalse($links->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'topic_detail'));
     }
 
     public function test_it_returns_null_for_unknown_or_unavailable_recommendation_subjects(): void
@@ -104,6 +142,22 @@ final class CareerFirstWaveRecommendationCompanionLinksServiceTest extends TestC
         ]);
 
         $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    private function createPublishedTopicProfile(string $topicCode, string $slug, string $locale): void
+    {
+        TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => $topicCode,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => strtoupper($topicCode).' Topic',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => 'v1',
+        ]);
     }
 
     /**


### PR DESCRIPTION
## What changed
- extend the existing recommendation companion-links authority surface additively with one new public-safe support route kind: `topic_detail`
- keep the same endpoint and subject kind, remapping internal `canonical_topic_detail` linkage to a curated public reason code and exposing only canonical topic fields needed publicly
- add focused coverage for canonical topic inclusion, locale-aware topic paths, non-MBTI support-link exclusion, and continued exclusion of `tests_index`, `test_take`, entry-group, and editorial/article URLs

## Why
- B39A already established internal canonical topic registry and recommendation-subject linkage truth, but B39 only publicized `test_landing`
- `topic_detail` is now strong enough for a narrow public extension as long as it stays recommendation-only, canonical-only, and free of CMS CTA or editorial metadata
- extending the existing B38/B39 companion surface is the lowest-risk path because it preserves the established recommendation companion contract and avoids a second endpoint

## Validation
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRecommendationCompanionLinksService.php app/DTO/Career/CareerFirstWaveRecommendationCompanionLinksSummary.php app/Http/Resources/Career/CareerFirstWaveRecommendationCompanionLinksSummaryResource.php app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRecommendationCompanionLinksServiceTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Career/CareerTransitionPreviewApiTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Feature/Career/CareerFirstWaveDiscoverabilityManifestApiTest.php tests/Feature/Career/CareerFirstWaveNextStepLinksApiTest.php tests/Feature/Career/CareerFirstWaveOccupationCompanionLinksApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no occupation-subject support links
- no new endpoint
- no `tests_index` or `test_take`
- no entry-group, article, or editorial URL publicization
- no frontend changes
