### PR TITLE
PR-B53: Career first-wave launch-readiness freshness integration

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveLaunchReadinessAuditMember.php
+++ b/backend/app/DTO/Career/CareerFirstWaveLaunchReadinessAuditMember.php
@@ -9,6 +9,7 @@ final class CareerFirstWaveLaunchReadinessAuditMember
     /**
      * @param  list<string>  $blockers
      * @param  array<string, array<string, string>>  $evidenceRefs
+     * @param  array<string, mixed>|null  $trustFreshness
      */
     public function __construct(
         public readonly string $occupationUuid,
@@ -28,6 +29,7 @@ final class CareerFirstWaveLaunchReadinessAuditMember
         public readonly bool $familyHubSupportingRoute,
         public readonly array $blockers,
         public readonly array $evidenceRefs,
+        public readonly ?array $trustFreshness = null,
     ) {}
 
     /**
@@ -35,7 +37,7 @@ final class CareerFirstWaveLaunchReadinessAuditMember
      */
     public function toArray(): array
     {
-        return [
+        $payload = [
             'member_kind' => 'career_job_detail',
             'occupation_uuid' => $this->occupationUuid,
             'canonical_slug' => $this->canonicalSlug,
@@ -55,5 +57,11 @@ final class CareerFirstWaveLaunchReadinessAuditMember
             'blockers' => $this->blockers,
             'evidence_refs' => $this->evidenceRefs,
         ];
+
+        if ($this->trustFreshness !== null) {
+            $payload['trust_freshness'] = $this->trustFreshness;
+        }
+
+        return $payload;
     }
 }

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditV2Service.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditV2Service.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveLaunchReadinessAudit;
+use App\DTO\Career\CareerFirstWaveLaunchReadinessAuditMember;
+use App\DTO\Career\CareerTrustFreshnessMember;
+
+final class CareerFirstWaveLaunchReadinessAuditV2Service
+{
+    public const SUMMARY_VERSION = 'career.launch_readiness.audit.v2';
+
+    public function __construct(
+        private readonly CareerFirstWaveLaunchReadinessAuditService $launchReadinessAuditService,
+        private readonly CareerTrustFreshnessAuthorityService $trustFreshnessAuthorityService,
+    ) {}
+
+    public function build(): CareerFirstWaveLaunchReadinessAudit
+    {
+        $audit = $this->launchReadinessAuditService->build();
+        $freshnessAuthority = $this->trustFreshnessAuthorityService->build();
+
+        $freshnessBySlug = [];
+        foreach ($freshnessAuthority->members as $freshnessMember) {
+            $freshnessBySlug[$freshnessMember->canonicalSlug] = $this->toEvidence($freshnessMember);
+        }
+
+        $members = array_map(function (CareerFirstWaveLaunchReadinessAuditMember $member) use ($freshnessBySlug): CareerFirstWaveLaunchReadinessAuditMember {
+            return new CareerFirstWaveLaunchReadinessAuditMember(
+                occupationUuid: $member->occupationUuid,
+                canonicalSlug: $member->canonicalSlug,
+                canonicalTitleEn: $member->canonicalTitleEn,
+                launchTier: $member->launchTier,
+                readinessStatus: $member->readinessStatus,
+                lifecycleState: $member->lifecycleState,
+                publicIndexState: $member->publicIndexState,
+                indexEligible: $member->indexEligible,
+                reviewerStatus: $member->reviewerStatus,
+                crosswalkMode: $member->crosswalkMode,
+                allowStrongClaim: $member->allowStrongClaim,
+                confidenceScore: $member->confidenceScore,
+                blockedGovernanceStatus: $member->blockedGovernanceStatus,
+                nextStepLinksCount: $member->nextStepLinksCount,
+                familyHubSupportingRoute: $member->familyHubSupportingRoute,
+                blockers: $member->blockers,
+                evidenceRefs: $member->evidenceRefs,
+                trustFreshness: $freshnessBySlug[$member->canonicalSlug] ?? null,
+            );
+        }, $audit->members);
+
+        return new CareerFirstWaveLaunchReadinessAudit(
+            summaryVersion: self::SUMMARY_VERSION,
+            scope: $audit->scope,
+            counts: $audit->counts,
+            members: $members,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toEvidence(CareerTrustFreshnessMember $member): array
+    {
+        return [
+            'reviewed_at' => $member->reviewedAt,
+            'next_review_due_at' => $member->nextReviewDueAt,
+            'review_due_known' => $member->reviewDueKnown,
+            'review_staleness_state' => $member->reviewStalenessState,
+            'review_freshness_basis' => $member->reviewFreshnessBasis,
+        ];
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1119,7 +1119,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open_checks_failed",
       "branch": "codex/pr-b53-career-first-wave-launch-readiness-freshness-integration",
-      "commit_sha": "6b0f8af7bbf21c77050e8be0b2bd4a0562f43a5e",
+      "commit_sha": "b10b92a3fff9d9363159e15d89f30235955bc941",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/898",
       "checks": {
         "local": [
@@ -1140,22 +1140,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436971747/job/71393200243"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436994958/job/71393276670"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436971747/job/71393205663"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436994958/job/71393282566"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436980010/job/71393228762"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436995769/job/71393279554"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436980010/job/71393233408"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436995769/job/71393284740"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1117,10 +1117,10 @@
     "PR-B53": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b53-career-first-wave-launch-readiness-freshness-integration",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "6b0f8af7bbf21c77050e8be0b2bd4a0562f43a5e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/898",
       "checks": {
         "local": [
           {
@@ -1136,9 +1136,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436971747/job/71393200243"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436971747/job/71393205663"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436980010/job/71393228762"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24436980010/job/71393233408"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately on both PR-B53 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1113,6 +1113,36 @@
       "merged_at": "",
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-B53": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b53-career-first-wave-launch-readiness-freshness-integration",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditV2Service.php app/DTO/Career/CareerFirstWaveLaunchReadinessAudit*.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -699,6 +699,33 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B53
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b53-career-first-wave-launch-readiness-freshness-integration
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave launch-readiness freshness integration.
+      Add an internal-only composition layer that joins B52 trust freshness evidence
+      onto B51 first-wave launch-readiness audit members as a nested trust_freshness
+      object without changing counts, adding public APIs, introducing stale/expired
+      semantics, or expanding member scope beyond career_job_detail.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditV2Service.php app/DTO/Career/CareerFirstWaveLaunchReadinessAudit*.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php
@@ -66,7 +66,7 @@ final class CareerFirstWaveLaunchReadinessAuditServiceTest extends TestCase
         $this->assertArrayNotHasKey('demand_signal', $registeredNurses);
         $this->assertArrayNotHasKey('novelty_score', $registeredNurses);
         $this->assertArrayNotHasKey('canonical_conflict', $registeredNurses);
-        $this->assertArrayNotHasKey('trust_freshness_state', $registeredNurses);
+        $this->assertArrayNotHasKey('trust_freshness', $registeredNurses);
     }
 
     public function test_it_projects_candidate_review_without_claiming_family_hubs_as_members(): void

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveLaunchReadinessAuditService;
+use App\Domain\Career\Publish\CareerFirstWaveLaunchReadinessAuditV2Service;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveLaunchReadinessAuditV2ServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_attaches_trust_freshness_evidence_without_changing_counts(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $v1 = app(CareerFirstWaveLaunchReadinessAuditService::class)->build()->toArray();
+        $v2 = app(CareerFirstWaveLaunchReadinessAuditV2Service::class)->build()->toArray();
+
+        $this->assertSame('career_first_wave_launch_readiness_audit', $v2['summary_kind']);
+        $this->assertSame(CareerFirstWaveLaunchReadinessAuditV2Service::SUMMARY_VERSION, $v2['summary_version']);
+        $this->assertSame($v1['scope'], $v2['scope']);
+        $this->assertSame($v1['counts'], $v2['counts']);
+
+        $registeredNurses = collect($v2['members'])->keyBy('canonical_slug')->get('registered-nurses');
+
+        $this->assertIsArray($registeredNurses);
+        $this->assertIsArray($registeredNurses['trust_freshness']);
+        $this->assertSame([
+            'reviewed_at',
+            'next_review_due_at',
+            'review_due_known',
+            'review_staleness_state',
+            'review_freshness_basis',
+        ], array_keys($registeredNurses['trust_freshness']));
+        $this->assertContains(
+            $registeredNurses['trust_freshness']['review_staleness_state'],
+            ['unknown_due_date', 'review_scheduled', 'review_due', 'review_unreviewed']
+        );
+        $this->assertCount(0, array_filter(
+            $v2['members'],
+            static fn (array $member): bool => ($member['member_kind'] ?? null) === 'career_family_hub'
+        ));
+        $this->assertArrayNotHasKey('review_expired', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('trust_expired', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('review_stale', $registeredNurses['trust_freshness']);
+    }
+
+    public function test_it_preserves_candidate_and_blocked_classification_when_freshness_changes(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+        $candidate->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewed_at' => now()->subDay(),
+            'next_review_due_at' => now()->subMinute(),
+        ]);
+
+        $v2 = app(CareerFirstWaveLaunchReadinessAuditV2Service::class)->build()->toArray();
+        $row = collect($v2['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertSame(5, $v2['counts']['launch_ready']);
+        $this->assertSame(1, $v2['counts']['candidate_review']);
+        $this->assertSame(0, $v2['counts']['hold']);
+        $this->assertSame(4, $v2['counts']['blocked']);
+
+        $this->assertIsArray($row);
+        $this->assertSame('candidate', $row['launch_tier']);
+        $this->assertSame('review_due', data_get($row, 'trust_freshness.review_staleness_state'));
+        $this->assertContains('not_publish_ready', $row['blockers']);
+        $this->assertFalse(in_array('review_due', $row['blockers'], true));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add an internal-only `CareerFirstWaveLaunchReadinessAuditV2Service` that composes B51 launch-readiness audit truth with B52 trust freshness evidence
- attach a nested `trust_freshness` object to B51 v2 member rows using `canonical_slug` joins
- keep the integration evidence-only and limit the nested object to five conservative fields:
  - `reviewed_at`
  - `next_review_due_at`
  - `review_due_known`
  - `review_staleness_state`
  - `review_freshness_basis`
- keep B51 v1 counts and classification logic unchanged
- keep B51 v1 output shape unchanged by only emitting `trust_freshness` when the v2 composition layer provides it
- add focused unit coverage for evidence attachment, count stability, and no blocker mutation

## Why
- B51 already consolidated launch/readiness/lifecycle/governance truth, and B52 already normalized conservative trust freshness truth, but they were still separate internal layers
- the safe next step is a composition layer that enriches member rows with mild freshness evidence without turning freshness into release policy
- this preserves the backend truth boundary: no stale/expired overclaim, no count drift, no family-hub member expansion, and no public surface changes

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditV2Service.php app/DTO/Career/CareerFirstWaveLaunchReadinessAudit*.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php`

## Intentionally deferred
- no public API or OpenAPI changes
- no frontend changes
- no freshness-driven count or blocker changes
- no `review_expired`, `trust_expired`, or threshold-based `review_stale`
- no family-hub audited members
- no demand/novelty/canonical-conflict or promotion-score work
