### PR TITLE
PR-B63: Career claim-blocked attribution taxonomy refinement (backend first)

### DIFF
--- a/backend/app/Services/Analytics/CareerAttributionEventMapper.php
+++ b/backend/app/Services/Analytics/CareerAttributionEventMapper.php
@@ -32,6 +32,7 @@ final class CareerAttributionEventMapper
         'career_alias_resolution_no_result',
         'career_ready_surface_exposed',
         'career_blocked_surface_exposed',
+        'career_claim_blocked_surface_exposed',
     ];
 
     /**
@@ -92,6 +93,16 @@ final class CareerAttributionEventMapper
     ];
 
     /**
+     * @var list<string>
+     */
+    private const ALLOWED_BLOCKED_CLAIM_KINDS = [
+        'salary',
+        'strong_claim',
+        'ai_strategy',
+        'transition_recommendation',
+    ];
+
+    /**
      * @param  array<string, mixed>  $envelope
      * @return array{event_code:string,meta:array<string,mixed>,context:array<string,mixed>}
      */
@@ -141,6 +152,8 @@ final class CareerAttributionEventMapper
             'query_mode'
         );
         $subjectKey = $this->normalizeSubjectKey($payload['subject_key'] ?? null, $subjectKind);
+        $blockedClaimKind = $this->normalizeBlockedClaimKind($eventCode, $payload['blocked_claim_kind'] ?? null);
+        $this->validateClaimBlockedEventScope($eventCode, $sourcePageType, $routeFamily, $subjectKind);
 
         $meta = [
             'entry_surface' => $this->normalizeOptionalString($payload['entry_surface'] ?? null, 128) ?? 'unknown',
@@ -152,6 +165,10 @@ final class CareerAttributionEventMapper
             'subject_key' => $subjectKey,
             'query_mode' => $queryMode,
         ];
+
+        if ($blockedClaimKind !== null) {
+            $meta['blocked_claim_kind'] = $blockedClaimKind;
+        }
 
         return [
             'event_code' => $eventCode,
@@ -189,6 +206,70 @@ final class CareerAttributionEventMapper
         }
 
         return $normalized;
