### PR TITLE
PR-B58: Career first-wave rollout wave-plan artifact projection / cohort whitelist projection

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveRolloutWavePlanArtifact.php
+++ b/backend/app/DTO/Career/CareerFirstWaveRolloutWavePlanArtifact.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveRolloutWavePlanArtifact
+{
+    /**
+     * @param  array{stable:int,candidate:int,hold:int,blocked:int,manual_review_needed:int}  $counts
+     * @param  array{stable:list<string>,candidate:list<string>,hold:list<string>,blocked:list<string>}  $cohorts
+     * @param  array{manual_review_needed:list<string>}  $advisory
+     * @param  list<array<string, mixed>>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $cohorts,
+        public readonly array $advisory,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'artifact_kind' => 'career_rollout_wave_plan',
+            'artifact_version' => 'career.rollout_wave_plan.export.v1',
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'cohorts' => $this->cohorts,
+            'advisory' => $this->advisory,
+            'members' => $this->members,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanArtifactProjectionService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanArtifactProjectionService.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveRolloutWavePlanArtifact;
+
+final class CareerFirstWaveRolloutWavePlanArtifactProjectionService
+{
+    public function __construct(
+        private readonly CareerFirstWaveRolloutWavePlanService $rolloutWavePlanService,
+    ) {}
+
+    public function build(): CareerFirstWaveRolloutWavePlanArtifact
+    {
+        $plan = $this->rolloutWavePlanService->build()->toArray();
+
+        $members = array_map(function (array $member): array {
+            $trustFreshness = null;
+            if (is_array($member['trust_freshness'] ?? null)) {
+                $trustFreshness = [
+                    'review_due_known' => (bool) data_get($member, 'trust_freshness.review_due_known', false),
+                    'review_staleness_state' => (string) data_get($member, 'trust_freshness.review_staleness_state', 'unknown_due_date'),
+                ];
+            }
+
+            return [
+                'canonical_slug' => (string) ($member['canonical_slug'] ?? ''),
+                'rollout_cohort' => (string) ($member['rollout_cohort'] ?? ''),
+                'launch_tier' => (string) ($member['launch_tier'] ?? ''),
+                'readiness_status' => (string) ($member['readiness_status'] ?? ''),
+                'lifecycle_state' => (string) ($member['lifecycle_state'] ?? ''),
+                'public_index_state' => (string) ($member['public_index_state'] ?? ''),
+                'supporting_routes' => [
+                    'family_hub' => (bool) data_get($member, 'supporting_routes.family_hub', false),
+                    'next_step_links_count' => (int) data_get($member, 'supporting_routes.next_step_links_count', 0),
+                ],
+                'trust_freshness' => $trustFreshness,
+            ];
+        }, (array) ($plan['members'] ?? []));
+
+        return new CareerFirstWaveRolloutWavePlanArtifact(
+            scope: (string) ($plan['scope'] ?? ''),
+            counts: [
+                'stable' => (int) data_get($plan, 'counts.stable', 0),
+                'candidate' => (int) data_get($plan, 'counts.candidate', 0),
+                'hold' => (int) data_get($plan, 'counts.hold', 0),
+                'blocked' => (int) data_get($plan, 'counts.blocked', 0),
+                'manual_review_needed' => (int) data_get($plan, 'counts.manual_review_needed', 0),
+            ],
+            cohorts: [
+                'stable' => array_values((array) data_get($plan, 'cohorts.stable', [])),
+                'candidate' => array_values((array) data_get($plan, 'cohorts.candidate', [])),
+                'hold' => array_values((array) data_get($plan, 'cohorts.hold', [])),
+                'blocked' => array_values((array) data_get($plan, 'cohorts.blocked', [])),
+            ],
+            advisory: [
+                'manual_review_needed' => array_values((array) data_get($plan, 'cohorts.manual_review_needed', [])),
+            ],
+            members: $members,
+        );
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T08:00:42Z",
+  "updated_at": "2026-04-15T08:04:13Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1378,10 +1378,10 @@
     "PR-B58": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b58-career-first-wave-rollout-wave-plan-artifact-projection-cohort-whitelist-projection",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "e9c05c17948381ad1117cacc6588d0382386e4a3",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/903",
       "checks": {
         "local": [
           {
@@ -1401,9 +1401,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24443308760/job/71413338110"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24443287899/job/71413270555"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24443308760/job/71413345829"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24443287899/job/71413279171"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B58 verification passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T07:59:12Z",
+  "updated_at": "2026-04-15T08:00:42Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -45,7 +45,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pending",
       "branch": "codex/pr-b8-career-first-wave-alias-hardening",
-      "commit_sha": "",
+      "commit_sha": "8db6e45c63472df4f04c617c302a6c28a6a2da7c",
       "pr_url": "",
       "checks": {
         "local": [],

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T07:42:09Z",
+  "updated_at": "2026-04-15T07:59:12Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1370,6 +1370,40 @@
         ]
       },
       "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B57 verification passed.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B58": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b58-career-first-wave-rollout-wave-plan-artifact-projection-cohort-whitelist-projection",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanArtifactProjectionService.php app/DTO/Career/CareerFirstWaveRolloutWavePlanArtifact.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -838,6 +838,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B58
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b58-career-first-wave-rollout-wave-plan-artifact-projection-cohort-whitelist-projection
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave rollout wave-plan artifact projection / cohort whitelist projection.
+      Add an internal-only projection layer that narrows B57 rollout wave-plan authority
+      into an export-safe career-rollout-wave-plan artifact with stable/candidate/hold/blocked
+      primary cohorts and advisory-only manual_review_needed, while preserving job-detail-only
+      member scope and family-hub supporting-evidence semantics.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanArtifactProjectionService.php app/DTO/Career/CareerFirstWaveRolloutWavePlanArtifact.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRolloutWavePlanArtifactProjectionService;
+use App\Domain\Career\Publish\CareerFirstWaveRolloutWavePlanService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_projects_an_export_safe_rollout_wave_plan_artifact(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $artifact = app(CareerFirstWaveRolloutWavePlanArtifactProjectionService::class)->build()->toArray();
+        $members = collect($artifact['members'])->keyBy('canonical_slug');
+        $registeredNurses = $members->get('registered-nurses');
+        $internalPlan = app(CareerFirstWaveRolloutWavePlanService::class)->build()->toArray();
+        $internalMemberSlugs = collect($internalPlan['members'])->pluck('canonical_slug')->values()->all();
+
+        $this->assertSame('career_rollout_wave_plan', $artifact['artifact_kind']);
+        $this->assertSame('career.rollout_wave_plan.export.v1', $artifact['artifact_version']);
+        $this->assertSame('career_first_wave_10', $artifact['scope']);
+        $this->assertSame(['stable', 'candidate', 'hold', 'blocked', 'manual_review_needed'], array_keys($artifact['counts']));
+        $this->assertSame(['stable', 'candidate', 'hold', 'blocked'], array_keys($artifact['cohorts']));
+        $this->assertSame(['manual_review_needed'], array_keys($artifact['advisory']));
+        $this->assertSame($internalMemberSlugs, $members->keys()->values()->all());
+
+        $this->assertIsArray($registeredNurses);
+        $this->assertSame([
+            'canonical_slug',
+            'rollout_cohort',
+            'launch_tier',
+            'readiness_status',
+            'lifecycle_state',
+            'public_index_state',
+            'supporting_routes',
+            'trust_freshness',
+        ], array_keys($registeredNurses));
+        $this->assertSame([
+            'family_hub',
+            'next_step_links_count',
+        ], array_keys($registeredNurses['supporting_routes']));
+        $this->assertSame([
+            'review_due_known',
+            'review_staleness_state',
+        ], array_keys($registeredNurses['trust_freshness']));
+
+        $this->assertArrayNotHasKey('member_kind', $registeredNurses);
+        $this->assertArrayNotHasKey('defer_reasons', $registeredNurses);
+        $this->assertArrayNotHasKey('blockers', $registeredNurses);
+        $this->assertArrayNotHasKey('evidence_refs', $registeredNurses);
+        $this->assertArrayNotHasKey('reviewed_at', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('next_review_due_at', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('review_freshness_basis', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('demand_signal', $registeredNurses);
+        $this->assertArrayNotHasKey('novelty_score', $registeredNurses);
+        $this->assertArrayNotHasKey('canonical_conflict', $registeredNurses);
+    }
+
+    public function test_it_keeps_manual_review_needed_in_advisory_without_mutating_primary_cohorts(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+        $candidate->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewed_at' => now()->subDay(),
+            'next_review_due_at' => now()->subMinute(),
+        ]);
+
+        $internalPlan = app(CareerFirstWaveRolloutWavePlanService::class)->build()->toArray();
+        $artifact = app(CareerFirstWaveRolloutWavePlanArtifactProjectionService::class)->build()->toArray();
+        $candidateRow = collect($artifact['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertSame($internalPlan['counts']['stable'], $artifact['counts']['stable']);
+        $this->assertSame($internalPlan['counts']['candidate'], $artifact['counts']['candidate']);
+        $this->assertSame($internalPlan['counts']['hold'], $artifact['counts']['hold']);
+        $this->assertSame($internalPlan['counts']['blocked'], $artifact['counts']['blocked']);
+        $this->assertSame($internalPlan['cohorts']['stable'], $artifact['cohorts']['stable']);
+        $this->assertSame($internalPlan['cohorts']['candidate'], $artifact['cohorts']['candidate']);
+        $this->assertSame($internalPlan['cohorts']['hold'], $artifact['cohorts']['hold']);
+        $this->assertSame($internalPlan['cohorts']['blocked'], $artifact['cohorts']['blocked']);
+        $this->assertSame($internalPlan['cohorts']['manual_review_needed'], $artifact['advisory']['manual_review_needed']);
+
+        $this->assertIsArray($candidateRow);
+        $this->assertSame('candidate', $candidateRow['rollout_cohort']);
+        $this->assertSame('review_due', data_get($candidateRow, 'trust_freshness.review_staleness_state'));
+        $this->assertContains('data-scientists', $artifact['advisory']['manual_review_needed']);
+        $this->assertArrayNotHasKey('manual_review_needed', $artifact['cohorts']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What Changed
- Added internal-only rollout artifact projection service:
  - `CareerFirstWaveRolloutWavePlanArtifactProjectionService`
- Added rollout artifact DTO:
  - `CareerFirstWaveRolloutWavePlanArtifact`
- Added focused projection tests:
  - `CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest`
- Added PR-B58 train manifest/state entries.

## Why
- Narrow B57 rollout wave-plan authority into an export-safe internal artifact contract.
- Keep primary cohorts unchanged (`stable/candidate/hold/blocked`) and export `manual_review_needed` as advisory only.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRolloutWavePlanArtifactProjectionService.php app/DTO/Career/CareerFirstWaveRolloutWavePlanArtifact.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php`

## Intentionally Deferred
- No public API/OpenAPI/frontend changes.
- No B57 semantic rewrite.
- No runtime smoke/final release approval semantics.
