### PR TITLE
PR-B51: Career first-wave launch readiness audit / contract consolidation

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveLaunchReadinessAudit.php
+++ b/backend/app/DTO/Career/CareerFirstWaveLaunchReadinessAudit.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveLaunchReadinessAudit
+{
+    /**
+     * @param  array<string, int>  $counts
+     * @param  list<CareerFirstWaveLaunchReadinessAuditMember>  $members
+     */
+    public function __construct(
+        public readonly string $summaryVersion,
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'summary_kind' => 'career_first_wave_launch_readiness_audit',
+            'summary_version' => $this->summaryVersion,
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'members' => array_map(
+                static fn (CareerFirstWaveLaunchReadinessAuditMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveLaunchReadinessAuditMember.php
+++ b/backend/app/DTO/Career/CareerFirstWaveLaunchReadinessAuditMember.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveLaunchReadinessAuditMember
+{
+    /**
+     * @param  list<string>  $blockers
+     * @param  array<string, array<string, string>>  $evidenceRefs
+     */
+    public function __construct(
+        public readonly string $occupationUuid,
+        public readonly string $canonicalSlug,
+        public readonly string $canonicalTitleEn,
+        public readonly string $launchTier,
+        public readonly string $readinessStatus,
+        public readonly string $lifecycleState,
+        public readonly string $publicIndexState,
+        public readonly bool $indexEligible,
+        public readonly ?string $reviewerStatus,
+        public readonly ?string $crosswalkMode,
+        public readonly bool $allowStrongClaim,
+        public readonly ?int $confidenceScore,
+        public readonly ?string $blockedGovernanceStatus,
+        public readonly int $nextStepLinksCount,
+        public readonly bool $familyHubSupportingRoute,
+        public readonly array $blockers,
+        public readonly array $evidenceRefs,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'member_kind' => 'career_job_detail',
+            'occupation_uuid' => $this->occupationUuid,
+            'canonical_slug' => $this->canonicalSlug,
+            'canonical_title_en' => $this->canonicalTitleEn,
+            'launch_tier' => $this->launchTier,
+            'readiness_status' => $this->readinessStatus,
+            'lifecycle_state' => $this->lifecycleState,
+            'public_index_state' => $this->publicIndexState,
+            'index_eligible' => $this->indexEligible,
+            'reviewer_status' => $this->reviewerStatus,
+            'crosswalk_mode' => $this->crosswalkMode,
+            'allow_strong_claim' => $this->allowStrongClaim,
+            'confidence_score' => $this->confidenceScore,
+            'blocked_governance_status' => $this->blockedGovernanceStatus,
+            'next_step_links_count' => $this->nextStepLinksCount,
+            'family_hub_supporting_route' => $this->familyHubSupportingRoute,
+            'blockers' => $this->blockers,
+            'evidence_refs' => $this->evidenceRefs,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditService.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveLaunchReadinessAudit;
+use App\DTO\Career\CareerFirstWaveLaunchReadinessAuditMember;
+
+final class CareerFirstWaveLaunchReadinessAuditService
+{
+    public const SUMMARY_VERSION = 'career.launch_readiness.audit.v1';
+
+    /**
+     * @var array<string, true>
+     */
+    private const REVIEW_APPROVED_STATUSES = [
+        'approved' => true,
+        'reviewed' => true,
+    ];
+
+    /**
+     * @var array<string, true>
+     */
+    private const DISALLOWED_CROSSWALK_MODES = [
+        'local_heavy_interpretation' => true,
+        'family_proxy' => true,
+        'unmapped' => true,
+    ];
+
+    public function __construct(
+        private readonly CareerFirstWaveLaunchTierSummaryService $launchTierSummaryService,
+        private readonly FirstWaveReadinessSummaryService $readinessSummaryService,
+        private readonly CareerFirstWaveLifecycleSummaryService $lifecycleSummaryService,
+        private readonly CareerFirstWaveNextStepLinksService $nextStepLinksService,
+    ) {}
+
+    public function build(): CareerFirstWaveLaunchReadinessAudit
+    {
+        $launchTierSummary = $this->launchTierSummaryService->build()->toArray();
+        $readinessSummary = $this->readinessSummaryService->build()->toArray();
+        $lifecycleSummary = $this->lifecycleSummaryService->build()->toArray();
+
+        $readinessBySlug = [];
+        foreach ((array) ($readinessSummary['occupations'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug !== '') {
+                $readinessBySlug[$slug] = $row;
+            }
+        }
+
+        $lifecycleBySlug = [];
+        foreach ((array) ($lifecycleSummary['occupations'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug !== '') {
+                $lifecycleBySlug[$slug] = $row;
+            }
+        }
+
+        $counts = [
+            'total' => 0,
+            'launch_ready' => 0,
+            'candidate_review' => 0,
+            'hold' => 0,
+            'blocked' => 0,
+        ];
+        $members = [];
+
+        foreach ((array) ($launchTierSummary['occupations'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $readiness = $readinessBySlug[$slug] ?? [];
+            $lifecycle = $lifecycleBySlug[$slug] ?? [];
+            $nextStepLinks = $this->nextStepLinksService->buildBySlug($slug)?->toArray();
+
+            $nextStepLinksCount = (int) data_get($nextStepLinks, 'counts.total', 0);
+            $familyHubSupportingRoute = (int) data_get($nextStepLinks, 'counts.family_hub', 0) > 0;
+            $blockers = $this->curateBlockers(
+                readinessStatus: $this->normalizeNullableString($readiness['status'] ?? null),
+                blockedGovernanceStatus: $this->normalizeNullableString($row['blocked_governance_status'] ?? null),
+                reviewerStatus: $this->normalizeNullableString($row['reviewer_status'] ?? null),
+                crosswalkMode: $this->normalizeNullableString($row['crosswalk_mode'] ?? null),
+                indexEligible: (bool) ($row['index_eligible'] ?? false),
+                allowStrongClaim: (bool) ($row['allow_strong_claim'] ?? false),
+                confidenceScore: $this->normalizeNullableInt($row['confidence_score'] ?? null),
+                nextStepLinksCount: $nextStepLinksCount,
+            );
+
+            $member = new CareerFirstWaveLaunchReadinessAuditMember(
+                occupationUuid: (string) ($row['occupation_uuid'] ?? ''),
+                canonicalSlug: $slug,
+                canonicalTitleEn: (string) ($row['canonical_title_en'] ?? ''),
+                launchTier: (string) ($row['launch_tier'] ?? WaveClassification::HOLD),
+                readinessStatus: $this->normalizeNullableString($readiness['status'] ?? null) ?? 'blocked_not_safely_remediable',
+                lifecycleState: (string) ($lifecycle['lifecycle_state'] ?? CareerIndexLifecycleState::NOINDEX),
+                publicIndexState: (string) ($lifecycle['public_index_state'] ?? 'noindex'),
+                indexEligible: (bool) ($row['index_eligible'] ?? false),
+                reviewerStatus: $this->normalizeNullableString($row['reviewer_status'] ?? null),
+                crosswalkMode: $this->normalizeNullableString($row['crosswalk_mode'] ?? null),
+                allowStrongClaim: (bool) ($row['allow_strong_claim'] ?? false),
+                confidenceScore: $this->normalizeNullableInt($row['confidence_score'] ?? null),
+                blockedGovernanceStatus: $this->normalizeNullableString($row['blocked_governance_status'] ?? null),
+                nextStepLinksCount: $nextStepLinksCount,
+                familyHubSupportingRoute: $familyHubSupportingRoute,
+                blockers: $blockers,
+                evidenceRefs: $this->buildEvidenceRefs($slug),
+            );
+
+            $counts['total']++;
+            $counts[$this->classifyMember($member)]++;
+            $members[] = $member;
+        }
+
+        return new CareerFirstWaveLaunchReadinessAudit(
+            summaryVersion: self::SUMMARY_VERSION,
+            scope: (string) ($launchTierSummary['scope'] ?? CareerFirstWaveLaunchTierSummaryService::SCOPE),
+            counts: $counts,
+            members: $members,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function curateBlockers(
+        ?string $readinessStatus,
+        ?string $blockedGovernanceStatus,
+        ?string $reviewerStatus,
+        ?string $crosswalkMode,
+        bool $indexEligible,
+        bool $allowStrongClaim,
+        ?int $confidenceScore,
+        int $nextStepLinksCount,
+    ): array {
+        $blockers = [];
+
+        if ($blockedGovernanceStatus !== null) {
+            $blockers[] = 'blocked_governance';
+        }
+
+        if ($reviewerStatus === null || ! isset(self::REVIEW_APPROVED_STATUSES[strtolower($reviewerStatus)])) {
+            $blockers[] = 'reviewer_not_approved';
+        }
+
+        if ($crosswalkMode !== null && isset(self::DISALLOWED_CROSSWALK_MODES[strtolower($crosswalkMode)])) {
+            $blockers[] = 'crosswalk_disallowed';
+        }
+
+        if (! $indexEligible) {
+            $blockers[] = 'not_index_eligible';
+        }
+
+        if (! $allowStrongClaim) {
+            $blockers[] = 'strong_claim_disallowed';
+        }
+
+        if ($confidenceScore !== null && $confidenceScore < 60) {
+            $blockers[] = 'low_confidence';
+        }
+
+        if ($nextStepLinksCount < 1) {
+            $blockers[] = 'insufficient_next_step_links';
+        }
+
+        if ($readinessStatus !== 'publish_ready') {
+            $blockers[] = 'not_publish_ready';
+        }
+
+        return array_values(array_unique($blockers));
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private function buildEvidenceRefs(string $slug): array
+    {
+        return [
+            'launch_tier' => [
+                'summary_kind' => 'career_first_wave_launch_tier',
+                'canonical_slug' => $slug,
+            ],
+            'readiness' => [
+                'summary_kind' => 'career_first_wave_readiness',
+                'canonical_slug' => $slug,
+            ],
+            'lifecycle' => [
+                'summary_kind' => 'career_first_wave_lifecycle',
+                'canonical_slug' => $slug,
+            ],
+            'next_step_links' => [
+                'summary_kind' => 'career_first_wave_next_step_links',
+                'canonical_slug' => $slug,
+            ],
+        ];
+    }
+
+    private function classifyMember(CareerFirstWaveLaunchReadinessAuditMember $member): string
+    {
+        if (
+            $member->blockedGovernanceStatus !== null
+            || in_array($member->readinessStatus, ['blocked_override_eligible', 'blocked_not_safely_remediable'], true)
+        ) {
+            return 'blocked';
+        }
+
+        if ($member->launchTier === WaveClassification::STABLE && $member->readinessStatus === 'publish_ready') {
+            return 'launch_ready';
+        }
+
+        if (
+            $member->launchTier === WaveClassification::CANDIDATE
+            || $member->lifecycleState === CareerIndexLifecycleState::PROMOTION_CANDIDATE
+        ) {
+            return 'candidate_review';
+        }
+
+        return 'hold';
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeNullableInt(mixed $value): ?int
+    {
+        return is_numeric($value) ? (int) round((float) $value) : null;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T00:48:10Z",
+  "updated_at": "2026-04-15T04:11:51Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -999,6 +999,40 @@
         ]
       },
       "failure_reason": "GitHub hygiene failed immediately on both PR-B50 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B51": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b51-career-first-wave-launch-readiness-audit-contract-consolidation",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Publish/*.php app/DTO/Career/CareerFirstWaveLaunchReadinessAudit*.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchTierSummaryServiceTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveNextStepLinksServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T04:11:51Z",
+  "updated_at": "2026-04-15T04:15:44Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1007,10 +1007,10 @@
     "PR-B51": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b51-career-first-wave-launch-readiness-audit-contract-consolidation",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "d9f4c8a7d3b925f52e67b871820f2464f1c27e3c",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/896",
       "checks": {
         "local": [
           {
@@ -1030,9 +1030,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436073628/job/71390491727"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436074577/job/71390494612"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436073628/job/71390495807"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436074577/job/71390498296"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately on both PR-B51 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -642,6 +642,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B51
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b51-career-first-wave-launch-readiness-audit-contract-consolidation
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave launch readiness audit / contract consolidation.
+      Add an internal-only first-wave launch readiness audit layer for career_job_detail
+      members that consolidates existing launch tier, readiness, lifecycle/index posture,
+      reviewer/claim/crosswalk/governance blockers, next-step links count, and family-hub
+      supporting-route evidence without adding public APIs, OpenAPI changes, family-hub
+      audited members, or unsupported promotion-scoring semantics.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/*.php app/DTO/Career/CareerFirstWaveLaunchReadinessAudit*.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchTierSummaryServiceTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveNextStepLinksServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveLaunchReadinessAuditService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveLaunchReadinessAuditServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_an_internal_first_wave_launch_readiness_audit_for_job_detail_members_only(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $audit = app(CareerFirstWaveLaunchReadinessAuditService::class)->build()->toArray();
+        $members = collect($audit['members'])->keyBy('canonical_slug');
+
+        $this->assertSame('career_first_wave_launch_readiness_audit', $audit['summary_kind']);
+        $this->assertSame(CareerFirstWaveLaunchReadinessAuditService::SUMMARY_VERSION, $audit['summary_version']);
+        $this->assertSame('career_first_wave_10', $audit['scope']);
+        $this->assertSame(10, $audit['counts']['total']);
+        $this->assertSame(6, $audit['counts']['launch_ready']);
+        $this->assertSame(0, $audit['counts']['candidate_review']);
+        $this->assertSame(0, $audit['counts']['hold']);
+        $this->assertSame(4, $audit['counts']['blocked']);
+
+        $registeredNurses = $members->get('registered-nurses');
+        $softwareDevelopers = $members->get('software-developers');
+
+        $this->assertIsArray($registeredNurses);
+        $this->assertSame('career_job_detail', $registeredNurses['member_kind']);
+        $this->assertSame('stable', $registeredNurses['launch_tier']);
+        $this->assertSame('publish_ready', $registeredNurses['readiness_status']);
+        $this->assertSame('indexed', $registeredNurses['lifecycle_state']);
+        $this->assertSame('indexable', $registeredNurses['public_index_state']);
+        $this->assertTrue($registeredNurses['index_eligible']);
+        $this->assertSame('approved', $registeredNurses['reviewer_status']);
+        $this->assertSame('exact', $registeredNurses['crosswalk_mode']);
+        $this->assertTrue($registeredNurses['allow_strong_claim']);
+        $this->assertSame(90, $registeredNurses['confidence_score']);
+        $this->assertSame(1, $registeredNurses['next_step_links_count']);
+        $this->assertTrue($registeredNurses['family_hub_supporting_route']);
+        $this->assertSame([], $registeredNurses['blockers']);
+        $this->assertSame('career_first_wave_launch_tier', data_get($registeredNurses, 'evidence_refs.launch_tier.summary_kind'));
+        $this->assertSame('registered-nurses', data_get($registeredNurses, 'evidence_refs.next_step_links.canonical_slug'));
+
+        $this->assertIsArray($softwareDevelopers);
+        $this->assertSame('hold', $softwareDevelopers['launch_tier']);
+        $this->assertSame('blocked_override_eligible', $softwareDevelopers['readiness_status']);
+        $this->assertSame('blocked_override_eligible', $softwareDevelopers['blocked_governance_status']);
+        $this->assertContains('blocked_governance', $softwareDevelopers['blockers']);
+        $this->assertContains('not_index_eligible', $softwareDevelopers['blockers']);
+        $this->assertContains('strong_claim_disallowed', $softwareDevelopers['blockers']);
+        $this->assertContains('not_publish_ready', $softwareDevelopers['blockers']);
+
+        $this->assertCount(0, array_filter(
+            $audit['members'],
+            static fn (array $member): bool => ($member['member_kind'] ?? null) === 'career_family_hub'
+        ));
+        $this->assertArrayNotHasKey('demand_signal', $registeredNurses);
+        $this->assertArrayNotHasKey('novelty_score', $registeredNurses);
+        $this->assertArrayNotHasKey('canonical_conflict', $registeredNurses);
+        $this->assertArrayNotHasKey('trust_freshness_state', $registeredNurses);
+    }
+
+    public function test_it_projects_candidate_review_without_claiming_family_hubs_as_members(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+
+        $audit = app(CareerFirstWaveLaunchReadinessAuditService::class)->build()->toArray();
+        $members = collect($audit['members'])->keyBy('canonical_slug');
+        $candidateRow = $members->get('data-scientists');
+
+        $this->assertSame(5, $audit['counts']['launch_ready']);
+        $this->assertSame(1, $audit['counts']['candidate_review']);
+        $this->assertSame(0, $audit['counts']['hold']);
+        $this->assertSame(4, $audit['counts']['blocked']);
+
+        $this->assertIsArray($candidateRow);
+        $this->assertSame('candidate', $candidateRow['launch_tier']);
+        $this->assertSame('partial_raw', $candidateRow['readiness_status']);
+        $this->assertContains('not_publish_ready', $candidateRow['blockers']);
+    }
+
+    public function test_it_can_hold_non_blocked_members_when_current_truth_stays_non_releasable(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $subject = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $subject->update([
+            'crosswalk_mode' => 'exact',
+        ]);
+        $subject->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewer_status' => 'approved',
+            'quality' => [
+                'confidence_score' => 55,
+            ],
+        ]);
+
+        $audit = app(CareerFirstWaveLaunchReadinessAuditService::class)->build()->toArray();
+        $members = collect($audit['members'])->keyBy('canonical_slug');
+        $row = $members->get('data-scientists');
+
+        $this->assertSame(5, $audit['counts']['launch_ready']);
+        $this->assertSame(0, $audit['counts']['candidate_review']);
+        $this->assertSame(1, $audit['counts']['hold']);
+        $this->assertSame(4, $audit['counts']['blocked']);
+
+        $this->assertIsArray($row);
+        $this->assertSame('hold', $row['launch_tier']);
+        $this->assertSame('partial_raw', $row['readiness_status']);
+        $this->assertContains('low_confidence', $row['blockers']);
+        $this->assertFalse(in_array('blocked_governance', $row['blockers'], true));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add an internal-only first-wave launch readiness audit layer for `career_job_detail` members
- consolidate existing backend-owned release truth from launch tier, readiness, lifecycle, and next-step-links authorities into one auditable contract
- expose only the current strong member-level fields: launch tier, readiness status, lifecycle/index posture, reviewer/crosswalk/claim/governance state, next-step links count, family-hub supporting-route evidence, curated blockers, and internal evidence refs
- keep family hubs out of the audited member set and use them only as supporting route evidence
- add focused unit coverage for audited member scope, launch-ready/candidate-review/hold/blocked counts, blocker curation, supporting-route evidence, and omission of unsupported strategy inputs

## Why
- first-wave release truth already existed in several backend authority services, but it was still fragmented across launch/readiness/lifecycle/links layers
- the safe consolidation is an internal audit contract that reuses current truth without inventing a stronger promotion-decision policy
- this gives the backend one reusable, auditable authority for launch posture while staying narrow: no public API, no OpenAPI change, no family-hub audited members, and no unsupported demand/novelty/canonical-conflict semantics

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/*.php app/DTO/Career/CareerFirstWaveLaunchReadinessAudit*.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchTierSummaryServiceTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveNextStepLinksServiceTest.php`

## Intentionally deferred
- no public API or OpenAPI surface
- no family-hub first-class audited members
- no `demand_signal`, `novelty_score`, `canonical_conflict`, or synthetic promotion scoring
- no normalized stale/expired trust release classification
- no dataset publication, editorial workflow, or frontend rollout work
