### PR TITLE
PR-B61: Career first-wave rollout bundle / cohort whitelist materialization / export command

### DIFF
--- a/backend/app/Console/Commands/CareerExportFirstWaveRolloutBundleArtifacts.php
+++ b/backend/app/Console/Commands/CareerExportFirstWaveRolloutBundleArtifacts.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Career\CareerFirstWaveRolloutBundleArtifactMaterializationService;
+use Illuminate\Console\Command;
+
+final class CareerExportFirstWaveRolloutBundleArtifacts extends Command
+{
+    protected $signature = 'career:export-first-wave-rollout-bundle-artifacts
+        {--timestamp= : Optional output directory timestamp segment}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Materialize internal first-wave rollout bundle/list artifacts to storage/app/private/career_rollout_bundle_artifacts in one atomic export.';
+
+    public function __construct(
+        private readonly CareerFirstWaveRolloutBundleArtifactMaterializationService $materializationService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $payload = $this->materializationService->materialize(
+                $this->option('timestamp') !== null ? (string) $this->option('timestamp') : null,
+            );
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                $this->error('failed to encode export payload json');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+
+            return self::SUCCESS;
+        }
+
+        $this->line('status='.(string) ($payload['status'] ?? ''));
+        $this->line('output_dir='.(string) ($payload['output_dir'] ?? ''));
+        $this->line('career-rollout-bundle='.(string) data_get($payload, 'artifacts.career-rollout-bundle.json', ''));
+        $this->line('career-stable-whitelist='.(string) data_get($payload, 'artifacts.career-stable-whitelist.json', ''));
+        $this->line('career-candidate-whitelist='.(string) data_get($payload, 'artifacts.career-candidate-whitelist.json', ''));
+        $this->line('career-hold-list='.(string) data_get($payload, 'artifacts.career-hold-list.json', ''));
+        $this->line('career-blocked-list='.(string) data_get($payload, 'artifacts.career-blocked-list.json', ''));
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -9,6 +9,7 @@ use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerCompileAuthorityWave;
+use App\Console\Commands\CareerExportFirstWaveRolloutBundleArtifacts;
 use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutWavePlanArtifact;
 use App\Console\Commands\CareerImportAuthorityWave;
@@ -132,6 +133,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPostCommitFailed::class,
         CareerImportAuthorityWave::class,
         CareerCompileAuthorityWave::class,
+        CareerExportFirstWaveRolloutBundleArtifacts::class,
         CareerExportFirstWaveReleaseArtifacts::class,
         CareerExportFirstWaveRolloutWavePlanArtifact::class,
         RefreshCareerAttributionDailyCommand::class,

--- a/backend/app/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationService.php
+++ b/backend/app/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationService.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRolloutBundleProjectionService;
+use Illuminate\Support\Facades\File;
+
+class CareerFirstWaveRolloutBundleArtifactMaterializationService
+{
+    public const OUTPUT_ROOT = 'app/private/career_rollout_bundle_artifacts';
+
+    public function __construct(
+        private readonly CareerFirstWaveRolloutBundleProjectionService $projectionService,
+    ) {}
+
+    /**
+     * @return array{
+     *   status:string,
+     *   output_dir:string,
+     *   artifacts:array{
+     *     career-rollout-bundle.json:string,
+     *     career-stable-whitelist.json:string,
+     *     career-candidate-whitelist.json:string,
+     *     career-hold-list.json:string,
+     *     career-blocked-list.json:string
+     *   }
+     * }
+     */
+    public function materialize(?string $timestamp = null): array
+    {
+        $normalizedTimestamp = $this->normalizeTimestamp($timestamp);
+        $rootDir = storage_path(self::OUTPUT_ROOT);
+        $finalDir = $rootDir.DIRECTORY_SEPARATOR.$normalizedTimestamp;
+        $tmpDir = $finalDir.'.tmp';
+
+        if (is_dir($finalDir)) {
+            throw new \RuntimeException('rollout bundle artifact output dir already exists: '.$finalDir);
+        }
+        if (is_dir($tmpDir)) {
+            throw new \RuntimeException('rollout bundle artifact temp dir already exists: '.$tmpDir);
+        }
+
+        $projected = $this->projectedArtifacts();
+        $this->validateProjectedFilenameSet($projected);
+
+        $payloads = [];
+        foreach ($this->expectedFilenames() as $filename) {
+            $payloads[$filename] = $this->extractArtifactPayload($projected, $filename);
+        }
+
+        $this->validateArtifactPayloads($payloads);
+
+        File::ensureDirectoryExists($tmpDir);
+
+        try {
+            foreach ($payloads as $filename => $payload) {
+                $this->writeJsonFile($tmpDir.DIRECTORY_SEPARATOR.$filename, $payload);
+            }
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize rollout bundle artifact directory: '.$finalDir);
+            }
+        } catch (\Throwable $e) {
+            if (is_dir($tmpDir)) {
+                File::deleteDirectory($tmpDir);
+            }
+
+            throw $e;
+        }
+
+        return [
+            'status' => 'materialized',
+            'output_dir' => $finalDir,
+            'artifacts' => collect($this->expectedFilenames())
+                ->mapWithKeys(fn (string $filename): array => [$filename => $finalDir.DIRECTORY_SEPARATOR.$filename])
+                ->all(),
+        ];
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    protected function projectedArtifacts(): array
+    {
+        return $this->projectionService->build();
+    }
+
+    /**
+     * @param  array<string, object>  $projected
+     */
+    private function validateProjectedFilenameSet(array $projected): void
+    {
+        $actual = array_values(array_keys($projected));
+        sort($actual);
+
+        $expected = $this->expectedFilenames();
+        sort($expected);
+
+        if ($actual !== $expected) {
+            throw new \RuntimeException('projected rollout bundle artifacts filename set is invalid');
+        }
+    }
+
+    /**
+     * @param  array<string, object>  $projected
+     * @return array<string, mixed>
+     */
+    private function extractArtifactPayload(array $projected, string $filename): array
+    {
+        $artifact = $projected[$filename] ?? null;
+        if (! is_object($artifact) || ! method_exists($artifact, 'toArray')) {
+            throw new \RuntimeException('invalid projected artifact for '.$filename);
+        }
+
+        /** @var mixed $payload */
+        $payload = $artifact->toArray();
+        if (! is_array($payload)) {
+            throw new \RuntimeException('projected artifact payload is not an array for '.$filename);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $payloads
+     */
+    private function validateArtifactPayloads(array $payloads): void
+    {
+        foreach ($this->expectedFilenames() as $filename) {
+            $encoded = json_encode($payloads[$filename], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                throw new \RuntimeException('failed to encode json for '.$filename);
+            }
+
+            $decoded = json_decode($encoded, true);
+            if (! is_array($decoded)) {
+                throw new \RuntimeException('json round-trip decode failed for '.$filename);
+            }
+        }
+
+        $bundle = $payloads[CareerFirstWaveRolloutBundleProjectionService::BUNDLE_FILENAME] ?? [];
+        $stable = $payloads[CareerFirstWaveRolloutBundleProjectionService::STABLE_LIST_FILENAME] ?? [];
+        $candidate = $payloads[CareerFirstWaveRolloutBundleProjectionService::CANDIDATE_LIST_FILENAME] ?? [];
+        $hold = $payloads[CareerFirstWaveRolloutBundleProjectionService::HOLD_LIST_FILENAME] ?? [];
+        $blocked = $payloads[CareerFirstWaveRolloutBundleProjectionService::BLOCKED_LIST_FILENAME] ?? [];
+
+        $bundleStable = $this->normalizedSlugList((array) data_get($bundle, 'cohorts.stable', []), 'bundle.cohorts.stable');
+        $bundleCandidate = $this->normalizedSlugList((array) data_get($bundle, 'cohorts.candidate', []), 'bundle.cohorts.candidate');
+        $bundleHold = $this->normalizedSlugList((array) data_get($bundle, 'cohorts.hold', []), 'bundle.cohorts.hold');
+        $bundleBlocked = $this->normalizedSlugList((array) data_get($bundle, 'cohorts.blocked', []), 'bundle.cohorts.blocked');
+
+        $stableMembers = $this->normalizedSlugList((array) ($stable['members'] ?? []), 'stable.members');
+        $candidateMembers = $this->normalizedSlugList((array) ($candidate['members'] ?? []), 'candidate.members');
+        $holdMembers = $this->normalizedSlugList((array) ($hold['members'] ?? []), 'hold.members');
+        $blockedMembers = $this->normalizedSlugList((array) ($blocked['members'] ?? []), 'blocked.members');
+
+        if ($bundleStable !== $stableMembers) {
+            throw new \RuntimeException('bundle/list slug mismatch for stable cohort');
+        }
+        if ($bundleCandidate !== $candidateMembers) {
+            throw new \RuntimeException('bundle/list slug mismatch for candidate cohort');
+        }
+        if ($bundleHold !== $holdMembers) {
+            throw new \RuntimeException('bundle/list slug mismatch for hold cohort');
+        }
+        if ($bundleBlocked !== $blockedMembers) {
+            throw new \RuntimeException('bundle/list slug mismatch for blocked cohort');
+        }
+
+        $membersByCohort = collect((array) ($bundle['members'] ?? []))
+            ->groupBy(static fn (array $member): string => (string) ($member['rollout_cohort'] ?? ''))
+            ->map(static function ($rows): array {
+                return collect($rows)
+                    ->map(static fn (array $row): string => trim((string) ($row['canonical_slug'] ?? '')))
+                    ->all();
+            });
+
+        $this->assertSameSlugSet(
+            $this->normalizedSlugList((array) ($membersByCohort->get('stable', [])), 'members.stable'),
+            $bundleStable,
+            'stable'
+        );
+        $this->assertSameSlugSet(
+            $this->normalizedSlugList((array) ($membersByCohort->get('candidate', [])), 'members.candidate'),
+            $bundleCandidate,
+            'candidate'
+        );
+        $this->assertSameSlugSet(
+            $this->normalizedSlugList((array) ($membersByCohort->get('hold', [])), 'members.hold'),
+            $bundleHold,
+            'hold'
+        );
+        $this->assertSameSlugSet(
+            $this->normalizedSlugList((array) ($membersByCohort->get('blocked', [])), 'members.blocked'),
+            $bundleBlocked,
+            'blocked'
+        );
+
+        if (array_key_exists('career-manual-review-needed.json', $payloads)) {
+            throw new \RuntimeException('unexpected advisory standalone artifact detected');
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $slugs
+     * @return list<string>
+     */
+    private function normalizedSlugList(array $slugs, string $label): array
+    {
+        $normalized = array_map(
+            static fn (mixed $slug): string => trim((string) $slug),
+            array_values($slugs),
+        );
+
+        if (in_array('', $normalized, true)) {
+            throw new \RuntimeException('empty canonical_slug found in '.$label);
+        }
+
+        if (count(array_unique($normalized)) !== count($normalized)) {
+            throw new \RuntimeException('duplicate canonical_slug found in '.$label);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  list<string>  $fromMembers
+     * @param  list<string>  $fromBundle
+     */
+    private function assertSameSlugSet(array $fromMembers, array $fromBundle, string $cohort): void
+    {
+        $left = $fromMembers;
+        $right = $fromBundle;
+        sort($left);
+        sort($right);
+
+        if ($left !== $right) {
+            throw new \RuntimeException('bundle members/cohort slug mismatch for '.$cohort);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJsonFile(string $path, array $payload): void
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode json: '.$path);
+        }
+
+        File::put($path, $encoded.PHP_EOL);
+    }
+
+    /**
+     * @return array{
+     *   0:string,
+     *   1:string,
+     *   2:string,
+     *   3:string,
+     *   4:string
+     * }
+     */
+    private function expectedFilenames(): array
+    {
+        return [
+            CareerFirstWaveRolloutBundleProjectionService::BUNDLE_FILENAME,
+            CareerFirstWaveRolloutBundleProjectionService::STABLE_LIST_FILENAME,
+            CareerFirstWaveRolloutBundleProjectionService::CANDIDATE_LIST_FILENAME,
+            CareerFirstWaveRolloutBundleProjectionService::HOLD_LIST_FILENAME,
+            CareerFirstWaveRolloutBundleProjectionService::BLOCKED_LIST_FILENAME,
+        ];
+    }
+
+    private function normalizeTimestamp(?string $timestamp): string
+    {
+        $value = trim((string) $timestamp);
+        if ($value === '') {
+            $value = now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $value)) {
+            throw new \RuntimeException('invalid timestamp segment for rollout bundle artifact export');
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationService.php
+++ b/backend/app/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationService.php
@@ -169,7 +169,17 @@ class CareerFirstWaveRolloutBundleArtifactMaterializationService
             throw new \RuntimeException('bundle/list slug mismatch for blocked cohort');
         }
 
-        $membersByCohort = collect((array) ($bundle['members'] ?? []))
+        $allowedCohorts = ['stable', 'candidate', 'hold', 'blocked'];
+        $memberRows = (array) ($bundle['members'] ?? []);
+        $memberRolloutCohorts = collect($memberRows)
+            ->map(static fn (array $member): string => trim((string) ($member['rollout_cohort'] ?? '')))
+            ->values();
+
+        if ($memberRolloutCohorts->contains(static fn (string $cohort): bool => ! in_array($cohort, $allowedCohorts, true))) {
+            throw new \RuntimeException('bundle contains unexpected rollout_cohort values');
+        }
+
+        $membersByCohort = collect($memberRows)
             ->groupBy(static fn (array $member): string => (string) ($member['rollout_cohort'] ?? ''))
             ->map(static function ($rows): array {
                 return collect($rows)

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T09:21:15Z",
+  "updated_at": "2026-04-15T09:30:38Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1543,15 +1543,53 @@
     "PR-B61": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pending",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b61-career-first-wave-rollout-bundle-cohort-whitelist-materialization-export-command",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "95d64cd2684fed4ca3bbf2b069af49ae3d179f75",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/906",
       "checks": {
-        "local": [],
-        "github": []
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationService.php app/Console/Commands/CareerExportFirstWaveRolloutBundleArtifacts.php tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutBundleArtifactsCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutBundleArtifactsCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": [
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24447061361/job/71426065234"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24447061361/job/71426055743"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24447043102/job/71426002326"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24447043102/job/71425992502"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B61 verification passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T09:04:20Z",
+  "updated_at": "2026-04-15T09:21:15Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1488,7 +1488,7 @@
     "PR-B60": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "github_checks_failed",
+      "status": "merged",
       "branch": "codex/pr-b60-career-first-wave-rollout-bundle-cohort-whitelist-projection",
       "commit_sha": "99b58894fc3768e904ed67aca1b8bee6f149fad3",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/905",
@@ -1534,7 +1534,24 @@
           }
         ]
       },
-      "failure_reason": "GitHub Actions reported account billing/spending-limit blockage; hygiene failed before execution and MBTI matrix jobs were skipped, while local PR-B60 verification passed.",
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-15T09:05:59Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B61": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "pending",
+      "branch": "codex/pr-b61-career-first-wave-rollout-bundle-cohort-whitelist-materialization-export-command",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -922,6 +922,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B61
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b61-career-first-wave-rollout-bundle-cohort-whitelist-materialization-export-command
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career first-wave rollout bundle / cohort whitelist materialization / export command.
+      Add an internal-only materialization service and export command that persist
+      the B60 projected rollout bundle and four primary cohort list artifacts to
+      internal storage in one temp-directory write and atomic finalize flow,
+      without changing B60 payload shape or introducing public API/OpenAPI/frontend
+      surfaces.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationService.php app/Console/Commands/CareerExportFirstWaveRolloutBundleArtifacts.php tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutBundleArtifactsCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutBundleArtifactsCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Console/CareerExportFirstWaveRolloutBundleArtifactsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportFirstWaveRolloutBundleArtifactsCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Services\Career\CareerFirstWaveRolloutBundleArtifactMaterializationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerExportFirstWaveRolloutBundleArtifactsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = storage_path(CareerFirstWaveRolloutBundleArtifactMaterializationService::OUTPUT_ROOT);
+        File::deleteDirectory($this->rootDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->rootDir);
+
+        parent::tearDown();
+    }
+
+    public function test_command_exports_rollout_bundle_and_primary_lists_to_internal_storage(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T131000Z';
+        $this->artisan('career:export-first-wave-rollout-bundle-artifacts', [
+            '--timestamp' => $timestamp,
+        ])
+            ->expectsOutputToContain('status=materialized')
+            ->expectsOutputToContain('output_dir=')
+            ->expectsOutputToContain('career-rollout-bundle=')
+            ->expectsOutputToContain('career-stable-whitelist=')
+            ->expectsOutputToContain('career-candidate-whitelist=')
+            ->expectsOutputToContain('career-hold-list=')
+            ->expectsOutputToContain('career-blocked-list=')
+            ->assertExitCode(0);
+
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $this->assertDirectoryExists($finalDir);
+        $this->assertStringStartsWith($this->rootDir, $finalDir);
+        $this->assertStringStartsWith(storage_path('app/private'), $finalDir);
+        $this->assertStringNotContainsString(base_path('docs'), $finalDir);
+        $this->assertStringNotContainsString(base_path('public'), $finalDir);
+
+        foreach ([
+            'career-rollout-bundle.json',
+            'career-stable-whitelist.json',
+            'career-candidate-whitelist.json',
+            'career-hold-list.json',
+            'career-blocked-list.json',
+        ] as $filename) {
+            $this->assertFileExists($finalDir.DIRECTORY_SEPARATOR.$filename);
+        }
+    }
+
+    public function test_command_can_emit_json_summary(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T131100Z';
+        $exitCode = Artisan::call('career:export-first-wave-rollout-bundle-artifacts', [
+            '--timestamp' => $timestamp,
+            '--json' => true,
+        ]);
+        $output = trim((string) Artisan::output());
+        $payload = json_decode($output, true);
+
+        $this->assertSame(0, $exitCode, $output);
+        $this->assertIsArray($payload);
+        $this->assertSame('materialized', $payload['status'] ?? null);
+        $this->assertArrayHasKey('output_dir', $payload);
+        $this->assertArrayHasKey('artifacts', $payload);
+
+        foreach ([
+            'career-rollout-bundle.json',
+            'career-stable-whitelist.json',
+            'career-candidate-whitelist.json',
+            'career-hold-list.json',
+            'career-blocked-list.json',
+        ] as $filename) {
+            $this->assertArrayHasKey($filename, $payload['artifacts']);
+            $this->assertFileExists((string) $payload['artifacts'][$filename]);
+        }
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveRolloutBundleProjectionService;
+use App\DTO\Career\CareerFirstWaveRolloutBundleArtifact;
+use App\DTO\Career\CareerFirstWaveRolloutCohortListArtifact;
+use App\Services\Career\CareerFirstWaveRolloutBundleArtifactMaterializationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = storage_path(CareerFirstWaveRolloutBundleArtifactMaterializationService::OUTPUT_ROOT);
+        File::deleteDirectory($this->rootDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->rootDir);
+
+        parent::tearDown();
+    }
+
+    public function test_it_materializes_rollout_bundle_and_primary_lists_with_atomic_finalize(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T130000Z';
+        $service = app(CareerFirstWaveRolloutBundleArtifactMaterializationService::class);
+        $result = $service->materialize($timestamp);
+
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+        $expectedFiles = [
+            'career-rollout-bundle.json',
+            'career-stable-whitelist.json',
+            'career-candidate-whitelist.json',
+            'career-hold-list.json',
+            'career-blocked-list.json',
+        ];
+
+        $this->assertSame('materialized', $result['status']);
+        $this->assertSame($finalDir, $result['output_dir']);
+        $this->assertDirectoryExists($finalDir);
+        $this->assertDirectoryDoesNotExist($tmpDir);
+
+        $projection = app(CareerFirstWaveRolloutBundleProjectionService::class)->build();
+        foreach ($expectedFiles as $filename) {
+            $artifactPath = $finalDir.DIRECTORY_SEPARATOR.$filename;
+            $this->assertArrayHasKey($filename, $result['artifacts']);
+            $this->assertSame($artifactPath, $result['artifacts'][$filename]);
+            $this->assertFileExists($artifactPath);
+
+            $payload = json_decode((string) File::get($artifactPath), true);
+            $this->assertIsArray($payload);
+            $this->assertSame($projection[$filename]->toArray(), $payload);
+        }
+    }
+
+    public function test_it_fails_when_output_directory_already_exists_without_finalizing_new_output(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $timestamp = '20260415T130100Z';
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+        File::ensureDirectoryExists($finalDir);
+
+        $service = app(CareerFirstWaveRolloutBundleArtifactMaterializationService::class);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('output dir already exists');
+
+        try {
+            $service->materialize($timestamp);
+        } finally {
+            $this->assertDirectoryExists($finalDir);
+            $this->assertDirectoryDoesNotExist($tmpDir);
+            $this->assertFileDoesNotExist($finalDir.DIRECTORY_SEPARATOR.'career-rollout-bundle.json');
+            $this->assertFileDoesNotExist($finalDir.DIRECTORY_SEPARATOR.'career-stable-whitelist.json');
+            $this->assertFileDoesNotExist($finalDir.DIRECTORY_SEPARATOR.'career-candidate-whitelist.json');
+            $this->assertFileDoesNotExist($finalDir.DIRECTORY_SEPARATOR.'career-hold-list.json');
+            $this->assertFileDoesNotExist($finalDir.DIRECTORY_SEPARATOR.'career-blocked-list.json');
+        }
+    }
+
+    public function test_it_rejects_inconsistent_bundle_and_list_projection_without_finalizing(): void
+    {
+        $badService = new class(app(CareerFirstWaveRolloutBundleProjectionService::class)) extends CareerFirstWaveRolloutBundleArtifactMaterializationService
+        {
+            /**
+             * @return array<string, object>
+             */
+            protected function projectedArtifacts(): array
+            {
+                return [
+                    'career-rollout-bundle.json' => new CareerFirstWaveRolloutBundleArtifact(
+                        scope: 'career_first_wave_10',
+                        counts: [
+                            'stable' => 1,
+                            'candidate' => 0,
+                            'hold' => 0,
+                            'blocked' => 0,
+                            'manual_review_needed' => 0,
+                        ],
+                        cohorts: [
+                            'stable' => ['registered-nurses'],
+                            'candidate' => [],
+                            'hold' => [],
+                            'blocked' => [],
+                        ],
+                        advisory: [
+                            'manual_review_needed' => [],
+                        ],
+                        members: [
+                            [
+                                'canonical_slug' => 'registered-nurses',
+                                'rollout_cohort' => 'stable',
+                                'launch_tier' => 'stable',
+                                'readiness_status' => 'publish_ready',
+                                'lifecycle_state' => 'indexed',
+                                'public_index_state' => 'indexable',
+                                'supporting_routes' => [
+                                    'family_hub' => true,
+                                    'next_step_links_count' => 2,
+                                ],
+                                'trust_freshness' => [
+                                    'review_due_known' => true,
+                                    'review_staleness_state' => 'review_scheduled',
+                                ],
+                            ],
+                        ],
+                    ),
+                    'career-stable-whitelist.json' => new CareerFirstWaveRolloutCohortListArtifact(
+                        scope: 'career_first_wave_10',
+                        cohort: 'stable',
+                        members: ['software-developers'],
+                    ),
+                    'career-candidate-whitelist.json' => new CareerFirstWaveRolloutCohortListArtifact(
+                        scope: 'career_first_wave_10',
+                        cohort: 'candidate',
+                        members: [],
+                    ),
+                    'career-hold-list.json' => new CareerFirstWaveRolloutCohortListArtifact(
+                        scope: 'career_first_wave_10',
+                        cohort: 'hold',
+                        members: [],
+                    ),
+                    'career-blocked-list.json' => new CareerFirstWaveRolloutCohortListArtifact(
+                        scope: 'career_first_wave_10',
+                        cohort: 'blocked',
+                        members: [],
+                    ),
+                ];
+            }
+        };
+
+        $timestamp = '20260415T130200Z';
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('bundle/list slug mismatch for stable cohort');
+
+        try {
+            $badService->materialize($timestamp);
+        } finally {
+            $this->assertDirectoryDoesNotExist($finalDir);
+            $this->assertDirectoryDoesNotExist($tmpDir);
+        }
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php
@@ -183,6 +183,92 @@ final class CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest exten
         }
     }
 
+    public function test_it_rejects_bundle_members_with_unexpected_rollout_cohort_without_finalizing(): void
+    {
+        $badService = new class(app(CareerFirstWaveRolloutBundleProjectionService::class)) extends CareerFirstWaveRolloutBundleArtifactMaterializationService
+        {
+            /**
+             * @return array<string, object>
+             */
+            protected function projectedArtifacts(): array
+            {
+                return [
+                    'career-rollout-bundle.json' => new CareerFirstWaveRolloutBundleArtifact(
+                        scope: 'career_first_wave_10',
+                        counts: [
+                            'stable' => 0,
+                            'candidate' => 0,
+                            'hold' => 0,
+                            'blocked' => 0,
+                            'manual_review_needed' => 0,
+                        ],
+                        cohorts: [
+                            'stable' => [],
+                            'candidate' => [],
+                            'hold' => [],
+                            'blocked' => [],
+                        ],
+                        advisory: [
+                            'manual_review_needed' => [],
+                        ],
+                        members: [
+                            [
+                                'canonical_slug' => 'registered-nurses',
+                                'rollout_cohort' => 'manual_review_needed',
+                                'launch_tier' => 'stable',
+                                'readiness_status' => 'publish_ready',
+                                'lifecycle_state' => 'indexed',
+                                'public_index_state' => 'indexable',
+                                'supporting_routes' => [
+                                    'family_hub' => true,
+                                    'next_step_links_count' => 2,
+                                ],
+                                'trust_freshness' => [
+                                    'review_due_known' => true,
+                                    'review_staleness_state' => 'review_scheduled',
+                                ],
+                            ],
+                        ],
+                    ),
+                    'career-stable-whitelist.json' => new CareerFirstWaveRolloutCohortListArtifact(
+                        scope: 'career_first_wave_10',
+                        cohort: 'stable',
+                        members: [],
+                    ),
+                    'career-candidate-whitelist.json' => new CareerFirstWaveRolloutCohortListArtifact(
+                        scope: 'career_first_wave_10',
+                        cohort: 'candidate',
+                        members: [],
+                    ),
+                    'career-hold-list.json' => new CareerFirstWaveRolloutCohortListArtifact(
+                        scope: 'career_first_wave_10',
+                        cohort: 'hold',
+                        members: [],
+                    ),
+                    'career-blocked-list.json' => new CareerFirstWaveRolloutCohortListArtifact(
+                        scope: 'career_first_wave_10',
+                        cohort: 'blocked',
+                        members: [],
+                    ),
+                ];
+            }
+        };
+
+        $timestamp = '20260415T130300Z';
+        $finalDir = $this->rootDir.DIRECTORY_SEPARATOR.$timestamp;
+        $tmpDir = $finalDir.'.tmp';
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('unexpected rollout_cohort values');
+
+        try {
+            $badService->materialize($timestamp);
+        } finally {
+            $this->assertDirectoryDoesNotExist($finalDir);
+            $this->assertDirectoryDoesNotExist($tmpDir);
+        }
+    }
+
     private function materializeCurrentFirstWaveFixture(): void
     {
         $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [


### PR DESCRIPTION
## What Changed
- Added `CareerFirstWaveRolloutBundleArtifactMaterializationService` to materialize B60 projection outputs into internal storage under `storage/app/private/career_rollout_bundle_artifacts/<timestamp>/` via temp directory + atomic rename.
- Added `career:export-first-wave-rollout-bundle-artifacts` command to export all 5 artifacts in one run:
  - `career-rollout-bundle.json`
  - `career-stable-whitelist.json`
  - `career-candidate-whitelist.json`
  - `career-hold-list.json`
  - `career-blocked-list.json`
- Added strict multi-file consistency validation before finalize:
  - all 5 payloads JSON encode/decode round-trip
  - exact expected filename set
  - bundle cohort slugs equal corresponding standalone list members
  - bundle cohort/member grouping consistency
  - no standalone advisory file export
  - non-empty/unique slugs for bundle/list cohorts
- Registered command in `app/Console/Kernel.php`.
- Updated train ledger:
  - added PR-B61 to `docs/codex/pr-train.yaml`
  - corrected PR-B60 as merged/synced in `docs/codex/pr-train-state.json`
  - initialized PR-B61 state entry
- Added tests:
  - unit: materialization success/failure/consistency behavior
  - feature: command human output + `--json` output and internal path assertions

## Why
B60 already projects an internal rollout bundle + 4 primary cohort list artifacts. B61 materializes those projection contracts in a single atomic batch so internal governance/review flows can consume stable backend-owned files without changing rollout semantics or public surfaces.

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationService.php app/Console/Commands/CareerExportFirstWaveRolloutBundleArtifacts.php tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutBundleArtifactsCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutBundleArtifactMaterializationServiceTest.php tests/Feature/Console/CareerExportFirstWaveRolloutBundleArtifactsCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveRolloutBundleProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactProjectionServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanArtifactMaterializationServiceTest.php`

## Intentionally Deferred
- No `--force` overwrite mode (default remains fail-on-existing-target-dir)
- No separate advisory artifact file for `manual_review_needed`
- No changes to public API/OpenAPI/frontend
