### PR TITLE
feat(attempts): remove start retake limits across scales

### DIFF
--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -448,18 +448,8 @@ class AttemptStartService
                 }
             }
 
-            if (strtoupper($scaleCode) === 'BIG5_OCEAN') {
-                $retakePolicy = $this->resolveBigFiveRetakePolicy($dirVersion !== '' ? $dirVersion : 'v1');
-                $this->attemptRateLimitService->assertRetakeAllowed(
-                    $orgId,
-                    $scaleCode,
-                    $actorUserId,
-                    $anonId,
-                    (int) ($retakePolicy['cooldown_hours'] ?? 24),
-                    (int) ($retakePolicy['max_attempts_per_30_days'] ?? 3),
-                    $resolvedFormCode
-                );
-            }
+            // Big Five retake cooldown/limit is intentionally disabled:
+            // users can restart BIG5 attempts without 24h or 30-day gating.
 
             return DB::connection($writeConnectionName)->transaction(function () use ($attemptPayload, $writeConnectionName): array {
                 $attempt = new Attempt;

--- a/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
+++ b/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
@@ -33,7 +33,7 @@ final class Big5RetakeCooldownTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_big5_retake_cooldown_blocks_recent_restart(): void
+    public function test_big5_retake_cooldown_is_disabled_and_allows_recent_restart(): void
     {
         (new ScaleRegistrySeeder)->run();
 
@@ -47,16 +47,12 @@ final class Big5RetakeCooldownTest extends TestCase
             'anon_id' => $anonId,
         ]);
 
-        $response->assertStatus(429);
-        $response->assertJsonPath('error_code', 'RETAKE_COOLDOWN');
-        $response->assertJsonPath('details.code', 'RETAKE_COOLDOWN');
-        $response->assertJsonPath('details.reason_code', 'RETAKE_COOLDOWN');
-        $response->assertJsonPath('details.form_code', 'big5_120');
-        $response->assertJsonPath('details.scope_key', 'org+scale+identity+form');
-        $this->assertGreaterThan(0, (int) $response->json('details.retry_after_seconds'));
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $this->assertNotEmpty((string) $response->json('attempt_id'));
     }
 
-    public function test_big5_retake_limit_blocks_when_max_attempts_reached_in_30_days(): void
+    public function test_big5_retake_limit_is_disabled_and_allows_repeated_attempts_in_30_days(): void
     {
         (new ScaleRegistrySeeder)->run();
 
@@ -72,14 +68,9 @@ final class Big5RetakeCooldownTest extends TestCase
             'anon_id' => $anonId,
         ]);
 
-        $response->assertStatus(429);
-        $response->assertJsonPath('error_code', 'RETAKE_LIMIT_EXCEEDED');
-        $response->assertJsonPath('details.code', 'RETAKE_LIMIT_EXCEEDED');
-        $response->assertJsonPath('details.reason_code', 'RETAKE_LIMIT_EXCEEDED');
-        $response->assertJsonPath('details.form_code', 'big5_120');
-        $response->assertJsonPath('details.scope_key', 'org+scale+identity+form');
-        $response->assertJsonPath('details.limit_window', '30_days');
-        $response->assertJsonPath('details.retry_after_seconds', null);
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $this->assertNotEmpty((string) $response->json('attempt_id'));
     }
 
     public function test_big5_retake_cooldown_is_form_aware_from_120_to_90(): void


### PR DESCRIPTION
## What changed
- Removed the retake-limit gate from attempt start persistence.
- This disables start-time cooldown/attempt-count blocking for all scales (Big Five, MBTI, and others).
- Updated `Big5RetakeCooldownTest` expectations to assert starts are allowed instead of returning 429.

## Why
Users should be able to retake tests any time without 24-hour or 30-day start limits.

## Validation
- `cd backend && php artisan test --filter=Big5RetakeCooldownTest`

## Notes
- This change targets start-time gating only.
- Existing generic API throttles (if any) remain independent.
