### PR TITLE
PR-B49: Career family-hub page-level SEO contract hardening

### DIFF
--- a/backend/app/DTO/Career/CareerFamilyHubBundle.php
+++ b/backend/app/DTO/Career/CareerFamilyHubBundle.php
@@ -10,11 +10,13 @@ final class CareerFamilyHubBundle
      * @param  array<string, mixed>  $family
      * @param  list<array<string, mixed>>  $visibleChildren
      * @param  array<string, int>  $counts
+     * @param  array<string, mixed>  $seoContract
      */
     public function __construct(
         public readonly array $family,
         public readonly array $visibleChildren,
         public readonly array $counts,
+        public readonly array $seoContract,
     ) {}
 
     /**
@@ -28,6 +30,7 @@ final class CareerFamilyHubBundle
             'family' => $this->family,
             'visible_children' => $this->visibleChildren,
             'counts' => $this->counts,
+            'seo_contract' => $this->seoContract,
         ];
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
@@ -10,6 +10,7 @@ use App\DTO\Career\CareerFamilyHubBundle;
 use App\Models\Occupation;
 use App\Models\OccupationFamily;
 use App\Models\RecommendationSnapshot;
+use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
 use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Support\Collection;
 
@@ -20,6 +21,7 @@ final class CareerFamilyHubBundleBuilder
     public function __construct(
         private readonly FirstWaveReadinessSummaryService $readinessSummaryService,
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
+        private readonly CareerStructuredDataBuilder $structuredDataBuilder,
     ) {}
 
     public function buildBySlug(string $slug): ?CareerFamilyHubBundle
@@ -47,7 +49,7 @@ final class CareerFamilyHubBundleBuilder
         $visibleChildren = $this->buildVisibleChildren($occupations, $readinessBySlug);
         $counts['visible_children_count'] = count($visibleChildren);
 
-        return new CareerFamilyHubBundle(
+        $bundle = new CareerFamilyHubBundle(
             family: [
                 'family_uuid' => $family->id,
                 'canonical_slug' => $family->canonical_slug,
@@ -56,6 +58,14 @@ final class CareerFamilyHubBundleBuilder
             ],
             visibleChildren: $visibleChildren,
             counts: $counts,
+            seoContract: [],
+        );
+
+        return new CareerFamilyHubBundle(
+            family: $bundle->family,
+            visibleChildren: $bundle->visibleChildren,
+            counts: $bundle->counts,
+            seoContract: $this->buildFamilySeoContract($bundle),
         );
     }
 
@@ -238,5 +248,96 @@ final class CareerFamilyHubBundleBuilder
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
             'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildFamilySeoContract(CareerFamilyHubBundle $bundle): array
+    {
+        $canonicalSlug = $this->normalizeString($bundle->family['canonical_slug'] ?? null);
+        $canonicalPath = $canonicalSlug !== null ? '/career/family/'.$canonicalSlug : null;
+        $canonicalTitle = $this->resolveFamilyTitle($bundle);
+        $indexEligible = (int) ($bundle->counts['visible_children_count'] ?? 0) > 0;
+        $indexState = $indexEligible ? 'index' : IndexStateValue::NOINDEX;
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $reasonCodes = $indexEligible ? ['visible_children_present'] : ['excluded_zero_visible_children'];
+        $structuredData = $this->structuredDataBuilder->build('career_family_hub', $bundle);
+        $structuredDataKeys = $this->extractTopLevelStructuredDataTypes(
+            is_array($structuredData['fragments'] ?? null) ? $structuredData['fragments'] : []
+        );
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_family_hub_bundle',
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $canonicalTitle,
+            'description' => $canonicalTitle,
+            'structured_data' => array_map(
+                static fn (string $type): array => ['@type' => $type],
+                $structuredDataKeys,
+            ),
+            'indexability_state' => $indexEligible ? IndexStateValue::INDEXABLE : IndexStateValue::NOINDEX,
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_title' => $canonicalTitle,
+            'index_state' => $indexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => $reasonCodes,
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+            'structured_data_keys' => $structuredDataKeys,
+        ];
+    }
+
+    private function resolveFamilyTitle(CareerFamilyHubBundle $bundle): string
+    {
+        return $this->normalizeString($bundle->family['title_en'] ?? null)
+            ?? $this->normalizeString($bundle->family['title_zh'] ?? null)
+            ?? $this->normalizeString($bundle->family['canonical_slug'] ?? null)
+            ?? 'Career family';
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $fragments
+     * @return list<string>
+     */
+    private function extractTopLevelStructuredDataTypes(array $fragments): array
+    {
+        $types = [];
+
+        foreach ($fragments as $fragment) {
+            if (! is_array($fragment) || ! is_string($fragment['@type'] ?? null)) {
+                continue;
+            }
+
+            $type = trim((string) $fragment['@type']);
+            if ($type === '') {
+                continue;
+            }
+
+            $types[] = $type;
+        }
+
+        $types = array_values(array_unique($types));
+        sort($types);
+
+        return $types;
     }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T14:43:46Z",
