### PR TITLE
PR-B57: Career first-wave rollout wave-plan authority

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveRolloutWavePlan.php
+++ b/backend/app/DTO/Career/CareerFirstWaveRolloutWavePlan.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveRolloutWavePlan
+{
+    /**
+     * @param  array{stable:int,candidate:int,hold:int,blocked:int,manual_review_needed:int}  $counts
+     * @param  array{stable:list<string>,candidate:list<string>,hold:list<string>,blocked:list<string>,manual_review_needed:list<string>}  $cohorts
+     * @param  list<CareerFirstWaveRolloutWavePlanMember>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $cohorts,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'plan_kind' => 'career_first_wave_rollout_wave_plan',
+            'plan_version' => 'career.rollout_wave_plan.first_wave.v1',
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'cohorts' => $this->cohorts,
+            'members' => array_map(
+                static fn (CareerFirstWaveRolloutWavePlanMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveRolloutWavePlanMember.php
+++ b/backend/app/DTO/Career/CareerFirstWaveRolloutWavePlanMember.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveRolloutWavePlanMember
+{
+    /**
+     * @param  array{family_hub:bool,next_step_links_count:int}  $supportingRoutes
+     * @param  array{review_due_known:bool,review_staleness_state:string}  $trustFreshness
+     * @param  list<string>  $deferReasons
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $rolloutCohort,
+        public readonly string $launchTier,
+        public readonly string $readinessStatus,
+        public readonly string $lifecycleState,
+        public readonly string $publicIndexState,
+        public readonly array $supportingRoutes,
+        public readonly array $trustFreshness,
+        public readonly array $deferReasons,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'member_kind' => 'career_job_detail',
+            'canonical_slug' => $this->canonicalSlug,
+            'rollout_cohort' => $this->rolloutCohort,
+            'launch_tier' => $this->launchTier,
+            'readiness_status' => $this->readinessStatus,
+            'lifecycle_state' => $this->lifecycleState,
+            'public_index_state' => $this->publicIndexState,
+            'supporting_routes' => $this->supportingRoutes,
+            'trust_freshness' => $this->trustFreshness,
+            'defer_reasons' => $this->deferReasons,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanService.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveRolloutWavePlan;
+use App\DTO\Career\CareerFirstWaveRolloutWavePlanMember;
+
+final class CareerFirstWaveRolloutWavePlanService
+{
+    /**
+     * @var array<string, true>
+     */
+    private const REVIEW_APPROVED_STATUSES = [
+        'approved' => true,
+        'reviewed' => true,
+    ];
+
+    public function __construct(
+        private readonly CareerFirstWaveLaunchManifestService $launchManifestService,
+        private readonly CareerFirstWaveLaunchReadinessAuditV2Service $launchReadinessAuditV2Service,
+    ) {}
+
+    public function build(): CareerFirstWaveRolloutWavePlan
+    {
+        $manifest = $this->launchManifestService->build()->toArray();
+        $audit = $this->launchReadinessAuditV2Service->build()->toArray();
+
+        $reviewerStatusBySlug = [];
+        foreach ((array) ($audit['members'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $reviewerStatusBySlug[$slug] = $this->normalizeNullableString($row['reviewer_status'] ?? null);
+        }
+
+        $cohortBySlug = [];
+        foreach (['stable', 'candidate', 'hold', 'blocked'] as $cohort) {
+            foreach ((array) data_get($manifest, 'groups.'.$cohort, []) as $slug) {
+                if (! is_string($slug) || trim($slug) === '') {
+                    continue;
+                }
+
+                $cohortBySlug[(string) $slug] = $cohort;
+            }
+        }
+
+        $members = [];
+        $manualReviewNeeded = [];
+
+        foreach ((array) ($manifest['members'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $rolloutCohort = $cohortBySlug[$slug] ?? 'hold';
+            $trustFreshness = $this->buildTrustFreshnessSummary((array) ($row['trust_freshness'] ?? []));
+            $reviewerStatus = $reviewerStatusBySlug[$slug] ?? null;
+
+            if ($this->requiresManualReview($reviewerStatus, $trustFreshness)) {
+                $manualReviewNeeded[] = $slug;
+            }
+
+            $members[] = new CareerFirstWaveRolloutWavePlanMember(
+                canonicalSlug: $slug,
+                rolloutCohort: $rolloutCohort,
+                launchTier: (string) ($row['launch_tier'] ?? ''),
+                readinessStatus: (string) ($row['readiness_status'] ?? ''),
+                lifecycleState: (string) ($row['lifecycle_state'] ?? ''),
+                publicIndexState: (string) ($row['public_index_state'] ?? ''),
+                supportingRoutes: [
+                    'family_hub' => (bool) data_get($row, 'supporting_routes.family_hub', false),
+                    'next_step_links_count' => (int) data_get($row, 'supporting_routes.next_step_links_count', 0),
+                ],
+                trustFreshness: $trustFreshness,
+                deferReasons: $this->buildDeferReasons(
+                    rolloutCohort: $rolloutCohort,
+                    readinessStatus: (string) ($row['readiness_status'] ?? ''),
+                    publicIndexState: (string) ($row['public_index_state'] ?? ''),
+                    nextStepLinksCount: (int) data_get($row, 'supporting_routes.next_step_links_count', 0),
+                    trustStalenessState: (string) $trustFreshness['review_staleness_state'],
+                ),
+            );
+        }
+
+        $manualReviewNeeded = array_values(array_unique($manualReviewNeeded));
+        sort($manualReviewNeeded);
+
+        return new CareerFirstWaveRolloutWavePlan(
+            scope: (string) ($manifest['scope'] ?? CareerFirstWaveLaunchTierSummaryService::SCOPE),
+            counts: [
+                'stable' => (int) data_get($manifest, 'counts.stable', 0),
+                'candidate' => (int) data_get($manifest, 'counts.candidate', 0),
+                'hold' => (int) data_get($manifest, 'counts.hold', 0),
+                'blocked' => (int) data_get($manifest, 'counts.blocked', 0),
+                'manual_review_needed' => count($manualReviewNeeded),
+            ],
+            cohorts: [
+                'stable' => array_values((array) data_get($manifest, 'groups.stable', [])),
+                'candidate' => array_values((array) data_get($manifest, 'groups.candidate', [])),
+                'hold' => array_values((array) data_get($manifest, 'groups.hold', [])),
+                'blocked' => array_values((array) data_get($manifest, 'groups.blocked', [])),
+                'manual_review_needed' => $manualReviewNeeded,
+            ],
+            members: $members,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $trustFreshness
+     * @return array{review_due_known:bool,review_staleness_state:string}
+     */
+    private function buildTrustFreshnessSummary(array $trustFreshness): array
+    {
+        $reviewStalenessState = $this->normalizeNullableString($trustFreshness['review_staleness_state'] ?? null) ?? 'unknown_due_date';
+
+        return [
+            'review_due_known' => (bool) ($trustFreshness['review_due_known'] ?? false),
+            'review_staleness_state' => $reviewStalenessState,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildDeferReasons(
+        string $rolloutCohort,
+        string $readinessStatus,
+        string $publicIndexState,
+        int $nextStepLinksCount,
+        string $trustStalenessState,
+    ): array {
+        $reasons = [];
+
+        if ($rolloutCohort === 'blocked') {
+            $reasons[] = 'blocked';
+        }
+
+        if ($readinessStatus !== 'publish_ready') {
+            $reasons[] = 'not_publish_ready';
+        }
+
+        if ($publicIndexState !== 'indexable') {
+            $reasons[] = 'not_indexable';
+        }
+
+        if ($nextStepLinksCount < 1) {
+            $reasons[] = 'insufficient_next_step_links';
+        }
+
+        if (in_array($trustStalenessState, ['review_due', 'review_unreviewed'], true)) {
+            $reasons[] = $trustStalenessState;
+        }
+
+        return array_values(array_unique($reasons));
+    }
+
+    /**
+     * @param  array{review_due_known:bool,review_staleness_state:string}  $trustFreshness
+     */
+    private function requiresManualReview(?string $reviewerStatus, array $trustFreshness): bool
+    {
+        if ($reviewerStatus === null || ! isset(self::REVIEW_APPROVED_STATUSES[strtolower($reviewerStatus)])) {
+            return true;
+        }
+
+        return in_array($trustFreshness['review_staleness_state'], ['review_due', 'review_unreviewed'], true);
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T07:35:35Z",
+  "updated_at": "2026-04-15T07:38:20Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -517,10 +517,10 @@
     "PR-B21": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b21-career-transition-path-internal-step-authoring-production-payload-enrichment",
       "commit_sha": "",
-      "pr_url": "",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/902",
       "checks": {
         "local": [
           {
@@ -532,9 +532,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442366542/job/71410205139"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442366542/job/71410213072"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442310771/job/71410016909"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442310771/job/71410023962"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B57 verification passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T07:39:46Z",
+  "updated_at": "2026-04-15T07:40:52Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1325,7 +1325,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open_checks_failed",
       "branch": "codex/pr-b57-career-first-wave-rollout-wave-plan-authority",
-      "commit_sha": "62c150052ada265a39323197ca7cc67971a6fab8",
+      "commit_sha": "7b573d7e884d4fa24c5b666785fd0adadc37a674",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/902",
       "checks": {
         "local": [
@@ -1350,22 +1350,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442415151/job/71410367760"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442477183/job/71410575462"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442415151/job/71410373996"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442477183/job/71410582494"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442412716/job/71410359800"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442475304/job/71410569483"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442412716/job/71410367824"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442475304/job/71410579898"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T07:38:20Z",
+  "updated_at": "2026-04-15T07:39:46Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -517,10 +517,10 @@
     "PR-B21": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open_checks_failed",
+      "status": "local_verified",
       "branch": "codex/pr-b21-career-transition-path-internal-step-authoring-production-payload-enrichment",
       "commit_sha": "",
-      "pr_url": "https://github.com/fermatmind/fap-api/pull/902",
+      "pr_url": "",
       "checks": {
         "local": [
           {
@@ -532,30 +532,9 @@
             "status": "passed"
           }
         ],
-        "github": [
-          {
-            "name": "hygiene",
-            "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442366542/job/71410205139"
-          },
-          {
-            "name": "verify-mbti-${{ matrix.mode }}",
-            "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442366542/job/71410213072"
-          },
-          {
-            "name": "hygiene",
-            "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442310771/job/71410016909"
-          },
-          {
-            "name": "verify-mbti-${{ matrix.mode }}",
-            "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442310771/job/71410023962"
-          }
-        ]
+        "github": []
       },
-      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B57 verification passed.",
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,
@@ -1344,10 +1323,10 @@
     "PR-B57": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b57-career-first-wave-rollout-wave-plan-authority",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "62c150052ada265a39323197ca7cc67971a6fab8",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/902",
       "checks": {
         "local": [
           {
@@ -1367,9 +1346,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442415151/job/71410367760"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442415151/job/71410373996"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442412716/job/71410359800"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442412716/job/71410367824"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B57 verification passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T07:33:50Z",
+  "updated_at": "2026-04-15T07:35:35Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -28,7 +28,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-web",
       "status": "pending",
       "branch": "codex/pr-f6-career-launch-manifest-smoke-alignment",
-      "commit_sha": "",
+      "commit_sha": "6c482777b06cbb2c1550dd74f425fbdaaa066707",
       "pr_url": "",
       "checks": {
         "local": [],

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T06:21:26Z",
+  "updated_at": "2026-04-15T07:32:53Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1315,6 +1315,40 @@
         ]
       },
       "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; both hygiene runs failed before execution and MBTI matrix jobs were skipped, while local PR-B56 verification passed.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B57": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b57-career-first-wave-rollout-wave-plan-authority",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanService.php app/DTO/Career/CareerFirstWaveRolloutWavePlan*.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T07:40:52Z",
+  "updated_at": "2026-04-15T07:42:09Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1325,7 +1325,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open_checks_failed",
       "branch": "codex/pr-b57-career-first-wave-rollout-wave-plan-authority",
-      "commit_sha": "7b573d7e884d4fa24c5b666785fd0adadc37a674",
+      "commit_sha": "877d232e95e2255b3b6b73dbad4670662e37549d",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/902",
       "checks": {
         "local": [
@@ -1350,22 +1350,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442477183/job/71410575462"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442519072/job/71410718729"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442477183/job/71410582494"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442519072/job/71410724908"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442475304/job/71410569483"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442515972/job/71410709014"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442475304/job/71410579898"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24442515972/job/71410715673"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T07:32:53Z",
+  "updated_at": "2026-04-15T07:33:50Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -11,7 +11,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pending",
       "branch": "codex/pr-b7-career-first-wave-manifest-publish-gate",
-      "commit_sha": "",
+      "commit_sha": "cb500090d448aa50099fe03ba482656fd5f7fea3",
       "pr_url": "",
       "checks": {
         "local": [],

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -810,6 +810,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B57
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b57-career-first-wave-rollout-wave-plan-authority
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave rollout wave-plan authority.
+      Add an internal-only rollout wave-plan authority for first-wave career_job_detail
+      members that reuses existing B54/B53 backend truth for stable/candidate/hold/blocked
+      primary cohorts and an advisory-only manual_review_needed cohort, while keeping
+      family hubs as supporting evidence only and avoiding public API/OpenAPI/frontend changes.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanService.php app/DTO/Career/CareerFirstWaveRolloutWavePlan*.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveLaunchManifestService;
+use App\Domain\Career\Publish\CareerFirstWaveRolloutWavePlanService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveRolloutWavePlanServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_an_internal_rollout_wave_plan_with_job_detail_members_only(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $plan = app(CareerFirstWaveRolloutWavePlanService::class)->build()->toArray();
+        $members = collect($plan['members'])->keyBy('canonical_slug');
+        $registeredNurses = $members->get('registered-nurses');
+
+        $this->assertSame('career_first_wave_rollout_wave_plan', $plan['plan_kind']);
+        $this->assertSame('career.rollout_wave_plan.first_wave.v1', $plan['plan_version']);
+        $this->assertSame('career_first_wave_10', $plan['scope']);
+        $this->assertSame(['stable', 'candidate', 'hold', 'blocked', 'manual_review_needed'], array_keys($plan['counts']));
+        $this->assertSame(['stable', 'candidate', 'hold', 'blocked', 'manual_review_needed'], array_keys($plan['cohorts']));
+        $this->assertSame(10, count($plan['members']));
+
+        $this->assertIsArray($registeredNurses);
+        $this->assertSame([
+            'member_kind',
+            'canonical_slug',
+            'rollout_cohort',
+            'launch_tier',
+            'readiness_status',
+            'lifecycle_state',
+            'public_index_state',
+            'supporting_routes',
+            'trust_freshness',
+            'defer_reasons',
+        ], array_keys($registeredNurses));
+        $this->assertSame('career_job_detail', $registeredNurses['member_kind']);
+        $this->assertSame([
+            'family_hub',
+            'next_step_links_count',
+        ], array_keys($registeredNurses['supporting_routes']));
+        $this->assertSame([
+            'review_due_known',
+            'review_staleness_state',
+        ], array_keys($registeredNurses['trust_freshness']));
+
+        $this->assertCount(0, array_filter(
+            $plan['members'],
+            static fn (array $member): bool => ($member['member_kind'] ?? null) === 'career_family_hub'
+        ));
+
+        $this->assertArrayNotHasKey('evidence_refs', $registeredNurses);
+        $this->assertArrayNotHasKey('blockers', $registeredNurses);
+        $this->assertArrayNotHasKey('reviewed_at', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('next_review_due_at', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('demand_signal', $registeredNurses);
+        $this->assertArrayNotHasKey('novelty_score', $registeredNurses);
+        $this->assertArrayNotHasKey('canonical_conflict', $registeredNurses);
+    }
+
+    public function test_it_keeps_manual_review_needed_as_advisory_without_mutating_primary_cohorts(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+        $candidate->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewed_at' => now()->subDay(),
+            'next_review_due_at' => now()->subMinute(),
+        ]);
+
+        $manifest = app(CareerFirstWaveLaunchManifestService::class)->build()->toArray();
+        $plan = app(CareerFirstWaveRolloutWavePlanService::class)->build()->toArray();
+        $members = collect($plan['members'])->keyBy('canonical_slug');
+        $candidateRow = $members->get('data-scientists');
+
+        $this->assertSame($manifest['counts']['stable'], $plan['counts']['stable']);
+        $this->assertSame($manifest['counts']['candidate'], $plan['counts']['candidate']);
+        $this->assertSame($manifest['counts']['hold'], $plan['counts']['hold']);
+        $this->assertSame($manifest['counts']['blocked'], $plan['counts']['blocked']);
+        $this->assertSame($manifest['groups']['stable'], $plan['cohorts']['stable']);
+        $this->assertSame($manifest['groups']['candidate'], $plan['cohorts']['candidate']);
+        $this->assertSame($manifest['groups']['hold'], $plan['cohorts']['hold']);
+        $this->assertSame($manifest['groups']['blocked'], $plan['cohorts']['blocked']);
+
+        $this->assertIsArray($candidateRow);
+        $this->assertSame('candidate', $candidateRow['rollout_cohort']);
+        $this->assertSame('review_due', data_get($candidateRow, 'trust_freshness.review_staleness_state'));
+        $this->assertContains('data-scientists', $plan['cohorts']['manual_review_needed']);
+        $this->assertGreaterThan(0, $plan['counts']['manual_review_needed']);
+        $this->assertArrayNotHasKey('promotion_candidate_ready', $plan['cohorts']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What Changed
- Added internal-only `CareerFirstWaveRolloutWavePlanService` to compose rollout wave-plan authority from existing backend services (B54 launch manifest + B53 readiness audit v2).
- Added rollout DTOs:
  - `CareerFirstWaveRolloutWavePlan`
  - `CareerFirstWaveRolloutWavePlanMember`
- Added focused unit tests for scope/cohort/advisory behavior.
- Added PR-B57 entries in train manifest/state.

## Why
- Consolidate current first-wave backend truth into a reusable internal rollout planning contract.
- Keep stable/candidate/hold/blocked as primary cohorts while exposing `manual_review_needed` as advisory only.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanService.php app/DTO/Career/CareerFirstWaveRolloutWavePlan*.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveReleaseArtifactProjectionServiceTest.php`

## Intentionally Deferred
- No public API/OpenAPI/frontend changes.
- No demand/novelty/canonical-conflict/promotion-scoring semantics.
- No runtime smoke or final rollout approval semantics.
