### PR TITLE
feat(big5): close Big Five paywall and open PDF via runtime override

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -601,6 +601,17 @@ class AttemptReadController extends Controller
             $refreshedAt = optional($projection?->refreshed_at)->toIso8601String();
         }
 
+        $isBigFive = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_BIG5_OCEAN;
+        if ($isBigFive && $resultExists) {
+            $accessState = 'ready';
+            $reportState = 'ready';
+            $pdfState = 'ready';
+            $payloadJson['access_level'] = ReportAccess::REPORT_ACCESS_FULL;
+            $payloadJson['variant'] = ReportAccess::VARIANT_FULL;
+            $payloadJson['unlock_stage'] = ReportAccess::UNLOCK_STAGE_FULL;
+            $payloadJson['unlock_source'] = ReportAccess::UNLOCK_SOURCE_NONE;
+        }
+
         if ($repairFailed && $resultExists) {
             $reasonCode = in_array($reasonCode, ['', 'projection_missing_result_ready'], true)
                 ? 'projection_repair_failed_result_ready_fallback'

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -74,8 +74,10 @@ class ReportGatekeeper
 
         $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
-        $forceFreeOnly = in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
+        $forceFreeOnly = strtoupper($scaleCode) === ReportAccess::SCALE_BIG5_OCEAN
+            || in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
         $accessState = $this->accessResolver->resolveAccess(
+            $scaleCode,
             $effectiveOrgId,
             $userId,
             $anonId,
@@ -132,11 +134,20 @@ class ReportGatekeeper
         $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
         $commercialSpec = $isMbtiContract ? $this->loadCommercialSpecForAttempt($attempt, $result) : [];
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
-        $forceFreeOnly = in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
-        $paywall = $this->offerResolver->buildPaywall($viewPolicy, $commercial, $commercialSpec, $scaleCode, $effectiveOrgId);
+        $forceFreeOnly = $scaleCode === ReportAccess::SCALE_BIG5_OCEAN
+            || in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
+        $paywall = $this->offerResolver->buildPaywall(
+            $viewPolicy,
+            $commercial,
+            $commercialSpec,
+            $scaleCode,
+            $effectiveOrgId,
+            $forceFreeOnly
+        );
         $viewPolicy = $paywall['view_policy'] ?? $viewPolicy;
 
         $accessState = $this->accessResolver->resolveAccess(
+            $scaleCode,
             $effectiveOrgId,
             $userId,
             $anonId,

--- a/backend/app/Services/Report/Resolvers/AccessResolver.php
+++ b/backend/app/Services/Report/Resolvers/AccessResolver.php
@@ -13,6 +13,7 @@ class AccessResolver
      * @return array{benefit_code:?string,has_full_access:bool}
      */
     public function resolveAccess(
+        string $scaleCode,
         int $orgId,
         ?string $userId,
         ?string $anonId,
@@ -20,13 +21,17 @@ class AccessResolver
         array $commercial,
         bool $forceFreeOnly
     ): array {
+        $scaleCode = strtoupper(trim($scaleCode));
         $benefitCode = $this->resolveBenefitCode($commercial);
         $hasFullAccess = $benefitCode !== ''
             ? $this->entitlements->hasFullAccess($orgId, $userId, $anonId, $attemptId, $benefitCode)
             : false;
 
-        if ($forceFreeOnly) {
+        if ($forceFreeOnly && $scaleCode !== ReportAccess::SCALE_BIG5_OCEAN) {
             $hasFullAccess = false;
+        }
+        if ($forceFreeOnly && $scaleCode === ReportAccess::SCALE_BIG5_OCEAN) {
+            $hasFullAccess = true;
         }
 
         return [
@@ -48,6 +53,19 @@ class AccessResolver
         array $modulesOffered
     ): array {
         $scaleCode = strtoupper(trim($scaleCode));
+        if ($forceFreeOnly && $scaleCode === ReportAccess::SCALE_BIG5_OCEAN) {
+            $modulesAllowed = ReportAccess::normalizeModules(array_merge(
+                ReportAccess::defaultModulesAllowedForLocked($scaleCode),
+                ReportAccess::allDefaultModulesOffered($scaleCode)
+            ));
+
+            return [
+                'modules_allowed' => $modulesAllowed,
+                'modules_preview' => [],
+                'has_paid_module_access' => true,
+                'unlock_stage' => ReportAccess::UNLOCK_STAGE_FULL,
+            ];
+        }
 
         $modulesAllowed = $this->entitlements->getAllowedModulesForAttempt($orgId, $attemptId);
         $modulesAllowed = $this->filterModulesForScale($scaleCode, $modulesAllowed);

--- a/backend/app/Services/Report/Resolvers/OfferResolver.php
+++ b/backend/app/Services/Report/Resolvers/OfferResolver.php
@@ -69,7 +69,14 @@ class OfferResolver
         return is_array($raw) ? $raw : [];
     }
 
-    public function buildPaywall(array $viewPolicy, array $commercial, array $commercialSpec, string $scaleCode, int $orgId): array
+    public function buildPaywall(
+        array $viewPolicy,
+        array $commercial,
+        array $commercialSpec,
+        string $scaleCode,
+        int $orgId,
+        bool $forceFreeOnly = false
+    ): array
     {
         $scaleCode = strtoupper(trim($scaleCode));
         $effectiveSku = strtoupper(trim((string) ($viewPolicy['upgrade_sku'] ?? '')));
@@ -89,6 +96,18 @@ class OfferResolver
             $offers = $this->normalizeOffers($commercial['offers'] ?? null);
         }
         $offers = $this->filterOffersForScale($scaleCode, $offers);
+
+        if ($forceFreeOnly && $scaleCode === ReportAccess::SCALE_BIG5_OCEAN) {
+            $viewPolicy['upgrade_sku'] = null;
+
+            return [
+                'upgrade_sku' => null,
+                'upgrade_sku_effective' => null,
+                'offers' => [],
+                'cta_copy' => null,
+                'view_policy' => $viewPolicy,
+            ];
+        }
 
         return [
             'upgrade_sku' => $anchorSku,

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -310,6 +310,16 @@ class MeAttemptsService
         $unlockSource = ReportAccess::normalizeUnlockSource((string) ($payload['unlock_source'] ?? ReportAccess::UNLOCK_SOURCE_NONE));
         $requiredInvitees = max(1, (int) ($inviteSnapshot['required_invitees'] ?? 2));
         $completedInvitees = max(0, min($requiredInvitees, (int) ($inviteSnapshot['completed_invitees'] ?? 0)));
+        $isBigFive = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_BIG5_OCEAN;
+        if ($isBigFive && $resultExists) {
+            $accessState = 'ready';
+            $reportState = 'ready';
+            $pdfState = 'ready';
+            $unlockStage = ReportAccess::UNLOCK_STAGE_FULL;
+            $unlockSource = ReportAccess::UNLOCK_SOURCE_NONE;
+            $payload['access_level'] = ReportAccess::REPORT_ACCESS_FULL;
+            $payload['variant'] = ReportAccess::VARIANT_FULL;
+        }
 
         return [
             'access_state' => $accessState,
@@ -580,6 +590,10 @@ class MeAttemptsService
      */
     private function buildOfferSummary(Attempt $attempt, ?array $accessSummary): array
     {
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_BIG5_OCEAN) {
+            return ['primary_offer' => null];
+        }
+
         $accessState = strtolower(trim((string) ($accessSummary['access_state'] ?? '')));
         $reportState = strtolower(trim((string) ($accessSummary['report_state'] ?? '')));
 

--- a/backend/database/seeders/Pr19CommerceSeeder.php
+++ b/backend/database/seeders/Pr19CommerceSeeder.php
@@ -132,13 +132,16 @@ class Pr19CommerceSeeder extends Seeder
 
                 $commercial['report_benefit_code'] = $benefits['report_benefit_code'];
                 $commercial['credit_benefit_code'] = $benefits['credit_benefit_code'];
-                if ($defaultEffective) {
+                if ($scaleCode !== 'BIG5_OCEAN' && $defaultEffective) {
                     $commercial['report_unlock_sku'] = $defaultEffective;
                 }
-                if ($defaultAnchor) {
+                if ($scaleCode !== 'BIG5_OCEAN' && $defaultAnchor) {
                     $commercial['upgrade_sku_anchor'] = $defaultAnchor;
                 }
-                if (count($offers) > 0) {
+                if ($scaleCode === 'BIG5_OCEAN') {
+                    $commercial['offers'] = [];
+                    unset($commercial['report_unlock_sku'], $commercial['upgrade_sku_anchor']);
+                } elseif (count($offers) > 0) {
                     $commercial['offers'] = $offers;
                 }
 

--- a/backend/database/seeders/ScaleRegistrySeeder.php
+++ b/backend/database/seeders/ScaleRegistrySeeder.php
@@ -119,13 +119,13 @@ final class ScaleRegistrySeeder extends Seeder
                 'enabled_in_prod' => true,
                 'enabled_regions' => ['CN_MAINLAND', 'GLOBAL'],
                 'rollout_ratio' => 1.0,
-                'paywall_mode' => 'full',
+                'paywall_mode' => 'free_only',
             ],
             'view_policy_json' => [
                 'free_sections' => ['disclaimer_top', 'summary', 'domains_overview', 'disclaimer'],
                 'blur_others' => false,
                 'teaser_percent' => 0.0,
-                'upgrade_sku' => 'SKU_BIG5_FULL_REPORT_299',
+                'upgrade_sku' => null,
             ],
             'commercial_json' => [
                 'price_tier' => 'PAID',

--- a/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
+++ b/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
@@ -128,22 +128,19 @@ final class BigFiveHistoryCompareTest extends TestCase
         $response->assertJsonPath('items.0.offer_summary.primary_offer', null);
         $response->assertJsonPath('items.0.share_summary.enabled', true);
         $response->assertJsonPath('items.0.share_summary.share_kind', 'big5_result');
-        $response->assertJsonPath('items.1.access_summary.access_state', 'locked');
+        $response->assertJsonPath('items.1.access_summary.access_state', 'ready');
         $response->assertJsonPath('items.1.access_summary.report_state', 'ready');
-        $response->assertJsonPath('items.1.access_summary.pdf_state', 'unavailable');
-        $response->assertJsonPath('items.1.access_summary.access_level', 'preview');
-        $response->assertJsonPath('items.1.access_summary.variant', 'free');
+        $response->assertJsonPath('items.1.access_summary.pdf_state', 'ready');
+        $response->assertJsonPath('items.1.access_summary.access_level', 'full');
+        $response->assertJsonPath('items.1.access_summary.variant', 'full');
         $response->assertJsonPath('items.1.access_summary.actions.page_href', "/result/{$olderAttemptId}");
-        $response->assertJsonPath('items.1.access_summary.actions.pdf_href', null);
+        $response->assertJsonPath('items.1.access_summary.actions.pdf_href', "/api/v0.3/attempts/{$olderAttemptId}/report.pdf");
         $response->assertJsonPath('items.1.top_facets_summary_v1.items.0.key', 'N1');
         $response->assertJsonPath('items.1.quality_summary.level', 'B');
         $response->assertJsonPath('items.1.quality_summary.grade', 'B');
         $response->assertJsonPath('items.1.norms_summary.status', 'CALIBRATED');
         $response->assertJsonPath('items.1.norms_summary.norms_version', '2025Q4');
-        $response->assertJsonPath('items.1.offer_summary.primary_offer.sku', 'SKU_BIG5_FULL_REPORT_299');
-        $response->assertJsonPath('items.1.offer_summary.primary_offer.benefit_code', 'BIG5_FULL_REPORT');
-        $response->assertJsonPath('items.1.offer_summary.primary_offer.formatted_price', '¥2.99');
-        $response->assertJsonPath('items.1.offer_summary.primary_offer.modules_included.0', 'big5_full');
+        $response->assertJsonPath('items.1.offer_summary.primary_offer', null);
         $response->assertJsonPath('items.1.share_summary.enabled', true);
     }
 

--- a/backend/tests/Feature/Commerce/BigFiveModulesUnlockFlowTest.php
+++ b/backend/tests/Feature/Commerce/BigFiveModulesUnlockFlowTest.php
@@ -151,16 +151,23 @@ final class BigFiveModulesUnlockFlowTest extends TestCase
 
         $before->assertStatus(200);
         $before->assertJson([
-            'locked' => true,
-            'variant' => 'free',
+            'locked' => false,
+            'access_level' => 'full',
+            'variant' => 'full',
         ]);
         $before->assertJsonPath('norms.status', (string) ($scorePayload['norms']['status'] ?? ''));
         $before->assertJsonPath('quality.level', (string) ($scorePayload['quality']['level'] ?? ''));
 
         $beforeAllowed = (array) $before->json('modules_allowed');
         $this->assertContains('big5_core', $beforeAllowed);
+        $this->assertContains('big5_full', $beforeAllowed);
+        $this->assertContains('big5_action_plan', $beforeAllowed);
+        $this->assertSame([], (array) $before->json('offers'));
         $beforeSections = array_map('strval', (array) array_column((array) $before->json('report.sections'), 'key'));
-        $this->assertSame(['disclaimer_top', 'summary', 'domains_overview', 'disclaimer'], $beforeSections);
+        $this->assertSame(
+            ['traits.overview', 'traits.why_this_profile', 'relationships.interpersonal_style', 'career.work_style', 'growth.next_actions', 'disclaimer_top', 'summary', 'domains_overview', 'facet_table', 'top_facets', 'facets_deepdive', 'action_plan', 'disclaimer'],
+            $beforeSections
+        );
 
         /** @var EntitlementManager $entitlements */
         $entitlements = app(EntitlementManager::class);
@@ -194,29 +201,22 @@ final class BigFiveModulesUnlockFlowTest extends TestCase
         $this->assertContains('big5_action_plan', $afterAllowed);
 
         $offers = (array) $after->json('offers');
-        $this->assertNotEmpty($offers);
-        foreach ($offers as $offer) {
-            $this->assertIsArray($offer);
-            $this->assertArrayHasKey('sku', $offer);
-            $this->assertNotSame('', (string) ($offer['sku'] ?? ''));
-            $this->assertArrayHasKey('sku_code', $offer);
-            $this->assertSame((string) $offer['sku'], (string) $offer['sku_code']);
-            $this->assertArrayHasKey('benefit_code', $offer);
-            $this->assertNotSame('', (string) ($offer['benefit_code'] ?? ''));
-            $this->assertArrayHasKey('offer_code', $offer);
-            $this->assertNotSame('', (string) ($offer['offer_code'] ?? ''));
-            $this->assertArrayHasKey('price_cents', $offer);
-            $this->assertIsInt($offer['price_cents']);
-            $this->assertArrayHasKey('currency', $offer);
-            $this->assertNotSame('', (string) ($offer['currency'] ?? ''));
-            $this->assertArrayHasKey('modules_included', $offer);
-            $this->assertIsArray($offer['modules_included']);
-        }
+        $this->assertSame([], $offers);
 
         $afterSections = array_map('strval', (array) array_column((array) $after->json('report.sections'), 'key'));
         $this->assertSame(
-            ['disclaimer_top', 'summary', 'domains_overview', 'facet_table', 'top_facets', 'facets_deepdive', 'action_plan', 'disclaimer'],
+            ['traits.overview', 'traits.why_this_profile', 'relationships.interpersonal_style', 'career.work_style', 'growth.next_actions', 'disclaimer_top', 'summary', 'domains_overview', 'facet_table', 'top_facets', 'facets_deepdive', 'action_plan', 'disclaimer'],
             $afterSections
         );
+
+        $reportAccess = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access');
+
+        $reportAccess->assertStatus(200);
+        $reportAccess->assertJsonPath('access_state', 'ready');
+        $reportAccess->assertJsonPath('pdf_state', 'ready');
+        $reportAccess->assertJsonPath('actions.pdf_href', "/api/v0.3/attempts/{$attemptId}/report.pdf");
     }
 }

--- a/backend/tests/Feature/Content/BigFivePaywallFlagModesTest.php
+++ b/backend/tests/Feature/Content/BigFivePaywallFlagModesTest.php
@@ -20,7 +20,7 @@ final class BigFivePaywallFlagModesTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_free_only_mode_forces_free_variant_even_with_entitlement(): void
+    public function test_free_only_mode_forces_full_readable_variant_and_removes_offers(): void
     {
         $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
         $this->seedBigFiveWithPaywallMode('free_only');
@@ -51,21 +51,27 @@ final class BigFivePaywallFlagModesTest extends TestCase
 
         $resp->assertStatus(200);
         $resp->assertJson([
-            'locked' => true,
-            'variant' => 'free',
+            'locked' => false,
+            'access_level' => 'full',
+            'variant' => 'full',
         ]);
 
         $allowed = array_map('strval', (array) $resp->json('modules_allowed'));
         $this->assertContains('big5_core', $allowed);
-        $this->assertNotContains('big5_full', $allowed);
-        $this->assertNotContains('big5_action_plan', $allowed);
+        $this->assertContains('big5_full', $allowed);
+        $this->assertContains('big5_action_plan', $allowed);
 
         $sections = array_map('strval', (array) array_column((array) $resp->json('report.sections'), 'key'));
-        $this->assertSame(['disclaimer_top', 'summary', 'domains_overview', 'disclaimer'], $sections);
-        $this->assertNotEmpty((array) $resp->json('offers'));
+        $this->assertSame(
+            ['traits.overview', 'traits.why_this_profile', 'relationships.interpersonal_style', 'career.work_style', 'growth.next_actions', 'disclaimer_top', 'summary', 'domains_overview', 'facet_table', 'top_facets', 'facets_deepdive', 'action_plan', 'disclaimer'],
+            $sections
+        );
+        $this->assertSame([], (array) $resp->json('offers'));
+        $this->assertNull($resp->json('upgrade_sku'));
+        $this->assertNull($resp->json('upgrade_sku_effective'));
     }
 
-    public function test_full_mode_allows_full_variant_after_entitlement(): void
+    public function test_runtime_override_keeps_big5_full_readable_even_when_registry_mode_is_full(): void
     {
         $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
         $this->seedBigFiveWithPaywallMode('full');
@@ -73,21 +79,6 @@ final class BigFivePaywallFlagModesTest extends TestCase
         $anonId = 'anon_big5_paywall_full';
         $token = $this->issueAnonToken($anonId);
         $attemptId = $this->createSubmittedBigFiveAttemptWithResult($anonId);
-
-        /** @var EntitlementManager $entitlements */
-        $entitlements = app(EntitlementManager::class);
-        $grant = $entitlements->grantAttemptUnlock(
-            0,
-            null,
-            $anonId,
-            'BIG5_FULL_REPORT',
-            $attemptId,
-            'order_big5_paywall_full',
-            'attempt',
-            null,
-            ['big5_full', 'big5_action_plan']
-        );
-        $this->assertTrue((bool) ($grant['ok'] ?? false));
 
         $resp = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -97,6 +88,7 @@ final class BigFivePaywallFlagModesTest extends TestCase
         $resp->assertStatus(200);
         $resp->assertJson([
             'locked' => false,
+            'access_level' => 'full',
             'variant' => 'full',
         ]);
 
@@ -104,6 +96,7 @@ final class BigFivePaywallFlagModesTest extends TestCase
         $this->assertContains('big5_core', $allowed);
         $this->assertContains('big5_full', $allowed);
         $this->assertContains('big5_action_plan', $allowed);
+        $this->assertSame([], (array) $resp->json('offers'));
     }
 
     private function seedBigFiveWithPaywallMode(string $mode): void

--- a/backend/tests/Feature/V0_3/NonMbtiReportContractRegressionTest.php
+++ b/backend/tests/Feature/V0_3/NonMbtiReportContractRegressionTest.php
@@ -251,9 +251,9 @@ final class NonMbtiReportContractRegressionTest extends TestCase
         $locked->assertStatus(200);
         $locked->assertJson([
             'ok' => true,
-            'locked' => true,
-            'access_level' => 'free',
-            'variant' => 'free',
+            'locked' => false,
+            'access_level' => 'full',
+            'variant' => 'full',
         ]);
         $this->assertSharedNonMbtiEnvelope($locked);
         $this->assertMbtiOnlyFieldsAreMissing($locked);
@@ -267,10 +267,15 @@ final class NonMbtiReportContractRegressionTest extends TestCase
                 'disclaimer_top',
                 'summary',
                 'domains_overview',
+                'facet_table',
+                'top_facets',
+                'facets_deepdive',
+                'action_plan',
                 'disclaimer',
             ],
             array_map('strval', (array) array_column((array) $locked->json('report.sections'), 'key'))
         );
+        $this->assertSame([], (array) $locked->json('offers'));
 
         /** @var EntitlementManager $entitlements */
         $entitlements = app(EntitlementManager::class);
@@ -319,6 +324,7 @@ final class NonMbtiReportContractRegressionTest extends TestCase
             ],
             array_map('strval', (array) array_column((array) $unlocked->json('report.sections'), 'key'))
         );
+        $this->assertSame([], (array) $unlocked->json('offers'));
     }
 
     public function test_sds20_report_contract_does_not_gain_mbti_only_fields_in_free_or_full_variants(): void


### PR DESCRIPTION
## What changed
- Added a Big Five-only runtime override so `BIG5_OCEAN` report payload resolves as full-readable and unlocked.
- Suppressed Big Five upsell outputs at runtime (`offers`, `upgrade_sku`, `upgrade_sku_effective`) while keeping MBTI logic unchanged.
- Aligned Big Five `report-access` and history access summaries to `ready` states (including PDF ready) when result exists.
- Cleared Big Five history `offer_summary.primary_offer` to remove unlock cards.
- Updated seeders for fresh env parity (`paywall_mode=free_only`, no Big Five offers surfaced), without relying on reseed for runtime behavior.
- Updated Big Five/non-MBTI regression tests to reflect free-readable, no-offer, PDF-ready behavior.

## Why
- Product requirement: close Big Five paywall and upgrade entrances, and open PDF download, with consistent semantics across `/report`, `/result`, `/report-access`, `/report.pdf`, and `/history`.
- Keep MBTI paywall behavior intact and avoid touching payment/webhook/entitlement main chains.

## Validation commands
- `php artisan route:list | rg "api/v0.3/(attempts/.*/(report|report-access|report\\.pdf)|me/attempts)"`
- `php artisan migrate:status`
- `php artisan test --filter=BigFivePaywallFlagModesTest`
- `php artisan test --filter=BigFiveModulesUnlockFlowTest`
- `php artisan test --filter=BigFiveUnlockDeliveryPipelineTest`
- `php artisan test --filter=AttemptReportPaymentUnlockFlowTest`
- `php artisan test --filter=BigFiveHistoryCompareTest`
- `php artisan test --filter=NonMbtiReportContractRegressionTest`
- `bash scripts/ci_verify_mbti.sh` (fails in `PartnerApiMvpTest` with 404, pre-existing/out-of-scope for this PR)

## Intentionally deferred
- No frontend changes in `fap-web` (backend payload now closes Big Five paywall surfaces).
- No modifications to webhook/entitlement/order/payment pipelines.
- No SKU data deletion or migration execution.
