### PR TITLE
PR-B59: Career first-wave rollout wave-plan artifact materialization / export command

### DIFF
--- a/backend/app/Console/Commands/CareerExportFirstWaveRolloutWavePlanArtifact.php
+++ b/backend/app/Console/Commands/CareerExportFirstWaveRolloutWavePlanArtifact.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Career\CareerFirstWaveRolloutWavePlanArtifactMaterializationService;
+use Illuminate\Console\Command;
+
+final class CareerExportFirstWaveRolloutWavePlanArtifact extends Command
+{
+    protected $signature = 'career:export-first-wave-rollout-wave-plan-artifact
+        {--timestamp= : Optional output directory timestamp segment}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Materialize internal first-wave rollout wave-plan artifact to storage/app/private/career_rollout_wave_plan_artifacts with atomic finalize.';
+
+    public function __construct(
+        private readonly CareerFirstWaveRolloutWavePlanArtifactMaterializationService $materializationService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $payload = $this->materializationService->materialize(
+                $this->option('timestamp') !== null ? (string) $this->option('timestamp') : null,
+            );
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode export payload json');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return self::SUCCESS;
+        }
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('output_dir='.(string) ($payload['output_dir'] ?? ''));
+        $this->line('career-rollout-wave-plan='.(string) data_get($payload, 'artifacts.career-rollout-wave-plan.json', ''));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -10,6 +10,7 @@ use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
+use App\Console\Commands\CareerExportFirstWaveRolloutWavePlanArtifact;
 use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CiScaleImpact;
 use App\Console\Commands\CommerceCompensatePendingOrders;
@@ -132,6 +133,7 @@ class Kernel extends ConsoleKernel
         CareerImportAuthorityWave::class,
         CareerCompileAuthorityWave::class,
         CareerExportFirstWaveReleaseArtifacts::class,
+        CareerExportFirstWaveRolloutWavePlanArtifact::class,
         RefreshCareerAttributionDailyCommand::class,
         PacksPublish::class,
         PacksRollback::class,

--- a/backend/app/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationService.php
+++ b/backend/app/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationService.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRolloutWavePlanArtifactProjectionService;
+use Illuminate\Support\Facades\File;
+
+class CareerFirstWaveRolloutWavePlanArtifactMaterializationService
+{
+    public const OUTPUT_ROOT = 'app/private/career_rollout_wave_plan_artifacts';
+
+    public const ARTIFACT_FILENAME = 'career-rollout-wave-plan.json';
+
+    public function __construct(
+        private readonly CareerFirstWaveRolloutWavePlanArtifactProjectionService $projectionService,
+    ) {}
+
+    /**
+     * @return array{
+     *   status:string,
+     *   output_dir:string,
+     *   artifacts:array{
+     *     career-rollout-wave-plan.json:string
+     *   }
+     * }
+     */
+    public function materialize(?string $timestamp = null): array
+    {
+        $normalizedTimestamp = $this->normalizeTimestamp($timestamp);
+        $rootDir = storage_path(self::OUTPUT_ROOT);
+        $finalDir = $rootDir.DIRECTORY_SEPARATOR.$normalizedTimestamp;
+        $tmpDir = $finalDir.'.tmp';
+
+        if (is_dir($finalDir)) {
+            throw new \RuntimeException('rollout wave-plan artifact output dir already exists: '.$finalDir);
+        }
+        if (is_dir($tmpDir)) {
+            throw new \RuntimeException('rollout wave-plan artifact temp dir already exists: '.$tmpDir);
+        }
+
+        $payload = $this->extractArtifactPayload($this->projectedArtifact());
+        $this->validateArtifactPayload($payload);
+
+        File::ensureDirectoryExists($tmpDir);
+
+        try {
+            $this->writeJsonFile($tmpDir.DIRECTORY_SEPARATOR.self::ARTIFACT_FILENAME, $payload);
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize rollout wave-plan artifact directory: '.$finalDir);
+            }
+        } catch (\Throwable $e) {
+            if (is_dir($tmpDir)) {
+                File::deleteDirectory($tmpDir);
+            }
+
+            throw $e;
+        }
+
+        return [
+            'status' => 'materialized',
+            'output_dir' => $finalDir,
+            'artifacts' => [
+                self::ARTIFACT_FILENAME => $finalDir.DIRECTORY_SEPARATOR.self::ARTIFACT_FILENAME,
+            ],
+        ];
+    }
+
+    protected function projectedArtifact(): object
+    {
+        return $this->projectionService->build();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function extractArtifactPayload(object $artifact): array
+    {
+        if (! method_exists($artifact, 'toArray')) {
+            throw new \RuntimeException('invalid projected rollout wave-plan artifact');
+        }
+
+        /** @var mixed $payload */
+        $payload = $artifact->toArray();
+        if (! is_array($payload)) {
+            throw new \RuntimeException('projected rollout wave-plan artifact payload is not an array');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateArtifactPayload(array $payload): void
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode rollout wave-plan artifact json');
+        }
+
+        $decoded = json_decode($encoded, true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('rollout wave-plan artifact json round-trip decode failed');
+        }
+
+        if (($decoded['artifact_kind'] ?? null) !== 'career_rollout_wave_plan') {
+            throw new \RuntimeException('invalid artifact_kind for rollout wave-plan artifact');
+        }
+
+        $slugs = collect((array) ($decoded['members'] ?? []))
+            ->map(static fn (array $row): string => trim((string) ($row['canonical_slug'] ?? '')))
+            ->all();
+
+        if (in_array('', $slugs, true)) {
+            throw new \RuntimeException('rollout wave-plan artifact contains empty canonical_slug');
+        }
+
+        if (count(array_unique($slugs)) !== count($slugs)) {
+            throw new \RuntimeException('rollout wave-plan artifact contains duplicate canonical_slug values');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJsonFile(string $path, array $payload): void
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode json: '.$path);
+        }
+
+        File::put($path, $encoded.PHP_EOL);
+    }
+
+    private function normalizeTimestamp(?string $timestamp): string
+    {
+        $value = trim((string) $timestamp);
+        if ($value === '') {
+            $value = now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $value)) {
+            throw new \RuntimeException('invalid timestamp segment for rollout wave-plan artifact export');
+        }
+
+        return $value;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T08:04:13Z",
+  "updated_at": "2026-04-15T08:26:51Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1378,9 +1378,9 @@
     "PR-B58": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "github_checks_failed",
+      "status": "merged",
       "branch": "codex/pr-b58-career-first-wave-rollout-wave-plan-artifact-projection-cohort-whitelist-projection",
-      "commit_sha": "e9c05c17948381ad1117cacc6588d0382386e4a3",
+      "commit_sha": "0540b40b1dbf131517cf32d2e6332c9f564db87e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/903",
       "checks": {
         "local": [
@@ -1424,7 +1424,41 @@
           }
         ]
       },
-      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B58 verification passed.",
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-15T08:20:41Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B59": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b59-career-first-wave-rollout-wave-plan-artifact-materialization-export-command",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationService.php app/Console/Commands/CareerExportFirstWaveRolloutWavePlanArtifact.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutWavePlanArtifactCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutWavePlanArtifactCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T08:31:53Z",
+  "updated_at": "2026-04-15T08:32:49Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1435,7 +1435,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "github_checks_failed",
       "branch": "codex/pr-b59-career-first-wave-rollout-wave-plan-artifact-materialization-export-command",
-      "commit_sha": "0e675c7808752ab50628ea94c6a35da6a1775716",
+      "commit_sha": "fd42bdd5624a297cacd38599b630d3f667fa17ab",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/904",
       "checks": {
         "local": [
@@ -1460,22 +1460,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444542246/job/71417393732"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444581283/job/71417524630"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444519050/job/71417314673"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444579395/job/71417519174"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444542246/job/71417401778"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444581283/job/71417532722"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444519050/job/71417325496"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444579395/job/71417525895"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T08:26:51Z",
+  "updated_at": "2026-04-15T08:31:53Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1433,10 +1433,10 @@
     "PR-B59": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b59-career-first-wave-rollout-wave-plan-artifact-materialization-export-command",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "0e675c7808752ab50628ea94c6a35da6a1775716",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/904",
       "checks": {
         "local": [
           {
@@ -1456,9 +1456,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444542246/job/71417393732"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444519050/job/71417314673"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444542246/job/71417401778"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24444519050/job/71417325496"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B59 verification passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -866,6 +866,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B59
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b59-career-first-wave-rollout-wave-plan-artifact-materialization-export-command
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave rollout wave-plan artifact materialization / export command.
+      Add an internal-only materialization service and export command that persist
+      the B58 projected rollout wave-plan artifact to internal storage with
+      temp-directory validation and atomic finalize semantics, without changing B58
+      payload shape or introducing public API/OpenAPI/frontend surfaces.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationService.php app/Console/Commands/CareerExportFirstWaveRolloutWavePlanArtifact.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutWavePlanArtifactCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutWavePlanArtifactCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Console/CareerExportFirstWaveRolloutWavePlanArtifactCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportFirstWaveRolloutWavePlanArtifactCommandTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Services\Career\CareerFirstWaveRolloutWavePlanArtifactMaterializationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerExportFirstWaveRolloutWavePlanArtifactCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = storage_path(CareerFirstWaveRolloutWavePlanArtifactMaterializationService::OUTPUT_ROOT);
+        File::deleteDirectory($this->rootDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->rootDir);
+
+        parent::tearDown();
+    }
+
+    public function test_command_exports_rollout_wave_plan_artifact_to_internal_storage(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T111000Z';
+        $this->artisan('career:export-first-wave-rollout-wave-plan-artifact', [
+            '--timestamp' => $timestamp,
+        ])
+            ->expectsOutputToContain('status=materialized')
+            ->expectsOutputToContain('output_dir=')
+            ->expectsOutputToContain('career-rollout-wave-plan=')
+            ->assertExitCode(0);
+
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $artifactPath = $finalDir.DIRECTORY_SEPARATOR.'career-rollout-wave-plan.json';
+
+        $this->assertDirectoryExists($finalDir);
+        $this->assertFileExists($artifactPath);
+        $this->assertStringStartsWith($this->rootDir, $finalDir);
+        $this->assertStringStartsWith(storage_path('app/private'), $artifactPath);
+        $this->assertStringNotContainsString(base_path('docs'), $finalDir);
+        $this->assertStringNotContainsString(base_path('public'), $finalDir);
+    }
+
+    public function test_command_can_emit_json_summary(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T111100Z';
+        $exitCode = Artisan::call('career:export-first-wave-rollout-wave-plan-artifact', [
+            '--timestamp' => $timestamp,
+            '--json' => true,
+        ]);
+        $output = trim((string) Artisan::output());
+        $payload = json_decode($output, true);
+
+        $this->assertSame(0, $exitCode, $output);
+        $this->assertIsArray($payload);
+        $this->assertSame('materialized', $payload['status'] ?? null);
+        $this->assertArrayHasKey('output_dir', $payload);
+        $this->assertArrayHasKey('artifacts', $payload);
+        $this->assertArrayHasKey('career-rollout-wave-plan.json', $payload['artifacts']);
+        $this->assertFileExists((string) $payload['artifacts']['career-rollout-wave-plan.json']);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRolloutWavePlanArtifactProjectionService;
+use App\DTO\Career\CareerFirstWaveRolloutWavePlanArtifact;
+use App\Services\Career\CareerFirstWaveRolloutWavePlanArtifactMaterializationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = storage_path(CareerFirstWaveRolloutWavePlanArtifactMaterializationService::OUTPUT_ROOT);
+        File::deleteDirectory($this->rootDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->rootDir);
+
+        parent::tearDown();
+    }
+
+    public function test_it_materializes_rollout_wave_plan_artifact_with_atomic_finalize(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T110000Z';
+        $service = app(CareerFirstWaveRolloutWavePlanArtifactMaterializationService::class);
+        $result = $service->materialize($timestamp);
+
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+        $artifactPath = $finalDir.DIRECTORY_SEPARATOR.'career-rollout-wave-plan.json';
+
+        $this->assertSame('materialized', $result['status']);
+        $this->assertSame($finalDir, $result['output_dir']);
+        $this->assertSame($artifactPath, $result['artifacts']['career-rollout-wave-plan.json']);
+        $this->assertDirectoryExists($finalDir);
+        $this->assertDirectoryDoesNotExist($tmpDir);
+        $this->assertFileExists($artifactPath);
+
+        $payload = json_decode((string) File::get($artifactPath), true);
+        $this->assertIsArray($payload);
+
+        $expected = app(CareerFirstWaveRolloutWavePlanArtifactProjectionService::class)->build()->toArray();
+        $this->assertSame($expected, $payload);
+    }
+
+    public function test_it_fails_when_output_directory_already_exists_without_finalize(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T110100Z';
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+        File::ensureDirectoryExists($finalDir);
+
+        $service = app(CareerFirstWaveRolloutWavePlanArtifactMaterializationService::class);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('output dir already exists');
+
+        try {
+            $service->materialize($timestamp);
+        } finally {
+            $this->assertDirectoryExists($finalDir);
+            $this->assertDirectoryDoesNotExist($tmpDir);
+            $this->assertFileDoesNotExist($finalDir.DIRECTORY_SEPARATOR.'career-rollout-wave-plan.json');
+        }
+    }
+
+    public function test_it_rejects_invalid_projection_without_finalizing_directory(): void
+    {
+        $badService = new class(app(CareerFirstWaveRolloutWavePlanArtifactProjectionService::class)) extends CareerFirstWaveRolloutWavePlanArtifactMaterializationService
+        {
+            protected function projectedArtifact(): object
+            {
+                return new CareerFirstWaveRolloutWavePlanArtifact(
+                    scope: 'career_first_wave_10',
+                    counts: ['stable' => 1, 'candidate' => 0, 'hold' => 0, 'blocked' => 0, 'manual_review_needed' => 0],
+                    cohorts: ['stable' => ['registered-nurses'], 'candidate' => [], 'hold' => [], 'blocked' => []],
+                    advisory: ['manual_review_needed' => []],
+                    members: [
+                        [
+                            'canonical_slug' => '',
+                            'rollout_cohort' => 'stable',
+                            'launch_tier' => 'stable',
+                            'readiness_status' => 'publish_ready',
+                            'lifecycle_state' => 'indexed',
+                            'public_index_state' => 'indexable',
+                            'supporting_routes' => [
+                                'family_hub' => true,
+                                'next_step_links_count' => 1,
+                            ],
+                            'trust_freshness' => [
+                                'review_due_known' => false,
+                                'review_staleness_state' => 'unknown_due_date',
+                            ],
+                        ],
+                    ],
+                );
+            }
+        };
+
+        $timestamp = '20260415T110200Z';
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('contains empty canonical_slug');
+
+        try {
+            $badService->materialize($timestamp);
+        } finally {
+            $this->assertDirectoryDoesNotExist($finalDir);
+            $this->assertDirectoryDoesNotExist($tmpDir);
+        }
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What Changed
- Added `CareerFirstWaveRolloutWavePlanArtifactMaterializationService` to materialize the B58 rollout artifact into internal storage only.
- Added `career:export-first-wave-rollout-wave-plan-artifact` command with `--timestamp` and `--json` options.
- Registered the new command in `app/Console/Kernel.php`.
- Added focused tests:
  - `CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest`
  - `CareerExportFirstWaveRolloutWavePlanArtifactCommandTest`
- Updated train ledger:
  - added `PR-B59` in `docs/codex/pr-train.yaml`
  - corrected `PR-B58` as merged and initialized/updated `PR-B59` state in `docs/codex/pr-train-state.json`

## Why
B58 already provides an export-safe internal projection (`career-rollout-wave-plan.json`) but does not materialize it. This PR adds a safe, repeatable, internal-only export path with atomic finalize semantics, without changing B57/B58 payload semantics.

## Implementation Notes
- Output path scheme:
  - `storage/app/private/career_rollout_wave_plan_artifacts/<timestamp>.tmp/career-rollout-wave-plan.json`
  - finalize to `storage/app/private/career_rollout_wave_plan_artifacts/<timestamp>/career-rollout-wave-plan.json`
- Default overwrite policy: fail when target `<timestamp>` directory already exists.
- Validation before finalize:
  - JSON encode success
  - JSON round-trip decode success
  - `artifact_kind === career_rollout_wave_plan`
  - `members[*].canonical_slug` non-empty and unique
- Payload contract is unchanged from B58 projection (`toArray()` output is written directly).

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationService.php app/Console/Commands/CareerExportFirstWaveRolloutWavePlanArtifact.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutWavePlanArtifactCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutWavePlanArtifactCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php`

## Intentionally Deferred
- No `--force` overwrite option in v1.
- No additional metadata fields inside artifact JSON payload.
- No public API/OpenAPI/frontend changes.
