### PR TITLE
PR-B42: Career attribution compatibility hardening + daily read-model alignment

### DIFF
--- a/backend/app/Services/Analytics/CareerAttributionDailyBuilder.php
+++ b/backend/app/Services/Analytics/CareerAttributionDailyBuilder.php
@@ -56,6 +56,7 @@ final class CareerAttributionDailyBuilder
                 : (json_decode((string) ($event->meta_json ?? '{}'), true) ?: []);
 
             $surface = $this->normalizeDimension($meta['entry_surface'] ?? null, 128, 'unknown');
+            $sourcePageType = $this->normalizeSourcePageType($meta['source_page_type'] ?? null);
             $routeFamily = $this->normalizeDimension($meta['route_family'] ?? null, 64, 'unknown');
             $subjectKind = $this->normalizeDimension($meta['subject_kind'] ?? null, 32, 'none');
             $subjectKey = $subjectKind === 'none'
@@ -75,6 +76,7 @@ final class CareerAttributionDailyBuilder
                 max(0, (int) ($event->org_id ?? 0)),
                 $locale,
                 $surface,
+                $sourcePageType,
                 $routeFamily,
                 $eventName,
                 $subjectKind,
@@ -89,6 +91,7 @@ final class CareerAttributionDailyBuilder
                     'org_id' => max(0, (int) ($event->org_id ?? 0)),
                     'locale' => $locale,
                     'surface' => $surface,
+                    'source_page_type' => $sourcePageType,
                     'route_family' => $routeFamily,
                     'event_name' => $eventName,
                     'subject_kind' => $subjectKind,
@@ -161,7 +164,7 @@ final class CareerAttributionDailyBuilder
 
                 DB::table('analytics_career_attribution_daily')->upsert(
                     $rows,
-                    ['day', 'org_id', 'locale', 'surface', 'route_family', 'event_name', 'subject_kind', 'subject_key', 'readiness_class', 'query_mode'],
+                    ['day', 'org_id', 'locale', 'surface', 'source_page_type', 'route_family', 'event_name', 'subject_kind', 'subject_key', 'readiness_class', 'query_mode'],
                     ['event_count', 'unique_anon_count', 'unique_session_count', 'last_refreshed_at', 'updated_at']
                 );
 
@@ -243,6 +246,21 @@ final class CareerAttributionDailyBuilder
         }
 
         return $normalized;
+    }
+
+    private function normalizeSourcePageType(mixed $value): string
+    {
+        $normalized = strtolower($this->normalizeDimension($value, 64, 'unknown'));
+
+        return match ($normalized) {
+            'career_job_index' => 'job_index',
+            'career_job_detail' => 'job_detail',
+            'career_recommendation_index' => 'recommendation_index',
+            'career_recommendation_detail' => 'recommendation_detail',
+            'career_family_hub' => 'family_hub',
+            'career_alias_disambiguation' => 'alias_disambiguation',
+            default => $normalized,
+        };
     }
 
     /**

--- a/backend/app/Services/Analytics/CareerAttributionEventMapper.php
+++ b/backend/app/Services/Analytics/CareerAttributionEventMapper.php
@@ -53,6 +53,31 @@ final class CareerAttributionEventMapper
     /**
      * @var list<string>
      */
