### PR TITLE
PR-B54: Career first-wave launch manifest / smoke matrix authority

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveLaunchManifest.php
+++ b/backend/app/DTO/Career/CareerFirstWaveLaunchManifest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveLaunchManifest
+{
+    /**
+     * @param  array<string, int>  $counts
+     * @param  array<string, list<string>>  $groups
+     * @param  list<CareerFirstWaveLaunchManifestMember>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $groups,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'manifest_kind' => 'career_first_wave_launch_manifest',
+            'manifest_version' => 'career.launch_manifest.first_wave.v1',
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'groups' => $this->groups,
+            'members' => array_map(
+                static fn (CareerFirstWaveLaunchManifestMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveLaunchManifestMember.php
+++ b/backend/app/DTO/Career/CareerFirstWaveLaunchManifestMember.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveLaunchManifestMember
+{
+    /**
+     * @param  list<string>  $blockers
+     * @param  array<string, mixed>  $trustFreshness
+     * @param  array{family_hub:bool,next_step_links_count:int}  $supportingRoutes
+     * @param  array{job_detail_route_known:bool,discoverable_route_known:bool,seo_contract_present:bool,structured_data_authority_present:bool,trust_freshness_present:bool,family_support_route_present:bool,next_step_support_present:bool}  $smokeMatrix
+     * @param  array<string, array<string, string>>  $evidenceRefs
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $canonicalTitleEn,
+        public readonly string $launchTier,
+        public readonly string $readinessStatus,
+        public readonly string $lifecycleState,
+        public readonly string $publicIndexState,
+        public readonly array $blockers,
+        public readonly array $trustFreshness,
+        public readonly array $supportingRoutes,
+        public readonly array $smokeMatrix,
+        public readonly array $evidenceRefs,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'member_kind' => 'career_job_detail',
+            'canonical_slug' => $this->canonicalSlug,
+            'canonical_title_en' => $this->canonicalTitleEn,
+            'launch_tier' => $this->launchTier,
+            'readiness_status' => $this->readinessStatus,
+            'lifecycle_state' => $this->lifecycleState,
+            'public_index_state' => $this->publicIndexState,
+            'blockers' => $this->blockers,
+            'trust_freshness' => $this->trustFreshness,
+            'supporting_routes' => $this->supportingRoutes,
+            'smoke_matrix' => $this->smokeMatrix,
+            'evidence_refs' => $this->evidenceRefs,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchManifestService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchManifestService.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveLaunchManifest;
+use App\DTO\Career\CareerFirstWaveLaunchManifestMember;
+use App\DTO\Career\CareerFirstWaveLaunchReadinessAuditMember;
+use App\Services\Career\Bundles\CareerFamilyHubBundleBuilder;
+use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
+use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
+
+final class CareerFirstWaveLaunchManifestService
+{
+    public function __construct(
+        private readonly CareerFirstWaveLaunchReadinessAuditV2Service $launchReadinessAuditV2Service,
+        private readonly CareerFirstWaveDiscoverabilityManifestService $discoverabilityManifestService,
+        private readonly CareerFirstWaveNextStepLinksService $nextStepLinksService,
+        private readonly CareerJobDetailBundleBuilder $jobDetailBundleBuilder,
+        private readonly CareerFamilyHubBundleBuilder $familyHubBundleBuilder,
+        private readonly CareerStructuredDataBuilder $structuredDataBuilder,
+    ) {}
+
+    public function build(): CareerFirstWaveLaunchManifest
+    {
+        $audit = $this->launchReadinessAuditV2Service->build();
+        $discoverabilityManifest = $this->discoverabilityManifestService->build()->toArray();
+
+        $jobRoutesBySlug = [];
+        foreach ((array) ($discoverabilityManifest['routes'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            if (($row['route_kind'] ?? null) !== 'career_job_detail') {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug !== '') {
+                $jobRoutesBySlug[$slug] = $row;
+            }
+        }
+
+        $counts = [
+            'total' => 0,
+            'stable' => 0,
+            'candidate' => 0,
+            'hold' => 0,
+            'blocked' => 0,
+        ];
+        $groups = [
+            'stable' => [],
+            'candidate' => [],
+            'hold' => [],
+            'blocked' => [],
+        ];
+        $members = [];
+
+        foreach ($audit->members as $auditMember) {
+            $group = $this->classifyGroup($auditMember);
+            $supportingRoute = $this->buildSupportingRoutes($auditMember);
+            $smokeMatrix = $this->buildSmokeMatrix(
+                auditMember: $auditMember,
+                discoverabilityRow: $jobRoutesBySlug[$auditMember->canonicalSlug] ?? null,
+                supportingRoutes: $supportingRoute,
+            );
+
+            $counts['total']++;
+            $counts[$group]++;
+            $groups[$group][] = $auditMember->canonicalSlug;
+
+            $members[] = new CareerFirstWaveLaunchManifestMember(
+                canonicalSlug: $auditMember->canonicalSlug,
+                canonicalTitleEn: $auditMember->canonicalTitleEn,
+                launchTier: $auditMember->launchTier,
+                readinessStatus: $auditMember->readinessStatus,
+                lifecycleState: $auditMember->lifecycleState,
+                publicIndexState: $auditMember->publicIndexState,
+                blockers: $auditMember->blockers,
+                trustFreshness: is_array($auditMember->trustFreshness) ? $auditMember->trustFreshness : [],
+                supportingRoutes: $supportingRoute,
+                smokeMatrix: $smokeMatrix,
+                evidenceRefs: $auditMember->evidenceRefs,
+            );
+        }
+
+        return new CareerFirstWaveLaunchManifest(
+            scope: $audit->scope,
+            counts: $counts,
+            groups: $groups,
+            members: $members,
+        );
+    }
+
+    /**
+     * @return array{family_hub:bool,next_step_links_count:int}
+     */
+    private function buildSupportingRoutes(CareerFirstWaveLaunchReadinessAuditMember $member): array
+    {
+        return [
+            'family_hub' => $member->familyHubSupportingRoute,
+            'next_step_links_count' => $member->nextStepLinksCount,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $discoverabilityRow
+     * @param  array{family_hub:bool,next_step_links_count:int}  $supportingRoutes
+     * @return array{job_detail_route_known:bool,discoverable_route_known:bool,seo_contract_present:bool,structured_data_authority_present:bool,trust_freshness_present:bool,family_support_route_present:bool,next_step_support_present:bool}
+     */
+    private function buildSmokeMatrix(
+        CareerFirstWaveLaunchReadinessAuditMember $auditMember,
+        ?array $discoverabilityRow,
+        array $supportingRoutes,
+    ): array {
+        $jobBundle = $this->jobDetailBundleBuilder->buildBySlug($auditMember->canonicalSlug);
+        $seoContractPresent = $jobBundle !== null
+            && is_array($jobBundle->seoContract)
+            && $jobBundle->seoContract !== [];
+        $structuredDataAuthorityPresent = $jobBundle !== null
+            && is_array($this->structuredDataBuilder->build('career_job_detail', $jobBundle));
+
+        $familySupportRoutePresent = false;
+        if ($supportingRoutes['family_hub'] === true) {
+            $nextStepLinks = $this->nextStepLinksService->buildBySlug($auditMember->canonicalSlug)?->toArray();
+            $familyHubSlug = null;
+
+            foreach ((array) ($nextStepLinks['next_step_links'] ?? []) as $link) {
+                if (! is_array($link) || ($link['route_kind'] ?? null) !== 'career_family_hub') {
+                    continue;
+                }
+
+                $candidateSlug = trim((string) ($link['canonical_slug'] ?? ''));
+                if ($candidateSlug !== '') {
+                    $familyHubSlug = $candidateSlug;
+                    break;
+                }
+            }
+
+            if ($familyHubSlug !== null) {
+                $familyBundle = $this->familyHubBundleBuilder->buildBySlug($familyHubSlug);
+                $familySupportRoutePresent = $familyBundle !== null
+                    && is_array($familyBundle->seoContract)
+                    && $familyBundle->seoContract !== [];
+            }
+        }
+
+        return [
+            'job_detail_route_known' => $jobBundle !== null,
+            'discoverable_route_known' => is_array($discoverabilityRow)
+                && is_string($discoverabilityRow['discoverability_state'] ?? null)
+                && trim((string) $discoverabilityRow['discoverability_state']) !== '',
+            'seo_contract_present' => $seoContractPresent,
+            'structured_data_authority_present' => $structuredDataAuthorityPresent,
+            'trust_freshness_present' => is_array($auditMember->trustFreshness) && $auditMember->trustFreshness !== [],
+            'family_support_route_present' => $familySupportRoutePresent,
+            'next_step_support_present' => $supportingRoutes['next_step_links_count'] > 0,
+        ];
+    }
+
+    private function classifyGroup(CareerFirstWaveLaunchReadinessAuditMember $member): string
+    {
+        if (
+            $member->blockedGovernanceStatus !== null
+            || in_array($member->readinessStatus, ['blocked_override_eligible', 'blocked_not_safely_remediable'], true)
+        ) {
+            return 'blocked';
+        }
+
+        if ($member->launchTier === WaveClassification::STABLE && $member->readinessStatus === 'publish_ready') {
+            return 'stable';
+        }
+
+        if (
+            $member->launchTier === WaveClassification::CANDIDATE
+            || $member->lifecycleState === CareerIndexLifecycleState::PROMOTION_CANDIDATE
+        ) {
+            return 'candidate';
+        }
+
+        return 'hold';
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1164,6 +1164,40 @@
       "merged_at": "",
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-B54": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b54-career-first-wave-launch-manifest-smoke-matrix-authority",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveLaunchManifestService.php app/DTO/Career/CareerFirstWaveLaunchManifest*.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1168,10 +1168,10 @@
     "PR-B54": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b54-career-first-wave-launch-manifest-smoke-matrix-authority",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "91505d3dc6e0ad2da0773302e0f78abe0e2fcc7c",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/899",
       "checks": {
         "local": [
           {
@@ -1191,9 +1191,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24437507127/job/71394934140"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24437507127/job/71394938718"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24437515440/job/71394959288"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24437515440/job/71394964533"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately on both PR-B54 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -726,6 +726,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B54
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b54-career-first-wave-launch-manifest-smoke-matrix-authority
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave launch manifest / smoke matrix authority.
+      Add an internal-only first-wave career_job_detail launch manifest authority that
+      groups existing B53 member truth into stable/candidate/hold/blocked whitelists,
+      preserves family hubs as supporting evidence only, and emits a backend-owned
+      smoke matrix limited to authority/signal presence rather than frontend/runtime truth.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveLaunchManifestService.php app/DTO/Career/CareerFirstWaveLaunchManifest*.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveLaunchManifestService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveLaunchManifestServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_an_internal_job_detail_only_launch_manifest_with_backend_owned_smoke_matrix(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $manifest = app(CareerFirstWaveLaunchManifestService::class)->build()->toArray();
+        $members = collect($manifest['members'])->keyBy('canonical_slug');
+        $registeredNurses = $members->get('registered-nurses');
+
+        $this->assertSame('career_first_wave_launch_manifest', $manifest['manifest_kind']);
+        $this->assertSame('career.launch_manifest.first_wave.v1', $manifest['manifest_version']);
+        $this->assertSame('career_first_wave_10', $manifest['scope']);
+        $this->assertSame([
+            'total' => 10,
+            'stable' => 6,
+            'candidate' => 0,
+            'hold' => 0,
+            'blocked' => 4,
+        ], $manifest['counts']);
+        $this->assertCount(6, $manifest['groups']['stable']);
+        $this->assertContains('registered-nurses', $manifest['groups']['stable']);
+
+        $this->assertIsArray($registeredNurses);
+        $this->assertSame('career_job_detail', $registeredNurses['member_kind']);
+        $this->assertArrayHasKey('supporting_routes', $registeredNurses);
+        $this->assertArrayHasKey('smoke_matrix', $registeredNurses);
+        $this->assertArrayHasKey('trust_freshness', $registeredNurses);
+
+        $this->assertSame([
+            'job_detail_route_known',
+            'discoverable_route_known',
+            'seo_contract_present',
+            'structured_data_authority_present',
+            'trust_freshness_present',
+            'family_support_route_present',
+            'next_step_support_present',
+        ], array_keys($registeredNurses['smoke_matrix']));
+        $this->assertTrue($registeredNurses['smoke_matrix']['job_detail_route_known']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['discoverable_route_known']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['seo_contract_present']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['structured_data_authority_present']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['trust_freshness_present']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['family_support_route_present']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['next_step_support_present']);
+
+        $this->assertSame(true, data_get($registeredNurses, 'supporting_routes.family_hub'));
+        $this->assertSame(1, data_get($registeredNurses, 'supporting_routes.next_step_links_count'));
+
+        $this->assertCount(0, array_filter(
+            $manifest['members'],
+            static fn (array $member): bool => ($member['member_kind'] ?? null) === 'career_family_hub'
+        ));
+        $this->assertArrayNotHasKey('demand_signal', $registeredNurses);
+        $this->assertArrayNotHasKey('novelty_score', $registeredNurses);
+        $this->assertArrayNotHasKey('canonical_conflict', $registeredNurses);
+        $this->assertArrayNotHasKey('frontend_smoke_passed', $registeredNurses['smoke_matrix']);
+        $this->assertArrayNotHasKey('jsonld_emitted', $registeredNurses['smoke_matrix']);
+        $this->assertArrayNotHasKey('attribution_fired', $registeredNurses['smoke_matrix']);
+    }
+
+    public function test_it_preserves_existing_group_truth_without_promoting_lifecycle_or_freshness_to_primary_axes(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+        $candidate->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewed_at' => now()->subDay(),
+            'next_review_due_at' => now()->subMinute(),
+        ]);
+
+        $manifest = app(CareerFirstWaveLaunchManifestService::class)->build()->toArray();
+        $candidateRow = collect($manifest['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertSame([
+            'total' => 10,
+            'stable' => 5,
+            'candidate' => 1,
+            'hold' => 0,
+            'blocked' => 4,
+        ], $manifest['counts']);
+        $this->assertSame(['data-scientists'], $manifest['groups']['candidate']);
+
+        $this->assertIsArray($candidateRow);
+        $this->assertSame('candidate', $candidateRow['launch_tier']);
+        $this->assertSame('review_due', data_get($candidateRow, 'trust_freshness.review_staleness_state'));
+        $this->assertContains('not_publish_ready', $candidateRow['blockers']);
+        $this->assertFalse(in_array('review_due', $candidateRow['blockers'], true));
+        $this->assertArrayNotHasKey('promotion_candidate', $manifest['groups']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add an internal-only `CareerFirstWaveLaunchManifestService` that composes B53 launch-readiness audit truth into a first-wave launch manifest
- add internal DTOs for the manifest and manifest member rows
- group first-wave `career_job_detail` members into `stable`, `candidate`, `hold`, and `blocked` using the current backend truth already owned by B51/B53
- attach per-member `supporting_routes`, `trust_freshness`, `smoke_matrix`, and `evidence_refs`
- keep family hubs out of the primary member set and represent them only as supporting route evidence
- keep the smoke matrix limited to backend-owned authority/signal presence:
  - route known
  - discoverability known
  - SEO contract present
  - structured-data authority present
  - trust freshness present
  - family support route present
  - next-step support present

## Why
- first-wave release truth already existed, but it was still spread across launch-readiness, discoverability, next-step links, SEO, structured-data, and trust freshness layers
- the safe next step is an internal manifest authority that consolidates those backend-owned signals into a release snapshot and smoke matrix without pretending it is a public rollout API or an end-to-end runtime smoke system
- keeping the manifest job-detail-only and backend-only avoids overclaiming readiness and keeps family hubs in their proper supporting role

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveLaunchManifestService.php app/DTO/Career/CareerFirstWaveLaunchManifest*.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php`

## Intentionally deferred
- no public API or OpenAPI changes
- no frontend/docs/release generation
- no dataset publication or editorial workflow integration
- no demand/novelty/canonical-conflict fields
- no family-hub primary members
- no frontend/runtime smoke claims such as rendered page success, emitted JSON-LD, or attribution firing success