+  "updated_at": "2026-04-14T14:45:12Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -901,10 +901,10 @@
     "PR-B49": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b49-career-family-hub-page-level-seo-contract-hardening",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "8cbf8cbb5341039874aa5a0991560838cee54698",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/894",
       "checks": {
         "local": [
           {
@@ -924,9 +924,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405567834/job/71287802026"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405584715/job/71287861736"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405567834/job/71287814975"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405584715/job/71287875266"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately on both runs for PR-B49 and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T14:45:12Z",
+  "updated_at": "2026-04-14T14:46:19Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -903,7 +903,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "github_checks_failed",
       "branch": "codex/pr-b49-career-family-hub-page-level-seo-contract-hardening",
-      "commit_sha": "8cbf8cbb5341039874aa5a0991560838cee54698",
+      "commit_sha": "abdd1d934f7de5ae612408c4ff1947caeadc78fc",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/894",
       "checks": {
         "local": [
@@ -928,26 +928,26 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405567834/job/71287802026"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405624872/job/71288004103"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405584715/job/71287861736"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405626904/job/71288010264"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405567834/job/71287814975"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405624872/job/71288018983"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405584715/job/71287875266"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24405626904/job/71288023787"
           }
         ]
       },
-      "failure_reason": "GitHub hygiene failed immediately on both runs for PR-B49 and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
+      "failure_reason": "GitHub hygiene failed immediately on both runs for the latest PR-B49 head and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T13:14:41Z",
+  "updated_at": "2026-04-14T14:43:46Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -883,6 +883,40 @@
           },
           {
             "command": "php artisan test tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B49": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b49-career-family-hub-page-level-seo-contract-hardening",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/DTO/Career/CareerFamilyHubBundle.php app/Http/Resources/Career/CareerFamilyHubResource.php tests/Feature/Career/CareerFamilyHubApiTest.php docs/contracts/openapi.snapshot.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/CareerFamilyHubApiTest.php",
             "status": "passed"
           },
           {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -585,6 +585,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B49
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b49-career-family-hub-page-level-seo-contract-hardening
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career family-hub page-level SEO contract hardening.
+      Add a backend-owned top-level seo_contract to the existing family hub public contract
+      using current family authority truth for canonical path/title, robots/index posture,
+      metadata fingerprinting, and structured_data_keys, while keeping zero-visible families
+      canonical but explicitly noindex and avoiding job-detail, dataset, recommendation,
+      search, alias, support, or editorial semantic creep.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/DTO/Career/CareerFamilyHubBundle.php app/Http/Resources/Career/CareerFamilyHubResource.php tests/Feature/Career/CareerFamilyHubApiTest.php docs/contracts/openapi.snapshot.json"
+      - "php artisan test tests/Feature/Career/CareerFamilyHubApiTest.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerFamilyHubApiTest.php
+++ b/backend/tests/Feature/Career/CareerFamilyHubApiTest.php
@@ -19,12 +19,23 @@ final class CareerFamilyHubApiTest extends TestCase
 
         $family = OccupationFamily::query()->where('canonical_slug', 'computer-and-information-technology')->firstOrFail();
 
-        $this->getJson('/api/v0.5/career/family/computer-and-information-technology')
+        $response = $this->getJson('/api/v0.5/career/family/computer-and-information-technology');
+
+        $response
             ->assertOk()
             ->assertJsonPath('bundle_kind', 'career_family_hub')
             ->assertJsonPath('bundle_version', 'career.protocol.family_hub.v1')
             ->assertJsonPath('family.family_uuid', $family->id)
             ->assertJsonPath('family.canonical_slug', 'computer-and-information-technology')
+            ->assertJsonPath('seo_contract.canonical_path', '/career/family/computer-and-information-technology')
+            ->assertJsonPath('seo_contract.canonical_title', $family->title_en)
+            ->assertJsonPath('seo_contract.index_state', 'index')
+            ->assertJsonPath('seo_contract.index_eligible', true)
+            ->assertJsonPath('seo_contract.reason_codes', ['visible_children_present'])
+            ->assertJsonPath('seo_contract.metadata_contract_version', 'seo.surface.v1')
+            ->assertJsonPath('seo_contract.surface_type', 'career_family_hub_bundle')
+            ->assertJsonPath('seo_contract.robots_policy', 'index,follow')
+            ->assertJsonPath('seo_contract.structured_data_keys', ['BreadcrumbList', 'CollectionPage', 'ItemList'])
             ->assertJsonPath('structured_data.collection_page.@type', 'CollectionPage')
             ->assertJsonPath('structured_data.item_list.@type', 'ItemList')
             ->assertJsonPath('structured_data.breadcrumb_list.@type', 'BreadcrumbList')
@@ -48,6 +59,11 @@ final class CareerFamilyHubApiTest extends TestCase
             ->assertJsonMissingPath('structured_data.dataset')
             ->assertJsonMissingPath('structured_data.article')
             ->assertJsonMissingPath('structured_data.defined_term_set')
+            ->assertJsonMissingPath('seo_contract.canonical_target')
+            ->assertJsonMissingPath('seo_contract.trust_manifest')
+            ->assertJsonMissingPath('seo_contract.provenance_meta')
+            ->assertJsonMissingPath('seo_contract.dataset')
+            ->assertJsonMissingPath('seo_contract.article')
             ->assertJsonMissingPath('visible_children.1')
             ->assertJsonStructure([
                 'bundle_kind',
@@ -73,6 +89,18 @@ final class CareerFamilyHubApiTest extends TestCase
                     'blocked_not_safely_remediable_count',
                     'blocked_total',
                 ],
+                'seo_contract' => [
+                    'canonical_path',
+                    'canonical_title',
+                    'index_state',
+                    'index_eligible',
+                    'reason_codes',
+                    'metadata_contract_version',
+                    'surface_type',
+                    'robots_policy',
+                    'metadata_fingerprint',
+                    'structured_data_keys',
+                ],
                 'structured_data' => [
                     'collection_page' => [
                         '@context',
@@ -95,6 +123,9 @@ final class CareerFamilyHubApiTest extends TestCase
                     ],
                 ],
             ]);
+
+        $this->assertIsString($response->json('seo_contract.metadata_fingerprint'));
+        $this->assertNotSame('', trim((string) $response->json('seo_contract.metadata_fingerprint')));
     }
 
     public function test_it_returns_not_found_for_unknown_family_slug(): void
