### PR TITLE
PR-B45: Career family-hub structured-data public additive extension

### DIFF
--- a/backend/app/Http/Resources/Career/CareerFamilyHubResource.php
+++ b/backend/app/Http/Resources/Career/CareerFamilyHubResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources\Career;
 
 use App\DTO\Career\CareerFamilyHubBundle;
+use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -23,6 +24,129 @@ final class CareerFamilyHubResource extends JsonResource
         /** @var CareerFamilyHubBundle $bundle */
         $bundle = $this->resource;
 
-        return $bundle->toArray();
+        return array_merge($bundle->toArray(), [
+            'structured_data' => $this->buildStructuredData($bundle),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildStructuredData(CareerFamilyHubBundle $bundle): array
+    {
+        $payload = app(CareerStructuredDataBuilder::class)->build('career_family_hub', $bundle);
+        $fragments = is_array($payload['fragments'] ?? null) ? $payload['fragments'] : [];
+
+        return [
+            'collection_page' => $this->projectCollectionPageFragment($fragments['collection_page'] ?? null),
+            'item_list' => $this->projectItemListFragment($fragments['item_list'] ?? null),
+            'breadcrumb_list' => $this->projectBreadcrumbListFragment($fragments['breadcrumb_list'] ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function projectCollectionPageFragment(mixed $fragment): array
+    {
+        if (! is_array($fragment)) {
+            return [];
+        }
+
+        return array_filter([
+            '@context' => $fragment['@context'] ?? null,
+            '@type' => $fragment['@type'] ?? null,
+            'name' => $fragment['name'] ?? null,
+            'url' => $fragment['url'] ?? null,
+            'mainEntityOfPage' => $fragment['mainEntityOfPage'] ?? null,
+            'numberOfItems' => $fragment['numberOfItems'] ?? null,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function projectItemListFragment(mixed $fragment): array
+    {
+        if (! is_array($fragment)) {
+            return [];
+        }
+
+        return array_filter([
+            '@context' => $fragment['@context'] ?? null,
+            '@type' => $fragment['@type'] ?? null,
+            'numberOfItems' => $fragment['numberOfItems'] ?? null,
+            'itemListElement' => $this->projectItemListElements($fragment['itemListElement'] ?? null),
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function projectItemListElements(mixed $items): array
+    {
+        if (! is_array($items)) {
+            return [];
+        }
+
+        $projected = [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $projected[] = array_filter([
+                '@type' => $item['@type'] ?? null,
+                'position' => $item['position'] ?? null,
+                'name' => $item['name'] ?? null,
+                'url' => $item['url'] ?? null,
+            ], static fn (mixed $value): bool => $value !== null);
+        }
+
+        return $projected;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function projectBreadcrumbListFragment(mixed $fragment): array
+    {
+        if (! is_array($fragment)) {
+            return [];
+        }
+
+        return array_filter([
+            '@context' => $fragment['@context'] ?? null,
+            '@type' => $fragment['@type'] ?? null,
+            'itemListElement' => $this->projectBreadcrumbListElements($fragment['itemListElement'] ?? null),
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function projectBreadcrumbListElements(mixed $items): array
+    {
+        if (! is_array($items)) {
+            return [];
+        }
+
+        $projected = [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $projected[] = array_filter([
+                '@type' => $item['@type'] ?? null,
+                'position' => $item['position'] ?? null,
+                'name' => $item['name'] ?? null,
+                'item' => $item['item'] ?? null,
+            ], static fn (mixed $value): bool => $value !== null);
+        }
+
+        return $projected;
     }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T00:42:00Z",
+  "updated_at": "2026-04-14T00:44:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -229,7 +229,7 @@
     "PR-B45": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b45-career-family-hub-structured-data-public-additive-extension",
       "commit_sha": "3250d77dc3afe4429acad4966ae5ed0e8ce130ad",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/891",
@@ -252,9 +252,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24354786650/job/71118740099"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24354788883/job/71118747602"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24354786650/job/71118751195"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24354788883/job/71118758571"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions hygiene jobs failed immediately on PR-B45; local validation passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T00:35:00Z",
+  "updated_at": "2026-04-14T00:42:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -229,10 +229,10 @@
     "PR-B45": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b45-career-family-hub-structured-data-public-additive-extension",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "3250d77dc3afe4429acad4966ae5ed0e8ce130ad",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/891",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-13T11:40:00Z",
+  "updated_at": "2026-04-14T00:35:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -221,6 +221,40 @@
         ]
       },
       "failure_reason": "GitHub Actions jobs were not started successfully; hygiene failed immediately and MBTI verification was skipped, consistent with the current repository CI/billing blockage.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B45": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b45-career-family-hub-structured-data-public-additive-extension",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Http/Resources/Career/CareerFamilyHubResource.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php docs/contracts/openapi.snapshot.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/CareerFamilyHubApiTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -500,6 +500,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B45
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b45-career-family-hub-structured-data-public-additive-extension
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career family-hub structured-data public additive extension.
+      Publicize only family hub structured_data.collection_page,
+      structured_data.item_list, and structured_data.breadcrumb_list
+      as a narrow additive extension of the existing Career family hub API,
+      with no new endpoint and no DefinedTermSet, Dataset, Article,
+      recommendation, search, alias, support-link, or editorial expansion.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Http/Resources/Career/CareerFamilyHubResource.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php docs/contracts/openapi.snapshot.json"
+      - "php artisan test tests/Feature/Career/CareerFamilyHubApiTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerFamilyHubApiTest.php
+++ b/backend/tests/Feature/Career/CareerFamilyHubApiTest.php
@@ -25,6 +25,14 @@ final class CareerFamilyHubApiTest extends TestCase
             ->assertJsonPath('bundle_version', 'career.protocol.family_hub.v1')
             ->assertJsonPath('family.family_uuid', $family->id)
             ->assertJsonPath('family.canonical_slug', 'computer-and-information-technology')
+            ->assertJsonPath('structured_data.collection_page.@type', 'CollectionPage')
+            ->assertJsonPath('structured_data.item_list.@type', 'ItemList')
+            ->assertJsonPath('structured_data.breadcrumb_list.@type', 'BreadcrumbList')
+            ->assertJsonPath('structured_data.collection_page.numberOfItems', 1)
+            ->assertJsonPath('structured_data.item_list.numberOfItems', 1)
+            ->assertJsonPath('structured_data.item_list.itemListElement.0.position', 1)
+            ->assertJsonPath('structured_data.item_list.itemListElement.0.name', 'Data scientists')
+            ->assertJsonPath('structured_data.item_list.itemListElement.0.url', '/career/jobs/data-scientists')
             ->assertJsonPath('counts.visible_children_count', 1)
             ->assertJsonPath('counts.publish_ready_count', 1)
             ->assertJsonPath('counts.blocked_override_eligible_count', 0)
@@ -33,6 +41,13 @@ final class CareerFamilyHubApiTest extends TestCase
             ->assertJsonPath('visible_children.0.canonical_slug', 'data-scientists')
             ->assertJsonPath('visible_children.0.seo_contract.index_eligible', true)
             ->assertJsonPath('visible_children.0.trust_summary.reviewer_status', 'approved')
+            ->assertJsonMissingPath('structured_data.route_kind')
+            ->assertJsonMissingPath('structured_data.canonical_path')
+            ->assertJsonMissingPath('structured_data.canonical_title')
+            ->assertJsonMissingPath('structured_data.breadcrumb_nodes')
+            ->assertJsonMissingPath('structured_data.dataset')
+            ->assertJsonMissingPath('structured_data.article')
+            ->assertJsonMissingPath('structured_data.defined_term_set')
             ->assertJsonMissingPath('visible_children.1')
             ->assertJsonStructure([
                 'bundle_kind',
@@ -57,6 +72,27 @@ final class CareerFamilyHubApiTest extends TestCase
                     'blocked_override_eligible_count',
                     'blocked_not_safely_remediable_count',
                     'blocked_total',
+                ],
+                'structured_data' => [
+                    'collection_page' => [
+                        '@context',
+                        '@type',
+                        'name',
+                        'url',
+                        'mainEntityOfPage',
+                        'numberOfItems',
+                    ],
+                    'item_list' => [
+                        '@context',
+                        '@type',
+                        'numberOfItems',
+                        'itemListElement',
+                    ],
+                    'breadcrumb_list' => [
+                        '@context',
+                        '@type',
+                        'itemListElement',
+                    ],
                 ],
             ]);
     }
@@ -87,6 +123,12 @@ final class CareerFamilyHubApiTest extends TestCase
             ->assertJsonPath('counts.blocked_override_eligible_count', 0)
             ->assertJsonPath('counts.blocked_not_safely_remediable_count', 0)
             ->assertJsonPath('counts.blocked_total', 0)
+            ->assertJsonPath('structured_data.collection_page.@type', 'CollectionPage')
+            ->assertJsonPath('structured_data.item_list.@type', 'ItemList')
+            ->assertJsonPath('structured_data.breadcrumb_list.@type', 'BreadcrumbList')
+            ->assertJsonPath('structured_data.collection_page.numberOfItems', 0)
+            ->assertJsonPath('structured_data.item_list.numberOfItems', 0)
+            ->assertJsonPath('structured_data.item_list.itemListElement', [])
             ->assertJsonPath('visible_children', []);
     }
 

--- a/backend/tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\DTO\Career\CareerFamilyHubBundle;
+use App\Http\Resources\Career\CareerFamilyHubResource;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+final class CareerFamilyHubStructuredDataPublicProjectionTest extends TestCase
+{
+    public function test_it_exposes_only_curated_family_hub_structured_data_fragments(): void
+    {
+        $bundle = new CareerFamilyHubBundle(
+            family: [
+                'canonical_slug' => 'computer-and-information-technology',
+                'title_en' => 'Computer and Information Technology',
+            ],
+            visibleChildren: [
+                [
+                    'canonical_slug' => 'backend-architect',
+                    'canonical_title_en' => 'Backend Architect',
+                    'seo_contract' => [
+                        'canonical_path' => '/career/jobs/backend-architect',
+                    ],
+                ],
+            ],
+            counts: [
+                'visible_children_count' => 1,
+                'publish_ready_count' => 1,
+                'blocked_override_eligible_count' => 0,
+                'blocked_not_safely_remediable_count' => 0,
+                'blocked_total' => 0,
+            ],
+        );
+
+        $payload = (new CareerFamilyHubResource($bundle))->toArray(Request::create('/api/v0.5/career/family/computer-and-information-technology', 'GET'));
+
+        $this->assertSame('CollectionPage', data_get($payload, 'structured_data.collection_page.@type'));
+        $this->assertSame('ItemList', data_get($payload, 'structured_data.item_list.@type'));
+        $this->assertSame('BreadcrumbList', data_get($payload, 'structured_data.breadcrumb_list.@type'));
+        $this->assertSame([
+            '@context',
+            '@type',
+            'name',
+            'url',
+            'mainEntityOfPage',
+            'numberOfItems',
+        ], array_keys((array) data_get($payload, 'structured_data.collection_page')));
+        $this->assertSame([
+            '@context',
+            '@type',
+            'numberOfItems',
+            'itemListElement',
+        ], array_keys((array) data_get($payload, 'structured_data.item_list')));
+        $this->assertSame([
+            '@type',
+            'position',
+            'name',
+            'url',
+        ], array_keys((array) data_get($payload, 'structured_data.item_list.itemListElement.0')));
+        $this->assertSame([
+            '@context',
+            '@type',
+            'itemListElement',
+        ], array_keys((array) data_get($payload, 'structured_data.breadcrumb_list')));
+        $this->assertSame([
+            '@type',
+            'position',
+            'name',
+            'item',
+        ], array_keys((array) data_get($payload, 'structured_data.breadcrumb_list.itemListElement.0')));
+        $this->assertArrayNotHasKey('route_kind', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('canonical_path', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('canonical_title', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('breadcrumb_nodes', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('dataset', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('article', (array) data_get($payload, 'structured_data'));
+        $this->assertArrayNotHasKey('defined_term_set', (array) data_get($payload, 'structured_data'));
+    }
+}


### PR DESCRIPTION
## What changed
- add a narrow top-level `structured_data` field to the existing Career family hub API
- publicize only the curated family-hub structured-data fragments produced by the B43 authority layer:
  - `structured_data.collection_page`
  - `structured_data.item_list`
  - `structured_data.breadcrumb_list`
- keep the B43 internal builder envelope internal via explicit resource-level projection
- add focused API and public-projection tests, including zero-visible family coverage

## Why
- B43 already established a Career-owned family-hub structured-data builder, but the public family hub API still exposed no structured-data fragments
- the safest public shape is a narrow additive field on the current family hub response rather than a second endpoint or a raw dump of internal builder output
- this keeps the rollout compatibility-first: no DefinedTermSet, Dataset, Article, or route contamination from recommendation, search, alias, support, or editorial surfaces

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Http/Resources/Career/CareerFamilyHubResource.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php docs/contracts/openapi.snapshot.json`
- `php artisan test tests/Feature/Career/CareerFamilyHubApiTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no job detail changes
- no recommendation/search/alias/support/editorial structured-data
- no DefinedTermSet
- no Dataset
- no Article
- no frontend changes