+    private const ALLOWED_SOURCE_PAGE_TYPES = [
+        'landing',
+        'job_index',
+        'job_detail',
+        'recommendation_index',
+        'recommendation_detail',
+        'family_hub',
+        'alias_disambiguation',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const SOURCE_PAGE_TYPE_ALIASES = [
+        'career_job_index' => 'job_index',
+        'career_job_detail' => 'job_detail',
+        'career_recommendation_index' => 'recommendation_index',
+        'career_recommendation_detail' => 'recommendation_detail',
+        'career_family_hub' => 'family_hub',
+        'career_alias_disambiguation' => 'alias_disambiguation',
+    ];
+
+    /**
+     * @var list<string>
+     */
     private const ALLOWED_QUERY_MODES = [
         'query',
         'non_query',
@@ -101,6 +126,7 @@ final class CareerAttributionEventMapper
             self::ALLOWED_SUBJECT_KINDS,
             'subject_kind'
         );
+        $sourcePageType = $this->normalizeSourcePageType($payload['source_page_type'] ?? null);
         $queryMode = $this->normalizeEnum(
             $payload['query_mode'] ?? null,
             self::ALLOWED_QUERY_MODES,
@@ -110,7 +136,7 @@ final class CareerAttributionEventMapper
 
         $meta = [
             'entry_surface' => $this->normalizeOptionalString($payload['entry_surface'] ?? null, 128) ?? 'unknown',
-            'source_page_type' => $this->normalizeOptionalString($payload['source_page_type'] ?? null, 64) ?? 'unknown',
+            'source_page_type' => $sourcePageType,
             'target_action' => $this->normalizeOptionalString($payload['target_action'] ?? null, 128),
             'landing_path' => $this->normalizePath($payload['landing_path'] ?? null) ?? $path,
             'route_family' => $routeFamily,
@@ -167,6 +193,24 @@ final class CareerAttributionEventMapper
         if ($normalized === null) {
             throw ValidationException::withMessages([
                 'payload.subject_key' => 'payload.subject_key is required when subject_kind is not none.',
+            ]);
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeSourcePageType(mixed $value): string
+    {
+        $normalized = strtolower((string) $this->normalizeOptionalString($value, 64));
+        if ($normalized === '') {
+            return 'unknown';
+        }
+
+        $normalized = self::SOURCE_PAGE_TYPE_ALIASES[$normalized] ?? $normalized;
+
+        if (! in_array($normalized, self::ALLOWED_SOURCE_PAGE_TYPES, true)) {
+            throw ValidationException::withMessages([
+                'payload.source_page_type' => 'payload.source_page_type is not supported by career attribution ingest.',
             ]);
         }
 

--- a/backend/database/migrations/2026_04_13_000100_add_source_page_type_to_analytics_career_attribution_daily_table.php
+++ b/backend/database/migrations/2026_04_13_000100_add_source_page_type_to_analytics_career_attribution_daily_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('analytics_career_attribution_daily')) {
+            return;
+        }
+
+        if (! Schema::hasColumn('analytics_career_attribution_daily', 'source_page_type')) {
+            Schema::table('analytics_career_attribution_daily', function (Blueprint $table): void {
+                $table->string('source_page_type', 64)->default('unknown')->after('surface');
+            });
+        }
+
+        Schema::table('analytics_career_attribution_daily', function (Blueprint $table): void {
+            try {
+                $table->dropUnique('analytics_career_attr_daily_unique');
+            } catch (\Throwable) {
+                // Index may not exist yet in some local or CI states.
+            }
+
+            try {
+                $table->dropIndex('analytics_career_attr_daily_surface_event_idx');
+            } catch (\Throwable) {
+                // Index may not exist yet in some local or CI states.
+            }
+        });
+
+        Schema::table('analytics_career_attribution_daily', function (Blueprint $table): void {
+            $table->unique(
+                ['day', 'org_id', 'locale', 'surface', 'source_page_type', 'route_family', 'event_name', 'subject_kind', 'subject_key', 'readiness_class', 'query_mode'],
+                'analytics_career_attr_daily_unique'
+            );
+            $table->index(
+                ['surface', 'source_page_type', 'event_name'],
+                'analytics_career_attr_daily_surface_event_idx'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
@@ -16,7 +16,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_refresh_builds_career_rows_grouped_by_surface_subject_and_readiness_class(): void
+    public function test_refresh_builds_career_rows_grouped_by_source_page_type_surface_subject_and_readiness_class(): void
     {
         $this->materializeCurrentFirstWaveFixture();
 
@@ -25,6 +25,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
 
         $this->insertCareerEvent($orgId, 'career_job_index_result_click', $day, [
             'entry_surface' => 'career_job_index',
+            'source_page_type' => 'job_index',
             'route_family' => 'jobs',
             'subject_kind' => 'job_slug',
             'subject_key' => 'data-scientists',
@@ -32,6 +33,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         ], 'anon_a', 'session_a');
         $this->insertCareerEvent($orgId, 'career_job_index_result_click', $day->copy()->addMinute(), [
             'entry_surface' => 'career_job_index',
+            'source_page_type' => 'job_index',
             'route_family' => 'jobs',
             'subject_kind' => 'job_slug',
             'subject_key' => 'data-scientists',
@@ -39,6 +41,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         ], 'anon_a', 'session_a');
         $this->insertCareerEvent($orgId, 'career_job_search_result_click', $day->copy()->addMinutes(2), [
             'entry_surface' => 'career_job_search',
+            'source_page_type' => 'job_index',
             'route_family' => 'jobs_search',
             'subject_kind' => 'job_slug',
             'subject_key' => 'software-developers',
@@ -46,6 +49,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         ], 'anon_b', 'session_b');
         $this->insertCareerEvent($orgId, 'career_recommendation_matched_job_click', $day->copy()->addMinutes(3), [
             'entry_surface' => 'career_recommendation_detail',
+            'source_page_type' => 'recommendation_detail',
             'route_family' => 'recommendation_detail',
             'subject_kind' => 'job_slug',
             'subject_key' => 'marketing-managers',
@@ -53,6 +57,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         ], 'anon_c', 'session_c');
         $this->insertCareerEvent($orgId, 'career_recommendation_result_click', $day->copy()->addMinutes(4), [
             'entry_surface' => 'career_recommendation_index',
+            'source_page_type' => 'recommendation_index',
             'route_family' => 'recommendations',
             'subject_kind' => 'recommendation_type',
             'subject_key' => 'intj',
@@ -60,6 +65,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         ], 'anon_d', 'session_d');
         $this->insertCareerEvent($orgId, 'career_transition_preview_view', $day->copy()->addMinutes(5), [
             'entry_surface' => 'career_recommendation_detail_transition_preview',
+            'source_page_type' => 'career_recommendation_detail',
             'route_family' => 'recommendation_detail',
             'subject_kind' => 'job_slug',
             'subject_key' => 'registered-nurses',
@@ -67,15 +73,32 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         ], 'anon_e', 'session_e');
         $this->insertCareerEvent($orgId, 'career_transition_preview_target_click', $day->copy()->addMinutes(6), [
             'entry_surface' => 'career_recommendation_detail_transition_preview',
+            'source_page_type' => 'career_recommendation_detail',
             'route_family' => 'recommendation_detail',
             'subject_kind' => 'job_slug',
             'subject_key' => 'registered-nurses',
             'query_mode' => 'non_query',
         ], 'anon_f', 'session_f');
+        $this->insertCareerEvent($orgId, 'career_blocked_surface_exposed', $day->copy()->addMinutes(7), [
+            'entry_surface' => 'career_blocked_surface',
+            'source_page_type' => 'job_detail',
+            'route_family' => 'job_detail',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'data-scientists',
+            'query_mode' => 'non_query',
+        ], 'anon_g', 'session_g');
+        $this->insertCareerEvent($orgId, 'career_blocked_surface_exposed', $day->copy()->addMinutes(8), [
+            'entry_surface' => 'career_blocked_surface',
+            'source_page_type' => 'recommendation_detail',
+            'route_family' => 'job_detail',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'data-scientists',
+            'query_mode' => 'non_query',
+        ], 'anon_h', 'session_h');
 
         $result = app(CareerAttributionDailyBuilder::class)->refresh($day, $day, [$orgId], false);
 
-        $this->assertSame(6, (int) ($result['upserted_rows'] ?? 0));
+        $this->assertSame(8, (int) ($result['upserted_rows'] ?? 0));
 
         $readyRow = DB::table('analytics_career_attribution_daily')
             ->where('day', $day->toDateString())
@@ -86,6 +109,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
 
         $this->assertNotNull($readyRow);
         $this->assertSame('publish_ready', $readyRow->readiness_class);
+        $this->assertSame('job_index', $readyRow->source_page_type);
         $this->assertSame(2, (int) $readyRow->event_count);
         $this->assertSame(1, (int) $readyRow->unique_anon_count);
         $this->assertSame(1, (int) $readyRow->unique_session_count);
@@ -97,6 +121,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
 
         $this->assertNotNull($blockedRow);
         $this->assertSame('blocked_override_eligible', $blockedRow->readiness_class);
+        $this->assertSame('job_index', $blockedRow->source_page_type);
         $this->assertSame('query', $blockedRow->query_mode);
         $this->assertSame('jobs_search', $blockedRow->route_family);
 
@@ -107,6 +132,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
 
         $this->assertNotNull($matchedJobRow);
         $this->assertSame('blocked_not_safely_remediable', $matchedJobRow->readiness_class);
+        $this->assertSame('recommendation_detail', $matchedJobRow->source_page_type);
         $this->assertSame('recommendation_detail', $matchedJobRow->route_family);
 
         $recommendationRow = DB::table('analytics_career_attribution_daily')
@@ -116,6 +142,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
 
         $this->assertNotNull($recommendationRow);
         $this->assertSame('recommendation_type', $recommendationRow->subject_kind);
+        $this->assertSame('recommendation_index', $recommendationRow->source_page_type);
         $this->assertSame('unknown', $recommendationRow->readiness_class);
 
         $transitionPreviewViewRow = DB::table('analytics_career_attribution_daily')
@@ -125,6 +152,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
 
         $this->assertNotNull($transitionPreviewViewRow);
         $this->assertSame('career_recommendation_detail_transition_preview', $transitionPreviewViewRow->surface);
+        $this->assertSame('recommendation_detail', $transitionPreviewViewRow->source_page_type);
         $this->assertSame('recommendation_detail', $transitionPreviewViewRow->route_family);
         $this->assertSame('job_slug', $transitionPreviewViewRow->subject_kind);
         $this->assertSame('publish_ready', $transitionPreviewViewRow->readiness_class);
@@ -136,9 +164,27 @@ final class CareerAttributionDailyBuilderTest extends TestCase
 
         $this->assertNotNull($transitionPreviewClickRow);
         $this->assertSame('career_recommendation_detail_transition_preview', $transitionPreviewClickRow->surface);
+        $this->assertSame('recommendation_detail', $transitionPreviewClickRow->source_page_type);
         $this->assertSame('recommendation_detail', $transitionPreviewClickRow->route_family);
         $this->assertSame('job_slug', $transitionPreviewClickRow->subject_kind);
         $this->assertSame('publish_ready', $transitionPreviewClickRow->readiness_class);
+
+        $jobBlockedRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_blocked_surface_exposed')
+            ->where('subject_key', 'data-scientists')
+            ->where('source_page_type', 'job_detail')
+            ->first();
+
+        $recommendationBlockedRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_blocked_surface_exposed')
+            ->where('subject_key', 'data-scientists')
+            ->where('source_page_type', 'recommendation_detail')
+            ->first();
+
+        $this->assertNotNull($jobBlockedRow);
+        $this->assertNotNull($recommendationBlockedRow);
+        $this->assertSame(1, (int) $jobBlockedRow->event_count);
+        $this->assertSame(1, (int) $recommendationBlockedRow->event_count);
     }
 
     private function materializeCurrentFirstWaveFixture(): void

--- a/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
@@ -56,10 +56,165 @@ final class CareerAttributionEventIngestTest extends TestCase
             : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
 
         $this->assertSame('career_job_index', $meta['entry_surface'] ?? null);
+        $this->assertSame('job_index', $meta['source_page_type'] ?? null);
         $this->assertSame('jobs_search', $meta['route_family'] ?? null);
         $this->assertSame('query', $meta['query_mode'] ?? null);
         $this->assertArrayNotHasKey('query_text', $meta);
         $this->assertArrayNotHasKey('raw_payload', $meta);
+    }
+
+    public function test_ingest_endpoint_accepts_the_current_stable_career_event_set_without_collapsing_it_into_generic_buckets(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $cases = [
+            [
+                'event' => 'career_job_detail_view',
+                'anon' => 'anon_b42_job_detail',
+                'path' => '/en/career/jobs/data-scientist',
+                'payload' => [
+                    'entry_surface' => 'career_job_detail',
+                    'source_page_type' => 'career_job_detail',
+                    'target_action' => 'view_job_detail',
+                    'landing_path' => '/en/career/jobs/data-scientist',
+                    'route_family' => 'job_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'data-scientist',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'job_detail',
+            ],
+            [
+                'event' => 'career_recommendation_detail_view',
+                'anon' => 'anon_b42_recommendation_detail',
+                'path' => '/en/career/recommendations/mbti/intj-a',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => 'view_recommendation_detail',
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'recommendation_type',
+                    'subject_key' => 'intj',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'recommendation_detail',
+            ],
+            [
+                'event' => 'career_transition_preview_view',
+                'anon' => 'anon_b42_transition_view',
+                'path' => '/en/career/recommendations/mbti/intj-a',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail_transition_preview',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => 'view_transition_preview',
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'registered-nurses',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'recommendation_detail',
+            ],
+            [
+                'event' => 'career_transition_preview_target_click',
+                'anon' => 'anon_b42_transition_click',
+                'path' => '/en/career/recommendations/mbti/intj-a',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail_transition_preview',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => 'open_transition_target_job',
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'registered-nurses',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'recommendation_detail',
+            ],
+            [
+                'event' => 'career_job_search_submit',
+                'anon' => 'anon_b42_search_submit',
+                'path' => '/en/career/jobs?q=data',
+                'payload' => [
+                    'entry_surface' => 'career_job_index',
+                    'source_page_type' => 'job_index',
+                    'target_action' => 'submit_search',
+                    'landing_path' => '/en/career/jobs?q=data',
+                    'route_family' => 'jobs_search',
+                    'subject_kind' => 'none',
+                    'query_mode' => 'query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'job_index',
+            ],
+            [
+                'event' => 'career_job_search_result_click',
+                'anon' => 'anon_b42_search_click',
+                'path' => '/en/career/jobs?q=data',
+                'payload' => [
+                    'entry_surface' => 'career_job_search',
+                    'source_page_type' => 'job_index',
+                    'target_action' => 'open_search_result',
+                    'landing_path' => '/en/career/jobs?q=data',
+                    'route_family' => 'jobs_search',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'data-scientists',
+                    'query_mode' => 'query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'job_index',
+            ],
+            [
+                'event' => 'career_blocked_surface_exposed',
+                'anon' => 'anon_b42_blocked_surface',
+                'path' => '/en/career/jobs/software-developers',
+                'payload' => [
+                    'entry_surface' => 'career_job_detail',
+                    'source_page_type' => 'career_job_detail',
+                    'target_action' => 'expose_blocked_surface',
+                    'landing_path' => '/en/career/jobs/software-developers',
+                    'route_family' => 'job_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'job_detail',
+            ],
+        ];
+
+        foreach ($cases as $case) {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ingest_test_token',
+            ])->postJson('/api/v0.5/career/attribution/events', [
+                'eventName' => $case['event'],
+                'anonymousId' => $case['anon'],
+                'path' => $case['path'],
+                'timestamp' => '2026-04-12T10:00:00+08:00',
+                'payload' => $case['payload'],
+            ]);
+
+            $response->assertStatus(202)
+                ->assertJsonPath('event_code', $case['event']);
+
+            $row = DB::table('events')
+                ->where('event_code', $case['event'])
+                ->where('anon_id', $case['anon'])
+                ->first();
+
+            $this->assertNotNull($row);
+
+            $meta = is_array($row->meta_json ?? null)
+                ? $row->meta_json
+                : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
+
+            $this->assertSame($case['expected_source_page_type'], $meta['source_page_type'] ?? null);
+        }
     }
 
     public function test_ingest_endpoint_keeps_recommendation_interactions_distinct_from_job_interactions(): void
@@ -181,29 +336,54 @@ final class CareerAttributionEventIngestTest extends TestCase
             : (json_decode((string) ($clickRow->meta_json ?? '{}'), true) ?: []);
 
         $this->assertSame('career_recommendation_detail_transition_preview', $viewMeta['entry_surface'] ?? null);
+        $this->assertSame('recommendation_detail', $viewMeta['source_page_type'] ?? null);
         $this->assertSame('view_transition_preview', $viewMeta['target_action'] ?? null);
         $this->assertSame('job_slug', $viewMeta['subject_kind'] ?? null);
         $this->assertSame('registered-nurses', $viewMeta['subject_key'] ?? null);
 
         $this->assertSame('career_recommendation_detail_transition_preview', $clickMeta['entry_surface'] ?? null);
+        $this->assertSame('recommendation_detail', $clickMeta['source_page_type'] ?? null);
         $this->assertSame('open_transition_target_job', $clickMeta['target_action'] ?? null);
         $this->assertSame('job_slug', $clickMeta['subject_kind'] ?? null);
         $this->assertSame('registered-nurses', $clickMeta['subject_key'] ?? null);
     }
 
-    public function test_ingest_endpoint_rejects_invalid_event_name(): void
+    public function test_ingest_endpoint_rejects_invalid_or_deferred_event_names(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        foreach (['career_unknown_event', 'career_view', 'career_alias_search', 'career_shortlist_add'] as $eventName) {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ingest_test_token',
+            ])->postJson('/api/v0.5/career/attribution/events', [
+                'eventName' => $eventName,
+                'payload' => [
+                    'entry_surface' => 'career_job_index',
+                    'source_page_type' => 'job_index',
+                    'route_family' => 'jobs',
+                    'subject_kind' => 'none',
+                    'query_mode' => 'non_query',
+                ],
+            ]);
+
+            $response->assertStatus(422);
+        }
+    }
+
+    public function test_ingest_endpoint_rejects_unsupported_source_page_type_values(): void
     {
         config()->set('fap.events.ingest_token', 'ingest_test_token');
 
         $response = $this->withHeaders([
             'Authorization' => 'Bearer ingest_test_token',
         ])->postJson('/api/v0.5/career/attribution/events', [
-            'eventName' => 'career_unknown_event',
+            'eventName' => 'career_job_detail_view',
             'payload' => [
-                'entry_surface' => 'career_job_index',
-                'source_page_type' => 'job_index',
-                'route_family' => 'jobs',
-                'subject_kind' => 'none',
+                'entry_surface' => 'career_job_detail',
+                'source_page_type' => 'editorial_detail',
+                'route_family' => 'job_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'data-scientist',
                 'query_mode' => 'non_query',
             ],
         ]);

--- a/backend/tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php
@@ -32,6 +32,7 @@ final class RefreshCareerAttributionDailyCommandTest extends TestCase
             'attempt_id' => null,
             'meta_json' => json_encode([
                 'entry_surface' => 'career_job_index',
+                'source_page_type' => 'job_index',
                 'route_family' => 'jobs',
                 'subject_kind' => 'job_slug',
                 'subject_key' => 'data-scientists',
@@ -66,6 +67,7 @@ final class RefreshCareerAttributionDailyCommandTest extends TestCase
 
         $this->assertNotNull($row);
         $this->assertSame('publish_ready', $row->readiness_class);
+        $this->assertSame('job_index', $row->source_page_type);
     }
 
     private function materializeCurrentFirstWaveFixture(): void


### PR DESCRIPTION
## What changed
- harden Career attribution ingest so `source_page_type` is normalized and preserved as a first-class dimension instead of being treated as optional loose metadata
- align the Career daily read model and unique key with that dimension by adding `source_page_type` to the aggregation schema and rollup key
- expand focused Career attribution coverage to lock the current stable event set, preserve ingest compatibility, and keep deferred events like `career_view`, `career_alias_search`, and `career_shortlist_add` explicitly unsupported

## Why
- Career attribution infrastructure already existed, but its daily read model was not compatible with the stated requirement to preserve both `entry_surface` and `source_page_type`
- the safest move is compatibility hardening, not a new analytics system: keep the current event taxonomy, preserve the current ingest path, and correct the daily model so surface normalization is not lossy
- this keeps Career attribution internal-only while making the backend ready for consistent downstream read-model use

## Validation
- `vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php database/migrations/2026_04_13_000100_add_source_page_type_to_analytics_career_attribution_daily_table.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php`
- `php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php`

## Intentionally deferred
- no public analytics endpoint
- no dashboard or operator UI
- no generic `career_view`
- no `career_alias_search`
- no `career_shortlist_add`
- no broader claim-blocked taxonomy redesign
