### PR TITLE
PR-B50: Career family-hub attribution taxonomy + daily read-model alignment

### DIFF
--- a/backend/app/Services/Analytics/CareerAttributionDailyBuilder.php
+++ b/backend/app/Services/Analytics/CareerAttributionDailyBuilder.php
@@ -214,6 +214,10 @@ final class CareerAttributionDailyBuilder
      */
     private function deriveReadinessClass(string $subjectKind, string $subjectKey, array $readinessBySlug): string
     {
+        if ($subjectKind === 'family_slug') {
+            return 'unknown';
+        }
+
         if ($subjectKind !== 'job_slug' || $subjectKey === '') {
             return 'unknown';
         }

--- a/backend/app/Services/Analytics/CareerAttributionEventMapper.php
+++ b/backend/app/Services/Analytics/CareerAttributionEventMapper.php
@@ -15,11 +15,13 @@ final class CareerAttributionEventMapper
         'career_landing_view',
         'career_job_index_view',
         'career_job_detail_view',
+        'career_family_hub_view',
         'career_recommendation_index_view',
         'career_recommendation_detail_view',
         'career_job_search_submit',
         'career_job_search_result_click',
         'career_job_index_result_click',
+        'career_family_hub_child_click',
         'career_job_detail_cta_click',
         'career_recommendation_result_click',
         'career_recommendation_matched_job_click',
@@ -37,6 +39,7 @@ final class CareerAttributionEventMapper
         'jobs',
         'jobs_search',
         'job_detail',
+        'family_hub',
         'recommendations',
         'recommendation_detail',
     ];
@@ -46,6 +49,7 @@ final class CareerAttributionEventMapper
      */
     private const ALLOWED_SUBJECT_KINDS = [
         'none',
+        'family_slug',
         'job_slug',
         'recommendation_type',
     ];

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-14T14:46:19Z",
+  "updated_at": "2026-04-15T00:00:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -948,6 +948,36 @@
         ]
       },
       "failure_reason": "GitHub hygiene failed immediately on both runs for the latest PR-B49 head and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B50": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b50-career-family-hub-attribution-taxonomy-daily-read-model-alignment",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T00:00:00Z",
