### PR TITLE
PR-B56: Career first-wave release artifact materialization / export command

### DIFF
--- a/backend/app/Console/Commands/CareerExportFirstWaveReleaseArtifacts.php
+++ b/backend/app/Console/Commands/CareerExportFirstWaveReleaseArtifacts.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Career\CareerFirstWaveReleaseArtifactMaterializationService;
+use Illuminate\Console\Command;
+
+final class CareerExportFirstWaveReleaseArtifacts extends Command
+{
+    protected $signature = 'career:export-first-wave-release-artifacts
+        {--timestamp= : Optional output directory timestamp segment}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Materialize internal first-wave release artifacts to storage/app/private/career_release_artifacts in one atomic export.';
+
+    public function __construct(
+        private readonly CareerFirstWaveReleaseArtifactMaterializationService $materializationService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $payload = $this->materializationService->materialize(
+                $this->option('timestamp') !== null ? (string) $this->option('timestamp') : null,
+            );
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode export payload json');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return self::SUCCESS;
+        }
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('output_dir='.(string) ($payload['output_dir'] ?? ''));
+        $this->line('career-launch-manifest='.(string) data_get($payload, 'artifacts.career-launch-manifest.json', ''));
+        $this->line('career-smoke-matrix='.(string) data_get($payload, 'artifacts.career-smoke-matrix.json', ''));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -9,6 +9,7 @@ use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerCompileAuthorityWave;
+use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
 use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CiScaleImpact;
 use App\Console\Commands\CommerceCompensatePendingOrders;
@@ -130,6 +131,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPostCommitFailed::class,
         CareerImportAuthorityWave::class,
         CareerCompileAuthorityWave::class,
+        CareerExportFirstWaveReleaseArtifacts::class,
         RefreshCareerAttributionDailyCommand::class,
         PacksPublish::class,
         PacksRollback::class,

--- a/backend/app/Services/Career/CareerFirstWaveReleaseArtifactMaterializationService.php
+++ b/backend/app/Services/Career/CareerFirstWaveReleaseArtifactMaterializationService.php
@@ -139,7 +139,18 @@ class CareerFirstWaveReleaseArtifactMaterializationService
             ->values()
             ->all();
 
-        if ($launchMemberSlugs !== $smokeMemberSlugs) {
+        $launchUniqueSlugs = array_values(array_unique($launchMemberSlugs));
+        $smokeUniqueSlugs = array_values(array_unique($smokeMemberSlugs));
+        if (count($launchUniqueSlugs) !== count($launchMemberSlugs)) {
+            throw new \RuntimeException('launch manifest contains duplicate member slugs');
+        }
+        if (count($smokeUniqueSlugs) !== count($smokeMemberSlugs)) {
+            throw new \RuntimeException('smoke matrix contains duplicate member slugs');
+        }
+
+        sort($launchUniqueSlugs);
+        sort($smokeUniqueSlugs);
+        if ($launchUniqueSlugs !== $smokeUniqueSlugs) {
             throw new \RuntimeException('launch/smoke member slug sets are inconsistent');
         }
 

--- a/backend/app/Services/Career/CareerFirstWaveReleaseArtifactMaterializationService.php
+++ b/backend/app/Services/Career/CareerFirstWaveReleaseArtifactMaterializationService.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveReleaseArtifactProjectionService;
+use Illuminate\Support\Facades\File;
+
+class CareerFirstWaveReleaseArtifactMaterializationService
+{
+    public const OUTPUT_ROOT = 'app/private/career_release_artifacts';
+
+    public const LAUNCH_MANIFEST_FILENAME = 'career-launch-manifest.json';
+
+    public const SMOKE_MATRIX_FILENAME = 'career-smoke-matrix.json';
+
+    public function __construct(
+        private readonly CareerFirstWaveReleaseArtifactProjectionService $projectionService,
+    ) {}
+
+    /**
+     * @return array{
+     *   status:string,
+     *   output_dir:string,
+     *   artifacts:array{
+     *     career-launch-manifest.json:string,
+     *     career-smoke-matrix.json:string
+     *   }
+     * }
+     */
+    public function materialize(?string $timestamp = null): array
+    {
+        $normalizedTimestamp = $this->normalizeTimestamp($timestamp);
+        $rootDir = storage_path(self::OUTPUT_ROOT);
+        $finalDir = $rootDir.DIRECTORY_SEPARATOR.$normalizedTimestamp;
+        $tmpDir = $finalDir.'.tmp';
+
+        if (is_dir($finalDir)) {
+            throw new \RuntimeException('release artifact output dir already exists: '.$finalDir);
+        }
+        if (is_dir($tmpDir)) {
+            throw new \RuntimeException('release artifact temp dir already exists: '.$tmpDir);
+        }
+
+        $projected = $this->projectedArtifacts();
+        $launchManifestPayload = $this->extractArtifactPayload($projected, self::LAUNCH_MANIFEST_FILENAME);
+        $smokeMatrixPayload = $this->extractArtifactPayload($projected, self::SMOKE_MATRIX_FILENAME);
+
+        $this->validateArtifactPayloads($launchManifestPayload, $smokeMatrixPayload);
+
+        File::ensureDirectoryExists($tmpDir);
+
+        try {
+            $this->writeJsonFile($tmpDir.DIRECTORY_SEPARATOR.self::LAUNCH_MANIFEST_FILENAME, $launchManifestPayload);
+            $this->writeJsonFile($tmpDir.DIRECTORY_SEPARATOR.self::SMOKE_MATRIX_FILENAME, $smokeMatrixPayload);
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize release artifact directory: '.$finalDir);
+            }
+        } catch (\Throwable $e) {
+            if (is_dir($tmpDir)) {
+                File::deleteDirectory($tmpDir);
+            }
+            throw $e;
+        }
+
+        return [
+            'status' => 'materialized',
+            'output_dir' => $finalDir,
+            'artifacts' => [
+                self::LAUNCH_MANIFEST_FILENAME => $finalDir.DIRECTORY_SEPARATOR.self::LAUNCH_MANIFEST_FILENAME,
+                self::SMOKE_MATRIX_FILENAME => $finalDir.DIRECTORY_SEPARATOR.self::SMOKE_MATRIX_FILENAME,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    protected function projectedArtifacts(): array
+    {
+        return $this->projectionService->build();
+    }
+
+    /**
+     * @param  array<string, object>  $projected
+     * @return array<string, mixed>
+     */
+    private function extractArtifactPayload(array $projected, string $filename): array
+    {
+        $artifact = $projected[$filename] ?? null;
+        if (! is_object($artifact) || ! method_exists($artifact, 'toArray')) {
+            throw new \RuntimeException('invalid projected artifact for '.$filename);
+        }
+
+        /** @var mixed $payload */
+        $payload = $artifact->toArray();
+        if (! is_array($payload)) {
+            throw new \RuntimeException('projected artifact payload is not an array for '.$filename);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $launchManifestPayload
+     * @param  array<string, mixed>  $smokeMatrixPayload
+     */
+    private function validateArtifactPayloads(array $launchManifestPayload, array $smokeMatrixPayload): void
+    {
+        $launchEncoded = json_encode($launchManifestPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        $smokeEncoded = json_encode($smokeMatrixPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+
+        if (! is_string($launchEncoded)) {
+            throw new \RuntimeException('failed to encode launch manifest artifact json');
+        }
+        if (! is_string($smokeEncoded)) {
+            throw new \RuntimeException('failed to encode smoke matrix artifact json');
+        }
+
+        $launchDecoded = json_decode($launchEncoded, true);
+        $smokeDecoded = json_decode($smokeEncoded, true);
+        if (! is_array($launchDecoded)) {
+            throw new \RuntimeException('launch manifest artifact json round-trip decode failed');
+        }
+        if (! is_array($smokeDecoded)) {
+            throw new \RuntimeException('smoke matrix artifact json round-trip decode failed');
+        }
+
+        $launchMemberSlugs = collect((array) ($launchDecoded['members'] ?? []))
+            ->map(static fn (array $row): string => trim((string) ($row['canonical_slug'] ?? '')))
+            ->filter(static fn (string $slug): bool => $slug !== '')
+            ->values()
+            ->all();
+        $smokeMemberSlugs = collect((array) ($smokeDecoded['members'] ?? []))
+            ->map(static fn (array $row): string => trim((string) ($row['canonical_slug'] ?? '')))
+            ->filter(static fn (string $slug): bool => $slug !== '')
+            ->values()
+            ->all();
+
+        if ($launchMemberSlugs !== $smokeMemberSlugs) {
+            throw new \RuntimeException('launch/smoke member slug sets are inconsistent');
+        }
+
+        foreach ((array) ($launchDecoded['members'] ?? []) as $member) {
+            if (! is_array($member)) {
+                continue;
+            }
+
+            foreach (['evidence_refs', 'blockers', 'demand_signal', 'novelty_score', 'canonical_conflict'] as $forbidden) {
+                if (array_key_exists($forbidden, $member)) {
+                    throw new \RuntimeException('launch manifest contains forbidden field: '.$forbidden);
+                }
+            }
+        }
+
+        foreach ((array) ($smokeDecoded['members'] ?? []) as $member) {
+            if (! is_array($member)) {
+                continue;
+            }
+
+            $smoke = $member['smoke_matrix'] ?? null;
+            if (! is_array($smoke)) {
+                continue;
+            }
+
+            foreach (['frontend_smoke_passed', 'jsonld_emitted', 'attribution_fired', 'render_success'] as $forbidden) {
+                if (array_key_exists($forbidden, $smoke)) {
+                    throw new \RuntimeException('smoke matrix contains forbidden field: '.$forbidden);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJsonFile(string $path, array $payload): void
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode json: '.$path);
+        }
+
+        File::put($path, $encoded.PHP_EOL);
+    }
+
+    private function normalizeTimestamp(?string $timestamp): string
+    {
+        $value = trim((string) $timestamp);
+        if ($value === '') {
+            $value = now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $value)) {
+            throw new \RuntimeException('invalid timestamp segment for release artifact export');
+        }
+
+        return $value;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T05:30:45Z",
+  "updated_at": "2026-04-15T06:20:14Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1270,6 +1270,40 @@
         ]
       },
       "failure_reason": "GitHub hygiene failed immediately on both PR-B55 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B56": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b56-career-first-wave-release-artifact-materialization-export-command",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Services/Career/CareerFirstWaveReleaseArtifactMaterializationService.php app/Console/Commands/CareerExportFirstWaveReleaseArtifacts.php tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveReleaseArtifactsCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveReleaseArtifactsCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1280,7 +1280,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open_checks_failed",
       "branch": "codex/pr-b56-career-first-wave-release-artifact-materialization-export-command",
-      "commit_sha": "2b725ec3e44fbbbdf4f06b7c04e3977bee337f37",
+      "commit_sha": "2aa00d18754c03430312bac19c6691554188ef97",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/901",
       "checks": {
         "local": [
@@ -1305,22 +1305,12 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439950354/job/71402385922"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439981758/job/71402487374"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439950354/job/71402392019"
-          },
-          {
-            "name": "hygiene",
-            "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439952100/job/71402390302"
-          },
-          {
-            "name": "verify-mbti-${{ matrix.mode }}",
-            "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439952100/job/71402397208"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439981758/job/71402492975"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1324,7 +1324,7 @@
           }
         ]
       },
-      "failure_reason": "GitHub hygiene failed immediately on both PR-B56 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
+      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; both hygiene runs failed before execution and MBTI matrix jobs were skipped, while local PR-B56 verification passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1280,7 +1280,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open_checks_failed",
       "branch": "codex/pr-b56-career-first-wave-release-artifact-materialization-export-command",
-      "commit_sha": "9706d443b42d8cc39bdc730c37211dba7e62b64b",
+      "commit_sha": "2b725ec3e44fbbbdf4f06b7c04e3977bee337f37",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/901",
       "checks": {
         "local": [
@@ -1305,22 +1305,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439651568/job/71401463954"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439950354/job/71402385922"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439651568/job/71401471679"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439950354/job/71402392019"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439666796/job/71401512226"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439952100/job/71402390302"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439666796/job/71401518185"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439952100/job/71402397208"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T06:20:14Z",
+  "updated_at": "2026-04-15T06:21:26Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1278,10 +1278,10 @@
     "PR-B56": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b56-career-first-wave-release-artifact-materialization-export-command",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "9706d443b42d8cc39bdc730c37211dba7e62b64b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/901",
       "checks": {
         "local": [
           {
@@ -1301,9 +1301,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439651568/job/71401463954"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439651568/job/71401471679"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439666796/job/71401512226"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24439666796/job/71401518185"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene failed immediately on both PR-B56 runs and the MBTI matrix jobs were skipped; local verification passed, but the remote CI run is currently not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -782,6 +782,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B56
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b56-career-first-wave-release-artifact-materialization-export-command
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave release artifact materialization / export command.
+      Add an internal-only materialization service and export command that persist
+      the two B55 projected artifacts together to internal storage with paired
+      validation and atomic finalize semantics, without changing B55 payload shape
+      or introducing public API/OpenAPI/frontend surfaces.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/CareerFirstWaveReleaseArtifactMaterializationService.php app/Console/Commands/CareerExportFirstWaveReleaseArtifacts.php tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveReleaseArtifactsCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveReleaseArtifactsCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Console/CareerExportFirstWaveReleaseArtifactsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportFirstWaveReleaseArtifactsCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Services\Career\CareerFirstWaveReleaseArtifactMaterializationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerExportFirstWaveReleaseArtifactsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = storage_path(CareerFirstWaveReleaseArtifactMaterializationService::OUTPUT_ROOT);
+        File::deleteDirectory($this->rootDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->rootDir);
+
+        parent::tearDown();
+    }
+
+    public function test_command_exports_both_internal_artifacts_in_one_run(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T100000Z';
+        $this->artisan('career:export-first-wave-release-artifacts', [
+            '--timestamp' => $timestamp,
+        ])
+            ->expectsOutputToContain('status=materialized')
+            ->expectsOutputToContain('output_dir=')
+            ->expectsOutputToContain('career-launch-manifest=')
+            ->expectsOutputToContain('career-smoke-matrix=')
+            ->assertExitCode(0);
+
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $launchPath = $finalDir.DIRECTORY_SEPARATOR.'career-launch-manifest.json';
+        $smokePath = $finalDir.DIRECTORY_SEPARATOR.'career-smoke-matrix.json';
+
+        $this->assertDirectoryExists($finalDir);
+        $this->assertFileExists($launchPath);
+        $this->assertFileExists($smokePath);
+        $this->assertStringStartsWith($this->rootDir, $finalDir);
+        $this->assertStringStartsWith(storage_path('app/private'), $launchPath);
+        $this->assertStringStartsWith(storage_path('app/private'), $smokePath);
+        $this->assertStringNotContainsString(base_path('docs'), $finalDir);
+        $this->assertStringNotContainsString(base_path('public'), $finalDir);
+    }
+
+    public function test_command_can_emit_json_summary_for_internal_export(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T100100Z';
+        $exitCode = Artisan::call('career:export-first-wave-release-artifacts', [
+            '--timestamp' => $timestamp,
+            '--json' => true,
+        ]);
+        $output = trim((string) Artisan::output());
+        $payload = json_decode($output, true);
+
+        $this->assertSame(0, $exitCode, $output);
+        $this->assertIsArray($payload);
+        $this->assertSame('materialized', $payload['status'] ?? null);
+        $this->assertArrayHasKey('output_dir', $payload);
+        $this->assertArrayHasKey('artifacts', $payload);
+        $this->assertArrayHasKey('career-launch-manifest.json', $payload['artifacts']);
+        $this->assertArrayHasKey('career-smoke-matrix.json', $payload['artifacts']);
+        $this->assertFileExists((string) $payload['artifacts']['career-launch-manifest.json']);
+        $this->assertFileExists((string) $payload['artifacts']['career-smoke-matrix.json']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveReleaseArtifactProjectionService;
+use App\DTO\Career\CareerFirstWaveLaunchManifestArtifact;
+use App\DTO\Career\CareerFirstWaveSmokeMatrixArtifact;
+use App\Services\Career\CareerFirstWaveReleaseArtifactMaterializationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerFirstWaveReleaseArtifactMaterializationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = storage_path(CareerFirstWaveReleaseArtifactMaterializationService::OUTPUT_ROOT);
+        File::deleteDirectory($this->rootDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->rootDir);
+
+        parent::tearDown();
+    }
+
+    public function test_it_materializes_two_release_artifacts_together_with_atomic_finalize(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T090000Z';
+        $service = app(CareerFirstWaveReleaseArtifactMaterializationService::class);
+        $result = $service->materialize($timestamp);
+
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+        $launchPath = $finalDir.DIRECTORY_SEPARATOR.'career-launch-manifest.json';
+        $smokePath = $finalDir.DIRECTORY_SEPARATOR.'career-smoke-matrix.json';
+
+        $this->assertSame('materialized', $result['status']);
+        $this->assertSame($finalDir, $result['output_dir']);
+        $this->assertSame($launchPath, $result['artifacts']['career-launch-manifest.json']);
+        $this->assertSame($smokePath, $result['artifacts']['career-smoke-matrix.json']);
+        $this->assertDirectoryExists($finalDir);
+        $this->assertFileExists($launchPath);
+        $this->assertFileExists($smokePath);
+        $this->assertDirectoryDoesNotExist($tmpDir);
+
+        $launchPayload = json_decode((string) File::get($launchPath), true);
+        $smokePayload = json_decode((string) File::get($smokePath), true);
+        $this->assertIsArray($launchPayload);
+        $this->assertIsArray($smokePayload);
+
+        $projection = app(CareerFirstWaveReleaseArtifactProjectionService::class)->build();
+        $expectedLaunch = $projection['career-launch-manifest.json']->toArray();
+        $expectedSmoke = $projection['career-smoke-matrix.json']->toArray();
+
+        $this->assertSame($expectedLaunch, $launchPayload);
+        $this->assertSame($expectedSmoke, $smokePayload);
+        $this->assertSame(
+            collect($launchPayload['members'])->pluck('canonical_slug')->values()->all(),
+            collect($smokePayload['members'])->pluck('canonical_slug')->values()->all(),
+        );
+    }
+
+    public function test_it_fails_when_output_directory_already_exists_without_finalizing_new_output(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T090100Z';
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+        File::ensureDirectoryExists($finalDir);
+
+        $service = app(CareerFirstWaveReleaseArtifactMaterializationService::class);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('output dir already exists');
+
+        try {
+            $service->materialize($timestamp);
+        } finally {
+            $this->assertDirectoryExists($finalDir);
+            $this->assertDirectoryDoesNotExist($tmpDir);
+            $this->assertFileDoesNotExist($finalDir.DIRECTORY_SEPARATOR.'career-launch-manifest.json');
+            $this->assertFileDoesNotExist($finalDir.DIRECTORY_SEPARATOR.'career-smoke-matrix.json');
+        }
+    }
+
+    public function test_it_rejects_projection_validation_failure_and_does_not_finalize(): void
+    {
+        $badService = new class(app(CareerFirstWaveReleaseArtifactProjectionService::class)) extends CareerFirstWaveReleaseArtifactMaterializationService
+        {
+            /**
+             * @return array<string, object>
+             */
+            protected function projectedArtifacts(): array
+            {
+                return [
+                    'career-launch-manifest.json' => new CareerFirstWaveLaunchManifestArtifact(
+                        scope: 'career_first_wave_10',
+                        counts: ['total' => 1, 'stable' => 1, 'candidate' => 0, 'hold' => 0, 'blocked' => 0],
+                        groups: ['stable' => ['registered-nurses'], 'candidate' => [], 'hold' => [], 'blocked' => []],
+                        members: [[
+                            'canonical_slug' => 'registered-nurses',
+                            'launch_tier' => 'stable',
+                            'readiness_status' => 'publish_ready',
+                            'lifecycle_state' => 'indexed',
+                            'public_index_state' => 'indexable',
+                            'supporting_routes' => ['family_hub' => true, 'next_step_links_count' => 1],
+                            'trust_freshness' => ['review_due_known' => false, 'review_staleness_state' => 'unknown_due_date'],
+                        ]],
+                    ),
+                    'career-smoke-matrix.json' => new CareerFirstWaveSmokeMatrixArtifact(
+                        scope: 'career_first_wave_10',
+                        members: [[
+                            'canonical_slug' => 'software-developers',
+                            'smoke_matrix' => [
+                                'job_detail_route_known' => true,
+                                'discoverable_route_known' => true,
+                                'seo_contract_present' => true,
+                                'structured_data_authority_present' => true,
+                                'trust_freshness_present' => true,
+                                'family_support_route_present' => true,
+                                'next_step_support_present' => true,
+                            ],
+                        ]],
+                    ),
+                ];
+            }
+        };
+
+        $timestamp = '20260415T090200Z';
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('slug sets are inconsistent');
+
+        try {
+            $badService->materialize($timestamp);
+        } finally {
+            $this->assertDirectoryDoesNotExist($finalDir);
+            $this->assertDirectoryDoesNotExist($tmpDir);
+        }
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php
@@ -155,6 +155,85 @@ final class CareerFirstWaveReleaseArtifactMaterializationServiceTest extends Tes
         }
     }
 
+    public function test_it_accepts_same_slug_set_even_when_member_order_differs_between_artifacts(): void
+    {
+        $service = new class(app(CareerFirstWaveReleaseArtifactProjectionService::class)) extends CareerFirstWaveReleaseArtifactMaterializationService
+        {
+            /**
+             * @return array<string, object>
+             */
+            protected function projectedArtifacts(): array
+            {
+                return [
+                    'career-launch-manifest.json' => new CareerFirstWaveLaunchManifestArtifact(
+                        scope: 'career_first_wave_10',
+                        counts: ['total' => 2, 'stable' => 2, 'candidate' => 0, 'hold' => 0, 'blocked' => 0],
+                        groups: ['stable' => ['registered-nurses', 'software-developers'], 'candidate' => [], 'hold' => [], 'blocked' => []],
+                        members: [
+                            [
+                                'canonical_slug' => 'registered-nurses',
+                                'launch_tier' => 'stable',
+                                'readiness_status' => 'publish_ready',
+                                'lifecycle_state' => 'indexed',
+                                'public_index_state' => 'indexable',
+                                'supporting_routes' => ['family_hub' => true, 'next_step_links_count' => 1],
+                                'trust_freshness' => ['review_due_known' => false, 'review_staleness_state' => 'unknown_due_date'],
+                            ],
+                            [
+                                'canonical_slug' => 'software-developers',
+                                'launch_tier' => 'stable',
+                                'readiness_status' => 'publish_ready',
+                                'lifecycle_state' => 'indexed',
+                                'public_index_state' => 'indexable',
+                                'supporting_routes' => ['family_hub' => true, 'next_step_links_count' => 1],
+                                'trust_freshness' => ['review_due_known' => false, 'review_staleness_state' => 'unknown_due_date'],
+                            ],
+                        ],
+                    ),
+                    'career-smoke-matrix.json' => new CareerFirstWaveSmokeMatrixArtifact(
+                        scope: 'career_first_wave_10',
+                        members: [
+                            [
+                                'canonical_slug' => 'software-developers',
+                                'smoke_matrix' => [
+                                    'job_detail_route_known' => true,
+                                    'discoverable_route_known' => true,
+                                    'seo_contract_present' => true,
+                                    'structured_data_authority_present' => true,
+                                    'trust_freshness_present' => true,
+                                    'family_support_route_present' => true,
+                                    'next_step_support_present' => true,
+                                ],
+                            ],
+                            [
+                                'canonical_slug' => 'registered-nurses',
+                                'smoke_matrix' => [
+                                    'job_detail_route_known' => true,
+                                    'discoverable_route_known' => true,
+                                    'seo_contract_present' => true,
+                                    'structured_data_authority_present' => true,
+                                    'trust_freshness_present' => true,
+                                    'family_support_route_present' => true,
+                                    'next_step_support_present' => true,
+                                ],
+                            ],
+                        ],
+                    ),
+                ];
+            }
+        };
+
+        $timestamp = '20260415T090300Z';
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+
+        $result = $service->materialize($timestamp);
+
+        $this->assertSame('materialized', $result['status']);
+        $this->assertDirectoryExists($finalDir);
+        $this->assertFileExists($finalDir.DIRECTORY_SEPARATOR.'career-launch-manifest.json');
+        $this->assertFileExists($finalDir.DIRECTORY_SEPARATOR.'career-smoke-matrix.json');
+    }
+
     private function materializeCurrentFirstWaveFixture(): void
     {
         $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [


### PR DESCRIPTION
## What changed
- add `CareerFirstWaveReleaseArtifactMaterializationService` as the internal-only materialization layer on top of B55 projection
- add `career:export-first-wave-release-artifacts` command for one-shot export of both internal artifacts in one run
- keep output payloads unchanged from B55 projection shape
- enforce paired write discipline:
  - one projection pass
  - write both artifacts into `<timestamp>.tmp` under `storage/app/private/career_release_artifacts`
  - validate both payloads and slug-set consistency before finalize
  - atomic directory rename from temp to final
  - fail-fast without finalize when validation or filesystem steps fail
- enforce internal-only pathing (no docs tree, no public path) by writing to:
  - `storage/app/private/career_release_artifacts/<timestamp>/career-launch-manifest.json`
  - `storage/app/private/career_release_artifacts/<timestamp>/career-smoke-matrix.json`
- add focused unit + feature coverage for:
  - paired/atomic materialization
  - output path and file naming
  - validation failure no-finalize behavior
  - command summary and json output contract

## Why
B55 established a stable, narrowed projection boundary for first-wave release artifacts but did not materialize those artifacts to internal storage. B56 closes that gap with a repeatable, backend-owned export command while preserving all B55 truth boundaries and omission rules.

The implementation intentionally avoids public surfaces and avoids changing release semantics. It treats B55 as the sole source for payload shape and adds only export discipline: path policy, paired atomic write, and invariant checks.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/CareerFirstWaveReleaseArtifactMaterializationService.php app/Console/Commands/CareerExportFirstWaveReleaseArtifacts.php tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveReleaseArtifactsCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveReleaseArtifactsCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php`

## Intentionally deferred
- no public API or OpenAPI changes
- no frontend changes or docs-tree release output
- no release dashboard semantics
- no B55 DTO contract expansion
- no family-hub primary member export
- no runtime smoke claims
