### PR TITLE
PR-B47: Career dataset metadata contract readiness (internal-only first)

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveDatasetAuthority.php
+++ b/backend/app/DTO/Career/CareerFirstWaveDatasetAuthority.php
@@ -12,6 +12,7 @@ final class CareerFirstWaveDatasetAuthority
      */
     public function __construct(
         public readonly CareerFirstWaveDatasetDescriptor $descriptor,
+        public readonly CareerFirstWaveDatasetMetadata $metadata,
         public readonly array $aggregate,
         public readonly array $members,
     ) {}
@@ -25,6 +26,7 @@ final class CareerFirstWaveDatasetAuthority
             'authority_kind' => 'career_first_wave_dataset_authority',
             'authority_version' => 'career.dataset_authority.first_wave.v1',
             'descriptor' => $this->descriptor->toArray(),
+            'metadata' => $this->metadata->toArray(),
             'aggregate' => $this->aggregate,
             'members' => array_map(
                 static fn (CareerFirstWaveDatasetMember $member): array => $member->toArray(),

--- a/backend/app/DTO/Career/CareerFirstWaveDatasetCoverage.php
+++ b/backend/app/DTO/Career/CareerFirstWaveDatasetCoverage.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveDatasetCoverage
+{
+    /**
+     * @param  list<string>  $includedRouteKinds
+     */
+    public function __construct(
+        public readonly string $datasetScope,
+        public readonly string $waveName,
+        public readonly string $memberKind,
+        public readonly int $memberCount,
+        public readonly int $countExpected,
+        public readonly int $countActual,
+        public readonly array $includedRouteKinds,
+        public readonly bool $familyHubsIncluded,
+        public readonly string $selectionPolicyVersion,
+        public readonly string $manifestVersion,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'dataset_scope' => $this->datasetScope,
+            'wave_name' => $this->waveName,
+            'member_kind' => $this->memberKind,
+            'member_count' => $this->memberCount,
+            'count_expected' => $this->countExpected,
+            'count_actual' => $this->countActual,
+            'included_route_kinds' => $this->includedRouteKinds,
+            'family_hubs_included' => $this->familyHubsIncluded,
+            'selection_policy_version' => $this->selectionPolicyVersion,
+            'manifest_version' => $this->manifestVersion,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveDatasetFreshness.php
+++ b/backend/app/DTO/Career/CareerFirstWaveDatasetFreshness.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveDatasetFreshness
+{
+    public function __construct(
+        public readonly ?string $compiledAt,
+        public readonly ?string $lastSubstantiveUpdateAt,
+        public readonly ?string $manifestGeneratedAt,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'compiled_at' => $this->compiledAt,
+            'last_substantive_update_at' => $this->lastSubstantiveUpdateAt,
+            'manifest_generated_at' => $this->manifestGeneratedAt,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveDatasetMetadata.php
+++ b/backend/app/DTO/Career/CareerFirstWaveDatasetMetadata.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveDatasetMetadata
+{
+    public function __construct(
+        public readonly CareerFirstWaveDatasetCoverage $coverage,
+        public readonly CareerFirstWaveDatasetProvenance $provenance,
+        public readonly CareerFirstWaveDatasetFreshness $freshness,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'coverage' => $this->coverage->toArray(),
+            'provenance' => $this->provenance->toArray(),
+            'freshness' => $this->freshness->toArray(),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveDatasetProvenance.php
+++ b/backend/app/DTO/Career/CareerFirstWaveDatasetProvenance.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveDatasetProvenance
+{
+    public function __construct(
+        public readonly ?string $datasetName,
+        public readonly ?string $datasetVersion,
+        public readonly ?string $datasetChecksum,
+        public readonly ?string $sourcePath,
+        public readonly ?string $importRunId,
+        public readonly ?string $compileRunId,
+        public readonly ?string $contentVersion,
+        public readonly ?string $dataVersion,
+        public readonly ?string $logicVersion,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'dataset_name' => $this->datasetName,
+            'dataset_version' => $this->datasetVersion,
+            'dataset_checksum' => $this->datasetChecksum,
+            'source_path' => $this->sourcePath,
+            'import_run_id' => $this->importRunId,
+            'compile_run_id' => $this->compileRunId,
+            'content_version' => $this->contentVersion,
+            'data_version' => $this->dataVersion,
+            'logic_version' => $this->logicVersion,
+        ];
+    }
+}

--- a/backend/app/Services/Career/Dataset/CareerFirstWaveDatasetAuthorityBuilder.php
+++ b/backend/app/Services/Career/Dataset/CareerFirstWaveDatasetAuthorityBuilder.php
@@ -26,6 +26,7 @@ final class CareerFirstWaveDatasetAuthorityBuilder
         private readonly FirstWaveManifestReader $manifestReader,
         private readonly CareerFirstWaveLaunchTierSummaryService $launchTierSummaryService,
         private readonly CareerFirstWaveDiscoverabilityManifestService $discoverabilityManifestService,
+        private readonly CareerFirstWaveDatasetMetadataBuilder $metadataBuilder,
     ) {}
 
     public function build(): CareerFirstWaveDatasetAuthority
@@ -43,18 +44,22 @@ final class CareerFirstWaveDatasetAuthorityBuilder
             discoverabilityRoutes: (array) ($discoverabilityManifest['routes'] ?? []),
         );
 
+        $descriptor = new CareerFirstWaveDatasetDescriptor(
+            datasetKey: self::DATASET_KEY,
+            datasetScope: $waveName,
+            manifestVersion: (string) ($manifest['manifest_version'] ?? 'unknown'),
+            selectionPolicyVersion: (string) ($manifest['selection_policy_version'] ?? 'unknown'),
+            datasetName: $this->normalizeString($importRun?->dataset_name),
+            datasetVersion: $this->normalizeString($importRun?->dataset_version),
+            datasetChecksum: $this->normalizeString($importRun?->dataset_checksum),
+            sourcePath: $this->normalizeString(data_get($importRun?->meta, 'source_path')),
+        );
+        $aggregate = $this->buildAggregate($members, $importRun, $compileRun);
+
         return new CareerFirstWaveDatasetAuthority(
-            descriptor: new CareerFirstWaveDatasetDescriptor(
-                datasetKey: self::DATASET_KEY,
-                datasetScope: $waveName,
-                manifestVersion: (string) ($manifest['manifest_version'] ?? 'unknown'),
-                selectionPolicyVersion: (string) ($manifest['selection_policy_version'] ?? 'unknown'),
-                datasetName: $this->normalizeString($importRun?->dataset_name),
-                datasetVersion: $this->normalizeString($importRun?->dataset_version),
-                datasetChecksum: $this->normalizeString($importRun?->dataset_checksum),
-                sourcePath: $this->normalizeString(data_get($importRun?->meta, 'source_path')),
-            ),
-            aggregate: $this->buildAggregate($members, $importRun, $compileRun),
+            descriptor: $descriptor,
+            metadata: $this->metadataBuilder->build($descriptor, $aggregate, $members, $importRun, $compileRun),
+            aggregate: $aggregate,
             members: $members,
         );
     }

--- a/backend/app/Services/Career/Dataset/CareerFirstWaveDatasetMetadataBuilder.php
+++ b/backend/app/Services/Career/Dataset/CareerFirstWaveDatasetMetadataBuilder.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Dataset;
+
+use App\Domain\Career\Publish\FirstWaveManifestReader;
+use App\DTO\Career\CareerFirstWaveDatasetCoverage;
+use App\DTO\Career\CareerFirstWaveDatasetDescriptor;
+use App\DTO\Career\CareerFirstWaveDatasetFreshness;
+use App\DTO\Career\CareerFirstWaveDatasetMember;
+use App\DTO\Career\CareerFirstWaveDatasetMetadata;
+use App\DTO\Career\CareerFirstWaveDatasetProvenance;
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\TrustManifest;
+
+final class CareerFirstWaveDatasetMetadataBuilder
+{
+    private const INCLUDED_ROUTE_KINDS = ['career_job_detail'];
+
+    public function __construct(
+        private readonly FirstWaveManifestReader $manifestReader,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $aggregate
+     * @param  list<CareerFirstWaveDatasetMember>  $members
+     */
+    public function build(
+        CareerFirstWaveDatasetDescriptor $descriptor,
+        array $aggregate,
+        array $members,
+        ?CareerImportRun $importRun,
+        ?CareerCompileRun $compileRun,
+    ): CareerFirstWaveDatasetMetadata {
+        $manifest = $this->manifestReader->read();
+        [$contentVersion, $dataVersion, $logicVersion] = $this->resolveConsensusVersions(
+            $members,
+            $importRun?->id,
+        );
+
+        return new CareerFirstWaveDatasetMetadata(
+            coverage: new CareerFirstWaveDatasetCoverage(
+                datasetScope: $descriptor->datasetScope,
+                waveName: (string) ($manifest['wave_name'] ?? $descriptor->datasetScope),
+                memberKind: (string) ($aggregate['member_kind'] ?? ''),
+                memberCount: (int) ($aggregate['member_count'] ?? 0),
+                countExpected: (int) ($manifest['count_expected'] ?? 0),
+                countActual: (int) ($manifest['count_actual'] ?? 0),
+                includedRouteKinds: self::INCLUDED_ROUTE_KINDS,
+                familyHubsIncluded: false,
+                selectionPolicyVersion: $descriptor->selectionPolicyVersion,
+                manifestVersion: $descriptor->manifestVersion,
+            ),
+            provenance: new CareerFirstWaveDatasetProvenance(
+                datasetName: $descriptor->datasetName,
+                datasetVersion: $descriptor->datasetVersion,
+                datasetChecksum: $descriptor->datasetChecksum,
+                sourcePath: $descriptor->sourcePath,
+                importRunId: $importRun?->id,
+                compileRunId: $compileRun?->id,
+                contentVersion: $contentVersion,
+                dataVersion: $dataVersion,
+                logicVersion: $logicVersion,
+            ),
+            freshness: new CareerFirstWaveDatasetFreshness(
+                compiledAt: $this->normalizeString($aggregate['compiled_at'] ?? null),
+                lastSubstantiveUpdateAt: $this->normalizeString($aggregate['last_substantive_update_at'] ?? null),
+                manifestGeneratedAt: $this->normalizeString($manifest['generated_at'] ?? null),
+            ),
+        );
+    }
+
+    /**
+     * @param  list<CareerFirstWaveDatasetMember>  $members
+     * @return array{0:?string,1:?string,2:?string}
+     */
+    private function resolveConsensusVersions(array $members, ?string $importRunId): array
+    {
+        $slugs = array_map(
+            static fn (CareerFirstWaveDatasetMember $member): string => $member->canonicalSlug,
+            $members,
+        );
+
+        if ($slugs === []) {
+            return [null, null, null];
+        }
+
+        $occupationIds = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->pluck('id')
+            ->all();
+
+        if ($occupationIds === []) {
+            return [null, null, null];
+        }
+
+        $query = TrustManifest::query()
+            ->whereIn('occupation_id', $occupationIds);
+
+        if ($importRunId !== null && $importRunId !== '') {
+            $query->where('import_run_id', $importRunId);
+        }
+
+        $trustManifests = $query->get(['content_version', 'data_version', 'logic_version']);
+
+        if ($trustManifests->isEmpty()) {
+            return [null, null, null];
+        }
+
+        return [
+            $this->resolveConsensusValue($trustManifests->pluck('content_version')->all()),
+            $this->resolveConsensusValue($trustManifests->pluck('data_version')->all()),
+            $this->resolveConsensusValue($trustManifests->pluck('logic_version')->all()),
+        ];
+    }
+
+    /**
+     * @param  list<mixed>  $values
+     */
+    private function resolveConsensusValue(array $values): ?string
+    {
+        $normalized = array_values(array_unique(array_filter(array_map(
+            fn (mixed $value): ?string => $this->normalizeString($value),
+            $values,
+        ))));
+
+        return count($normalized) === 1 ? $normalized[0] : null;
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T13:10:43Z",
+  "updated_at": "2026-04-14T13:13:52Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -335,10 +335,10 @@
     "PR-B47": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "pr_open",
       "branch": "codex/pr-b47-career-dataset-metadata-contract-readiness-internal-only-first",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "51124756e58d07ac1e0078fb186ebcaf95db097a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/893",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T13:13:52Z",
+  "updated_at": "2026-04-14T13:14:41Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -335,9 +335,9 @@
     "PR-B47": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b47-career-dataset-metadata-contract-readiness-internal-only-first",
-      "commit_sha": "51124756e58d07ac1e0078fb186ebcaf95db097a",
+      "commit_sha": "8abff748cefa592bd6c9e6a3b68ab2c63746e476",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/893",
       "checks": {
         "local": [
@@ -354,9 +354,25 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24401002096/job/71271278436"
+          },
+          {
+            "name": "hygiene",
+            "status": "queued",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24401004025/job/71271284760"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24401002096/job/71271292060"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions hygiene failed immediately on PR-B47; local validation passed, but required remote checks are not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T12:37:02Z",
+  "updated_at": "2026-04-14T13:10:43Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -327,6 +327,36 @@
         ]
       },
       "failure_reason": "GitHub Actions hygiene jobs failed immediately on PR-B46; local validation passed, but the remote CI run is currently not green.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B47": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-b47-career-dataset-metadata-contract-readiness-internal-only-first",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Dataset/*.php app/DTO/Career/CareerFirstWaveDataset*.php tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php tests/Unit/Services/Career/CareerFirstWaveDatasetMetadataBuilderTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php tests/Unit/Services/Career/CareerFirstWaveDatasetMetadataBuilderTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -557,6 +557,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B47
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b47-career-dataset-metadata-contract-readiness-internal-only-first
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career dataset metadata contract readiness (internal-only first).
+      Add a narrow internal-only dataset metadata block with coverage,
+      provenance, and freshness on top of the B46 internal dataset authority,
+      with no public API, no OpenAPI changes, no Dataset/DataCatalog
+      publicization, no member-scope expansion, and no invented publisher,
+      license, usage, distribution, download, or prose metadata.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Dataset/*.php app/DTO/Career/CareerFirstWaveDataset*.php tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php tests/Unit/Services/Career/CareerFirstWaveDatasetMetadataBuilderTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php tests/Unit/Services/Career/CareerFirstWaveDatasetMetadataBuilderTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php
@@ -34,6 +34,23 @@ final class CareerFirstWaveDatasetAuthorityBuilderTest extends TestCase
             'tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv',
             (string) data_get($authority, 'descriptor.source_path')
         );
+        $this->assertSame('career_first_wave_10', data_get($authority, 'metadata.coverage.dataset_scope'));
+        $this->assertSame('career_first_wave_10', data_get($authority, 'metadata.coverage.wave_name'));
+        $this->assertSame('career_job_detail', data_get($authority, 'metadata.coverage.member_kind'));
+        $this->assertSame(10, data_get($authority, 'metadata.coverage.member_count'));
+        $this->assertSame(10, data_get($authority, 'metadata.coverage.count_expected'));
+        $this->assertSame(10, data_get($authority, 'metadata.coverage.count_actual'));
+        $this->assertSame(['career_job_detail'], data_get($authority, 'metadata.coverage.included_route_kinds'));
+        $this->assertFalse((bool) data_get($authority, 'metadata.coverage.family_hubs_included'));
+        $this->assertSame('first_wave_readiness_summary_subset.csv', data_get($authority, 'metadata.provenance.dataset_name'));
+        $this->assertNotNull(data_get($authority, 'metadata.provenance.import_run_id'));
+        $this->assertNotNull(data_get($authority, 'metadata.provenance.compile_run_id'));
+        $this->assertArrayHasKey('content_version', $authority['metadata']['provenance']);
+        $this->assertArrayHasKey('data_version', $authority['metadata']['provenance']);
+        $this->assertArrayHasKey('logic_version', $authority['metadata']['provenance']);
+        $this->assertNotNull(data_get($authority, 'metadata.freshness.compiled_at'));
+        $this->assertNotNull(data_get($authority, 'metadata.freshness.last_substantive_update_at'));
+        $this->assertSame('2026-04-09T00:00:00Z', data_get($authority, 'metadata.freshness.manifest_generated_at'));
         $this->assertSame('career_job_detail', data_get($authority, 'aggregate.member_kind'));
         $this->assertSame(10, data_get($authority, 'aggregate.member_count'));
         $this->assertSame(6, data_get($authority, 'aggregate.counts.stable'));
@@ -81,6 +98,13 @@ final class CareerFirstWaveDatasetAuthorityBuilderTest extends TestCase
         $this->assertArrayNotHasKey('license', $authority['descriptor']);
         $this->assertArrayNotHasKey('distribution', $authority['descriptor']);
         $this->assertArrayNotHasKey('download_url', $authority['descriptor']);
+        $this->assertArrayNotHasKey('publisher', $authority['metadata']);
+        $this->assertArrayNotHasKey('license', $authority['metadata']);
+        $this->assertArrayNotHasKey('terms_of_use', $authority['metadata']);
+        $this->assertArrayNotHasKey('distribution', $authority['metadata']);
+        $this->assertArrayNotHasKey('download_url', $authority['metadata']);
+        $this->assertArrayNotHasKey('description', $authority['metadata']);
+        $this->assertArrayNotHasKey('methodology', $authority['metadata']);
         $this->assertStringNotContainsString('Dataset', json_encode($authority, JSON_THROW_ON_ERROR));
         $this->assertStringNotContainsString('DataCatalog', json_encode($authority, JSON_THROW_ON_ERROR));
         $this->assertStringNotContainsString('DefinedTermSet', json_encode($authority, JSON_THROW_ON_ERROR));

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveDatasetMetadataBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveDatasetMetadataBuilderTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Import\RunStatus;
+use App\DTO\Career\CareerFirstWaveDatasetDescriptor;
+use App\DTO\Career\CareerFirstWaveDatasetMember;
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use App\Models\TrustManifest;
+use App\Services\Career\Dataset\CareerFirstWaveDatasetAuthorityBuilder;
+use App\Services\Career\Dataset\CareerFirstWaveDatasetMetadataBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerFirstWaveDatasetMetadataBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_internal_only_coverage_provenance_and_freshness_metadata_from_grounded_truth(): void
+    {
+        $family = OccupationFamily::query()->create([
+            'id' => (string) Str::uuid(),
+            'canonical_slug' => 'computer-and-information-technology',
+            'title_en' => 'Computer and information technology',
+            'title_zh' => '计算机与信息技术',
+        ]);
+
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'career_dataset_fixture.csv',
+            'dataset_version' => 'fixture.v1',
+            'dataset_checksum' => 'fixture-checksum',
+            'source_path' => '/tmp/career-dataset-fixture.csv',
+            'scope_mode' => 'exact',
+            'dry_run' => false,
+            'status' => RunStatus::COMPLETED,
+            'started_at' => now()->subHour(),
+            'finished_at' => now()->subMinutes(30),
+            'meta' => [
+                'wave_name' => 'career_first_wave_10',
+                'source_path' => '/tmp/career-dataset-fixture.csv',
+            ],
+        ]);
+
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => 'career-compiler.v1',
+            'scope_mode' => 'exact',
+            'dry_run' => false,
+            'status' => RunStatus::COMPLETED,
+            'started_at' => now()->subMinutes(20),
+            'finished_at' => now()->subMinutes(10),
+            'meta' => [
+                'compiled_at' => '2026-04-14T01:23:45Z',
+            ],
+        ]);
+
+        $occupation = Occupation::query()->create([
+            'id' => (string) Str::uuid(),
+            'family_id' => $family->id,
+            'parent_id' => null,
+            'canonical_slug' => 'data-scientists',
+            'entity_level' => 'occupation',
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => 'Data scientists',
+            'canonical_title_zh' => '数据科学家',
+            'search_h1_zh' => '数据科学家',
+        ]);
+
+        TrustManifest::query()->create([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => $occupation->id,
+            'content_version' => 'career_first_wave.v1',
+            'data_version' => 'fixture.v1',
+            'logic_version' => 'career-compiler.v1',
+            'locale_context' => ['truth_market' => 'US'],
+            'methodology' => ['scope_mode' => 'exact'],
+            'reviewer_status' => 'approved',
+            'reviewed_at' => null,
+            'ai_assistance' => [],
+            'quality' => [],
+            'last_substantive_update_at' => '2026-04-13T00:00:00Z',
+            'next_review_due_at' => null,
+            'import_run_id' => $importRun->id,
+            'row_fingerprint' => 'tm-fixture',
+        ]);
+
+        $olderImportRun = CareerImportRun::query()->create([
+            'dataset_name' => 'career_dataset_fixture.csv',
+            'dataset_version' => 'fixture.v0',
+            'dataset_checksum' => 'fixture-checksum-older',
+            'source_path' => '/tmp/career-dataset-fixture-older.csv',
+            'scope_mode' => 'exact',
+            'dry_run' => false,
+            'status' => RunStatus::COMPLETED,
+            'started_at' => now()->subHours(2),
+            'finished_at' => now()->subHours(2)->addMinutes(15),
+            'meta' => [
+                'wave_name' => 'career_first_wave_10',
+                'source_path' => '/tmp/career-dataset-fixture-older.csv',
+            ],
+        ]);
+
+        TrustManifest::query()->create([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => $occupation->id,
+            'content_version' => 'career_first_wave.v0',
+            'data_version' => 'fixture.v0',
+            'logic_version' => 'career-compiler.v0',
+            'locale_context' => ['truth_market' => 'US'],
+            'methodology' => ['scope_mode' => 'exact'],
+            'reviewer_status' => 'approved',
+            'reviewed_at' => null,
+            'ai_assistance' => [],
+            'quality' => [],
+            'last_substantive_update_at' => '2026-04-12T00:00:00Z',
+            'next_review_due_at' => null,
+            'import_run_id' => $olderImportRun->id,
+            'row_fingerprint' => 'tm-fixture-older',
+        ]);
+
+        $descriptor = new CareerFirstWaveDatasetDescriptor(
+            datasetKey: 'career_first_wave_job_detail_dataset',
+            datasetScope: 'career_first_wave_10',
+            manifestVersion: '2026.04.09.first_wave.v1',
+            selectionPolicyVersion: 'first_wave_publish_gate.v1',
+            datasetName: 'career_dataset_fixture.csv',
+            datasetVersion: 'fixture.v1',
+            datasetChecksum: 'fixture-checksum',
+            sourcePath: '/tmp/career-dataset-fixture.csv',
+        );
+
+        $members = [
+            new CareerFirstWaveDatasetMember(
+                occupationUuid: 'occ-1',
+                canonicalSlug: 'data-scientists',
+                canonicalTitleEn: 'Data scientists',
+                canonicalPath: '/career/jobs/data-scientists',
+                launchTier: 'stable',
+                discoverabilityState: 'discoverable',
+                indexEligible: true,
+            ),
+        ];
+
+        $aggregate = [
+            'member_kind' => 'career_job_detail',
+            'member_count' => 1,
+            'compiled_at' => '2026-04-14T01:23:45Z',
+            'last_substantive_update_at' => '2026-04-13T00:00:00Z',
+        ];
+
+        $metadata = app(CareerFirstWaveDatasetMetadataBuilder::class)
+            ->build($descriptor, $aggregate, $members, $importRun, $compileRun)
+            ->toArray();
+
+        $this->assertSame('career_first_wave_10', data_get($metadata, 'coverage.dataset_scope'));
+        $this->assertSame('career_first_wave_10', data_get($metadata, 'coverage.wave_name'));
+        $this->assertSame(['career_job_detail'], data_get($metadata, 'coverage.included_route_kinds'));
+        $this->assertFalse((bool) data_get($metadata, 'coverage.family_hubs_included'));
+        $this->assertSame('career_dataset_fixture.csv', data_get($metadata, 'provenance.dataset_name'));
+        $this->assertSame('fixture.v1', data_get($metadata, 'provenance.dataset_version'));
+        $this->assertSame('fixture-checksum', data_get($metadata, 'provenance.dataset_checksum'));
+        $this->assertSame('/tmp/career-dataset-fixture.csv', data_get($metadata, 'provenance.source_path'));
+        $this->assertSame($importRun->id, data_get($metadata, 'provenance.import_run_id'));
+        $this->assertSame($compileRun->id, data_get($metadata, 'provenance.compile_run_id'));
+        $this->assertSame('career_first_wave.v1', data_get($metadata, 'provenance.content_version'));
+        $this->assertSame('fixture.v1', data_get($metadata, 'provenance.data_version'));
+        $this->assertSame('career-compiler.v1', data_get($metadata, 'provenance.logic_version'));
+        $this->assertSame('2026-04-14T01:23:45Z', data_get($metadata, 'freshness.compiled_at'));
+        $this->assertSame('2026-04-13T00:00:00Z', data_get($metadata, 'freshness.last_substantive_update_at'));
+        $this->assertSame('2026-04-09T00:00:00Z', data_get($metadata, 'freshness.manifest_generated_at'));
+    }
+
+    public function test_it_uses_real_first_wave_truth_without_changing_member_scope(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $authority = app(CareerFirstWaveDatasetAuthorityBuilder::class)->build()->toArray();
+        $descriptor = new CareerFirstWaveDatasetDescriptor(
+            datasetKey: (string) data_get($authority, 'descriptor.dataset_key'),
+            datasetScope: (string) data_get($authority, 'descriptor.dataset_scope'),
+            manifestVersion: (string) data_get($authority, 'descriptor.manifest_version'),
+            selectionPolicyVersion: (string) data_get($authority, 'descriptor.selection_policy_version'),
+            datasetName: data_get($authority, 'descriptor.dataset_name'),
+            datasetVersion: data_get($authority, 'descriptor.dataset_version'),
+            datasetChecksum: data_get($authority, 'descriptor.dataset_checksum'),
+            sourcePath: data_get($authority, 'descriptor.source_path'),
+        );
+        $members = collect((array) ($authority['members'] ?? []))
+            ->map(static fn (array $member): CareerFirstWaveDatasetMember => new CareerFirstWaveDatasetMember(
+                occupationUuid: (string) ($member['occupation_uuid'] ?? ''),
+                canonicalSlug: (string) ($member['canonical_slug'] ?? ''),
+                canonicalTitleEn: (string) ($member['canonical_title_en'] ?? ''),
+                canonicalPath: (string) ($member['canonical_path'] ?? ''),
+                launchTier: (string) ($member['launch_tier'] ?? ''),
+                discoverabilityState: (string) ($member['discoverability_state'] ?? ''),
+                indexEligible: (bool) ($member['index_eligible'] ?? false),
+            ))
+            ->all();
+        $aggregate = (array) ($authority['aggregate'] ?? []);
+        $importRun = CareerImportRun::query()->find((string) data_get($authority, 'aggregate.import_run_id'));
+        $compileRun = CareerCompileRun::query()->find((string) data_get($authority, 'aggregate.compile_run_id'));
+
+        $metadata = app(CareerFirstWaveDatasetMetadataBuilder::class)
+            ->build($descriptor, $aggregate, $members, $importRun, $compileRun)
+            ->toArray();
+
+        $this->assertSame('career_first_wave_10', data_get($metadata, 'coverage.dataset_scope'));
+        $this->assertSame('career_first_wave_10', data_get($metadata, 'coverage.wave_name'));
+        $this->assertSame(10, data_get($metadata, 'coverage.member_count'));
+        $this->assertSame(10, data_get($metadata, 'coverage.count_expected'));
+        $this->assertSame(10, data_get($metadata, 'coverage.count_actual'));
+        $this->assertSame(['career_job_detail'], data_get($metadata, 'coverage.included_route_kinds'));
+        $this->assertFalse((bool) data_get($metadata, 'coverage.family_hubs_included'));
+        $this->assertSame('first_wave_readiness_summary_subset.csv', data_get($metadata, 'provenance.dataset_name'));
+        $this->assertNotSame('', (string) data_get($metadata, 'provenance.dataset_checksum'));
+        $this->assertStringContainsString(
+            'tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv',
+            (string) data_get($metadata, 'provenance.source_path')
+        );
+        $this->assertNotNull(data_get($metadata, 'provenance.import_run_id'));
+        $this->assertNotNull(data_get($metadata, 'provenance.compile_run_id'));
+        $this->assertNotNull(data_get($metadata, 'freshness.compiled_at'));
+        $this->assertNotNull(data_get($metadata, 'freshness.last_substantive_update_at'));
+        $this->assertSame('2026-04-09T00:00:00Z', data_get($metadata, 'freshness.manifest_generated_at'));
+        $this->assertFalse(collect($members)->contains(
+            static fn (CareerFirstWaveDatasetMember $member): bool => str_contains($member->canonicalPath, '/career/family/')
+        ));
+    }
+
+    public function test_it_omits_unsupported_metadata_families_and_keeps_member_scope_separate(): void
+    {
+        $descriptor = new CareerFirstWaveDatasetDescriptor(
+            datasetKey: 'career_first_wave_job_detail_dataset',
+            datasetScope: 'career_first_wave_10',
+            manifestVersion: '2026.04.09.first_wave.v1',
+            selectionPolicyVersion: 'first_wave_publish_gate.v1',
+            datasetName: null,
+            datasetVersion: null,
+            datasetChecksum: null,
+            sourcePath: null,
+        );
+
+        $metadata = app(CareerFirstWaveDatasetMetadataBuilder::class)
+            ->build(
+                $descriptor,
+                [
+                    'member_kind' => 'career_job_detail',
+                    'member_count' => 0,
+                    'compiled_at' => null,
+                    'last_substantive_update_at' => null,
+                ],
+                [],
+                null,
+                null,
+            )
+            ->toArray();
+
+        $this->assertArrayHasKey('coverage', $metadata);
+        $this->assertArrayHasKey('provenance', $metadata);
+        $this->assertArrayHasKey('freshness', $metadata);
+        $this->assertArrayNotHasKey('publisher', $metadata);
+        $this->assertArrayNotHasKey('license', $metadata);
+        $this->assertArrayNotHasKey('terms_of_use', $metadata);
+        $this->assertArrayNotHasKey('distribution', $metadata);
+        $this->assertArrayNotHasKey('download_url', $metadata);
+        $this->assertArrayNotHasKey('description', $metadata);
+        $this->assertArrayNotHasKey('methodology', $metadata);
+        $this->assertFalse((bool) data_get($metadata, 'coverage.family_hubs_included'));
+        $this->assertSame(['career_job_detail'], data_get($metadata, 'coverage.included_route_kinds'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add a narrow internal-only dataset metadata block on top of the B46 Career first-wave dataset authority
- include only the safe metadata families grounded in existing backend truth:
  - `coverage`
  - `provenance`
  - `freshness`
- keep member scope unchanged at first-wave `career_job_detail` members only
- add focused unit coverage for metadata sourcing, omission of unsupported metadata families, and protection against cross-run provenance drift

## Why
- B46 established internal dataset inventory truth, but the backend still lacked a structured metadata contract to prepare later dataset-level work
- the safe next step is internal-only metadata grounded in manifest/import/compile/trust truth without inventing publisher, license, distribution, or prose dataset semantics
- this keeps the scope narrow and avoids public API changes, OpenAPI drift, member-scope expansion, and premature Dataset/DataCatalog promotion

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Dataset/*.php app/DTO/Career/CareerFirstWaveDataset*.php tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php tests/Unit/Services/Career/CareerFirstWaveDatasetMetadataBuilderTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveDatasetAuthorityBuilderTest.php tests/Unit/Services/Career/CareerFirstWaveDatasetMetadataBuilderTest.php`

## Intentionally deferred
- no public Dataset or DataCatalog output
- no public API or OpenAPI changes
- no publisher, license, usage, distribution, or download contract
- no prose description or prose methodology
- no member-scope expansion beyond first-wave `career_job_detail`
- no frontend changes