### PR TITLE
PR-B43: Career structured-data authority readiness (job detail / family hub first)

### DIFF
--- a/backend/app/Services/Career/StructuredData/CareerBreadcrumbBuilder.php
+++ b/backend/app/Services/Career/StructuredData/CareerBreadcrumbBuilder.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\StructuredData;
+
+use App\DTO\Career\CareerFamilyHubBundle;
+use App\DTO\Career\CareerJobDetailBundle;
+
+final class CareerBreadcrumbBuilder
+{
+    /**
+     * @return list<array{name:string,path:string}>
+     */
+    public function buildForJobDetail(CareerJobDetailBundle $bundle): array
+    {
+        $canonicalPath = $this->normalizeString($bundle->seoContract['canonical_path'] ?? null)
+            ?? '/career/jobs/'.$this->normalizeString($bundle->identity['canonical_slug'] ?? null);
+        $canonicalTitle = $this->resolveJobTitle($bundle);
+
+        return $this->filterNodes([
+            ['name' => 'Career', 'path' => '/career'],
+            ['name' => $canonicalTitle, 'path' => $canonicalPath],
+        ]);
+    }
+
+    /**
+     * @return list<array{name:string,path:string}>
+     */
+    public function buildForFamilyHub(CareerFamilyHubBundle $bundle): array
+    {
+        $canonicalSlug = $this->normalizeString($bundle->family['canonical_slug'] ?? null);
+        $canonicalPath = $canonicalSlug !== null ? '/career/family/'.$canonicalSlug : null;
+        $canonicalTitle = $this->resolveFamilyTitle($bundle);
+
+        return $this->filterNodes([
+            ['name' => 'Career', 'path' => '/career'],
+            ['name' => $canonicalTitle, 'path' => $canonicalPath],
+        ]);
+    }
+
+    /**
+     * @param  list<array{name:string,path:string}>  $nodes
+     * @return array<string, mixed>
+     */
+    public function buildBreadcrumbList(array $nodes): array
+    {
+        $items = [];
+
+        foreach (array_values($nodes) as $index => $node) {
+            $items[] = [
+                '@type' => 'ListItem',
+                'position' => $index + 1,
+                'name' => $node['name'],
+                'item' => $node['path'],
+            ];
+        }
+
+        return [
+            '@context' => 'https://schema.org',
+            '@type' => 'BreadcrumbList',
+            'itemListElement' => $items,
+        ];
+    }
+
+    private function resolveJobTitle(CareerJobDetailBundle $bundle): string
+    {
+        return $this->normalizeString($bundle->titles['canonical_en'] ?? null)
+            ?? $this->normalizeString($bundle->titles['canonical_zh'] ?? null)
+            ?? $this->normalizeString($bundle->identity['canonical_slug'] ?? null)
+            ?? 'Career role';
+    }
+
+    private function resolveFamilyTitle(CareerFamilyHubBundle $bundle): string
+    {
+        return $this->normalizeString($bundle->family['title_en'] ?? null)
+            ?? $this->normalizeString($bundle->family['title_zh'] ?? null)
+            ?? $this->normalizeString($bundle->family['canonical_slug'] ?? null)
+            ?? 'Career family';
+    }
+
+    /**
+     * @param  list<array{name:string,path:?string}>  $nodes
+     * @return list<array{name:string,path:string}>
+     */
+    private function filterNodes(array $nodes): array
+    {
+        $filtered = [];
+
+        foreach ($nodes as $node) {
+            $name = $this->normalizeString($node['name'] ?? null);
+            $path = $this->normalizeString($node['path'] ?? null);
+
+            if ($name === null || $path === null) {
+                continue;
+            }
+
+            $filtered[] = [
+                'name' => $name,
+                'path' => $path,
+            ];
+        }
+
+        return $filtered;
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/Career/StructuredData/CareerFamilyHubStructuredDataBuilder.php
+++ b/backend/app/Services/Career/StructuredData/CareerFamilyHubStructuredDataBuilder.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\StructuredData;
+
+use App\DTO\Career\CareerFamilyHubBundle;
+
+final class CareerFamilyHubStructuredDataBuilder
+{
+    public function __construct(
+        private readonly CareerBreadcrumbBuilder $breadcrumbBuilder,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(CareerFamilyHubBundle $bundle): array
+    {
+        $canonicalSlug = $this->normalizeString($bundle->family['canonical_slug'] ?? null);
+        $canonicalPath = $canonicalSlug !== null ? '/career/family/'.$canonicalSlug : null;
+        $canonicalTitle = $this->resolveTitle($bundle);
+        $breadcrumbNodes = $this->breadcrumbBuilder->buildForFamilyHub($bundle);
+        $itemListElements = $this->buildItemListElements($bundle);
+
+        return [
+            'route_kind' => 'career_family_hub',
+            'canonical_path' => $canonicalPath,
+            'canonical_title' => $canonicalTitle,
+            'breadcrumb_nodes' => $breadcrumbNodes,
+            'fragments' => [
+                'collection_page' => $this->buildCollectionPageFragment($canonicalPath, $canonicalTitle, count($itemListElements)),
+                'item_list' => $this->buildItemListFragment($itemListElements),
+                'breadcrumb_list' => $this->breadcrumbBuilder->buildBreadcrumbList($breadcrumbNodes),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildCollectionPageFragment(?string $canonicalPath, string $canonicalTitle, int $numberOfItems): array
+    {
+        return array_filter([
+            '@context' => 'https://schema.org',
+            '@type' => 'CollectionPage',
+            'name' => $canonicalTitle,
+            'url' => $canonicalPath,
+            'mainEntityOfPage' => $canonicalPath,
+            'numberOfItems' => $numberOfItems,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function buildItemListElements(CareerFamilyHubBundle $bundle): array
+    {
+        $items = [];
+
+        foreach (array_values($bundle->visibleChildren) as $child) {
+            $name = $this->normalizeString($child['canonical_title_en'] ?? null)
+                ?? $this->normalizeString($child['canonical_title_zh'] ?? null)
+                ?? $this->normalizeString($child['canonical_slug'] ?? null);
+            $path = $this->normalizeString(data_get($child, 'seo_contract.canonical_path'));
+
+            if ($name === null || $path === null) {
+                continue;
+            }
+
+            $items[] = [
+                '@type' => 'ListItem',
+                'position' => count($items) + 1,
+                'name' => $name,
+                'url' => $path,
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function buildItemListFragment(array $items): array
+    {
+        return [
+            '@context' => 'https://schema.org',
+            '@type' => 'ItemList',
+            'itemListElement' => $items,
+            'numberOfItems' => count($items),
+        ];
+    }
+
+    private function resolveTitle(CareerFamilyHubBundle $bundle): string
+    {
+        return $this->normalizeString($bundle->family['title_en'] ?? null)
+            ?? $this->normalizeString($bundle->family['title_zh'] ?? null)
+            ?? $this->normalizeString($bundle->family['canonical_slug'] ?? null)
+            ?? 'Career family';
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/Career/StructuredData/CareerJobDetailStructuredDataBuilder.php
+++ b/backend/app/Services/Career/StructuredData/CareerJobDetailStructuredDataBuilder.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\StructuredData;
+
+use App\DTO\Career\CareerJobDetailBundle;
+
+final class CareerJobDetailStructuredDataBuilder
+{
+    public function __construct(
+        private readonly CareerBreadcrumbBuilder $breadcrumbBuilder,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(CareerJobDetailBundle $bundle): array
+    {
+        $canonicalPath = $this->normalizeString($bundle->seoContract['canonical_path'] ?? null)
+            ?? '/career/jobs/'.$this->normalizeString($bundle->identity['canonical_slug'] ?? null);
+        $canonicalTitle = $this->resolveTitle($bundle);
+        $breadcrumbNodes = $this->breadcrumbBuilder->buildForJobDetail($bundle);
+
+        return [
+            'route_kind' => 'career_job_detail',
+            'canonical_path' => $canonicalPath,
+            'canonical_title' => $canonicalTitle,
+            'breadcrumb_nodes' => $breadcrumbNodes,
+            'fragments' => [
+                'occupation' => $this->buildOccupationFragment($bundle, $canonicalPath, $canonicalTitle),
+                'breadcrumb_list' => $this->breadcrumbBuilder->buildBreadcrumbList($breadcrumbNodes),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildOccupationFragment(
+        CareerJobDetailBundle $bundle,
+        ?string $canonicalPath,
+        string $canonicalTitle,
+    ): array {
+        $fragment = [
+            '@context' => 'https://schema.org',
+            '@type' => 'Occupation',
+            'name' => $canonicalTitle,
+            'url' => $canonicalPath,
+            'mainEntityOfPage' => $canonicalPath,
+        ];
+
+        $educationRequirements = $this->normalizeString($bundle->truthLayer['entry_education'] ?? null);
+        $experienceRequirements = $this->normalizeString($bundle->truthLayer['work_experience'] ?? null);
+
+        if ($educationRequirements !== null) {
+            $fragment['educationRequirements'] = $educationRequirements;
+        }
+
+        if ($experienceRequirements !== null) {
+            $fragment['experienceRequirements'] = $experienceRequirements;
+        }
+
+        return array_filter($fragment, static fn (mixed $value): bool => $value !== null);
+    }
+
+    private function resolveTitle(CareerJobDetailBundle $bundle): string
+    {
+        return $this->normalizeString($bundle->titles['canonical_en'] ?? null)
+            ?? $this->normalizeString($bundle->titles['canonical_zh'] ?? null)
+            ?? $this->normalizeString($bundle->identity['canonical_slug'] ?? null)
+            ?? 'Career role';
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/Career/StructuredData/CareerStructuredDataBuilder.php
+++ b/backend/app/Services/Career/StructuredData/CareerStructuredDataBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\StructuredData;
+
+use App\DTO\Career\CareerFamilyHubBundle;
+use App\DTO\Career\CareerJobDetailBundle;
+
+final class CareerStructuredDataBuilder
+{
+    public function __construct(
+        private readonly CareerJobDetailStructuredDataBuilder $jobDetailBuilder,
+        private readonly CareerFamilyHubStructuredDataBuilder $familyHubBuilder,
+    ) {}
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function build(string $routeKind, mixed $payload): ?array
+    {
+        return match ($routeKind) {
+            'career_job_detail' => $payload instanceof CareerJobDetailBundle
+                ? $this->jobDetailBuilder->build($payload)
+                : null,
+            'career_family_hub' => $payload instanceof CareerFamilyHubBundle
+                ? $this->familyHubBuilder->build($payload)
+                : null,
+            default => null,
+        };
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-12T13:02:05Z",
+  "updated_at": "2026-04-13T09:30:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -671,6 +671,36 @@
           },
           {
             "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B43": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b43-career-structured-data-authority-readiness",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/StructuredData/CareerBreadcrumbBuilder.php app/Services/Career/StructuredData/CareerJobDetailStructuredDataBuilder.php app/Services/Career/StructuredData/CareerFamilyHubStructuredDataBuilder.php app/Services/Career/StructuredData/CareerStructuredDataBuilder.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php",
             "status": "passed"
           }
         ],

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-13T09:30:00Z",
+  "updated_at": "2026-04-13T09:40:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -685,10 +685,10 @@
     "PR-B43": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b43-career-structured-data-authority-readiness",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "e98be0f4ba9a02f0c64539f10b410ff91e12ddcb",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/889",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -444,6 +444,33 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B43
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b43-career-structured-data-authority-readiness
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career structured-data authority readiness (job detail / family hub first).
+      Add an internal-first Career-owned structured-data builder family for
+      career_job_detail and career_family_hub only, limited to Occupation,
+      CollectionPage, ItemList, and BreadcrumbList fragments, with no public API
+      or OpenAPI changes.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/StructuredData/CareerBreadcrumbBuilder.php app/Services/Career/StructuredData/CareerJobDetailStructuredDataBuilder.php app/Services/Career/StructuredData/CareerFamilyHubStructuredDataBuilder.php app/Services/Career/StructuredData/CareerStructuredDataBuilder.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\DTO\Career\CareerFamilyHubBundle;
+use App\DTO\Career\CareerJobDetailBundle;
+use App\Services\Career\StructuredData\CareerBreadcrumbBuilder;
+use Tests\TestCase;
+
+final class CareerBreadcrumbBuilderTest extends TestCase
+{
+    public function test_it_builds_job_detail_breadcrumb_nodes_and_fragment(): void
+    {
+        $bundle = new CareerJobDetailBundle(
+            identity: [
+                'canonical_slug' => 'backend-architect',
+            ],
+            localePolicy: [],
+            titles: [
+                'canonical_en' => 'Backend Architect',
+            ],
+            aliasIndex: [],
+            ontology: [],
+            truthLayer: [],
+            trustManifest: [],
+            scoreBundle: [],
+            warnings: [],
+            claimPermissions: [],
+            integritySummary: [],
+            seoContract: [
+                'canonical_path' => '/career/jobs/backend-architect',
+            ],
+            provenanceMeta: [],
+        );
+
+        $builder = app(CareerBreadcrumbBuilder::class);
+        $nodes = $builder->buildForJobDetail($bundle);
+        $fragment = $builder->buildBreadcrumbList($nodes);
+
+        $this->assertSame([
+            ['name' => 'Career', 'path' => '/career'],
+            ['name' => 'Backend Architect', 'path' => '/career/jobs/backend-architect'],
+        ], $nodes);
+        $this->assertSame('BreadcrumbList', data_get($fragment, '@type'));
+        $this->assertSame('Career', data_get($fragment, 'itemListElement.0.name'));
+        $this->assertSame('/career/jobs/backend-architect', data_get($fragment, 'itemListElement.1.item'));
+    }
+
+    public function test_it_builds_family_hub_breadcrumb_nodes_and_fragment(): void
+    {
+        $bundle = new CareerFamilyHubBundle(
+            family: [
+                'canonical_slug' => 'computer-and-information-technology',
+                'title_en' => 'Computer and Information Technology',
+            ],
+            visibleChildren: [],
+            counts: [],
+        );
+
+        $builder = app(CareerBreadcrumbBuilder::class);
+        $nodes = $builder->buildForFamilyHub($bundle);
+        $fragment = $builder->buildBreadcrumbList($nodes);
+
+        $this->assertSame([
+            ['name' => 'Career', 'path' => '/career'],
+            ['name' => 'Computer and Information Technology', 'path' => '/career/family/computer-and-information-technology'],
+        ], $nodes);
+        $this->assertSame('BreadcrumbList', data_get($fragment, '@type'));
+        $this->assertSame('/career/family/computer-and-information-technology', data_get($fragment, 'itemListElement.1.item'));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\DTO\Career\CareerFamilyHubBundle;
+use App\DTO\Career\CareerJobDetailBundle;
+use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
+use Tests\TestCase;
+
+final class CareerStructuredDataBuilderTest extends TestCase
+{
+    public function test_it_builds_internal_job_detail_structured_data_fragments(): void
+    {
+        $bundle = new CareerJobDetailBundle(
+            identity: [
+                'canonical_slug' => 'backend-architect',
+            ],
+            localePolicy: [],
+            titles: [
+                'canonical_en' => 'Backend Architect',
+            ],
+            aliasIndex: [],
+            ontology: [],
+            truthLayer: [
+                'entry_education' => 'Bachelor\'s degree',
+                'work_experience' => '5 years or more',
+                'on_the_job_training' => 'None',
+                'outlook_description' => 'Designs and maintains backend systems.',
+            ],
+            trustManifest: [],
+            scoreBundle: [],
+            warnings: [],
+            claimPermissions: [],
+            integritySummary: [],
+            seoContract: [
+                'canonical_path' => '/career/jobs/backend-architect',
+            ],
+            provenanceMeta: [],
+        );
+
+        $payload = app(CareerStructuredDataBuilder::class)->build('career_job_detail', $bundle);
+
+        $this->assertNotNull($payload);
+        $this->assertSame('career_job_detail', data_get($payload, 'route_kind'));
+        $this->assertSame('/career/jobs/backend-architect', data_get($payload, 'canonical_path'));
+        $this->assertSame('Backend Architect', data_get($payload, 'canonical_title'));
+        $this->assertSame('Occupation', data_get($payload, 'fragments.occupation.@type'));
+        $this->assertSame('BreadcrumbList', data_get($payload, 'fragments.breadcrumb_list.@type'));
+        $this->assertSame('Bachelor\'s degree', data_get($payload, 'fragments.occupation.educationRequirements'));
+        $this->assertSame('5 years or more', data_get($payload, 'fragments.occupation.experienceRequirements'));
+        $this->assertArrayNotHasKey('occupationalExperienceRequirements', (array) data_get($payload, 'fragments.occupation'));
+        $this->assertArrayNotHasKey('description', (array) data_get($payload, 'fragments.occupation'));
+        $this->assertStringNotContainsString('Dataset', json_encode($payload, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('Article', json_encode($payload, JSON_THROW_ON_ERROR));
+    }
+
+    public function test_it_builds_internal_family_hub_structured_data_fragments_from_visible_children_only(): void
+    {
+        $bundle = new CareerFamilyHubBundle(
+            family: [
+                'canonical_slug' => 'computer-and-information-technology',
+                'title_en' => 'Computer and Information Technology',
+            ],
+            visibleChildren: [
+                [
+                    'canonical_slug' => 'backend-architect',
+                    'canonical_title_en' => 'Backend Architect',
+                    'seo_contract' => [
+                        'canonical_path' => '/career/jobs/backend-architect',
+                    ],
+                ],
+                [
+                    'canonical_slug' => 'data-scientists',
+                    'canonical_title_en' => 'Data Scientists',
+                    'seo_contract' => [
+                        'canonical_path' => '/career/jobs/data-scientists',
+                    ],
+                ],
+                [
+                    'canonical_slug' => 'orphaned-role',
+                    'canonical_title_en' => 'Orphaned Role',
+                    'seo_contract' => [],
+                ],
+            ],
+            counts: [
+                'visible_children_count' => 3,
+            ],
+        );
+
+        $payload = app(CareerStructuredDataBuilder::class)->build('career_family_hub', $bundle);
+
+        $this->assertNotNull($payload);
+        $this->assertSame('career_family_hub', data_get($payload, 'route_kind'));
+        $this->assertSame('/career/family/computer-and-information-technology', data_get($payload, 'canonical_path'));
+        $this->assertSame('CollectionPage', data_get($payload, 'fragments.collection_page.@type'));
+        $this->assertSame('ItemList', data_get($payload, 'fragments.item_list.@type'));
+        $this->assertSame('BreadcrumbList', data_get($payload, 'fragments.breadcrumb_list.@type'));
+        $this->assertSame(2, data_get($payload, 'fragments.item_list.numberOfItems'));
+        $this->assertSame(2, data_get($payload, 'fragments.collection_page.numberOfItems'));
+        $this->assertSame('Backend Architect', data_get($payload, 'fragments.item_list.itemListElement.0.name'));
+        $this->assertSame('/career/jobs/backend-architect', data_get($payload, 'fragments.item_list.itemListElement.0.url'));
+        $this->assertSame(1, data_get($payload, 'fragments.item_list.itemListElement.0.position'));
+        $this->assertSame(2, data_get($payload, 'fragments.item_list.itemListElement.1.position'));
+        $this->assertStringNotContainsString('Orphaned Role', json_encode($payload, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('Dataset', json_encode($payload, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('Article', json_encode($payload, JSON_THROW_ON_ERROR));
+    }
+
+    public function test_it_excludes_unsupported_route_kinds_from_the_internal_builder(): void
+    {
+        $builder = app(CareerStructuredDataBuilder::class);
+
+        $this->assertNull($builder->build('career_recommendation_detail', []));
+        $this->assertNull($builder->build('career_search', []));
+        $this->assertNull($builder->build('career_alias_resolution', []));
+        $this->assertNull($builder->build('test_landing', []));
+        $this->assertNull($builder->build('topic_detail', []));
+        $this->assertNull($builder->build('article_public_detail', []));
+    }
+}


### PR DESCRIPTION
## What changed
- add a Career-owned internal structured-data builder family for `career_job_detail` and `career_family_hub`
- support only first-pass schema fragments grounded in existing Career authority bundles:
  - job detail: `Occupation` + `BreadcrumbList`
  - family hub: `CollectionPage` + `ItemList` + `BreadcrumbList`
- add a dedicated Career breadcrumb builder and focused unit coverage for supported route kinds and excluded route kinds
- keep the work internal-first with no public API or OpenAPI changes

## Why
- Career route authority for job detail and family hub is already strong enough for a backend-owned structured-data layer, but the repo did not yet have Career-specific builders or breadcrumb generation
- this creates the internal authority layer needed for later public structured-data output without prematurely shipping JSON-LD contracts or over-claiming unsupported schema families
- the scope stays narrow on purpose: no Dataset, no Article, and no recommendation/search/support/editorial route kinds

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/StructuredData/CareerBreadcrumbBuilder.php app/Services/Career/StructuredData/CareerJobDetailStructuredDataBuilder.php app/Services/Career/StructuredData/CareerFamilyHubStructuredDataBuilder.php app/Services/Career/StructuredData/CareerStructuredDataBuilder.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php`
- `php artisan test tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php`

## Intentionally deferred
- no public API or resource/controller changes
- no OpenAPI changes
- no recommendation detail structured data
- no search, alias, support-link, or editorial/content route support
- no `Dataset`
- no `Article`