@@ -123,6 +154,13 @@ final class CareerFamilyHubApiTest extends TestCase
             ->assertJsonPath('counts.blocked_override_eligible_count', 0)
             ->assertJsonPath('counts.blocked_not_safely_remediable_count', 0)
             ->assertJsonPath('counts.blocked_total', 0)
+            ->assertJsonPath('seo_contract.canonical_path', '/career/family/empty-family-api')
+            ->assertJsonPath('seo_contract.canonical_title', 'Empty Family')
+            ->assertJsonPath('seo_contract.index_state', 'noindex')
+            ->assertJsonPath('seo_contract.index_eligible', false)
+            ->assertJsonPath('seo_contract.reason_codes', ['excluded_zero_visible_children'])
+            ->assertJsonPath('seo_contract.robots_policy', 'noindex,follow')
+            ->assertJsonPath('seo_contract.structured_data_keys', ['BreadcrumbList', 'CollectionPage', 'ItemList'])
             ->assertJsonPath('structured_data.collection_page.@type', 'CollectionPage')
             ->assertJsonPath('structured_data.item_list.@type', 'ItemList')
             ->assertJsonPath('structured_data.breadcrumb_list.@type', 'BreadcrumbList')

--- a/backend/tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php
@@ -57,6 +57,7 @@ final class CareerBreadcrumbBuilderTest extends TestCase
             ],
             visibleChildren: [],
             counts: [],
+            seoContract: [],
         );
 
         $builder = app(CareerBreadcrumbBuilder::class);

--- a/backend/tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFamilyHubStructuredDataPublicProjectionTest.php
@@ -34,6 +34,7 @@ final class CareerFamilyHubStructuredDataPublicProjectionTest extends TestCase
                 'blocked_not_safely_remediable_count' => 0,
                 'blocked_total' => 0,
             ],
+            seoContract: [],
         );
 
         $payload = (new CareerFamilyHubResource($bundle))->toArray(Request::create('/api/v0.5/career/family/computer-and-information-technology', 'GET'));

--- a/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
@@ -87,6 +87,7 @@ final class CareerStructuredDataBuilderTest extends TestCase
             counts: [
                 'visible_children_count' => 3,
             ],
+            seoContract: [],
         );
 
         $payload = app(CareerStructuredDataBuilder::class)->build('career_family_hub', $bundle);


### PR DESCRIPTION
## What changed
- add a backend-owned top-level `seo_contract` to the existing career family hub public contract
- source the family hub page-level SEO contract only from existing family authority truth: canonical slug/title, visible child count, explicit zero-visible posture, and the currently public structured-data fragment family
- keep zero-visible family hubs canonical but explicitly noindex
- add focused API assertions and adjust affected unit fixtures to keep family hub bundle/structured-data tests aligned with the new bundle shape

## Why
- family hub already had stable authority truth for page identity and discoverability posture, but it still lacked a formal page-level SEO contract like other backend-owned career surfaces
- the safe move is a narrow additive contract for canonical path/title, index posture, and metadata fingerprinting, without copying occupation-specific job-detail semantics
- this makes family hub SEO ownership backend-auditable while keeping scope tightly limited to family hub only

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/DTO/Career/CareerFamilyHubBundle.php app/Http/Resources/Career/CareerFamilyHubResource.php tests/Feature/Career/CareerFamilyHubApiTest.php docs/contracts/openapi.snapshot.json`
- `php artisan test tests/Feature/Career/CareerFamilyHubApiTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- no controller or route changes
- no job-detail SEO contract changes
- no dataset, article, recommendation, search, alias, support, or editorial expansion
- no structured-data family expansion beyond reusing current B45 fragments
- no trust/provenance/canonical_target semantics on family hub `seo_contract`
