### PR TITLE
PR-B64: Career white-box score payload completion

### DIFF
--- a/backend/app/DTO/Career/CareerJobDetailBundle.php
+++ b/backend/app/DTO/Career/CareerJobDetailBundle.php
@@ -15,6 +15,7 @@ final class CareerJobDetailBundle
      * @param  array<string, mixed>  $truthLayer
      * @param  array<string, mixed>  $trustManifest
      * @param  array<string, mixed>  $scoreBundle
+     * @param  array<string, mixed>  $whiteBoxScores
      * @param  array<string, mixed>  $warnings
      * @param  array<string, mixed>  $claimPermissions
      * @param  array<string, mixed>  $integritySummary
@@ -30,6 +31,7 @@ final class CareerJobDetailBundle
         public readonly array $truthLayer,
         public readonly array $trustManifest,
         public readonly array $scoreBundle,
+        public readonly array $whiteBoxScores,
         public readonly array $warnings,
         public readonly array $claimPermissions,
         public readonly array $integritySummary,
@@ -53,6 +55,7 @@ final class CareerJobDetailBundle
             'truth_layer' => $this->truthLayer,
             'trust_manifest' => $this->trustManifest,
             'score_bundle' => $this->scoreBundle,
+            'white_box_scores' => $this->whiteBoxScores,
             'warnings' => $this->warnings,
             'claim_permissions' => $this->claimPermissions,
             'integrity_summary' => $this->integritySummary,

--- a/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
+++ b/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
@@ -11,6 +11,7 @@ final class CareerRecommendationDetailBundle
      * @param  array<string, mixed>  $recommendationSubjectMeta
      * @param  array<string, mixed>  $supportingTruthSummary
      * @param  array<string, mixed>  $scoreBundle
+     * @param  array<string, mixed>  $whiteBoxScores
      * @param  array<string, mixed>  $warnings
      * @param  array<string, mixed>  $claimPermissions
      * @param  array<string, mixed>  $integritySummary
@@ -24,6 +25,7 @@ final class CareerRecommendationDetailBundle
         public readonly array $recommendationSubjectMeta,
         public readonly array $supportingTruthSummary,
         public readonly array $scoreBundle,
+        public readonly array $whiteBoxScores,
         public readonly array $warnings,
         public readonly array $claimPermissions,
         public readonly array $integritySummary,
@@ -45,6 +47,7 @@ final class CareerRecommendationDetailBundle
             'recommendation_subject_meta' => $this->recommendationSubjectMeta,
             'supporting_truth_summary' => $this->supportingTruthSummary,
             'score_bundle' => $this->scoreBundle,
+            'white_box_scores' => $this->whiteBoxScores,
             'warnings' => $this->warnings,
             'claim_permissions' => $this->claimPermissions,
             'integrity_summary' => $this->integritySummary,

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -8,12 +8,14 @@ use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerJobDetailBundle;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
+use App\Services\Career\Scoring\CareerWhiteBoxScorePayloadBuilder;
 use App\Services\PublicSurface\SeoSurfaceContractService;
 
 final class CareerJobDetailBundleBuilder
 {
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
+        private readonly CareerWhiteBoxScorePayloadBuilder $whiteBoxScorePayloadBuilder,
     ) {}
 
     public function buildBySlug(string $slug): ?CareerJobDetailBundle
@@ -72,6 +74,9 @@ final class CareerJobDetailBundleBuilder
         $importRunId = $truthMetric?->import_run_id
             ?? $trustManifest?->import_run_id
             ?? $indexState?->import_run_id;
+
+        $scoreBundle = $this->normalizeArray($payload['score_bundle'] ?? []);
+        $warnings = $this->normalizeArray($payload['warnings'] ?? []);
 
         return new CareerJobDetailBundle(
             identity: [
@@ -179,8 +184,9 @@ final class CareerJobDetailBundleBuilder
                     'notes' => is_array($editorialPatch?->notes) ? $editorialPatch->notes : [],
                 ],
             ],
