### PR TITLE
PR-B52: Career trust freshness / review staleness authority

### DIFF
--- a/backend/app/DTO/Career/CareerTrustFreshnessAuthority.php
+++ b/backend/app/DTO/Career/CareerTrustFreshnessAuthority.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerTrustFreshnessAuthority
+{
+    /**
+     * @param  list<CareerTrustFreshnessMember>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'authority_kind' => 'career_trust_freshness_authority',
+            'authority_version' => 'career.trust_freshness.v1',
+            'scope' => $this->scope,
+            'members' => array_map(
+                static fn (CareerTrustFreshnessMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerTrustFreshnessMember.php
+++ b/backend/app/DTO/Career/CareerTrustFreshnessMember.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerTrustFreshnessMember
+{
+    /**
+     * @param  array<string, bool>  $signals
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly ?string $reviewerStatus,
+        public readonly ?string $reviewedAt,
+        public readonly ?string $lastSubstantiveUpdateAt,
+        public readonly ?string $nextReviewDueAt,
+        public readonly ?string $truthLastReviewedAt,
+        public readonly bool $reviewDueKnown,
+        public readonly string $reviewFreshnessBasis,
+        public readonly string $reviewStalenessState,
+        public readonly array $signals,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'member_kind' => 'career_job_detail',
+            'canonical_slug' => $this->canonicalSlug,
+            'reviewer_status' => $this->reviewerStatus,
+            'reviewed_at' => $this->reviewedAt,
+            'last_substantive_update_at' => $this->lastSubstantiveUpdateAt,
+            'next_review_due_at' => $this->nextReviewDueAt,
+            'truth_last_reviewed_at' => $this->truthLastReviewedAt,
+            'review_due_known' => $this->reviewDueKnown,
+            'review_freshness_basis' => $this->reviewFreshnessBasis,
+            'review_staleness_state' => $this->reviewStalenessState,
+            'signals' => $this->signals,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php
+++ b/backend/app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerTrustFreshnessAuthority;
+use App\DTO\Career\CareerTrustFreshnessMember;
+use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
+
+final class CareerTrustFreshnessAuthorityService
+{
+    /**
+     * @var array<string, true>
+     */
+    private const REVIEW_COMPLETED_STATUSES = [
+        'approved' => true,
+        'reviewed' => true,
+    ];
+
+    public function __construct(
+        private readonly CareerFirstWaveLaunchReadinessAuditService $launchReadinessAuditService,
+        private readonly CareerJobDetailBundleBuilder $jobDetailBundleBuilder,
+    ) {}
+
+    public function build(): CareerTrustFreshnessAuthority
+    {
+        $audit = $this->launchReadinessAuditService->build();
+        $members = [];
+
+        foreach ($audit->members as $auditMember) {
+            $bundle = $this->jobDetailBundleBuilder->buildBySlug($auditMember->canonicalSlug);
+            $trustManifest = $bundle?->trustManifest ?? [];
+            $truthLayer = $bundle?->truthLayer ?? [];
+
+            $reviewerStatus = $this->normalizeNullableString($trustManifest['reviewer_status'] ?? null);
+            $reviewedAt = $this->normalizeNullableString($trustManifest['reviewed_at'] ?? null);
+            $lastSubstantiveUpdateAt = $this->normalizeNullableString($trustManifest['last_substantive_update_at'] ?? null);
+            $nextReviewDueAt = $this->normalizeNullableString($trustManifest['next_review_due_at'] ?? null);
+            $truthLastReviewedAt = $this->normalizeNullableString($truthLayer['truth_last_reviewed_at'] ?? null);
+
+            $members[] = new CareerTrustFreshnessMember(
+                canonicalSlug: $auditMember->canonicalSlug,
+                reviewerStatus: $reviewerStatus,
+                reviewedAt: $reviewedAt,
+                lastSubstantiveUpdateAt: $lastSubstantiveUpdateAt,
+                nextReviewDueAt: $nextReviewDueAt,
+                truthLastReviewedAt: $truthLastReviewedAt,
+                reviewDueKnown: $nextReviewDueAt !== null,
+                reviewFreshnessBasis: $this->resolveFreshnessBasis(
+                    nextReviewDueAt: $nextReviewDueAt,
+                    reviewedAt: $reviewedAt,
+                    lastSubstantiveUpdateAt: $lastSubstantiveUpdateAt,
+                    truthLastReviewedAt: $truthLastReviewedAt,
+                ),
+                reviewStalenessState: $this->resolveStalenessState(
+                    reviewerStatus: $reviewerStatus,
+                    reviewedAt: $reviewedAt,
+                    nextReviewDueAt: $nextReviewDueAt,
+                ),
+                signals: [
+                    'has_review_timestamp' => $reviewedAt !== null,
+                    'has_due_date' => $nextReviewDueAt !== null,
+                    'has_substantive_update_timestamp' => $lastSubstantiveUpdateAt !== null,
+                ],
+            );
+        }
+
+        return new CareerTrustFreshnessAuthority(
+            scope: $audit->scope,
+            members: $members,
+        );
+    }
+
+    private function resolveFreshnessBasis(
+        ?string $nextReviewDueAt,
+        ?string $reviewedAt,
+        ?string $lastSubstantiveUpdateAt,
+        ?string $truthLastReviewedAt,
+    ): string {
+        return match (true) {
+            $nextReviewDueAt !== null => 'trust_manifest_next_review_due_at',
+            $reviewedAt !== null => 'trust_manifest_reviewed_at',
+            $lastSubstantiveUpdateAt !== null => 'trust_manifest_last_substantive_update_at',
+            $truthLastReviewedAt !== null => 'truth_metric_reviewed_at',
+            default => 'no_review_freshness_basis',
+        };
+    }
+
+    private function resolveStalenessState(
+        ?string $reviewerStatus,
+        ?string $reviewedAt,
+        ?string $nextReviewDueAt,
+    ): string {
+        if (
+            $reviewedAt === null
+            && ! isset(self::REVIEW_COMPLETED_STATUSES[strtolower((string) $reviewerStatus)])
+        ) {
+            return 'review_unreviewed';
+        }
+
+        if ($nextReviewDueAt === null) {
+            return 'unknown_due_date';
+        }
+
+        $dueAt = strtotime($nextReviewDueAt);
+        if ($dueAt === false) {
+            return 'unknown_due_date';
+        }
+
+        return $dueAt > time() ? 'review_scheduled' : 'review_due';
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1062,10 +1062,10 @@
     "PR-B52": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b52-career-trust-freshness-review-staleness-authority",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "3f5c153b354ae60cff959a9df4609d4f95328f85",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/897",
       "checks": {
         "local": [
           {
@@ -1085,9 +1085,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436537880/job/71391847831"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436537880/job/71391851734"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436545679/job/71391870069"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436545679/job/71391874168"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately on both PR-B52 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1058,6 +1058,40 @@
       "merged_at": "",
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-B52": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b52-career-trust-freshness-review-staleness-authority",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php app/DTO/Career/CareerTrustFreshness*.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1064,7 +1064,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open_checks_failed",
       "branch": "codex/pr-b52-career-trust-freshness-review-staleness-authority",
-      "commit_sha": "3f5c153b354ae60cff959a9df4609d4f95328f85",
+      "commit_sha": "55ba3fb6d67e87571613f7f5b63a7b817826bba9",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/897",
       "checks": {
         "local": [
@@ -1089,22 +1089,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436537880/job/71391847831"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436564121/job/71391926471"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436537880/job/71391851734"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436564121/job/71391930671"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436545679/job/71391870069"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436565063/job/71391929193"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436545679/job/71391874168"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436565063/job/71391932912"
           }
         ]
       },

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -671,6 +671,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B52
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b52-career-trust-freshness-review-staleness-authority
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career trust freshness / review staleness authority.
+      Add an internal-only first-wave career_job_detail trust freshness authority that
+      normalizes current trust/review timestamps and conservative due-date states
+      without introducing public APIs, OpenAPI changes, family-hub members, or
+      release-grade stale/expired semantics.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php app/DTO/Career/CareerTrustFreshness*.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerTrustFreshnessAuthorityService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerTrustFreshnessAuthorityServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_first_wave_job_detail_only_internal_trust_freshness_authority(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $authority = app(CareerTrustFreshnessAuthorityService::class)->build()->toArray();
+        $members = collect($authority['members'])->keyBy('canonical_slug');
+        $registeredNurses = $members->get('registered-nurses');
+
+        $this->assertSame('career_trust_freshness_authority', $authority['authority_kind']);
+        $this->assertSame('career.trust_freshness.v1', $authority['authority_version']);
+        $this->assertSame('career_first_wave_10', $authority['scope']);
+        $this->assertCount(10, $authority['members']);
+
+        $this->assertIsArray($registeredNurses);
+        $this->assertSame('career_job_detail', $registeredNurses['member_kind']);
+        $this->assertArrayHasKey('reviewer_status', $registeredNurses);
+        $this->assertArrayHasKey('reviewed_at', $registeredNurses);
+        $this->assertArrayHasKey('last_substantive_update_at', $registeredNurses);
+        $this->assertArrayHasKey('next_review_due_at', $registeredNurses);
+        $this->assertArrayHasKey('truth_last_reviewed_at', $registeredNurses);
+        $this->assertArrayHasKey('review_due_known', $registeredNurses);
+        $this->assertArrayHasKey('review_freshness_basis', $registeredNurses);
+        $this->assertArrayHasKey('review_staleness_state', $registeredNurses);
+        $this->assertArrayHasKey('signals', $registeredNurses);
+
+        $this->assertCount(0, array_filter(
+            $authority['members'],
+            static fn (array $member): bool => ($member['member_kind'] ?? null) === 'career_family_hub'
+        ));
+        $this->assertArrayNotHasKey('compiled_at', $registeredNurses);
+        $this->assertArrayNotHasKey('retrieved_at', $registeredNurses);
+        $this->assertArrayNotHasKey('review_expired', $registeredNurses);
+        $this->assertArrayNotHasKey('trust_expired', $registeredNurses);
+    }
+
+    public function test_it_marks_future_due_dates_as_review_scheduled(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $subject = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $subject->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewed_at' => now()->subDay(),
+            'next_review_due_at' => now()->addDays(5),
+        ]);
+
+        $authority = app(CareerTrustFreshnessAuthorityService::class)->build()->toArray();
+        $row = collect($authority['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertIsArray($row);
+        $this->assertTrue($row['review_due_known']);
+        $this->assertSame('review_scheduled', $row['review_staleness_state']);
+        $this->assertSame('trust_manifest_next_review_due_at', $row['review_freshness_basis']);
+    }
+
+    public function test_it_marks_past_or_current_due_dates_as_review_due(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $subject = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $subject->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewed_at' => now()->subDay(),
+            'next_review_due_at' => now()->subMinute(),
+        ]);
+
+        $authority = app(CareerTrustFreshnessAuthorityService::class)->build()->toArray();
+        $row = collect($authority['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertIsArray($row);
+        $this->assertTrue($row['review_due_known']);
+        $this->assertSame('review_due', $row['review_staleness_state']);
+    }
+
+    public function test_it_marks_missing_due_dates_as_unknown_due_date(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $authority = app(CareerTrustFreshnessAuthorityService::class)->build()->toArray();
+        $row = collect($authority['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertIsArray($row);
+        $this->assertFalse($row['review_due_known']);
+        $this->assertSame('unknown_due_date', $row['review_staleness_state']);
+    }
+
+    public function test_it_marks_missing_review_timestamp_with_non_completed_status_as_review_unreviewed(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $subject = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $subject->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewer_status' => 'pending',
+            'reviewed_at' => null,
+            'next_review_due_at' => null,
+        ]);
+
+        $authority = app(CareerTrustFreshnessAuthorityService::class)->build()->toArray();
+        $row = collect($authority['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertIsArray($row);
+        $this->assertSame('review_unreviewed', $row['review_staleness_state']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add an internal-only `CareerTrustFreshnessAuthorityService` for first-wave `career_job_detail` members
- add internal DTO contracts for the authority summary and member rows
- normalize only the current strong trust/review timestamp truth:
  - `reviewer_status`
  - `reviewed_at`
  - `last_substantive_update_at`
  - `next_review_due_at`
  - `truth_last_reviewed_at`
- derive only conservative review cadence states:
  - `unknown_due_date`
  - `review_scheduled`
  - `review_due`
  - `review_unreviewed`
- keep provenance timestamps and stronger stale/expired semantics out of the authority
- add focused unit coverage for scope, state derivation, and omission boundaries

## Why
- B51 established an internal launch-readiness audit, but one missing backend-owned truth remained: a reusable, conservative normalization of trust freshness and review due-date status
- the repo already has strong review timestamps, but they were scattered across trust manifests, job-detail bundle projection, and first-wave services
- the safe move is to consolidate those existing fields into an internal authority without pretending it is a release blocker or a full stale/expired policy layer

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php app/DTO/Career/CareerTrustFreshness*.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php`

## Intentionally deferred
- no public API or OpenAPI changes
- no frontend changes
- no family-hub members
- no `review_expired`, `trust_expired`, or threshold-based `review_stale`
- no use of `compiled_at` or `retrieved_at` as review-validity truth
- no demand/novelty/canonical-conflict work