+    }
+
+    private function normalizeBlockedClaimKind(string $eventCode, mixed $value): ?string
+    {
+        $normalized = strtolower((string) $this->normalizeOptionalString($value, 64));
+        if ($eventCode !== 'career_claim_blocked_surface_exposed') {
+            if ($normalized === '') {
+                return null;
+            }
+
+            throw ValidationException::withMessages([
+                'payload.blocked_claim_kind' => 'payload.blocked_claim_kind is only allowed for career_claim_blocked_surface_exposed.',
+            ]);
+        }
+
+        if ($normalized === '') {
+            throw ValidationException::withMessages([
+                'payload.blocked_claim_kind' => 'payload.blocked_claim_kind is required for career_claim_blocked_surface_exposed.',
+            ]);
+        }
+
+        if (! in_array($normalized, self::ALLOWED_BLOCKED_CLAIM_KINDS, true)) {
+            throw ValidationException::withMessages([
+                'payload.blocked_claim_kind' => 'payload.blocked_claim_kind is not supported by career attribution ingest.',
+            ]);
+        }
+
+        return $normalized;
+    }
+
+    private function validateClaimBlockedEventScope(
+        string $eventCode,
+        string $sourcePageType,
+        string $routeFamily,
+        string $subjectKind,
+    ): void {
+        if ($eventCode !== 'career_claim_blocked_surface_exposed') {
+            return;
+        }
+
+        if (! in_array($sourcePageType, ['job_detail', 'recommendation_detail'], true)) {
+            throw ValidationException::withMessages([
+                'payload.source_page_type' => 'payload.source_page_type is not supported for career_claim_blocked_surface_exposed.',
+            ]);
+        }
+
+        if (! in_array($routeFamily, ['job_detail', 'recommendation_detail'], true)) {
+            throw ValidationException::withMessages([
+                'payload.route_family' => 'payload.route_family is not supported for career_claim_blocked_surface_exposed.',
+            ]);
+        }
+
+        if (($sourcePageType === 'job_detail' && $routeFamily !== 'job_detail')
+            || ($sourcePageType === 'recommendation_detail' && $routeFamily !== 'recommendation_detail')) {
+            throw ValidationException::withMessages([
+                'payload.route_family' => 'payload.route_family must align with payload.source_page_type for career_claim_blocked_surface_exposed.',
+            ]);
+        }
+
+        if (! in_array($subjectKind, ['job_slug', 'none'], true)) {
+            throw ValidationException::withMessages([
+                'payload.subject_kind' => 'payload.subject_kind is not supported for career_claim_blocked_surface_exposed.',
+            ]);
+        }
     }
 
     private function normalizeSubjectKey(mixed $value, string $subjectKind): string

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T12:05:00Z",
+  "updated_at": "2026-04-15T13:18:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1644,10 +1644,10 @@
     "PR-B63": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b63-career-claim-blocked-attribution-taxonomy-refinement-backend-first",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "0e807070524b01445ebdf8febf1cd30228447cd7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/908",
       "checks": {
         "local": [
           {
@@ -1663,9 +1663,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456472569/job/71458444771"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456491332/job/71458509656"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456472569/job/71458455189"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456491332/job/71458521439"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions jobs were blocked by repository billing/spending-limit failure; hygiene failed before execution and MBTI jobs were skipped while local validation passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T13:18:00Z",
+  "updated_at": "2026-04-15T13:22:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1646,7 +1646,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "github_checks_failed",
       "branch": "codex/pr-b63-career-claim-blocked-attribution-taxonomy-refinement-backend-first",
-      "commit_sha": "0e807070524b01445ebdf8febf1cd30228447cd7",
+      "commit_sha": "5c2c632f29de3bf7f15dc7f3cd22f846663fd6cf",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/908",
       "checks": {
         "local": [
@@ -1667,22 +1667,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456472569/job/71458444771"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456551260/job/71458725029"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456491332/job/71458509656"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456553680/job/71458732251"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456472569/job/71458455189"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456551260/job/71458737558"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456491332/job/71458521439"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456553680/job/71458745737"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T10:24:00Z",
+  "updated_at": "2026-04-15T12:05:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1616,6 +1616,36 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "local_verified",
       "branch": "codex/pr-b62-career-alias-search-attribution-taxonomy-resolution-flow-alignment-backend-first",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B63": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b63-career-claim-blocked-attribution-taxonomy-refinement-backend-first",
       "commit_sha": "",
       "pr_url": "",
       "checks": {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -978,6 +978,33 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B63
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b63-career-claim-blocked-attribution-taxonomy-refinement-backend-first
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career claim-blocked attribution taxonomy refinement (backend first).
+      Keep the broad blocked-surface exposure bucket for compatibility and add
+      an additive, backend-owned claim-blocked taxonomy layer for salary,
+      strong-claim, AI-strategy, and transition-recommendation claim-permission
+      gates, without public API/OpenAPI/frontend changes.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php"
+      - "php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
@@ -143,10 +143,28 @@ final class CareerAttributionDailyBuilderTest extends TestCase
             'subject_key' => '',
             'query_mode' => 'query',
         ], 'anon_alias_no_result', 'session_alias_no_result');
+        $this->insertCareerEvent($orgId, 'career_claim_blocked_surface_exposed', $day->copy()->addMinutes(14), [
+            'entry_surface' => 'career_claim_blocked_surface',
+            'source_page_type' => 'career_job_detail',
+            'route_family' => 'job_detail',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'data-scientists',
+            'query_mode' => 'non_query',
+            'blocked_claim_kind' => 'salary',
+        ], 'anon_claim_blocked_job', 'session_claim_blocked_job');
+        $this->insertCareerEvent($orgId, 'career_claim_blocked_surface_exposed', $day->copy()->addMinutes(15), [
+            'entry_surface' => 'career_claim_blocked_surface',
+            'source_page_type' => 'career_recommendation_detail',
+            'route_family' => 'recommendation_detail',
+            'subject_kind' => 'none',
+            'subject_key' => '',
+            'query_mode' => 'non_query',
+            'blocked_claim_kind' => 'ai_strategy',
+        ], 'anon_claim_blocked_none', 'session_claim_blocked_none');
 
         $result = app(CareerAttributionDailyBuilder::class)->refresh($day, $day, [$orgId], false);
 
-        $this->assertSame(14, (int) ($result['upserted_rows'] ?? 0));
+        $this->assertSame(16, (int) ($result['upserted_rows'] ?? 0));
 
         $readyRow = DB::table('analytics_career_attribution_daily')
             ->where('day', $day->toDateString())
@@ -302,6 +320,25 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         $this->assertSame('alias_resolution', $aliasNoResultRow->route_family);
         $this->assertSame('unknown', $aliasNoResultRow->readiness_class);
         $this->assertSame('query', $aliasNoResultRow->query_mode);
+
+        $claimBlockedJobRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_claim_blocked_surface_exposed')
+            ->where('subject_kind', 'job_slug')
+            ->where('subject_key', 'data-scientists')
+            ->first();
+
+        $claimBlockedNoneRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_claim_blocked_surface_exposed')
+            ->where('subject_kind', 'none')
+            ->where('subject_key', '')
+            ->first();
+
+        $this->assertNotNull($claimBlockedJobRow);
+        $this->assertNotNull($claimBlockedNoneRow);
+        $this->assertSame('job_detail', $claimBlockedJobRow->source_page_type);
+        $this->assertSame('publish_ready', $claimBlockedJobRow->readiness_class);
+        $this->assertSame('recommendation_detail', $claimBlockedNoneRow->source_page_type);
+        $this->assertSame('unknown', $claimBlockedNoneRow->readiness_class);
     }
 
     private function materializeCurrentFirstWaveFixture(): void

--- a/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
@@ -220,6 +220,24 @@ final class CareerAttributionEventIngestTest extends TestCase
                 ],
                 'expected_source_page_type' => 'job_detail',
             ],
+            [
+                'event' => 'career_claim_blocked_surface_exposed',
+                'anon' => 'anon_b63_claim_blocked_surface',
+                'path' => '/en/career/jobs/software-developers',
+                'payload' => [
+                    'entry_surface' => 'career_job_detail',
+                    'source_page_type' => 'career_job_detail',
+                    'target_action' => 'expose_claim_blocked_surface',
+                    'landing_path' => '/en/career/jobs/software-developers',
+                    'route_family' => 'job_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'non_query',
+                    'blocked_claim_kind' => 'salary',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'job_detail',
+            ],
         ];
 
         foreach ($cases as $case) {
@@ -594,6 +612,214 @@ final class CareerAttributionEventIngestTest extends TestCase
                     'subject_kind' => 'none',
                     'query_mode' => 'non_query',
                 ],
+            ]);
+
+            $response->assertStatus(422);
+        }
+    }
+
+    public function test_ingest_endpoint_accepts_claim_blocked_surface_event_with_restricted_blocked_claim_kind(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        foreach ([
+            [
+                'anon' => 'anon_b63_claim_salary',
+                'route_family' => 'job_detail',
+                'source_page_type' => 'career_job_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'software-developers',
+                'blocked_claim_kind' => 'salary',
+            ],
+            [
+                'anon' => 'anon_b63_claim_strong',
+                'route_family' => 'job_detail',
+                'source_page_type' => 'career_job_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'software-developers',
+                'blocked_claim_kind' => 'strong_claim',
+            ],
+            [
+                'anon' => 'anon_b63_claim_ai',
+                'route_family' => 'recommendation_detail',
+                'source_page_type' => 'career_recommendation_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'software-developers',
+                'blocked_claim_kind' => 'ai_strategy',
+            ],
+            [
+                'anon' => 'anon_b63_claim_transition',
+                'route_family' => 'recommendation_detail',
+                'source_page_type' => 'career_recommendation_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'software-developers',
+                'blocked_claim_kind' => 'transition_recommendation',
+            ],
+            [
+                'anon' => 'anon_b63_claim_none_subject',
+                'route_family' => 'recommendation_detail',
+                'source_page_type' => 'career_recommendation_detail',
+                'subject_kind' => 'none',
+                'subject_key' => '',
+                'blocked_claim_kind' => 'ai_strategy',
+            ],
+        ] as $case) {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ingest_test_token',
+            ])->postJson('/api/v0.5/career/attribution/events', [
+                'eventName' => 'career_claim_blocked_surface_exposed',
+                'anonymousId' => $case['anon'],
+                'path' => '/en/career/jobs/software-developers',
+                'timestamp' => '2026-04-15T12:00:00+08:00',
+                'payload' => [
+                    'entry_surface' => 'career_claim_blocked_surface',
+                    'source_page_type' => $case['source_page_type'],
+                    'target_action' => 'expose_claim_blocked_surface',
+                    'landing_path' => '/en/career/jobs/software-developers',
+                    'route_family' => $case['route_family'],
+                    'subject_kind' => $case['subject_kind'],
+                    'subject_key' => $case['subject_key'],
+                    'query_mode' => 'non_query',
+                    'blocked_claim_kind' => $case['blocked_claim_kind'],
+                    'locale' => 'en',
+                ],
+            ]);
+
+            $response->assertStatus(202)
+                ->assertJsonPath('event_code', 'career_claim_blocked_surface_exposed');
+
+            $row = DB::table('events')
+                ->where('event_code', 'career_claim_blocked_surface_exposed')
+                ->where('anon_id', $case['anon'])
+                ->first();
+
+            $this->assertNotNull($row);
+
+            $meta = is_array($row->meta_json ?? null)
+                ? $row->meta_json
+                : (json_decode((string) ($row->meta_json ?? '{}'), true) ?: []);
+
+            $this->assertSame($case['blocked_claim_kind'], $meta['blocked_claim_kind'] ?? null);
+        }
+    }
+
+    public function test_ingest_endpoint_rejects_invalid_or_missing_blocked_claim_kind_for_claim_blocked_event(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        foreach ([
+            ['anon' => 'anon_b63_missing_claim_kind', 'blocked_claim_kind' => null],
+            ['anon' => 'anon_b63_invalid_claim_kind', 'blocked_claim_kind' => 'warning'],
+        ] as $case) {
+            $payload = [
+                'entry_surface' => 'career_claim_blocked_surface',
+                'source_page_type' => 'career_job_detail',
+                'target_action' => 'expose_claim_blocked_surface',
+                'landing_path' => '/en/career/jobs/software-developers',
+                'route_family' => 'job_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'software-developers',
+                'query_mode' => 'non_query',
+                'locale' => 'en',
+            ];
+
+            if ($case['blocked_claim_kind'] !== null) {
+                $payload['blocked_claim_kind'] = $case['blocked_claim_kind'];
+            }
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ingest_test_token',
+            ])->postJson('/api/v0.5/career/attribution/events', [
+                'eventName' => 'career_claim_blocked_surface_exposed',
+                'anonymousId' => $case['anon'],
+                'path' => '/en/career/jobs/software-developers',
+                'timestamp' => '2026-04-15T12:05:00+08:00',
+                'payload' => $payload,
+            ]);
+
+            $response->assertStatus(422);
+        }
+    }
+
+    public function test_ingest_endpoint_rejects_blocked_claim_kind_on_non_claim_blocked_events(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ingest_test_token',
+        ])->postJson('/api/v0.5/career/attribution/events', [
+            'eventName' => 'career_blocked_surface_exposed',
+            'anonymousId' => 'anon_b63_broad_with_claim_kind',
+            'path' => '/en/career/jobs/software-developers',
+            'timestamp' => '2026-04-15T12:10:00+08:00',
+            'payload' => [
+                'entry_surface' => 'career_blocked_surface',
+                'source_page_type' => 'career_job_detail',
+                'target_action' => 'expose_blocked_surface',
+                'landing_path' => '/en/career/jobs/software-developers',
+                'route_family' => 'job_detail',
+                'subject_kind' => 'job_slug',
+                'subject_key' => 'software-developers',
+                'query_mode' => 'non_query',
+                'blocked_claim_kind' => 'salary',
+                'locale' => 'en',
+            ],
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_ingest_endpoint_rejects_claim_blocked_event_outside_supported_scope_boundaries(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        foreach ([
+            [
+                'anon' => 'anon_b63_claim_invalid_source_page_type',
+                'source_page_type' => 'job_index',
+                'route_family' => 'job_detail',
+                'subject_kind' => 'job_slug',
+            ],
+            [
+                'anon' => 'anon_b63_claim_invalid_route_family',
+                'source_page_type' => 'career_job_detail',
+                'route_family' => 'jobs',
+                'subject_kind' => 'job_slug',
+            ],
+            [
+                'anon' => 'anon_b63_claim_misaligned_source_route',
+                'source_page_type' => 'career_recommendation_detail',
+                'route_family' => 'job_detail',
+                'subject_kind' => 'job_slug',
+            ],
+            [
+                'anon' => 'anon_b63_claim_invalid_subject_kind',
+                'source_page_type' => 'career_recommendation_detail',
+                'route_family' => 'recommendation_detail',
+                'subject_kind' => 'family_slug',
+            ],
+        ] as $case) {
+            $payload = [
+                'entry_surface' => 'career_claim_blocked_surface',
+                'source_page_type' => $case['source_page_type'],
+                'target_action' => 'expose_claim_blocked_surface',
+                'landing_path' => '/en/career/jobs/software-developers',
+                'route_family' => $case['route_family'],
+                'subject_kind' => $case['subject_kind'],
+                'subject_key' => $case['subject_kind'] === 'none' ? '' : 'software-developers',
+                'query_mode' => 'non_query',
+                'blocked_claim_kind' => 'salary',
+                'locale' => 'en',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ingest_test_token',
+            ])->postJson('/api/v0.5/career/attribution/events', [
+                'eventName' => 'career_claim_blocked_surface_exposed',
+                'anonymousId' => $case['anon'],
+                'path' => '/en/career/jobs/software-developers',
+                'timestamp' => '2026-04-15T12:20:00+08:00',
+                'payload' => $payload,
             ]);
 
             $response->assertStatus(422);


### PR DESCRIPTION
## What Changed
- Added additive claim-blocked taxonomy event support in backend ingest mapper:
  - `career_claim_blocked_surface_exposed`
- Kept existing broad fallback bucket unchanged:
  - `career_blocked_surface_exposed`
- Added strict `blocked_claim_kind` normalization for claim-blocked events only:
  - allowed values: `salary`, `strong_claim`, `ai_strategy`, `transition_recommendation`
- Added strict scope guards for claim-blocked event to prevent taxonomy drift:
  - `source_page_type` must be `job_detail` or `recommendation_detail`
  - `route_family` must be `job_detail` or `recommendation_detail`
  - `source_page_type` and `route_family` must align
  - `subject_kind` must be `job_slug` or `none`
- Extended analytics ingest and daily builder feature tests for:
  - new event acceptance
  - restricted kind allowlist
  - rejection of invalid/missing kind
  - rejection of kind on non-claim-blocked events
  - rejection of out-of-scope source/route/subject combinations
  - daily aggregation compatibility and unchanged readiness derivation behavior
- Added PR-B63 entries to train manifest/state.

## Why
Current blocked attribution semantics are too broad for claim-permission analysis. This PR introduces a minimal additive refinement layer grounded in backend-owned claim-permission truth, while preserving backward compatibility via the existing broad blocked bucket.

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php`
- `php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php`

## Intentionally Deferred
- Frontend instrumentation changes
- Public analytics API / OpenAPI changes
- Trust-freshness / warning/info / missing-data blocked taxonomy
- Additional blocked event family expansion beyond this minimal additive layer