-            scoreBundle: $this->normalizeArray($payload['score_bundle'] ?? []),
-            warnings: $this->normalizeArray($payload['warnings'] ?? []),
+            scoreBundle: $scoreBundle,
+            whiteBoxScores: $this->whiteBoxScorePayloadBuilder->build($scoreBundle, $warnings),
+            warnings: $warnings,
             claimPermissions: $this->normalizeArray($payload['claim_permissions'] ?? []),
             integritySummary: $this->normalizeArray($payload['integrity_summary'] ?? []),
             seoContract: $this->buildSeoContract($occupation, $snapshot),

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -8,6 +8,7 @@ use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerRecommendationDetailBundle;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
+use App\Services\Career\Scoring\CareerWhiteBoxScorePayloadBuilder;
 use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Support\Collection;
 
@@ -15,6 +16,7 @@ final class CareerRecommendationDetailBundleBuilder
 {
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
+        private readonly CareerWhiteBoxScorePayloadBuilder $whiteBoxScorePayloadBuilder,
     ) {}
 
     public function buildByType(string $type): ?CareerRecommendationDetailBundle
@@ -50,6 +52,9 @@ final class CareerRecommendationDetailBundleBuilder
             ?? $trustManifest?->import_run_id
             ?? $indexState?->import_run_id;
 
+        $scoreBundle = $this->normalizeArray($payload['score_bundle'] ?? []);
+        $warnings = $this->normalizeArray($payload['warnings'] ?? []);
+
         return new CareerRecommendationDetailBundle(
             identity: [
                 'occupation_uuid' => $snapshot->occupation->id,
@@ -75,8 +80,9 @@ final class CareerRecommendationDetailBundleBuilder
                     'evidence_strength' => $sourceTrace->evidence_strength,
                 ] : null,
             ],