+  "updated_at": "2026-04-15T00:48:10Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -956,10 +956,10 @@
     "PR-B50": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b50-career-family-hub-attribution-taxonomy-daily-read-model-alignment",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "db7ee6890c9f37e820ae00ac24072fbd678b876e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/895",
       "checks": {
         "local": [
           {
@@ -975,9 +975,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24430471780/job/71373608597"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24430479039/job/71373630124"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24430471780/job/71373614300"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24430479039/job/71373634618"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately on both PR-B50 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -614,6 +614,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B50
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b50-career-family-hub-attribution-taxonomy-daily-read-model-alignment
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career family-hub attribution taxonomy + daily read-model alignment.
+      Add only career_family_hub_view and career_family_hub_child_click to the existing
+      Career attribution spine, extend mapper allowlists and daily aggregation compatibility
+      for family_hub route taxonomy, and add focused analytics tests without schema changes,
+      OpenAPI changes, frontend changes, or attribution expansion into alias, search, dataset,
+      editorial, or support-link surfaces.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php"
+      - "php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
@@ -47,7 +47,23 @@ final class CareerAttributionDailyBuilderTest extends TestCase
             'subject_key' => 'software-developers',
             'query_mode' => 'query',
         ], 'anon_b', 'session_b');
-        $this->insertCareerEvent($orgId, 'career_recommendation_matched_job_click', $day->copy()->addMinutes(3), [
+        $this->insertCareerEvent($orgId, 'career_family_hub_view', $day->copy()->addMinutes(2), [
+            'entry_surface' => 'career_family_hub',
+            'source_page_type' => 'career_family_hub',
+            'route_family' => 'family_hub',
+            'subject_kind' => 'family_slug',
+            'subject_key' => 'data-and-ai',
+            'query_mode' => 'non_query',
+        ], 'anon_family_view', 'session_family_view');
+        $this->insertCareerEvent($orgId, 'career_family_hub_child_click', $day->copy()->addMinutes(3), [
+            'entry_surface' => 'career_family_hub',
+            'source_page_type' => 'career_family_hub',
+            'route_family' => 'family_hub',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'registered-nurses',
+            'query_mode' => 'non_query',
+        ], 'anon_family_click', 'session_family_click');
+        $this->insertCareerEvent($orgId, 'career_recommendation_matched_job_click', $day->copy()->addMinutes(4), [
             'entry_surface' => 'career_recommendation_detail',
             'source_page_type' => 'recommendation_detail',
             'route_family' => 'recommendation_detail',
@@ -55,7 +71,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
             'subject_key' => 'marketing-managers',
             'query_mode' => 'non_query',
         ], 'anon_c', 'session_c');
-        $this->insertCareerEvent($orgId, 'career_recommendation_result_click', $day->copy()->addMinutes(4), [
+        $this->insertCareerEvent($orgId, 'career_recommendation_result_click', $day->copy()->addMinutes(5), [
             'entry_surface' => 'career_recommendation_index',
             'source_page_type' => 'recommendation_index',
             'route_family' => 'recommendations',
@@ -63,7 +79,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
             'subject_key' => 'intj',
             'query_mode' => 'non_query',
         ], 'anon_d', 'session_d');
-        $this->insertCareerEvent($orgId, 'career_transition_preview_view', $day->copy()->addMinutes(5), [
+        $this->insertCareerEvent($orgId, 'career_transition_preview_view', $day->copy()->addMinutes(6), [
             'entry_surface' => 'career_recommendation_detail_transition_preview',
             'source_page_type' => 'career_recommendation_detail',
             'route_family' => 'recommendation_detail',
@@ -71,7 +87,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
             'subject_key' => 'registered-nurses',
             'query_mode' => 'non_query',
         ], 'anon_e', 'session_e');
-        $this->insertCareerEvent($orgId, 'career_transition_preview_target_click', $day->copy()->addMinutes(6), [
+        $this->insertCareerEvent($orgId, 'career_transition_preview_target_click', $day->copy()->addMinutes(7), [
             'entry_surface' => 'career_recommendation_detail_transition_preview',
             'source_page_type' => 'career_recommendation_detail',
             'route_family' => 'recommendation_detail',
@@ -79,7 +95,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
             'subject_key' => 'registered-nurses',
             'query_mode' => 'non_query',
         ], 'anon_f', 'session_f');
-        $this->insertCareerEvent($orgId, 'career_blocked_surface_exposed', $day->copy()->addMinutes(7), [
+        $this->insertCareerEvent($orgId, 'career_blocked_surface_exposed', $day->copy()->addMinutes(8), [
             'entry_surface' => 'career_blocked_surface',
             'source_page_type' => 'job_detail',
             'route_family' => 'job_detail',
@@ -87,7 +103,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
             'subject_key' => 'data-scientists',
             'query_mode' => 'non_query',
         ], 'anon_g', 'session_g');
-        $this->insertCareerEvent($orgId, 'career_blocked_surface_exposed', $day->copy()->addMinutes(8), [
+        $this->insertCareerEvent($orgId, 'career_blocked_surface_exposed', $day->copy()->addMinutes(9), [
             'entry_surface' => 'career_blocked_surface',
             'source_page_type' => 'recommendation_detail',
             'route_family' => 'job_detail',
@@ -98,7 +114,7 @@ final class CareerAttributionDailyBuilderTest extends TestCase
 
         $result = app(CareerAttributionDailyBuilder::class)->refresh($day, $day, [$orgId], false);
 
-        $this->assertSame(8, (int) ($result['upserted_rows'] ?? 0));
+        $this->assertSame(10, (int) ($result['upserted_rows'] ?? 0));
 
         $readyRow = DB::table('analytics_career_attribution_daily')
             ->where('day', $day->toDateString())
@@ -124,6 +140,30 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         $this->assertSame('job_index', $blockedRow->source_page_type);
         $this->assertSame('query', $blockedRow->query_mode);
         $this->assertSame('jobs_search', $blockedRow->route_family);
+
+        $familyHubViewRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_family_hub_view')
+            ->where('subject_key', 'data-and-ai')
+            ->first();
+
+        $this->assertNotNull($familyHubViewRow);
+        $this->assertSame('career_family_hub', $familyHubViewRow->surface);
+        $this->assertSame('family_hub', $familyHubViewRow->source_page_type);
+        $this->assertSame('family_hub', $familyHubViewRow->route_family);
+        $this->assertSame('family_slug', $familyHubViewRow->subject_kind);
+        $this->assertSame('unknown', $familyHubViewRow->readiness_class);
+
+        $familyHubChildClickRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_family_hub_child_click')
+            ->where('subject_key', 'registered-nurses')
+            ->first();
+
+        $this->assertNotNull($familyHubChildClickRow);
+        $this->assertSame('career_family_hub', $familyHubChildClickRow->surface);
+        $this->assertSame('family_hub', $familyHubChildClickRow->source_page_type);
+        $this->assertSame('family_hub', $familyHubChildClickRow->route_family);
+        $this->assertSame('job_slug', $familyHubChildClickRow->subject_kind);
+        $this->assertSame('publish_ready', $familyHubChildClickRow->readiness_class);
 
         $matchedJobRow = DB::table('analytics_career_attribution_daily')
             ->where('event_name', 'career_recommendation_matched_job_click')

--- a/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
@@ -103,6 +103,23 @@ final class CareerAttributionEventIngestTest extends TestCase
                 'expected_source_page_type' => 'recommendation_detail',
             ],
             [
+                'event' => 'career_family_hub_view',
+                'anon' => 'anon_b50_family_hub_view',
+                'path' => '/en/career/family/data-and-ai',
+                'payload' => [
+                    'entry_surface' => 'career_family_hub',
+                    'source_page_type' => 'career_family_hub',
+                    'target_action' => 'view_family_hub',
+                    'landing_path' => '/en/career/family/data-and-ai',
+                    'route_family' => 'family_hub',
+                    'subject_kind' => 'family_slug',
+                    'subject_key' => 'data-and-ai',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'family_hub',
+            ],
+            [
                 'event' => 'career_transition_preview_view',
                 'anon' => 'anon_b42_transition_view',
                 'path' => '/en/career/recommendations/mbti/intj-a',
@@ -170,6 +187,23 @@ final class CareerAttributionEventIngestTest extends TestCase
                 'expected_source_page_type' => 'job_index',
             ],
             [
+                'event' => 'career_family_hub_child_click',
+                'anon' => 'anon_b50_family_hub_child_click',
+                'path' => '/en/career/family/data-and-ai',
+                'payload' => [
+                    'entry_surface' => 'career_family_hub',
+                    'source_page_type' => 'career_family_hub',
+                    'target_action' => 'open_family_hub_child',
+                    'landing_path' => '/en/career/family/data-and-ai',
+                    'route_family' => 'family_hub',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'data-scientists',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'family_hub',
+            ],
+            [
                 'event' => 'career_blocked_surface_exposed',
                 'anon' => 'anon_b42_blocked_surface',
                 'path' => '/en/career/jobs/software-developers',
@@ -214,6 +248,81 @@ final class CareerAttributionEventIngestTest extends TestCase
                 : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
 
             $this->assertSame($case['expected_source_page_type'], $meta['source_page_type'] ?? null);
+        }
+    }
+
+    public function test_ingest_endpoint_normalizes_family_hub_view_and_child_click_dimensions(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $cases = [
+            [
+                'event' => 'career_family_hub_view',
+                'anon' => 'anon_b50_family_hub_view_dimensions',
+                'payload' => [
+                    'entry_surface' => 'career_family_hub',
+                    'source_page_type' => 'career_family_hub',
+                    'target_action' => 'view_family_hub',
+                    'landing_path' => '/en/career/family/business-and-finance',
+                    'route_family' => 'family_hub',
+                    'subject_kind' => 'family_slug',
+                    'subject_key' => 'business-and-finance',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_subject_kind' => 'family_slug',
+                'expected_subject_key' => 'business-and-finance',
+            ],
+            [
+                'event' => 'career_family_hub_child_click',
+                'anon' => 'anon_b50_family_hub_child_dimensions',
+                'payload' => [
+                    'entry_surface' => 'career_family_hub',
+                    'source_page_type' => 'career_family_hub',
+                    'target_action' => 'open_family_hub_child',
+                    'landing_path' => '/en/career/family/business-and-finance',
+                    'route_family' => 'family_hub',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'financial-managers',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_subject_kind' => 'job_slug',
+                'expected_subject_key' => 'financial-managers',
+            ],
+        ];
+
+        foreach ($cases as $case) {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ingest_test_token',
+            ])->postJson('/api/v0.5/career/attribution/events', [
+                'eventName' => $case['event'],
+                'anonymousId' => $case['anon'],
+                'path' => '/en/career/family/business-and-finance',
+                'timestamp' => '2026-04-14T10:00:00+08:00',
+                'payload' => $case['payload'],
+            ]);
+
+            $response->assertStatus(202)
+                ->assertJsonPath('event_code', $case['event']);
+
+            $row = DB::table('events')
+                ->where('event_code', $case['event'])
+                ->where('anon_id', $case['anon'])
+                ->first();
+
+            $this->assertNotNull($row);
+
+            $meta = is_array($row->meta_json ?? null)
+                ? $row->meta_json
+                : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
+
+            $this->assertSame('career_family_hub', $meta['entry_surface'] ?? null);
+            $this->assertSame('family_hub', $meta['source_page_type'] ?? null);
+            $this->assertSame('family_hub', $meta['route_family'] ?? null);
+            $this->assertSame($case['expected_subject_kind'], $meta['subject_kind'] ?? null);
+            $this->assertSame($case['expected_subject_key'], $meta['subject_key'] ?? null);
+            $this->assertSame('non_query', $meta['query_mode'] ?? null);
         }
     }
 
@@ -352,7 +461,14 @@ final class CareerAttributionEventIngestTest extends TestCase
     {
         config()->set('fap.events.ingest_token', 'ingest_test_token');
 
-        foreach (['career_unknown_event', 'career_view', 'career_alias_search', 'career_shortlist_add'] as $eventName) {
+        foreach ([
+            'career_unknown_event',
+            'career_view',
+            'career_alias_search',
+            'career_shortlist_add',
+            'career_family_hub_ready_surface_exposed',
+            'career_family_hub_blocked_surface_exposed',
+        ] as $eventName) {
             $response = $this->withHeaders([
                 'Authorization' => 'Bearer ingest_test_token',
             ])->postJson('/api/v0.5/career/attribution/events', [


### PR DESCRIPTION
## What changed
- add two new family-hub attribution events to the existing Career attribution taxonomy:
  - `career_family_hub_view`
  - `career_family_hub_child_click`
- extend mapper allowlists and normalization so family hub is accepted as a first-class source surface with:
  - `route_family = family_hub`
  - `subject_kind = family_slug` for views
  - `subject_kind = job_slug` for child clicks
- keep family-hub child clicks distinct from `career_job_index_result_click`
- align the daily builder so family-hub view rows aggregate with `readiness_class = unknown`, while family-hub child clicks continue to derive readiness from existing job readiness truth
- add focused ingest and daily-builder coverage for the new taxonomy, plus rejection coverage for deferred family-hub event families

## Why
- B42 established the ingest and daily read-model spine, but family hub was intentionally deferred from the attribution taxonomy
- B23, B35, B45, and B49 now give family hub a stable route identity and backend-owned page authority, so it is strong enough to become an attribution source surface
- the safe extension is narrow: add only the two justified event names and let them flow through the existing ingest -> normalize -> daily aggregation path without schema changes or taxonomy sprawl

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php`
- `php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php tests/Feature/Analytics/RefreshCareerAttributionDailyCommandTest.php`

## Intentionally deferred
- no public analytics endpoint or dashboard work
- no frontend instrumentation changes
- no ready/block surface family-hub events
- no alias, search, dataset, editorial, or support-link attribution
- no daily schema migration or storage redesign
