### PR TITLE
PR-B44: Career job-detail structured-data public additive extension

### DIFF
--- a/backend/app/Http/Resources/Career/CareerJobDetailResource.php
+++ b/backend/app/Http/Resources/Career/CareerJobDetailResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources\Career;
 
 use App\DTO\Career\CareerJobDetailBundle;
+use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -23,6 +24,22 @@ final class CareerJobDetailResource extends JsonResource
         /** @var CareerJobDetailBundle $bundle */
         $bundle = $this->resource;
 
-        return $bundle->toArray();
+        return array_merge($bundle->toArray(), [
+            'structured_data' => $this->buildStructuredData($bundle),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildStructuredData(CareerJobDetailBundle $bundle): array
+    {
+        $payload = app(CareerStructuredDataBuilder::class)->build('career_job_detail', $bundle);
+        $fragments = is_array($payload['fragments'] ?? null) ? $payload['fragments'] : [];
+
+        return [
+            'occupation' => is_array($fragments['occupation'] ?? null) ? $fragments['occupation'] : [],
+            'breadcrumb_list' => is_array($fragments['breadcrumb_list'] ?? null) ? $fragments['breadcrumb_list'] : [],
+        ];
     }
 }

--- a/backend/app/Http/Resources/Career/CareerJobDetailResource.php
+++ b/backend/app/Http/Resources/Career/CareerJobDetailResource.php
@@ -38,8 +38,44 @@ final class CareerJobDetailResource extends JsonResource
         $fragments = is_array($payload['fragments'] ?? null) ? $payload['fragments'] : [];
 
         return [
-            'occupation' => is_array($fragments['occupation'] ?? null) ? $fragments['occupation'] : [],
-            'breadcrumb_list' => is_array($fragments['breadcrumb_list'] ?? null) ? $fragments['breadcrumb_list'] : [],
+            'occupation' => $this->projectOccupationFragment($fragments['occupation'] ?? null),
+            'breadcrumb_list' => $this->projectBreadcrumbListFragment($fragments['breadcrumb_list'] ?? null),
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function projectOccupationFragment(mixed $fragment): array
+    {
+        if (! is_array($fragment)) {
+            return [];
+        }
+
+        return array_filter([
+            '@context' => $fragment['@context'] ?? null,
+            '@type' => $fragment['@type'] ?? null,
+            'name' => $fragment['name'] ?? null,
+            'url' => $fragment['url'] ?? null,
+            'mainEntityOfPage' => $fragment['mainEntityOfPage'] ?? null,
+            'educationRequirements' => $fragment['educationRequirements'] ?? null,
+            'experienceRequirements' => $fragment['experienceRequirements'] ?? null,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function projectBreadcrumbListFragment(mixed $fragment): array
+    {
+        if (! is_array($fragment)) {
+            return [];
+        }
+
+        return array_filter([
+            '@context' => $fragment['@context'] ?? null,
+            '@type' => $fragment['@type'] ?? null,
+            'itemListElement' => is_array($fragment['itemListElement'] ?? null) ? $fragment['itemListElement'] : null,
+        ], static fn (mixed $value): bool => $value !== null);
     }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-13T09:40:00Z",
+  "updated_at": "2026-04-13T11:15:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -701,6 +701,40 @@
           },
           {
             "command": "php artisan test tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B44": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b44-career-job-detail-structured-data-public-additive-extension",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Http/Resources/Career/CareerJobDetailResource.php app/DTO/Career/CareerJobDetailBundle.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/StructuredData/CareerStructuredDataBuilder.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php docs/contracts/openapi.snapshot.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
             "status": "passed"
           }
         ],

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-13T11:25:00Z",
+  "updated_at": "2026-04-13T11:40:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -717,7 +717,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open",
       "branch": "codex/pr-b44-career-job-detail-structured-data-public-additive-extension",
-      "commit_sha": "3dac790b840f248f1fd81f2c7c0ea9ad8e9cc88c",
+      "commit_sha": "86971ea08e8873df4f5dd6abcf801f47ab329720",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/890",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-13T11:15:00Z",
+  "updated_at": "2026-04-13T11:25:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -715,10 +715,10 @@
     "PR-B44": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b44-career-job-detail-structured-data-public-additive-extension",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "3dac790b840f248f1fd81f2c7c0ea9ad8e9cc88c",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/890",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -471,6 +471,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B44
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b44-career-job-detail-structured-data-public-additive-extension
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career job-detail structured-data public additive extension. Publicize
+      only job detail structured_data.occupation and
+      structured_data.breadcrumb_list as a narrow additive extension of the
+      existing Career job detail API, with no new endpoint and no family hub,
+      Dataset, Article, recommendation, search, alias, support-link, or
+      editorial structured-data expansion.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Http/Resources/Career/CareerJobDetailResource.php app/DTO/Career/CareerJobDetailBundle.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/StructuredData/CareerStructuredDataBuilder.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php docs/contracts/openapi.snapshot.json"
+      - "php artisan test tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -62,6 +62,8 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/backend-architect')
             ->assertJsonPath('structured_data.occupation.@type', 'Occupation')
             ->assertJsonPath('structured_data.breadcrumb_list.@type', 'BreadcrumbList')
+            ->assertJsonMissingPath('structured_data.occupation.description')
+            ->assertJsonMissingPath('structured_data.occupation.occupationalExperienceRequirements')
             ->assertJsonMissingPath('structured_data.dataset')
             ->assertJsonMissingPath('structured_data.article')
             ->assertJsonMissingPath('structured_data.route_kind')

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -60,6 +60,14 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertJsonPath('identity.canonical_slug', 'backend-architect')
             ->assertJsonPath('trust_manifest.content_version', 'v4.1')
             ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/backend-architect')
+            ->assertJsonPath('structured_data.occupation.@type', 'Occupation')
+            ->assertJsonPath('structured_data.breadcrumb_list.@type', 'BreadcrumbList')
+            ->assertJsonMissingPath('structured_data.dataset')
+            ->assertJsonMissingPath('structured_data.article')
+            ->assertJsonMissingPath('structured_data.route_kind')
+            ->assertJsonMissingPath('structured_data.canonical_path')
+            ->assertJsonMissingPath('structured_data.canonical_title')
+            ->assertJsonMissingPath('structured_data.breadcrumb_nodes')
             ->assertJsonStructure([
                 'identity',
                 'locale_policy',
@@ -73,6 +81,10 @@ final class CareerJobDetailApiTest extends TestCase
                 'claim_permissions',
                 'integrity_summary',
                 'seo_contract',
+                'structured_data' => [
+                    'occupation',
+                    'breadcrumb_list',
+                ],
                 'provenance_meta' => ['compiler_version', 'compile_refs'],
             ]);
     }

--- a/backend/tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\DTO\Career\CareerJobDetailBundle;
+use App\Http\Resources\Career\CareerJobDetailResource;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+final class CareerJobDetailStructuredDataPublicProjectionTest extends TestCase
+{
+    public function test_it_exposes_only_curated_job_detail_structured_data_fragments(): void
+    {
+        $bundle = new CareerJobDetailBundle(
+            identity: [
+                'canonical_slug' => 'backend-architect',
+            ],
+            localePolicy: [],
+            titles: [
+                'canonical_en' => 'Backend Architect',
+            ],
+            aliasIndex: [],
+            ontology: [],
+            truthLayer: [
+                'entry_education' => 'Bachelor\'s degree',
+                'work_experience' => '5 years or more',
+            ],
+            trustManifest: [],
+            scoreBundle: [],
+            warnings: [],
+            claimPermissions: [],
+            integritySummary: [],
+            seoContract: [
+                'canonical_path' => '/career/jobs/backend-architect',
+            ],
+            provenanceMeta: [],
+        );
+
+        $payload = (new CareerJobDetailResource($bundle))->toArray(Request::create('/api/v0.5/career/jobs/backend-architect', 'GET'));
+
+        $this->assertSame('Occupation', data_get($payload, 'structured_data.occupation.@type'));
+        $this->assertSame('BreadcrumbList', data_get($payload, 'structured_data.breadcrumb_list.@type'));
+        $this->assertArrayNotHasKey('route_kind', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('canonical_path', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('canonical_title', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('breadcrumb_nodes', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('dataset', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('article', (array) data_get($payload, 'structured_data'));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php
@@ -42,11 +42,27 @@ final class CareerJobDetailStructuredDataPublicProjectionTest extends TestCase
 
         $this->assertSame('Occupation', data_get($payload, 'structured_data.occupation.@type'));
         $this->assertSame('BreadcrumbList', data_get($payload, 'structured_data.breadcrumb_list.@type'));
+        $this->assertSame([
+            '@context',
+            '@type',
+            'name',
+            'url',
+            'mainEntityOfPage',
+            'educationRequirements',
+            'experienceRequirements',
+        ], array_keys((array) data_get($payload, 'structured_data.occupation')));
+        $this->assertSame([
+            '@context',
+            '@type',
+            'itemListElement',
+        ], array_keys((array) data_get($payload, 'structured_data.breadcrumb_list')));
         $this->assertArrayNotHasKey('route_kind', (array) data_get($payload, 'structured_data'));
         $this->assertArrayNotHasKey('canonical_path', (array) data_get($payload, 'structured_data'));
         $this->assertArrayNotHasKey('canonical_title', (array) data_get($payload, 'structured_data'));
         $this->assertArrayNotHasKey('breadcrumb_nodes', (array) data_get($payload, 'structured_data'));
         $this->assertArrayNotHasKey('dataset', (array) data_get($payload, 'structured_data'));
         $this->assertArrayNotHasKey('article', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('description', (array) data_get($payload, 'structured_data.occupation'));
+        $this->assertArrayNotHasKey('occupationalExperienceRequirements', (array) data_get($payload, 'structured_data.occupation'));
     }
 }


### PR DESCRIPTION
## What changed
- add a narrow top-level `structured_data` field to the existing Career job detail API
- publicize only the curated job-detail structured-data fragments produced by the B43 authority layer:
  - `structured_data.occupation`
  - `structured_data.breadcrumb_list`
- keep the B43 internal builder envelope internal and add focused API/resource coverage for the public projection
- keep the change additive with no new endpoint and no family hub, Dataset, Article, recommendation, search, alias, support-link, or editorial structured-data expansion

## Why
- B43 already established a Career-owned structured-data builder family, but job detail still did not expose any public structured-data fragment on the existing API
- the safest public shape is a narrow additive field on the current job detail response rather than a second endpoint or a raw dump of internal builder output
- this moves job-detail structured data forward without broadening scope into family hub publicization or speculative schema families

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Http/Resources/Career/CareerJobDetailResource.php app/DTO/Career/CareerJobDetailBundle.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/StructuredData/CareerStructuredDataBuilder.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php docs/contracts/openapi.snapshot.json`
- `php artisan test tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no family hub public structured data
- no new endpoint
- no `Dataset`
- no `Article`
- no recommendation, search, alias, support-link, or editorial structured data
- no frontend changes