-            scoreBundle: $this->normalizeArray($payload['score_bundle'] ?? []),
-            warnings: $this->normalizeArray($payload['warnings'] ?? []),
+            scoreBundle: $scoreBundle,
+            whiteBoxScores: $this->whiteBoxScorePayloadBuilder->build($scoreBundle, $warnings),
+            warnings: $warnings,
             claimPermissions: $this->normalizeArray($payload['claim_permissions'] ?? []),
             integritySummary: $this->normalizeArray($payload['integrity_summary'] ?? []),
             trustManifest: [

--- a/backend/app/Services/Career/Scoring/CareerWhiteBoxScorePayloadBuilder.php
+++ b/backend/app/Services/Career/Scoring/CareerWhiteBoxScorePayloadBuilder.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Scoring;
+
+final class CareerWhiteBoxScorePayloadBuilder
+{
+    /**
+     * @var list<string>
+     */
+    private const SUPPORTED_SCORE_FAMILIES = [
+        'fit_score',
+        'strain_score',
+        'ai_survival_score',
+        'mobility_score',
+        'confidence_score',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const STRAIN_RADAR_DIMENSIONS = [
+        'people_friction',
+        'context_switch_load',
+        'political_load',
+        'uncertainty_load',
+        'low_autonomy_trap',
+        'repetition_mismatch',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $scoreBundle
+     * @param  array<string, mixed>  $warnings
+     * @return array<string, array<string, mixed>>
+     */
+    public function build(array $scoreBundle, array $warnings): array
+    {
+        $payload = [];
+
+        foreach (self::SUPPORTED_SCORE_FAMILIES as $scoreFamily) {
+            $score = $scoreBundle[$scoreFamily] ?? null;
+            if (! is_array($score)) {
+                continue;
+            }
+
+            $componentBreakdown = is_array($score['component_breakdown'] ?? null)
+                ? $score['component_breakdown']
+                : [];
+
+            $entry = [
+                'score' => (int) ($score['value'] ?? 0),
+                'integrity_state' => is_scalar($score['integrity_state'] ?? null)
+                    ? (string) $score['integrity_state']
+                    : null,
+                'degradation_factor' => round((float) ($score['degradation_factor'] ?? 0.0), 4),
+                'formula_breakdown' => $this->buildFormulaBreakdown($componentBreakdown),
+                'component_weights' => $this->buildComponentWeights($componentBreakdown),
+                'penalties' => $this->buildPenalties($score['penalties'] ?? null),
+                'warnings' => $this->buildWarnings($warnings, $scoreFamily, $score['penalties'] ?? null),
+            ];
+
+            $radarDimensions = $this->buildStrainRadarDimensions($scoreFamily, $componentBreakdown);
+            if ($radarDimensions !== []) {
+                $entry['radar_dimensions'] = $radarDimensions;
+            }
+
+            $payload[$scoreFamily] = $entry;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $componentBreakdown
+     * @return list<array<string, mixed>>
+     */
+    private function buildFormulaBreakdown(array $componentBreakdown): array
+    {
+        $breakdown = [];
+        $inputs = $componentBreakdown['inputs'] ?? null;
+        if (is_array($inputs)) {
+            foreach ($inputs as $component => $value) {
+                if (! is_string($component)) {
+                    continue;
+                }
+
+                $breakdown[] = [
+                    'component' => $component,
+                    'value' => round((float) $value, 4),
+                ];
+            }
+        }
+
+        if (is_numeric($componentBreakdown['base_score'] ?? null)) {
+            $breakdown[] = [
+                'component' => 'base_score',
+                'value' => round((float) $componentBreakdown['base_score'], 4),
+            ];
+        }
+
+        if (is_numeric($componentBreakdown['penalty_factor'] ?? null)) {
+            $breakdown[] = [
+                'component' => 'penalty_factor',
+                'value' => round((float) $componentBreakdown['penalty_factor'], 4),
+            ];
+        }
+
+        return $breakdown;
+    }
+
+    /**
+     * @param  array<string, mixed>  $componentBreakdown
+     * @return array<string, float>
+     */
+    private function buildComponentWeights(array $componentBreakdown): array
+    {
+        $weights = $componentBreakdown['weights'] ?? null;
+        if (! is_array($weights)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($weights as $component => $weight) {
+            if (! is_string($component) || ! is_numeric($weight)) {
+                continue;
+            }
+
+            $normalized[$component] = round((float) $weight, 4);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function buildPenalties(mixed $penalties): array
+    {
+        if (! is_array($penalties)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($penalties as $penalty) {
+            if (! is_array($penalty)) {
+                continue;
+            }
+
+            $entry = [];
+
+            if (is_scalar($penalty['code'] ?? null)) {
+                $entry['code'] = (string) $penalty['code'];
+            }
+            if (is_numeric($penalty['weight'] ?? null)) {
+                $entry['weight'] = round((float) $penalty['weight'], 4);
+            }
+            if (is_numeric($penalty['value'] ?? null)) {
+                $entry['value'] = round((float) $penalty['value'], 4);
+            }
+            if (is_array($penalty['fields'] ?? null)) {
+                $entry['fields'] = array_values(array_filter(
+                    $penalty['fields'],
+                    static fn (mixed $field): bool => is_string($field) && trim($field) !== ''
+                ));
+            }
+
+            if ($entry !== []) {
+                $normalized[] = $entry;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $warnings
+     * @return list<string>
+     */
+    private function buildWarnings(array $warnings, string $scoreFamily, mixed $penalties): array
+    {
+        $result = [];
+
+        foreach (['red_flags', 'amber_flags'] as $bucket) {
+            $flags = $warnings[$bucket] ?? null;
+            if (! is_array($flags)) {
+                continue;
+            }
+
+            foreach ($flags as $flag) {
+                if (! is_string($flag)) {
+                    continue;
+                }
+
+                if (str_starts_with($flag, $scoreFamily.'.')) {
+                    $result[] = $flag;
+                }
+            }
+        }
+
+        if (is_array($penalties)) {
+            foreach ($penalties as $penalty) {
+                if (! is_array($penalty) || ! is_scalar($penalty['code'] ?? null)) {
+                    continue;
+                }
+
+                $result[] = 'penalty:'.(string) $penalty['code'];
+            }
+        }
+
+        return array_values(array_unique($result));
+    }
+
+    /**
+     * @param  array<string, mixed>  $componentBreakdown
+     * @return list<array<string, mixed>>
+     */
+    private function buildStrainRadarDimensions(string $scoreFamily, array $componentBreakdown): array
+    {
+        if ($scoreFamily !== 'strain_score') {
+            return [];
+        }
+
+        $inputs = $componentBreakdown['inputs'] ?? null;
+        if (! is_array($inputs)) {
+            return [];
+        }
+
+        $dimensions = [];
+
+        foreach (self::STRAIN_RADAR_DIMENSIONS as $dimension) {
+            if (! array_key_exists($dimension, $inputs)) {
+                continue;
+            }
+
+            $dimensions[] = [
+                'dimension' => $dimension,
+                'value' => round((float) $inputs[$dimension], 4),
+            ];
+        }
+
+        return $dimensions;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T13:22:00Z",
+  "updated_at": "2026-04-16T08:28:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1644,9 +1644,9 @@
     "PR-B63": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "github_checks_failed",
+      "status": "merged",
       "branch": "codex/pr-b63-career-claim-blocked-attribution-taxonomy-refinement-backend-first",
-      "commit_sha": "5c2c632f29de3bf7f15dc7f3cd22f846663fd6cf",
+      "commit_sha": "e0c52d948be3dff0c581610a510b3e23e4bc51ae",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/908",
       "checks": {
         "local": [
@@ -1663,30 +1663,47 @@
             "status": "passed"
           }
         ],
-        "github": [
-          {
-            "name": "hygiene",
-            "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456551260/job/71458725029"
-          },
-          {
-            "name": "hygiene",
-            "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456553680/job/71458732251"
-          },
-          {
-            "name": "verify-mbti-${{ matrix.mode }}",
-            "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456551260/job/71458737558"
-          },
-          {
-            "name": "verify-mbti-${{ matrix.mode }}",
-            "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24456553680/job/71458745737"
-          }
-        ]
+        "github": []
       },
-      "failure_reason": "GitHub Actions jobs were blocked by repository billing/spending-limit failure; hygiene failed before execution and MBTI jobs were skipped while local validation passed.",
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-15T13:15:27Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B64": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b64-career-white-box-score-payload-completion",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "vendor/bin/pint --test app/Services/Career/Scoring/CareerWhiteBoxScorePayloadBuilder.php tests/Unit/Services/Career/CareerWhiteBoxScorePayloadBuilderTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendation*.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Unit/Services/Career/CareerWhiteBoxScorePayloadBuilderTest.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendation*.php",
+            "status": "passed"
+          },
+          {
+            "name": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T08:44:00Z",
+  "updated_at": "2026-04-16T08:46:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -91,22 +91,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466448485/job/71494748343"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466476354/job/71494846903"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466447743/job/71494746546"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466474686/job/71494841681"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466448485/job/71494758820"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466476354/job/71494856343"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466447743/job/71494758203"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466474686/job/71494850992"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T08:28:00Z",
+  "updated_at": "2026-04-16T08:40:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1674,10 +1674,10 @@
     "PR-B64": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-b64-career-white-box-score-payload-completion",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "2ea1e88afa5b71e7805acbdb82ba60a7574fbbc3",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/911",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T08:42:00Z",
+  "updated_at": "2026-04-16T08:44:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -91,22 +91,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466409378/job/71494604425"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466448485/job/71494748343"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466407656/job/71494598217"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466447743/job/71494746546"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466409378/job/71494617337"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466448485/job/71494758820"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466407656/job/71494608215"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466447743/job/71494758203"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T08:40:00Z",
+  "updated_at": "2026-04-16T08:42:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -60,7 +60,7 @@
     "PR-B12": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b12-first-wave-blocked-governance",
       "commit_sha": "17bcdef3da55f217d76bf42c39f0b361dd034751",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/852",
@@ -87,9 +87,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466409378/job/71494604425"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466407656/job/71494598217"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466409378/job/71494617337"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24466407656/job/71494608215"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions jobs were blocked by repository billing/spending-limit failure; hygiene failed before execution and MBTI jobs were skipped while local validation passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1005,6 +1005,36 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B64
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b64-career-white-box-score-payload-completion
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Career white-box score payload completion.
+      Add a unified backend-owned white_box_scores payload builder and wire it
+      additively into career job-detail and recommendation-detail bundles so
+      formula breakdown, penalties, degradation factor, component weights, and
+      warnings are machine-consumable without inventing new formulas or exposing
+      internal debug-only traces.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Scoring/CareerWhiteBoxScorePayloadBuilder.php tests/Unit/Services/Career/CareerWhiteBoxScorePayloadBuilderTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendation*.php"
+      - "php artisan test tests/Unit/Services/Career/CareerWhiteBoxScorePayloadBuilderTest.php"
+      - "php artisan test tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendation*.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -54,7 +54,7 @@ final class CareerJobDetailApiTest extends TestCase
             'import_run_id' => $importRun->id,
         ]);
 
-        $this->getJson('/api/v0.5/career/jobs/backend-architect')
+        $response = $this->getJson('/api/v0.5/career/jobs/backend-architect')
             ->assertOk()
             ->assertJsonPath('bundle_kind', 'career_job_detail')
             ->assertJsonPath('identity.canonical_slug', 'backend-architect')
@@ -79,6 +79,17 @@ final class CareerJobDetailApiTest extends TestCase
                 'truth_layer',
                 'trust_manifest',
                 'score_bundle' => ['fit_score'],
+                'white_box_scores' => [
+                    'fit_score' => [
+                        'score',
+                        'integrity_state',
+                        'degradation_factor',
+                        'formula_breakdown',
+                        'component_weights',
+                        'penalties',
+                        'warnings',
+                    ],
+                ],
                 'warnings',
                 'claim_permissions',
                 'integrity_summary',
@@ -88,7 +99,13 @@ final class CareerJobDetailApiTest extends TestCase
                     'breadcrumb_list',
                 ],
                 'provenance_meta' => ['compiler_version', 'compile_refs'],
-            ]);
+            ])
+            ->assertJsonMissingPath('white_box_scores.fit_score.formula_ref')
+            ->assertJsonMissingPath('white_box_scores.fit_score.critical_missing_fields');
+
+        $this->assertIsNumeric($response->json('white_box_scores.fit_score.score'));
+        $this->assertIsString((string) $response->json('white_box_scores.fit_score.integrity_state'));
+        $this->assertIsNumeric($response->json('white_box_scores.fit_score.degradation_factor'));
     }
 
     public function test_it_remains_conservative_and_does_not_fall_back_to_legacy_cms_jobs(): void

--- a/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
@@ -35,6 +35,17 @@ final class CareerRecommendationDetailApiTest extends TestCase
                 'recommendation_subject_meta',
                 'supporting_truth_summary',
                 'score_bundle' => ['fit_score'],
+                'white_box_scores' => [
+                    'strain_score' => [
+                        'score',
+                        'integrity_state',
+                        'degradation_factor',
+                        'formula_breakdown',
+                        'component_weights',
+                        'penalties',
+                        'warnings',
+                    ],
+                ],
                 'warnings',
                 'claim_permissions',
                 'integrity_summary',
@@ -48,10 +59,15 @@ final class CareerRecommendationDetailApiTest extends TestCase
                 ]],
                 'seo_contract',
                 'provenance_meta' => ['compiler_version', 'compile_refs'],
-            ]);
+            ])
+            ->assertJsonPath('white_box_scores.strain_score.radar_dimensions.0.dimension', 'people_friction')
+            ->assertJsonMissingPath('white_box_scores.strain_score.formula_ref')
+            ->assertJsonMissingPath('white_box_scores.strain_score.critical_missing_fields');
 
         $this->assertIsString((string) $response->json('matched_jobs.0.occupation_uuid'));
         $this->assertNotSame('', (string) $response->json('matched_jobs.0.occupation_uuid'));
