### PR TITLE
PR-B60: Career first-wave rollout bundle / cohort whitelist projection

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveRolloutBundleArtifact.php
+++ b/backend/app/DTO/Career/CareerFirstWaveRolloutBundleArtifact.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveRolloutBundleArtifact
+{
+    /**
+     * @param  array{stable:int,candidate:int,hold:int,blocked:int,manual_review_needed:int}  $counts
+     * @param  array{stable:list<string>,candidate:list<string>,hold:list<string>,blocked:list<string>}  $cohorts
+     * @param  array{manual_review_needed:list<string>}  $advisory
+     * @param  list<array<string, mixed>>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $cohorts,
+        public readonly array $advisory,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'artifact_kind' => 'career_rollout_bundle',
+            'artifact_version' => 'career.rollout_bundle.export.v1',
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'cohorts' => $this->cohorts,
+            'advisory' => $this->advisory,
+            'members' => $this->members,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveRolloutCohortListArtifact.php
+++ b/backend/app/DTO/Career/CareerFirstWaveRolloutCohortListArtifact.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveRolloutCohortListArtifact
+{
+    /**
+     * @param  list<string>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly string $cohort,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'artifact_kind' => 'career_rollout_cohort_list',
+            'artifact_version' => 'career.rollout_cohort_list.export.v1',
+            'scope' => $this->scope,
+            'cohort' => $this->cohort,
+            'members' => $this->members,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveRolloutBundleProjectionService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveRolloutBundleProjectionService.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\DTO\Career\CareerFirstWaveRolloutBundleArtifact;
+use App\DTO\Career\CareerFirstWaveRolloutCohortListArtifact;
+
+final class CareerFirstWaveRolloutBundleProjectionService
+{
+    public const BUNDLE_FILENAME = 'career-rollout-bundle.json';
+
+    public const STABLE_LIST_FILENAME = 'career-stable-whitelist.json';
+
+    public const CANDIDATE_LIST_FILENAME = 'career-candidate-whitelist.json';
+
+    public const HOLD_LIST_FILENAME = 'career-hold-list.json';
+
+    public const BLOCKED_LIST_FILENAME = 'career-blocked-list.json';
+
+    public function __construct(
+        private readonly CareerFirstWaveRolloutWavePlanArtifactProjectionService $rolloutArtifactProjectionService,
+    ) {}
+
+    /**
+     * @return array{
+     *   career-rollout-bundle.json: CareerFirstWaveRolloutBundleArtifact,
+     *   career-stable-whitelist.json: CareerFirstWaveRolloutCohortListArtifact,
+     *   career-candidate-whitelist.json: CareerFirstWaveRolloutCohortListArtifact,
+     *   career-hold-list.json: CareerFirstWaveRolloutCohortListArtifact,
+     *   career-blocked-list.json: CareerFirstWaveRolloutCohortListArtifact
+     * }
+     */
+    public function build(): array
+    {
+        $rolloutArtifact = $this->rolloutArtifactProjectionService->build()->toArray();
+
+        $cohorts = [
+            'stable' => array_values((array) data_get($rolloutArtifact, 'cohorts.stable', [])),
+            'candidate' => array_values((array) data_get($rolloutArtifact, 'cohorts.candidate', [])),
+            'hold' => array_values((array) data_get($rolloutArtifact, 'cohorts.hold', [])),
+            'blocked' => array_values((array) data_get($rolloutArtifact, 'cohorts.blocked', [])),
+        ];
+
+        $members = array_map(function (array $member): array {
+            $trustFreshness = null;
+            if (is_array($member['trust_freshness'] ?? null)) {
+                $trustFreshness = [
+                    'review_due_known' => (bool) data_get($member, 'trust_freshness.review_due_known', false),
+                    'review_staleness_state' => (string) data_get($member, 'trust_freshness.review_staleness_state', 'unknown_due_date'),
+                ];
+            }
+
+            return [
+                'canonical_slug' => (string) ($member['canonical_slug'] ?? ''),
+                'rollout_cohort' => (string) ($member['rollout_cohort'] ?? ''),
+                'launch_tier' => (string) ($member['launch_tier'] ?? ''),
+                'readiness_status' => (string) ($member['readiness_status'] ?? ''),
+                'lifecycle_state' => (string) ($member['lifecycle_state'] ?? ''),
+                'public_index_state' => (string) ($member['public_index_state'] ?? ''),
+                'supporting_routes' => [
+                    'family_hub' => (bool) data_get($member, 'supporting_routes.family_hub', false),
+                    'next_step_links_count' => (int) data_get($member, 'supporting_routes.next_step_links_count', 0),
+                ],
+                'trust_freshness' => $trustFreshness,
+            ];
+        }, (array) ($rolloutArtifact['members'] ?? []));
+
+        $scope = (string) ($rolloutArtifact['scope'] ?? '');
+
+        return [
+            self::BUNDLE_FILENAME => new CareerFirstWaveRolloutBundleArtifact(
+                scope: $scope,
+                counts: [
+                    'stable' => (int) data_get($rolloutArtifact, 'counts.stable', 0),
+                    'candidate' => (int) data_get($rolloutArtifact, 'counts.candidate', 0),
+                    'hold' => (int) data_get($rolloutArtifact, 'counts.hold', 0),
+                    'blocked' => (int) data_get($rolloutArtifact, 'counts.blocked', 0),
+                    'manual_review_needed' => (int) data_get($rolloutArtifact, 'counts.manual_review_needed', 0),
+                ],
+                cohorts: $cohorts,
+                advisory: [
+                    'manual_review_needed' => array_values((array) data_get($rolloutArtifact, 'advisory.manual_review_needed', [])),
+                ],
+                members: $members,
+            ),
+            self::STABLE_LIST_FILENAME => new CareerFirstWaveRolloutCohortListArtifact(
+                scope: $scope,
+                cohort: 'stable',
+                members: $cohorts['stable'],
+            ),
+            self::CANDIDATE_LIST_FILENAME => new CareerFirstWaveRolloutCohortListArtifact(
+                scope: $scope,
+                cohort: 'candidate',
+                members: $cohorts['candidate'],
+            ),
+            self::HOLD_LIST_FILENAME => new CareerFirstWaveRolloutCohortListArtifact(
+                scope: $scope,
+                cohort: 'hold',
+                members: $cohorts['hold'],
+            ),
+            self::BLOCKED_LIST_FILENAME => new CareerFirstWaveRolloutCohortListArtifact(
+                scope: $scope,
+                cohort: 'blocked',
+                members: $cohorts['blocked'],
+            ),
+        ];
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T08:32:49Z",
+  "updated_at": "2026-04-15T09:00:56Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1433,9 +1433,9 @@
     "PR-B59": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "github_checks_failed",
+      "status": "merged",
       "branch": "codex/pr-b59-career-first-wave-rollout-wave-plan-artifact-materialization-export-command",
-      "commit_sha": "fd42bdd5624a297cacd38599b630d3f667fa17ab",
+      "commit_sha": "6b816a246f8ce547c17025b4af261559a4c5d6ee",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/904",
       "checks": {
         "local": [
@@ -1479,7 +1479,41 @@
           }
         ]
       },
-      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B59 verification passed.",
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-15T08:55:44Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B60": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b60-career-first-wave-rollout-bundle-cohort-whitelist-projection",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRolloutBundleProjectionService.php app/DTO/Career/CareerFirstWaveRolloutBundleArtifact.php app/DTO/Career/CareerFirstWaveRolloutCohortListArtifact.php tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T09:03:38Z",
+  "updated_at": "2026-04-15T09:04:20Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1490,7 +1490,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "github_checks_failed",
       "branch": "codex/pr-b60-career-first-wave-rollout-bundle-cohort-whitelist-projection",
-      "commit_sha": "a8d43e03802201e24f6594d7a61e8dd53032af50",
+      "commit_sha": "99b58894fc3768e904ed67aca1b8bee6f149fad3",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/905",
       "checks": {
         "local": [
@@ -1515,22 +1515,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445889840/job/71422018862"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445932223/job/71422164767"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445868604/job/71421945604"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445930308/job/71422158911"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445889840/job/71422027799"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445932223/job/71422173420"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445868604/job/71421954980"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445930308/job/71422171686"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T09:00:56Z",
+  "updated_at": "2026-04-15T09:03:38Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1488,10 +1488,10 @@
     "PR-B60": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b60-career-first-wave-rollout-bundle-cohort-whitelist-projection",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "a8d43e03802201e24f6594d7a61e8dd53032af50",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/905",
       "checks": {
         "local": [
           {
@@ -1511,9 +1511,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445889840/job/71422018862"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445868604/job/71421945604"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445889840/job/71422027799"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24445868604/job/71421954980"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B60 verification passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -894,6 +894,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B60
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b60-career-first-wave-rollout-bundle-cohort-whitelist-projection
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave rollout bundle / cohort whitelist projection.
+      Add an internal-only projection layer that exports one rollout bundle artifact
+      plus four primary cohort whitelist/list artifacts derived from B57/B58 service
+      truth, while keeping manual_review_needed advisory-only and family hubs as
+      supporting evidence only.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRolloutBundleProjectionService.php app/DTO/Career/CareerFirstWaveRolloutBundleArtifact.php app/DTO/Career/CareerFirstWaveRolloutCohortListArtifact.php tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRolloutBundleProjectionService;
+use App\Domain\Career\Publish\CareerFirstWaveRolloutWavePlanArtifactProjectionService;
+use App\Models\Occupation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerFirstWaveRolloutBundleProjectionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_projects_rollout_bundle_and_primary_cohort_lists_from_single_truth_source(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $projected = app(CareerFirstWaveRolloutBundleProjectionService::class)->build();
+
+        $this->assertSame([
+            'career-rollout-bundle.json',
+            'career-stable-whitelist.json',
+            'career-candidate-whitelist.json',
+            'career-hold-list.json',
+            'career-blocked-list.json',
+        ], array_keys($projected));
+
+        $bundle = $projected['career-rollout-bundle.json']->toArray();
+        $stableList = $projected['career-stable-whitelist.json']->toArray();
+        $candidateList = $projected['career-candidate-whitelist.json']->toArray();
+        $holdList = $projected['career-hold-list.json']->toArray();
+        $blockedList = $projected['career-blocked-list.json']->toArray();
+
+        $b58Artifact = app(CareerFirstWaveRolloutWavePlanArtifactProjectionService::class)->build()->toArray();
+        $bundleMembers = collect($bundle['members'])->keyBy('canonical_slug');
+        $registeredNurses = $bundleMembers->get('registered-nurses');
+
+        $this->assertSame('career_rollout_bundle', $bundle['artifact_kind']);
+        $this->assertSame('career.rollout_bundle.export.v1', $bundle['artifact_version']);
+        $this->assertSame('career_first_wave_10', $bundle['scope']);
+        $this->assertSame(['stable', 'candidate', 'hold', 'blocked', 'manual_review_needed'], array_keys($bundle['counts']));
+        $this->assertSame(['stable', 'candidate', 'hold', 'blocked'], array_keys($bundle['cohorts']));
+        $this->assertSame(['manual_review_needed'], array_keys($bundle['advisory']));
+        $this->assertSame($b58Artifact['counts'], $bundle['counts']);
+        $this->assertSame($b58Artifact['cohorts'], $bundle['cohorts']);
+        $this->assertSame($b58Artifact['advisory'], $bundle['advisory']);
+
+        $this->assertIsArray($registeredNurses);
+        $this->assertSame([
+            'canonical_slug',
+            'rollout_cohort',
+            'launch_tier',
+            'readiness_status',
+            'lifecycle_state',
+            'public_index_state',
+            'supporting_routes',
+            'trust_freshness',
+        ], array_keys($registeredNurses));
+        $this->assertSame([
+            'family_hub',
+            'next_step_links_count',
+        ], array_keys($registeredNurses['supporting_routes']));
+        $this->assertSame([
+            'review_due_known',
+            'review_staleness_state',
+        ], array_keys($registeredNurses['trust_freshness']));
+        $this->assertArrayNotHasKey('member_kind', $registeredNurses);
+        $this->assertArrayNotHasKey('defer_reasons', $registeredNurses);
+        $this->assertArrayNotHasKey('blockers', $registeredNurses);
+        $this->assertArrayNotHasKey('evidence_refs', $registeredNurses);
+        $this->assertArrayNotHasKey('reviewed_at', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('next_review_due_at', $registeredNurses['trust_freshness']);
+        $this->assertArrayNotHasKey('review_freshness_basis', $registeredNurses['trust_freshness']);
+
+        $this->assertSame('career_rollout_cohort_list', $stableList['artifact_kind']);
+        $this->assertSame('career.rollout_cohort_list.export.v1', $stableList['artifact_version']);
+        $this->assertSame('career_first_wave_10', $stableList['scope']);
+        $this->assertSame('stable', $stableList['cohort']);
+        $this->assertSame($bundle['cohorts']['stable'], $stableList['members']);
+
+        $this->assertSame('candidate', $candidateList['cohort']);
+        $this->assertSame($bundle['cohorts']['candidate'], $candidateList['members']);
+        $this->assertSame('hold', $holdList['cohort']);
+        $this->assertSame($bundle['cohorts']['hold'], $holdList['members']);
+        $this->assertSame('blocked', $blockedList['cohort']);
+        $this->assertSame($bundle['cohorts']['blocked'], $blockedList['members']);
+    }
+
+    public function test_it_keeps_manual_review_needed_advisory_only_without_primary_list_projection(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'crosswalk_mode' => 'direct_match',
+        ]);
+        $candidate->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewed_at' => now()->subDay(),
+            'next_review_due_at' => now()->subMinute(),
+        ]);
+
+        $projected = app(CareerFirstWaveRolloutBundleProjectionService::class)->build();
+        $bundle = $projected['career-rollout-bundle.json']->toArray();
+
+        $this->assertArrayNotHasKey('manual_review_needed', $bundle['cohorts']);
+        $this->assertContains('data-scientists', $bundle['advisory']['manual_review_needed']);
+        $this->assertGreaterThan(0, $bundle['counts']['manual_review_needed']);
+        $this->assertArrayNotHasKey('career-manual-review-needed.json', $projected);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}


### PR DESCRIPTION
## What changed
- Added `CareerFirstWaveRolloutBundleProjectionService` to project one internal rollout bundle and four primary cohort list artifacts from rollout authority truth.
- Added DTOs:
  - `CareerFirstWaveRolloutBundleArtifact`
  - `CareerFirstWaveRolloutCohortListArtifact`
- Added focused test:
  - `CareerFirstWaveRolloutBundleProjectionServiceTest`
- Updated train ledger:
  - added `PR-B60` in `docs/codex/pr-train.yaml`
  - corrected `PR-B59` as merged/synced and initialized/updated `PR-B60` in `docs/codex/pr-train-state.json`

## Why
B57/B58 already provide stable rollout truth, but there is no single projection output for internal bundle + primary cohort slug lists. This PR adds that projection-only layer for governance/manual review/batch progression consumption, without changing rollout semantics.

## Projection outputs
- `career-rollout-bundle.json`
- `career-stable-whitelist.json`
- `career-candidate-whitelist.json`
- `career-hold-list.json`
- `career-blocked-list.json`

## Guardrails preserved
- first-wave `career_job_detail` only
- family hub stays supporting evidence only (`supporting_routes.family_hub`)
- `manual_review_needed` stays advisory only (in `counts` + `advisory`, not primary cohorts)
- no public API / OpenAPI / frontend changes
- no runtime smoke/final approval semantics
- no read-back from B59 materialized JSON as source-of-truth

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveRolloutBundleProjectionService.php app/DTO/Career/CareerFirstWaveRolloutBundleArtifact.php app/DTO/Career/CareerFirstWaveRolloutCohortListArtifact.php tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php`

## Intentionally deferred
- No materialization/command changes in B60 (projection-only scope).
- No separate `career-manual-review-needed.json` file.
