### PR TITLE
PR-B55: Career first-wave release artifact export / whitelist projection

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveLaunchManifestArtifact.php
+++ b/backend/app/DTO/Career/CareerFirstWaveLaunchManifestArtifact.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveLaunchManifestArtifact
+{
+    /**
+     * @param  array<string, int>  $counts
+     * @param  array<string, list<string>>  $groups
+     * @param  list<array<string, mixed>>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $groups,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'artifact_kind' => 'career_launch_manifest',
+            'artifact_version' => 'career.launch_manifest.export.v1',
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'groups' => $this->groups,
+            'members' => $this->members,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveSmokeMatrixArtifact.php
+++ b/backend/app/DTO/Career/CareerFirstWaveSmokeMatrixArtifact.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveSmokeMatrixArtifact
+{
+    /**
+     * @param  list<array<string, mixed>>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'artifact_kind' => 'career_smoke_matrix',
+            'artifact_version' => 'career.smoke_matrix.export.v1',
+            'scope' => $this->scope,
+            'members' => $this->members,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveReleaseArtifactProjectionService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveReleaseArtifactProjectionService.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveLaunchManifestArtifact;
+use App\DTO\Career\CareerFirstWaveSmokeMatrixArtifact;
+
+final class CareerFirstWaveReleaseArtifactProjectionService
+{
+    public function __construct(
+        private readonly CareerFirstWaveLaunchManifestService $launchManifestService,
+    ) {}
+
+    /**
+     * @return array{
+     *   career-launch-manifest.json: CareerFirstWaveLaunchManifestArtifact,
+     *   career-smoke-matrix.json: CareerFirstWaveSmokeMatrixArtifact
+     * }
+     */
+    public function build(): array
+    {
+        $manifest = $this->launchManifestService->build()->toArray();
+
+        return [
+            'career-launch-manifest.json' => $this->buildLaunchManifestArtifact($manifest),
+            'career-smoke-matrix.json' => $this->buildSmokeMatrixArtifact($manifest),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     */
+    private function buildLaunchManifestArtifact(array $manifest): CareerFirstWaveLaunchManifestArtifact
+    {
+        $members = array_map(function (array $member): array {
+            $trustFreshness = null;
+            if (is_array($member['trust_freshness'] ?? null)) {
+                $trustFreshness = [
+                    'review_due_known' => (bool) data_get($member, 'trust_freshness.review_due_known', false),
+                    'review_staleness_state' => data_get($member, 'trust_freshness.review_staleness_state'),
+                ];
+            }
+
+            return [
+                'canonical_slug' => (string) ($member['canonical_slug'] ?? ''),
+                'launch_tier' => (string) ($member['launch_tier'] ?? ''),
+                'readiness_status' => (string) ($member['readiness_status'] ?? ''),
+                'lifecycle_state' => (string) ($member['lifecycle_state'] ?? ''),
+                'public_index_state' => (string) ($member['public_index_state'] ?? ''),
+                'supporting_routes' => [
+                    'family_hub' => (bool) data_get($member, 'supporting_routes.family_hub', false),
+                    'next_step_links_count' => (int) data_get($member, 'supporting_routes.next_step_links_count', 0),
+                ],
+                'trust_freshness' => $trustFreshness,
+            ];
+        }, (array) ($manifest['members'] ?? []));
+
+        return new CareerFirstWaveLaunchManifestArtifact(
+            scope: (string) ($manifest['scope'] ?? ''),
+            counts: (array) ($manifest['counts'] ?? []),
+            groups: (array) ($manifest['groups'] ?? []),
+            members: $members,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     */
+    private function buildSmokeMatrixArtifact(array $manifest): CareerFirstWaveSmokeMatrixArtifact
+    {
+        $members = array_map(function (array $member): array {
+            return [
+                'canonical_slug' => (string) ($member['canonical_slug'] ?? ''),
+                'smoke_matrix' => [
+                    'job_detail_route_known' => (bool) data_get($member, 'smoke_matrix.job_detail_route_known', false),
+                    'discoverable_route_known' => (bool) data_get($member, 'smoke_matrix.discoverable_route_known', false),
+                    'seo_contract_present' => (bool) data_get($member, 'smoke_matrix.seo_contract_present', false),
+                    'structured_data_authority_present' => (bool) data_get($member, 'smoke_matrix.structured_data_authority_present', false),
+                    'trust_freshness_present' => (bool) data_get($member, 'smoke_matrix.trust_freshness_present', false),
+                    'family_support_route_present' => (bool) data_get($member, 'smoke_matrix.family_support_route_present', false),
+                    'next_step_support_present' => (bool) data_get($member, 'smoke_matrix.next_step_support_present', false),
+                ],
+            ];
+        }, (array) ($manifest['members'] ?? []));
+
+        return new CareerFirstWaveSmokeMatrixArtifact(
+            scope: (string) ($manifest['scope'] ?? ''),
+            members: $members,
+        );
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T05:25:36Z",
+  "updated_at": "2026-04-15T05:30:06Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1223,10 +1223,10 @@
     "PR-B55": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b55-career-first-wave-release-artifact-export-whitelist-projection",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "c685909057fbe500e4c6a86f1744fc704fdbfbb7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/900",
       "checks": {
         "local": [
           {
@@ -1246,9 +1246,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438102348/job/71396735151"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438102348/job/71396739937"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438111543/job/71396762439"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438111543/job/71396767325"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately on both PR-B55 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T05:30:06Z",
+  "updated_at": "2026-04-15T05:30:45Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1225,7 +1225,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open_checks_failed",
       "branch": "codex/pr-b55-career-first-wave-release-artifact-export-whitelist-projection",
-      "commit_sha": "c685909057fbe500e4c6a86f1744fc704fdbfbb7",
+      "commit_sha": "5dc0d3c7dd1bb534fab98d4ff82f4f09992fae25",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/900",
       "checks": {
         "local": [
@@ -1250,22 +1250,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438102348/job/71396735151"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438129290/job/71396820599"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438102348/job/71396739937"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438129290/job/71396825273"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438111543/job/71396762439"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438130379/job/71396823671"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438111543/job/71396767325"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24438130379/job/71396828500"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T04:15:44Z",
+  "updated_at": "2026-04-15T05:25:36Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1215,6 +1215,40 @@
         ]
       },
       "failure_reason": "GitHub hygiene failed immediately on both PR-B54 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B55": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b55-career-first-wave-release-artifact-export-whitelist-projection",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveReleaseArtifactProjectionService.php app/DTO/Career/CareerFirstWave*Artifact*.php tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -754,6 +754,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B55
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b55-career-first-wave-release-artifact-export-whitelist-projection
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave release artifact export / whitelist projection.
+      Add an internal-only projection/export layer on top of the first-wave launch
+      manifest authority that emits narrowed release artifacts for launch-manifest and
+      smoke-matrix consumption, keeps family hubs as supporting evidence only, and
+      limits smoke truth to backend-owned authority presence rather than runtime success.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveReleaseArtifactProjectionService.php app/DTO/Career/CareerFirstWave*Artifact*.php tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveLaunchManifestService;
+use App\Domain\Career\Publish\CareerFirstWaveReleaseArtifactProjectionService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveReleaseArtifactProjectionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_projects_a_narrowed_launch_manifest_artifact_with_only_export_safe_fields(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $artifacts = app(CareerFirstWaveReleaseArtifactProjectionService::class)->build();
+        $launchManifest = $artifacts['career-launch-manifest.json']->toArray();
+        $members = collect($launchManifest['members'])->keyBy('canonical_slug');
+        $registeredNurses = $members->get('registered-nurses');
+        $internalMemberSlugs = collect(app(CareerFirstWaveLaunchManifestService::class)->build()->toArray()['members'])
+            ->pluck('canonical_slug')
+            ->values()
+            ->all();
+
+        $this->assertSame('career_launch_manifest', $launchManifest['artifact_kind']);
+        $this->assertSame('career.launch_manifest.export.v1', $launchManifest['artifact_version']);
+        $this->assertSame('career_first_wave_10', $launchManifest['scope']);
+        $this->assertSame([
+            'total' => 10,
+            'stable' => 6,
+            'candidate' => 0,
+            'hold' => 0,
+            'blocked' => 4,
+        ], $launchManifest['counts']);
+        $this->assertContains('registered-nurses', $launchManifest['groups']['stable']);
+        $this->assertSame($internalMemberSlugs, $members->keys()->values()->all());
+
+        $this->assertSame([
+            'canonical_slug',
+            'launch_tier',
+            'readiness_status',
+            'lifecycle_state',
+            'public_index_state',
+            'supporting_routes',
+            'trust_freshness',
+        ], array_keys($registeredNurses));
+        $this->assertSame([
+            'family_hub',
+            'next_step_links_count',
+        ], array_keys($registeredNurses['supporting_routes']));
+        $this->assertSame([
+            'review_due_known',
+            'review_staleness_state',
+        ], array_keys($registeredNurses['trust_freshness']));
+
+        $this->assertSame(true, data_get($registeredNurses, 'supporting_routes.family_hub'));
+        $this->assertSame(1, data_get($registeredNurses, 'supporting_routes.next_step_links_count'));
+        $this->assertArrayNotHasKey('member_kind', $registeredNurses);
+        $this->assertArrayNotHasKey('blockers', $registeredNurses);
+        $this->assertArrayNotHasKey('evidence_refs', $registeredNurses);
+        $this->assertArrayNotHasKey('reviewed_at', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('next_review_due_at', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('review_freshness_basis', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('demand_signal', $registeredNurses);
+        $this->assertArrayNotHasKey('novelty_score', $registeredNurses);
+        $this->assertArrayNotHasKey('canonical_conflict', $registeredNurses);
+    }
+
+    public function test_it_projects_a_smoke_matrix_artifact_with_backend_owned_authority_presence_only(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $artifacts = app(CareerFirstWaveReleaseArtifactProjectionService::class)->build();
+        $smokeMatrix = $artifacts['career-smoke-matrix.json']->toArray();
+        $members = collect($smokeMatrix['members'])->keyBy('canonical_slug');
+        $registeredNurses = $members->get('registered-nurses');
+
+        $this->assertSame('career_smoke_matrix', $smokeMatrix['artifact_kind']);
+        $this->assertSame('career.smoke_matrix.export.v1', $smokeMatrix['artifact_version']);
+        $this->assertSame('career_first_wave_10', $smokeMatrix['scope']);
+        $this->assertSame([
+            'canonical_slug',
+            'smoke_matrix',
+        ], array_keys($registeredNurses));
+        $this->assertSame([
+            'job_detail_route_known',
+            'discoverable_route_known',
+            'seo_contract_present',
+            'structured_data_authority_present',
+            'trust_freshness_present',
+            'family_support_route_present',
+            'next_step_support_present',
+        ], array_keys($registeredNurses['smoke_matrix']));
+        $this->assertTrue($registeredNurses['smoke_matrix']['job_detail_route_known']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['discoverable_route_known']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['seo_contract_present']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['structured_data_authority_present']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['trust_freshness_present']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['family_support_route_present']);
+        $this->assertTrue($registeredNurses['smoke_matrix']['next_step_support_present']);
+
+        $this->assertArrayNotHasKey('frontend_smoke_passed', $registeredNurses['smoke_matrix']);
+        $this->assertArrayNotHasKey('jsonld_emitted', $registeredNurses['smoke_matrix']);
+        $this->assertArrayNotHasKey('attribution_fired', $registeredNurses['smoke_matrix']);
+    }
+
+    public function test_it_keeps_b54_as_the_source_of_truth_and_does_not_mutate_internal_members(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+        $candidate->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewed_at' => now()->subDay(),
+            'next_review_due_at' => now()->subMinute(),
+        ]);
+
+        $projection = app(CareerFirstWaveReleaseArtifactProjectionService::class)->build();
+        $launchManifest = $projection['career-launch-manifest.json']->toArray();
+        $candidateRow = collect($launchManifest['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertSame([
+            'total' => 10,
+            'stable' => 5,
+            'candidate' => 1,
+            'hold' => 0,
+            'blocked' => 4,
+        ], $launchManifest['counts']);
+        $this->assertSame(['data-scientists'], $launchManifest['groups']['candidate']);
+        $this->assertSame('review_due', data_get($candidateRow, 'trust_freshness.review_staleness_state'));
+
+        $internalManifest = app(CareerFirstWaveLaunchManifestService::class)->build()->toArray();
+        $internalCandidate = collect($internalManifest['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertArrayHasKey('blockers', $internalCandidate);
+        $this->assertArrayHasKey('evidence_refs', $internalCandidate);
+        $this->assertContains('not_publish_ready', $internalCandidate['blockers']);
+        $this->assertArrayNotHasKey('promotion_candidate', $launchManifest['groups']);
+    }
+
+    public function test_it_does_not_invent_trust_freshness_summary_when_source_evidence_is_missing(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $internalManifest = app(CareerFirstWaveLaunchManifestService::class)->build()->toArray();
+        $member = collect($internalManifest['members'])->firstWhere('canonical_slug', 'registered-nurses');
+
+        $this->assertIsArray($member);
+        $this->assertArrayHasKey('trust_freshness', $member);
+
+        unset($member['trust_freshness']);
+
+        $manifestWithoutFreshness = $internalManifest;
+        $manifestWithoutFreshness['members'] = array_map(
+            static fn (array $row): array => ($row['canonical_slug'] ?? null) === 'registered-nurses' ? $member : $row,
+            $manifestWithoutFreshness['members'],
+        );
+
+        $service = app(CareerFirstWaveReleaseArtifactProjectionService::class);
+        $reflection = new \ReflectionClass(CareerFirstWaveReleaseArtifactProjectionService::class);
+        $method = $reflection->getMethod('buildLaunchManifestArtifact');
+        $method->setAccessible(true);
+
+        $artifact = $method->invoke($service, $manifestWithoutFreshness);
+        $row = collect($artifact->toArray()['members'])
+            ->firstWhere('canonical_slug', 'registered-nurses');
+
+        $this->assertArrayHasKey('trust_freshness', $row);
+        $this->assertNull($row['trust_freshness']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- add an internal-only `CareerFirstWaveReleaseArtifactProjectionService` on top of the B54 launch manifest authority
- project exactly two narrowed backend-owned release artifacts:
  - `career-launch-manifest.json`
  - `career-smoke-matrix.json`
- add export DTOs for the narrowed launch manifest artifact and smoke matrix artifact
- keep member scope limited to first-wave `career_job_detail` rows
- keep family hubs out of the primary exported member set and expose them only as supporting evidence through:
  - `supporting_routes.family_hub`
  - `smoke_matrix.family_support_route_present`
- narrow launch-manifest members to export-safe fields only:
  - `canonical_slug`
  - `launch_tier`
  - `readiness_status`
  - `lifecycle_state`
  - `public_index_state`
  - `supporting_routes.family_hub`
  - `supporting_routes.next_step_links_count`
  - `trust_freshness.review_due_known`
  - `trust_freshness.review_staleness_state`
- narrow smoke-matrix members to backend-owned authority-presence booleans only:
  - `job_detail_route_known`
  - `discoverable_route_known`
  - `seo_contract_present`
  - `structured_data_authority_present`
  - `trust_freshness_present`
  - `family_support_route_present`
  - `next_step_support_present`
- add focused unit coverage for export-safe projection, omission boundaries, and source-of-truth preservation

## Why
B54 already consolidated first-wave launch manifest and smoke matrix truth, but its internal contract still contained audit/debug-oriented fields that should not leak into downstream release artifacts. B55 narrows that authority into internal-only export artifacts that are stable enough for release governance, whitelist projection, and document consumption without turning the output into a public API, a release dashboard, or a claim about frontend/runtime smoke success.

This keeps the backend truth boundary intact. The projection service reuses B54 as the source of truth rather than recomputing policy, keeps family hubs in a supporting role only, and avoids leaking internal fields such as raw blockers, evidence refs, or full trust-freshness timestamps.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveReleaseArtifactProjectionService.php app/DTO/Career/CareerFirstWave*Artifact*.php tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php`

## Intentionally deferred
- no public API or OpenAPI changes
- no frontend/docs/release generation UI
- no release dashboard semantics
- no family-hub primary members or family-specific whitelist exports
- no runtime smoke claims such as render success, emitted JSON-LD, or attribution firing
- no `demand_signal`, `novelty_score`, `canonical_conflict`, raw blockers, or `evidence_refs` in the exported artifacts
- no full trust-freshness timestamp export