+        $this->assertIsNumeric($response->json('white_box_scores.strain_score.score'));
+        $this->assertIsString((string) $response->json('white_box_scores.strain_score.integrity_state'));
     }
 
     public function test_it_returns_authority_owned_matched_jobs_without_using_heavy_job_payload_fields(): void

--- a/backend/tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php
@@ -26,6 +26,7 @@ final class CareerBreadcrumbBuilderTest extends TestCase
             truthLayer: [],
             trustManifest: [],
             scoreBundle: [],
+            whiteBoxScores: [],
             warnings: [],
             claimPermissions: [],
             integritySummary: [],

--- a/backend/tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php
@@ -29,6 +29,7 @@ final class CareerJobDetailStructuredDataPublicProjectionTest extends TestCase
             ],
             trustManifest: [],
             scoreBundle: [],
+            whiteBoxScores: [],
             warnings: [],
             claimPermissions: [],
             integritySummary: [],

--- a/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
@@ -31,6 +31,7 @@ final class CareerStructuredDataBuilderTest extends TestCase
             ],
             trustManifest: [],
             scoreBundle: [],
+            whiteBoxScores: [],
             warnings: [],
             claimPermissions: [],
             integritySummary: [],

--- a/backend/tests/Unit/Services/Career/CareerWhiteBoxScorePayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerWhiteBoxScorePayloadBuilderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Scoring\CareerWhiteBoxScorePayloadBuilder;
+use Tests\TestCase;
+
+final class CareerWhiteBoxScorePayloadBuilderTest extends TestCase
+{
+    public function test_it_builds_machine_safe_white_box_payload_from_score_bundle_truth(): void
+    {
+        $builder = app(CareerWhiteBoxScorePayloadBuilder::class);
+
+        $payload = $builder->build([
+            'fit_score' => [
+                'value' => 78,
+                'integrity_state' => 'full',
+                'degradation_factor' => 1.0,
+                'component_breakdown' => [
+                    'inputs' => ['cognitive_fit' => 0.86, 'task_fit' => 0.74],
+                    'weights' => ['cognitive_fit' => 0.25, 'task_fit' => 0.2],
+                    'base_score' => 81.42,
+                    'penalty_factor' => 0.96,
+                ],
+                'penalties' => [
+                    ['code' => 'review_pending', 'weight' => 0.04, 'value' => 1.0],
+                ],
+            ],
+            'strain_score' => [
+                'value' => 41,
+                'integrity_state' => 'provisional',
+                'degradation_factor' => 0.82,
+                'component_breakdown' => [
+                    'inputs' => [
+                        'people_friction' => 0.43,
+                        'context_switch_load' => 0.58,
+                        'political_load' => 0.39,
+                        'uncertainty_load' => 0.55,
+                        'low_autonomy_trap' => 0.47,
+                        'repetition_mismatch' => 0.31,
+                    ],
+                    'weights' => [
+                        'people_friction' => 0.16,
+                        'context_switch_load' => 0.2,
+                    ],
+                    'base_score' => 46.2,
+                ],
+                'penalties' => [],
+            ],
+            'unknown_score' => [
+                'value' => 99,
+            ],
+        ], [
+            'red_flags' => ['fit_score.blocked', 'missing_median_pay'],
+            'amber_flags' => ['strain_score.provisional', 'review_pending'],
+            'blocked_claims' => ['strong_claim'],
+        ]);
+
+        $this->assertSame(['fit_score', 'strain_score'], array_keys($payload));
+
+        $this->assertSame(78, data_get($payload, 'fit_score.score'));
+        $this->assertSame('full', data_get($payload, 'fit_score.integrity_state'));
+        $this->assertSame(1.0, data_get($payload, 'fit_score.degradation_factor'));
+        $this->assertSame(0.25, data_get($payload, 'fit_score.component_weights.cognitive_fit'));
+        $this->assertSame('cognitive_fit', data_get($payload, 'fit_score.formula_breakdown.0.component'));
+        $this->assertSame('review_pending', data_get($payload, 'fit_score.penalties.0.code'));
+        $this->assertContains('fit_score.blocked', (array) data_get($payload, 'fit_score.warnings'));
+        $this->assertContains('penalty:review_pending', (array) data_get($payload, 'fit_score.warnings'));
+        $this->assertArrayNotHasKey('formula_ref', (array) data_get($payload, 'fit_score'));
+        $this->assertArrayNotHasKey('critical_missing_fields', (array) data_get($payload, 'fit_score'));
+
+        $this->assertSame('strain_score.provisional', data_get($payload, 'strain_score.warnings.0'));
+        $this->assertSame(
+            ['people_friction', 'context_switch_load', 'political_load', 'uncertainty_load', 'low_autonomy_trap', 'repetition_mismatch'],
+            array_map(static fn (array $row): string => (string) ($row['dimension'] ?? ''), (array) data_get($payload, 'strain_score.radar_dimensions'))
+        );
+    }
+
+    public function test_it_omits_unstable_entries_when_score_payload_is_missing(): void
+    {
+        $builder = app(CareerWhiteBoxScorePayloadBuilder::class);
+
+        $payload = $builder->build([
+            'fit_score' => 'invalid',
+            'ai_survival_score' => [
+                'value' => 63,
+                'integrity_state' => 'restricted',
+                'degradation_factor' => 0.74,
+            ],
+        ], []);
+
+        $this->assertArrayNotHasKey('fit_score', $payload);
+        $this->assertSame(63, data_get($payload, 'ai_survival_score.score'));
+        $this->assertSame([], data_get($payload, 'ai_survival_score.formula_breakdown'));
+        $this->assertSame([], data_get($payload, 'ai_survival_score.component_weights'));
+        $this->assertSame([], data_get($payload, 'ai_survival_score.penalties'));
+        $this->assertSame([], data_get($payload, 'ai_survival_score.warnings'));
+        $this->assertArrayNotHasKey('radar_dimensions', (array) data_get($payload, 'ai_survival_score'));
+    }
+}


### PR DESCRIPTION
## What changed
- Added backend white-box payload builder: `CareerWhiteBoxScorePayloadBuilder` to normalize score explainability into `white_box_scores`.
- Wired additive `white_box_scores` into job detail and recommendation detail bundles (no formula changes).
- Extended DTO contracts for `CareerJobDetailBundle` and `CareerRecommendationDetailBundle` with `white_box_scores`.
- Added focused unit tests for payload builder and API assertions for job/recommendation responses.
- Updated train ledger for PR-B64 and synchronized PR-B63 merged status.

## Why
- Frontend needs a stable, render-ready explainability contract for formula breakdown, component weights, penalties, degradation factor, and warnings, without re-deriving scoring logic.
- This keeps scoring authority in backend and avoids exposing debug-only internals.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Scoring/CareerWhiteBoxScorePayloadBuilder.php tests/Unit/Services/Career/CareerWhiteBoxScorePayloadBuilderTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendation*.php`
- `php artisan test tests/Unit/Services/Career/CareerWhiteBoxScorePayloadBuilderTest.php`
- `php artisan test tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerRecommendation*.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- No scoring formula changes.
- No family-hub explainability payload.
- No frontend changes.
- No trust/rollout/attribution semantics expansion beyond additive payload projection.