### PR TITLE
PR-B46: Career dataset authority readiness (internal-only first)

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveDatasetAuthority.php
+++ b/backend/app/DTO/Career/CareerFirstWaveDatasetAuthority.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveDatasetAuthority
+{
+    /**
+     * @param  list<CareerFirstWaveDatasetMember>  $members
+     * @param  array<string, mixed>  $aggregate
+     */
+    public function __construct(
+        public readonly CareerFirstWaveDatasetDescriptor $descriptor,
+        public readonly array $aggregate,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'authority_kind' => 'career_first_wave_dataset_authority',
+            'authority_version' => 'career.dataset_authority.first_wave.v1',
+            'descriptor' => $this->descriptor->toArray(),
+            'aggregate' => $this->aggregate,
+            'members' => array_map(
+                static fn (CareerFirstWaveDatasetMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveDatasetDescriptor.php
+++ b/backend/app/DTO/Career/CareerFirstWaveDatasetDescriptor.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveDatasetDescriptor
+{
+    public function __construct(
+        public readonly string $datasetKey,
+        public readonly string $datasetScope,
+        public readonly string $manifestVersion,
+        public readonly string $selectionPolicyVersion,
+        public readonly ?string $datasetName,
+        public readonly ?string $datasetVersion,
+        public readonly ?string $datasetChecksum,
+        public readonly ?string $sourcePath,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'dataset_key' => $this->datasetKey,
+            'dataset_scope' => $this->datasetScope,
+            'manifest_version' => $this->manifestVersion,
+            'selection_policy_version' => $this->selectionPolicyVersion,
+            'dataset_name' => $this->datasetName,
+            'dataset_version' => $this->datasetVersion,
+            'dataset_checksum' => $this->datasetChecksum,
+            'source_path' => $this->sourcePath,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveDatasetMember.php
+++ b/backend/app/DTO/Career/CareerFirstWaveDatasetMember.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveDatasetMember
+{
+    public function __construct(
+        public readonly string $occupationUuid,
+        public readonly string $canonicalSlug,
+        public readonly string $canonicalTitleEn,
+        public readonly string $canonicalPath,
+        public readonly string $launchTier,
+        public readonly string $discoverabilityState,
+        public readonly bool $indexEligible,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'occupation_uuid' => $this->occupationUuid,
+            'canonical_slug' => $this->canonicalSlug,
+            'canonical_title_en' => $this->canonicalTitleEn,
+            'canonical_path' => $this->canonicalPath,
+            'launch_tier' => $this->launchTier,
+            'discoverability_state' => $this->discoverabilityState,
+            'index_eligible' => $this->indexEligible,
+        ];
+    }
+}

--- a/backend/app/Services/Career/Dataset/CareerFirstWaveDatasetAuthorityBuilder.php
+++ b/backend/app/Services/Career/Dataset/CareerFirstWaveDatasetAuthorityBuilder.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Dataset;
+
+use App\Domain\Career\Import\RunStatus;
+use App\Domain\Career\Publish\CareerFirstWaveDiscoverabilityManifestService;
+use App\Domain\Career\Publish\CareerFirstWaveLaunchTierSummaryService;
+use App\Domain\Career\Publish\FirstWaveManifestReader;
+use App\DTO\Career\CareerFirstWaveDatasetAuthority;
+use App\DTO\Career\CareerFirstWaveDatasetDescriptor;
+use App\DTO\Career\CareerFirstWaveDatasetMember;
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\TrustManifest;
+
+final class CareerFirstWaveDatasetAuthorityBuilder
+{
+    private const DATASET_KEY = 'career_first_wave_job_detail_dataset';
+
+    private const MEMBER_KIND = 'career_job_detail';
+
+    public function __construct(
+        private readonly FirstWaveManifestReader $manifestReader,
+        private readonly CareerFirstWaveLaunchTierSummaryService $launchTierSummaryService,
+        private readonly CareerFirstWaveDiscoverabilityManifestService $discoverabilityManifestService,
+    ) {}
+
+    public function build(): CareerFirstWaveDatasetAuthority
+    {
+        $manifest = $this->manifestReader->read();
+        $waveName = (string) ($manifest['wave_name'] ?? CareerFirstWaveLaunchTierSummaryService::SCOPE);
+        $launchTierSummary = $this->launchTierSummaryService->build()->toArray();
+        $discoverabilityManifest = $this->discoverabilityManifestService->build()->toArray();
+        $importRun = $this->latestCompletedImportRun($waveName);
+        $compileRun = $this->latestCompletedCompileRun($importRun?->id);
+
+        $members = $this->buildMembers(
+            manifestOccupations: (array) ($manifest['occupations'] ?? []),
+            launchTierRows: (array) ($launchTierSummary['occupations'] ?? []),
+            discoverabilityRoutes: (array) ($discoverabilityManifest['routes'] ?? []),
+        );
+
+        return new CareerFirstWaveDatasetAuthority(
+            descriptor: new CareerFirstWaveDatasetDescriptor(
+                datasetKey: self::DATASET_KEY,
+                datasetScope: $waveName,
+                manifestVersion: (string) ($manifest['manifest_version'] ?? 'unknown'),
+                selectionPolicyVersion: (string) ($manifest['selection_policy_version'] ?? 'unknown'),
+                datasetName: $this->normalizeString($importRun?->dataset_name),
+                datasetVersion: $this->normalizeString($importRun?->dataset_version),
+                datasetChecksum: $this->normalizeString($importRun?->dataset_checksum),
+                sourcePath: $this->normalizeString(data_get($importRun?->meta, 'source_path')),
+            ),
+            aggregate: $this->buildAggregate($members, $importRun, $compileRun),
+            members: $members,
+        );
+    }
+
+    /**
+     * @param  list<mixed>  $manifestOccupations
+     * @param  list<mixed>  $launchTierRows
+     * @param  list<mixed>  $discoverabilityRoutes
+     * @return list<CareerFirstWaveDatasetMember>
+     */
+    private function buildMembers(array $manifestOccupations, array $launchTierRows, array $discoverabilityRoutes): array
+    {
+        $manifestBySlug = [];
+        foreach ($manifestOccupations as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = $this->normalizeString($row['canonical_slug'] ?? null);
+            if ($slug !== null) {
+                $manifestBySlug[$slug] = true;
+            }
+        }
+
+        $launchTierBySlug = [];
+        foreach ($launchTierRows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = $this->normalizeString($row['canonical_slug'] ?? null);
+            if ($slug !== null) {
+                $launchTierBySlug[$slug] = $row;
+            }
+        }
+
+        $discoverabilityBySlug = [];
+        foreach ($discoverabilityRoutes as $row) {
+            if (! is_array($row) || ($row['route_kind'] ?? null) !== self::MEMBER_KIND) {
+                continue;
+            }
+
+            $slug = $this->normalizeString($row['canonical_slug'] ?? null);
+            if ($slug !== null) {
+                $discoverabilityBySlug[$slug] = $row;
+            }
+        }
+
+        $members = [];
+        foreach (array_keys($manifestBySlug) as $slug) {
+            $launchTierRow = $launchTierBySlug[$slug] ?? null;
+            $discoverabilityRow = $discoverabilityBySlug[$slug] ?? null;
+
+            if (! is_array($launchTierRow) || ! is_array($discoverabilityRow)) {
+                continue;
+            }
+
+            $occupationUuid = $this->normalizeString($launchTierRow['occupation_uuid'] ?? null);
+            $canonicalTitleEn = $this->normalizeString($launchTierRow['canonical_title_en'] ?? null);
+            $canonicalPath = $this->normalizeString($discoverabilityRow['canonical_path'] ?? null);
+            $launchTier = $this->normalizeString($launchTierRow['launch_tier'] ?? null);
+            $discoverabilityState = $this->normalizeString($discoverabilityRow['discoverability_state'] ?? null);
+
+            if (
+                $occupationUuid === null
+                || $canonicalTitleEn === null
+                || $canonicalPath === null
+                || $launchTier === null
+                || $discoverabilityState === null
+            ) {
+                continue;
+            }
+
+            $members[] = new CareerFirstWaveDatasetMember(
+                occupationUuid: $occupationUuid,
+                canonicalSlug: $slug,
+                canonicalTitleEn: $canonicalTitleEn,
+                canonicalPath: $canonicalPath,
+                launchTier: $launchTier,
+                discoverabilityState: $discoverabilityState,
+                indexEligible: (bool) ($launchTierRow['index_eligible'] ?? false),
+            );
+        }
+
+        usort($members, static fn (CareerFirstWaveDatasetMember $left, CareerFirstWaveDatasetMember $right): int => strcmp(
+            $left->canonicalSlug,
+            $right->canonicalSlug,
+        ));
+
+        return $members;
+    }
+
+    /**
+     * @param  list<CareerFirstWaveDatasetMember>  $members
+     * @return array<string, mixed>
+     */
+    private function buildAggregate(
+        array $members,
+        ?CareerImportRun $importRun,
+        ?CareerCompileRun $compileRun,
+    ): array {
+        $slugs = array_map(
+            static fn (CareerFirstWaveDatasetMember $member): string => $member->canonicalSlug,
+            $members,
+        );
+
+        $occupationIds = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->pluck('id')
+            ->all();
+
+        $lastSubstantiveUpdateAt = null;
+        if ($occupationIds !== []) {
+            /** @var TrustManifest|null $latestTrustManifest */
+            $latestTrustManifest = TrustManifest::query()
+                ->whereIn('occupation_id', $occupationIds)
+                ->whereNotNull('last_substantive_update_at')
+                ->orderByDesc('last_substantive_update_at')
+                ->first();
+
+            $lastSubstantiveUpdateAt = optional($latestTrustManifest?->last_substantive_update_at)->toISOString();
+        }
+
+        $counts = [
+            'stable' => 0,
+            'candidate' => 0,
+            'hold' => 0,
+            'discoverable' => 0,
+            'excluded' => 0,
+        ];
+
+        foreach ($members as $member) {
+            if (array_key_exists($member->launchTier, $counts)) {
+                $counts[$member->launchTier]++;
+            }
+
+            if (array_key_exists($member->discoverabilityState, $counts)) {
+                $counts[$member->discoverabilityState]++;
+            }
+        }
+
+        return [
+            'member_kind' => self::MEMBER_KIND,
+            'member_count' => count($members),
+            'counts' => $counts,
+            'import_run_id' => $importRun?->id,
+            'compile_run_id' => $compileRun?->id,
+            'compiled_at' => $this->normalizeString(data_get($compileRun?->meta, 'compiled_at'))
+                ?? optional($compileRun?->finished_at)->toISOString()
+                ?? optional($compileRun?->started_at)->toISOString(),
+            'last_substantive_update_at' => $lastSubstantiveUpdateAt,
+        ];
+    }
+
+    private function latestCompletedImportRun(string $waveName): ?CareerImportRun
+    {
+        /** @var CareerImportRun|null $importRun */
+        $importRun = CareerImportRun::query()
+            ->where('status', RunStatus::COMPLETED)
+            ->where('meta->wave_name', $waveName)
+            ->orderByDesc('finished_at')
+            ->orderByDesc('started_at')
+            ->first();
+
+        return $importRun;
+    }
+
+    private function latestCompletedCompileRun(?string $importRunId): ?CareerCompileRun
+    {
+        $query = CareerCompileRun::query()
+            ->where('status', RunStatus::COMPLETED);
+
+        if ($importRunId !== null && $importRunId !== '') {
+            $query->where('import_run_id', $importRunId);
+        }
+
+        /** @var CareerCompileRun|null $compileRun */
+        $compileRun = $query
+            ->orderByDesc('finished_at')
+            ->orderByDesc('started_at')
+            ->first();
+
+        return $compileRun;
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T00:44:00Z",
+  "updated_at": "2026-04-14T12:36:03Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -284,12 +284,25 @@
     "PR-B46": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "pr_open",
       "branch": "codex/pr-b46-career-dataset-authority-readiness-internal-only-first",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "8b8de77ca2065f8ac3b2e9bc44571b9408fab82b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/892",
       "checks": {
-        "local": [],
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Dataset/*.php app/DTO/Career/CareerFirstWaveDataset*.php tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php",
+            "status": "passed"
+          }
+        ],
         "github": []
       },
       "failure_reason": "",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -281,6 +281,23 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
     },
+    "PR-B46": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-b46-career-dataset-authority-readiness-internal-only-first",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
     "PR-D1": {
       "repo": "fap-web",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-web",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T12:36:03Z",
+  "updated_at": "2026-04-14T12:37:02Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -284,9 +284,9 @@
     "PR-B46": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b46-career-dataset-authority-readiness-internal-only-first",
-      "commit_sha": "8b8de77ca2065f8ac3b2e9bc44571b9408fab82b",
+      "commit_sha": "a9358a00af858b0e13323b350bdc0391565e7698",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/892",
       "checks": {
         "local": [
@@ -303,9 +303,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24399257490/job/71265107771"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24399259235/job/71265113563"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24399257490/job/71265118498"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24399259235/job/71265123384"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions hygiene jobs failed immediately on PR-B46; local validation passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -529,6 +529,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B46
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b46-career-dataset-authority-readiness-internal-only-first
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career dataset authority readiness (internal-only first).
+      Add a Career-owned internal dataset descriptor, member registry,
+      and aggregate/freshness block for first-wave career_job_detail
+      members only, with no public API, no OpenAPI changes, no Dataset/DataCatalog
+      publicization, and no family hub, recommendation, search, alias,
+      support-link, or editorial member expansion.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Dataset/*.php app/DTO/Career/CareerFirstWaveDataset*.php tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Import\RunStatus;
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Services\Career\Dataset\CareerFirstWaveDatasetAuthorityBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveDatasetAuthorityBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_an_internal_first_wave_job_detail_dataset_authority(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $authority = app(CareerFirstWaveDatasetAuthorityBuilder::class)->build()->toArray();
+
+        $this->assertSame('career_first_wave_dataset_authority', $authority['authority_kind']);
+        $this->assertSame('career.dataset_authority.first_wave.v1', $authority['authority_version']);
+        $this->assertSame('career_first_wave_job_detail_dataset', data_get($authority, 'descriptor.dataset_key'));
+        $this->assertSame('career_first_wave_10', data_get($authority, 'descriptor.dataset_scope'));
+        $this->assertSame('2026.04.09.first_wave.v1', data_get($authority, 'descriptor.manifest_version'));
+        $this->assertSame('first_wave_publish_gate.v1', data_get($authority, 'descriptor.selection_policy_version'));
+        $this->assertSame('first_wave_readiness_summary_subset.csv', data_get($authority, 'descriptor.dataset_name'));
+        $this->assertNotSame('', (string) data_get($authority, 'descriptor.dataset_checksum'));
+        $this->assertStringContainsString(
+            'tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv',
+            (string) data_get($authority, 'descriptor.source_path')
+        );
+        $this->assertSame('career_job_detail', data_get($authority, 'aggregate.member_kind'));
+        $this->assertSame(10, data_get($authority, 'aggregate.member_count'));
+        $this->assertSame(6, data_get($authority, 'aggregate.counts.stable'));
+        $this->assertSame(0, data_get($authority, 'aggregate.counts.candidate'));
+        $this->assertSame(4, data_get($authority, 'aggregate.counts.hold'));
+        $this->assertSame(6, data_get($authority, 'aggregate.counts.discoverable'));
+        $this->assertSame(4, data_get($authority, 'aggregate.counts.excluded'));
+        $this->assertNotNull(data_get($authority, 'aggregate.import_run_id'));
+        $this->assertNotNull(data_get($authority, 'aggregate.compile_run_id'));
+        $this->assertNotNull(data_get($authority, 'aggregate.compiled_at'));
+        $this->assertNotNull(data_get($authority, 'aggregate.last_substantive_update_at'));
+        $this->assertCount(10, $authority['members']);
+        $this->assertSame('career_job_detail', data_get($authority, 'aggregate.member_kind'));
+        $this->assertSame('accountants-and-auditors', data_get($authority, 'members.0.canonical_slug'));
+        $this->assertSame('/career/jobs/accountants-and-auditors', data_get($authority, 'members.0.canonical_path'));
+        $this->assertFalse(collect($authority['members'])->contains(
+            static fn (array $member): bool => str_contains((string) ($member['canonical_path'] ?? ''), '/career/family/')
+        ));
+    }
+
+    public function test_it_limits_member_scope_to_first_wave_job_detail_members_only(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $authority = app(CareerFirstWaveDatasetAuthorityBuilder::class)->build()->toArray();
+        $memberSlugs = collect($authority['members'])->pluck('canonical_slug')->all();
+
+        $this->assertCount(10, $memberSlugs);
+        $this->assertContains('registered-nurses', $memberSlugs);
+        $this->assertContains('software-developers', $memberSlugs);
+        $this->assertNotContains('computer-and-information-technology', $memberSlugs);
+        $this->assertNotContains('blocked-tech-family-api', $memberSlugs);
+        $this->assertFalse(collect($authority['members'])->contains(
+            static fn (array $member): bool => array_key_exists('family_uuid', $member)
+        ));
+    }
+
+    public function test_it_does_not_invent_public_dataset_metadata_or_schema_fields(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $authority = app(CareerFirstWaveDatasetAuthorityBuilder::class)->build()->toArray();
+
+        $this->assertArrayNotHasKey('publisher', $authority['descriptor']);
+        $this->assertArrayNotHasKey('license', $authority['descriptor']);
+        $this->assertArrayNotHasKey('distribution', $authority['descriptor']);
+        $this->assertArrayNotHasKey('download_url', $authority['descriptor']);
+        $this->assertStringNotContainsString('Dataset', json_encode($authority, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('DataCatalog', json_encode($authority, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('DefinedTermSet', json_encode($authority, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('Article', json_encode($authority, JSON_THROW_ON_ERROR));
+    }
+
+    public function test_it_scopes_import_and_compile_freshness_to_the_current_first_wave(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $firstWaveAuthority = app(CareerFirstWaveDatasetAuthorityBuilder::class)->build()->toArray();
+        $expectedImportRunId = (string) data_get($firstWaveAuthority, 'aggregate.import_run_id');
+        $expectedCompileRunId = (string) data_get($firstWaveAuthority, 'aggregate.compile_run_id');
+
+        $otherWaveImportRun = CareerImportRun::query()->create([
+            'dataset_name' => 'other_wave_dataset.csv',
+            'dataset_version' => 'other_wave.v1',
+            'dataset_checksum' => 'other-wave-checksum',
+            'source_path' => '/tmp/other-wave.csv',
+            'scope_mode' => 'exact',
+            'dry_run' => false,
+            'status' => RunStatus::COMPLETED,
+            'started_at' => now()->addMinute(),
+            'finished_at' => now()->addMinutes(2),
+            'rows_seen' => 1,
+            'rows_accepted' => 1,
+            'rows_skipped' => 0,
+            'rows_failed' => 0,
+            'output_counts' => [],
+            'error_summary' => [],
+            'meta' => [
+                'source_path' => '/tmp/other-wave.csv',
+                'wave_name' => 'career_other_wave',
+            ],
+        ]);
+
+        $otherWaveCompileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $otherWaveImportRun->id,
+            'compiler_version' => 'test-compiler.v1',
+            'scope_mode' => 'exact',
+            'dry_run' => false,
+            'status' => RunStatus::COMPLETED,
+            'started_at' => now()->addMinutes(3),
+            'finished_at' => now()->addMinutes(4),
+            'subjects_seen' => 1,
+            'snapshots_created' => 1,
+            'snapshots_skipped' => 0,
+            'snapshots_failed' => 0,
+            'output_counts' => [],
+            'error_summary' => [],
+            'meta' => [
+                'compiled_at' => now()->addMinutes(4)->toISOString(),
+            ],
+        ]);
+
+        $authority = app(CareerFirstWaveDatasetAuthorityBuilder::class)->build()->toArray();
+
+        $this->assertSame($expectedImportRunId, data_get($authority, 'aggregate.import_run_id'));
+        $this->assertSame($expectedCompileRunId, data_get($authority, 'aggregate.compile_run_id'));
+        $this->assertNotSame($otherWaveImportRun->id, data_get($authority, 'aggregate.import_run_id'));
+        $this->assertNotSame($otherWaveCompileRun->id, data_get($authority, 'aggregate.compile_run_id'));
+        $this->assertSame('first_wave_readiness_summary_subset.csv', data_get($authority, 'descriptor.dataset_name'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a Career-owned internal first-wave dataset authority builder with a descriptor, aggregate/freshness block, and member registry
- scope dataset members strictly to first-wave career job detail pages using existing manifest, launch-tier, and discoverability authority truth
- keep the work internal-only with no public API, no OpenAPI changes, and no Dataset/DataCatalog public schema output
- add focused unit coverage for scope, aggregate counts, freshness, and omission of invented dataset metadata

## Why
- the backend already had strong first-wave inventory and provenance truth, but no Career-owned dataset authority layer to prepare future dataset-level work
- the safest first step is an internal-only authority contract that reuses real backend truth without over-claiming publisher, license, distribution, or public dataset semantics
- this keeps scope narrow: no family hubs as dataset members, no recommendation/search/alias/support/editorial expansion, and no public schema creep

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Dataset/*.php app/DTO/Career/CareerFirstWaveDataset*.php tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php`

## Intentionally deferred
- no public dataset hub or public API
- no OpenAPI changes
- no Dataset or DataCatalog JSON-LD output
- no family hub dataset membership
- no publisher, license, distribution, or download contract
- no frontend changes