### PR TITLE
PR-B65: Career transition engine contract expansion

### DIFF
--- a/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
+++ b/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
@@ -19,6 +19,7 @@ final class CareerRecommendationDetailBundle
      * @param  list<array<string, mixed>>  $matchedJobs
      * @param  array<string, mixed>  $seoContract
      * @param  array<string, mixed>  $provenanceMeta
+     * @param  array<string, mixed>|null  $transitionPath
      */
     public function __construct(
         public readonly array $identity,
@@ -31,6 +32,7 @@ final class CareerRecommendationDetailBundle
         public readonly array $integritySummary,
         public readonly array $trustManifest,
         public readonly array $matchedJobs,
+        public readonly ?array $transitionPath,
         public readonly array $seoContract,
         public readonly array $provenanceMeta,
     ) {}
@@ -40,7 +42,7 @@ final class CareerRecommendationDetailBundle
      */
     public function toArray(): array
     {
-        return [
+        $payload = [
             'bundle_kind' => 'career_recommendation_detail',
             'bundle_version' => 'career.protocol.recommendation_detail.v1',
             'identity' => $this->identity,
@@ -53,8 +55,15 @@ final class CareerRecommendationDetailBundle
             'integrity_summary' => $this->integritySummary,
             'trust_manifest' => $this->trustManifest,
             'matched_jobs' => $this->matchedJobs,
+            'transition_path' => $this->transitionPath,
             'seo_contract' => $this->seoContract,
             'provenance_meta' => $this->provenanceMeta,
         ];
+
+        if ($payload['transition_path'] === null || $payload['transition_path'] === []) {
+            unset($payload['transition_path']);
+        }
+
+        return $payload;
     }
 }

--- a/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
+++ b/backend/app/DTO/Career/CareerTransitionPreviewBundle.php
@@ -22,6 +22,11 @@ final class CareerTransitionPreviewBundle
         'target_job',
         'score_summary',
         'trust_summary',
+        'why_this_path',
+        'what_is_lost',
+        'bridge_steps_90d',
+        'rationale_codes',
+        'tradeoff_codes',
         'seo_contract',
         'provenance_meta',
     ];
@@ -32,6 +37,9 @@ final class CareerTransitionPreviewBundle
      * @param  array<string, mixed>  $trustSummary
      * @param  array<string, mixed>  $seoContract
      * @param  array<string, mixed>  $provenanceMeta
+     * @param  list<array{step_key:string,title:string,description:string,time_horizon:string}>|null  $bridgeSteps90d
+     * @param  list<string>|null  $rationaleCodes
+     * @param  list<string>|null  $tradeoffCodes
      * @param  list<string>|null  $steps
      * @param  array<string, array{source_value:string,target_value:string,direction:string}>|null  $delta
      */
@@ -42,6 +50,11 @@ final class CareerTransitionPreviewBundle
         public readonly array $targetJob,
         public readonly array $scoreSummary,
         public readonly array $trustSummary,
+        public readonly ?string $whyThisPath,
+        public readonly ?string $whatIsLost,
+        public readonly ?array $bridgeSteps90d,
+        public readonly ?array $rationaleCodes,
+        public readonly ?array $tradeoffCodes,
         public readonly array $seoContract,
         public readonly array $provenanceMeta,
     ) {}
@@ -60,6 +73,11 @@ final class CareerTransitionPreviewBundle
             'target_job' => $this->targetJob,
             'score_summary' => $this->scoreSummary,
             'trust_summary' => $this->trustSummary,
+            'why_this_path' => $this->whyThisPath,
+            'what_is_lost' => $this->whatIsLost,
+            'bridge_steps_90d' => $this->bridgeSteps90d,
+            'rationale_codes' => $this->rationaleCodes,
+            'tradeoff_codes' => $this->tradeoffCodes,
             'seo_contract' => $this->seoContract,
             'provenance_meta' => $this->provenanceMeta,
         ];
@@ -70,6 +88,26 @@ final class CareerTransitionPreviewBundle
 
         if ($payload['delta'] === null) {
             unset($payload['delta']);
+        }
+
+        if ($payload['why_this_path'] === null || $payload['why_this_path'] === '') {
+            unset($payload['why_this_path']);
+        }
+
+        if ($payload['what_is_lost'] === null || $payload['what_is_lost'] === '') {
+            unset($payload['what_is_lost']);
+        }
+
+        if ($payload['bridge_steps_90d'] === null || $payload['bridge_steps_90d'] === []) {
+            unset($payload['bridge_steps_90d']);
+        }
+
+        if ($payload['rationale_codes'] === null || $payload['rationale_codes'] === []) {
+            unset($payload['rationale_codes']);
+        }
+
+        if ($payload['tradeoff_codes'] === null || $payload['tradeoff_codes'] === []) {
+            unset($payload['tradeoff_codes']);
         }
 
         /** @var array<string, mixed> $publicPayload */

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -6,6 +6,7 @@ namespace App\Services\Career\Bundles;
 
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerRecommendationDetailBundle;
+use App\DTO\Career\CareerTransitionPreviewBundle;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
 use App\Services\Career\Scoring\CareerWhiteBoxScorePayloadBuilder;
@@ -17,6 +18,7 @@ final class CareerRecommendationDetailBundleBuilder
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly CareerWhiteBoxScorePayloadBuilder $whiteBoxScorePayloadBuilder,
+        private readonly CareerTransitionPreviewBundleBuilder $transitionPreviewBundleBuilder,
     ) {}
 
     public function buildByType(string $type): ?CareerRecommendationDetailBundle
@@ -54,6 +56,8 @@ final class CareerRecommendationDetailBundleBuilder
 
         $scoreBundle = $this->normalizeArray($payload['score_bundle'] ?? []);
         $warnings = $this->normalizeArray($payload['warnings'] ?? []);
+        $routeSubject = $this->routeSubject($subjectMeta, $requestedType);
+        $transitionPath = $this->recommendationTransitionPath($routeSubject);
 
         return new CareerRecommendationDetailBundle(
             identity: [
@@ -96,7 +100,8 @@ final class CareerRecommendationDetailBundleBuilder
                 'methodology' => is_array($trustManifest?->methodology) ? $trustManifest->methodology : [],
             ],
             matchedJobs: $this->buildMatchedJobs($snapshots),
-            seoContract: $this->buildSeoContract($snapshot, $subjectMeta, $requestedType),
+            transitionPath: $transitionPath,
+            seoContract: $this->buildSeoContract($snapshot, $routeSubject),
             provenanceMeta: [
                 'content_version' => $trustManifest?->content_version,
                 'data_version' => $trustManifest?->data_version,
@@ -216,10 +221,9 @@ final class CareerRecommendationDetailBundleBuilder
      * @param  array<string, mixed>  $subjectMeta
      * @return array<string, mixed>
      */
-    private function buildSeoContract(RecommendationSnapshot $snapshot, array $subjectMeta, string $requestedType): array
+    private function buildSeoContract(RecommendationSnapshot $snapshot, string $routeSubject): array
     {
         $indexState = $snapshot->indexState;
-        $routeSubject = $this->routeSubject($subjectMeta, $requestedType);
         $canonicalPath = '/career/recommendations/mbti/'.$routeSubject;
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
         $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
@@ -246,6 +250,22 @@ final class CareerRecommendationDetailBundleBuilder
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
             'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
         ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function recommendationTransitionPath(string $routeSubject): ?array
+    {
+        $bundle = $this->transitionPreviewBundleBuilder->buildByType($routeSubject);
+        if (! $bundle instanceof CareerTransitionPreviewBundle) {
+            return null;
+        }
+
+        $payload = $bundle->toArray();
+        unset($payload['bundle_kind'], $payload['bundle_version'], $payload['seo_contract'], $payload['provenance_meta']);
+
+        return $payload === [] ? null : $payload;
     }
 
     /**

--- a/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerTransitionPreviewBundleBuilder.php
@@ -10,12 +10,14 @@ use App\DTO\Career\CareerTransitionPreviewBundle;
 use App\Models\RecommendationSnapshot;
 use App\Models\TransitionPath;
 use App\Services\Career\CareerTransitionPreviewReadinessLookup;
+use App\Services\Career\Transition\CareerTransitionContractBuilder;
 use Illuminate\Support\Collection;
 
 final class CareerTransitionPreviewBundleBuilder
 {
     public function __construct(
         private readonly CareerTransitionPreviewReadinessLookup $readinessLookup,
+        private readonly CareerTransitionContractBuilder $transitionContractBuilder,
     ) {}
 
     public function buildByType(string $type): ?CareerTransitionPreviewBundle
@@ -119,6 +121,7 @@ final class CareerTransitionPreviewBundleBuilder
             ? null
             : array_values($normalizedPathPayload->steps);
         $publicDelta = $this->publicDelta($normalizedPathPayload->delta);
+        $transitionExpansion = $this->transitionContractBuilder->build($normalizedPathPayload);
 
         $scoreBundle = is_array($payload['score_bundle'] ?? null) ? $payload['score_bundle'] : [];
         $reasonCodes = is_array($claimPermissions['reason_codes'] ?? null) ? array_values($claimPermissions['reason_codes']) : [];
@@ -142,6 +145,21 @@ final class CareerTransitionPreviewBundleBuilder
                 'reviewer_status' => $readiness['reviewer_status'] ?? null,
                 'reason_codes' => $reasonCodes,
             ],
+            whyThisPath: is_string($transitionExpansion['why_this_path'] ?? null)
+                ? $transitionExpansion['why_this_path']
+                : null,
+            whatIsLost: is_string($transitionExpansion['what_is_lost'] ?? null)
+                ? $transitionExpansion['what_is_lost']
+                : null,
+            bridgeSteps90d: is_array($transitionExpansion['bridge_steps_90d'] ?? null)
+                ? $transitionExpansion['bridge_steps_90d']
+                : null,
+            rationaleCodes: is_array($transitionExpansion['rationale_codes'] ?? null)
+                ? $transitionExpansion['rationale_codes']
+                : null,
+            tradeoffCodes: is_array($transitionExpansion['tradeoff_codes'] ?? null)
+                ? $transitionExpansion['tradeoff_codes']
+                : null,
             seoContract: [
                 'canonical_path' => '/career/jobs/'.$targetOccupation->canonical_slug,
                 'canonical_target' => null,

--- a/backend/app/Services/Career/Transition/CareerTransitionContractBuilder.php
+++ b/backend/app/Services/Career/Transition/CareerTransitionContractBuilder.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Transition;
+
+use App\Domain\Career\Transition\TransitionPathPayload;
+
+final class CareerTransitionContractBuilder
+{
+    public const TIME_HORIZON_DAYS_0_30 = 'days_0_30';
+
+    public const TIME_HORIZON_DAYS_31_60 = 'days_31_60';
+
+    public const TIME_HORIZON_DAYS_61_90 = 'days_61_90';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(TransitionPathPayload $payload): array
+    {
+        $contract = [];
+
+        if ($payload->rationaleCodes !== []) {
+            $contract['rationale_codes'] = array_values($payload->rationaleCodes);
+            $contract['why_this_path'] = $this->summaryFromRationaleCodes($payload->rationaleCodes);
+        }
+
+        if ($payload->tradeoffCodes !== []) {
+            $contract['tradeoff_codes'] = array_values($payload->tradeoffCodes);
+            $contract['what_is_lost'] = $this->summaryFromTradeoffCodes($payload->tradeoffCodes);
+        }
+
+        $bridgeSteps = $this->bridgeStepsFromStepCodes($payload->steps);
+        if ($bridgeSteps !== []) {
+            $contract['bridge_steps_90d'] = $bridgeSteps;
+        }
+
+        return $contract;
+    }
+
+    /**
+     * @param  list<string>  $rationaleCodes
+     */
+    private function summaryFromRationaleCodes(array $rationaleCodes): string
+    {
+        $labels = [];
+        foreach ($rationaleCodes as $code) {
+            $labels[] = match ($code) {
+                TransitionPathPayload::STEP_SKILL_OVERLAP => 'skill overlap',
+                TransitionPathPayload::STEP_TASK_OVERLAP => 'task overlap',
+                TransitionPathPayload::STEP_TOOL_OVERLAP => 'tool overlap',
+                TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET => 'same-family target',
+                TransitionPathPayload::RATIONALE_PUBLISH_READY_TARGET => 'publish-ready target',
+                TransitionPathPayload::RATIONALE_INDEX_ELIGIBLE_TARGET => 'index-eligible target',
+                TransitionPathPayload::RATIONALE_APPROVED_REVIEWER_TARGET => 'approved reviewer status',
+                TransitionPathPayload::RATIONALE_SAFE_CROSSWALK_TARGET => 'safe crosswalk mode',
+                default => null,
+            };
+        }
+
+        $labels = array_values(array_filter($labels, static fn (mixed $label): bool => is_string($label) && $label !== ''));
+
+        if ($labels === []) {
+            return 'transition rationale available';
+        }
+
+        return 'Path selected from: '.implode('; ', $labels).'.';
+    }
+
+    /**
+     * @param  list<string>  $tradeoffCodes
+     */
+    private function summaryFromTradeoffCodes(array $tradeoffCodes): string
+    {
+        $labels = [];
+        foreach ($tradeoffCodes as $code) {
+            $labels[] = match ($code) {
+                TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED => 'higher entry education requirement',
+                TransitionPathPayload::TRADEOFF_HIGHER_WORK_EXPERIENCE_REQUIRED => 'higher work experience requirement',
+                TransitionPathPayload::TRADEOFF_HIGHER_TRAINING_REQUIRED => 'higher training requirement',
+                default => null,
+            };
+        }
+
+        $labels = array_values(array_filter($labels, static fn (mixed $label): bool => is_string($label) && $label !== ''));
+
+        if ($labels === []) {
+            return 'tradeoff summary available';
+        }
+
+        return 'Tradeoff emphasis: '.implode('; ', $labels).'.';
+    }
+
+    /**
+     * @param  list<string>  $steps
+     * @return list<array{step_key:string,title:string,description:string,time_horizon:string}>
+     */
+    private function bridgeStepsFromStepCodes(array $steps): array
+    {
+        $bridge = [];
+        foreach ($steps as $step) {
+            $bridgeStep = match ($step) {
+                TransitionPathPayload::STEP_SKILL_OVERLAP => [
+                    'step_key' => TransitionPathPayload::STEP_SKILL_OVERLAP,
+                    'title' => 'Validate overlapping skills',
+                    'description' => 'Document source-role strengths that transfer directly to the target role.',
+                    'time_horizon' => self::TIME_HORIZON_DAYS_0_30,
+                ],
+                TransitionPathPayload::STEP_TASK_OVERLAP => [
+                    'step_key' => TransitionPathPayload::STEP_TASK_OVERLAP,
+                    'title' => 'Translate task overlap',
+                    'description' => 'Map repeated target-role tasks to proof from recent source-role execution.',
+                    'time_horizon' => self::TIME_HORIZON_DAYS_31_60,
+                ],
+                TransitionPathPayload::STEP_TOOL_OVERLAP => [
+                    'step_key' => TransitionPathPayload::STEP_TOOL_OVERLAP,
+                    'title' => 'Close tooling gap',
+                    'description' => 'Build explicit exposure to core target-role tools through scoped practice.',
+                    'time_horizon' => self::TIME_HORIZON_DAYS_61_90,
+                ],
+                default => null,
+            };
+
+            if (is_array($bridgeStep)) {
+                $bridge[] = $bridgeStep;
+            }
+        }
+
+        return array_values($bridge);
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T23:53:35Z",
+  "updated_at": "2026-04-15T23:56:47Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1733,10 +1733,10 @@
     "PR-B65": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b65-career-transition-engine-contract-expansion",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "74a5beaf99783a476cd034cc50d4bd11bd767003",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/912",
       "checks": {
         "local": [
           {
@@ -1760,9 +1760,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24484495060/job/71556197635"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24484495060/job/71556201760"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions hygiene job failed immediately on PR-B65; local validation passed, but required remote checks are not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T08:46:00Z",
+  "updated_at": "2026-04-15T23:53:35Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1695,7 +1695,7 @@
     "PR-B64": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "merged",
       "branch": "codex/pr-b64-career-white-box-score-payload-completion",
       "commit_sha": "2ea1e88afa5b71e7805acbdb82ba60a7574fbbc3",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/911",
@@ -1719,6 +1719,44 @@
           },
           {
             "name": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-15T16:42:53Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B65": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-b65-career-transition-engine-contract-expansion",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Transition/*.php app/DTO/Career/CareerTransition*.php tests/Unit/Services/Career/CareerTransitionContractBuilderTest.php tests/Feature/Career/CareerRecommendation*.php tests/Feature/Career/CareerTransitionPreview*.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerTransitionContractBuilderTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/CareerRecommendation*.php tests/Feature/Career/CareerTransitionPreview*.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
             "status": "passed"
           }
         ],

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1035,6 +1035,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B65
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b65-career-transition-engine-contract-expansion
+    base: main
+    depends_on: ["PR-B64"]
+    mode: execute
+    scope: >
+      Career transition engine contract expansion.
+      Expand transition contract truth from preview-oriented shape into a
+      frontend-consumable structured contract by additively exposing
+      why_this_path, what_is_lost, bridge_steps_90d, rationale_codes, and
+      tradeoff_codes without changing transition algorithms or unrelated surfaces.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Transition/*.php app/DTO/Career/CareerTransition*.php tests/Unit/Services/Career/CareerTransitionContractBuilderTest.php tests/Feature/Career/CareerRecommendation*.php tests/Feature/Career/CareerTransitionPreview*.php"
+      - "php artisan test tests/Unit/Services/Career/CareerTransitionContractBuilderTest.php"
+      - "php artisan test tests/Feature/Career/CareerRecommendation*.php tests/Feature/Career/CareerTransitionPreview*.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Domain\Career\Transition\TransitionPathPayload;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
+use App\Models\Occupation;
+use App\Models\RecommendationSnapshot;
 use App\Services\Career\CareerRecommendationCompiler;
+use App\Services\Career\CareerTransitionPreviewReadinessLookup;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
 use Tests\Fixtures\Career\CareerFoundationFixture;
 use Tests\TestCase;
 
@@ -95,6 +100,80 @@ final class CareerRecommendationDetailApiTest extends TestCase
         $this->assertArrayNotHasKey('score_bundle', $matchedJobs[0]);
     }
 
+    public function test_it_additively_exposes_transition_path_contract_with_structured_bridge_and_tradeoff_fields(): void
+    {
+        $snapshot = $this->compileRecommendationChainBySlug('recommendation-transition-contract');
+        $target = $this->seedTargetOccupation('registered-nurses', 'Registered Nurses');
+        $this->mockReadinessSummary([
+            $this->readinessRow('registered-nurses', 'publish_ready', true, 'indexable', 'approved'),
+        ]);
+
+        \App\Models\TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $target->id,
+            'path_type' => 'stable_upside',
+            'path_payload' => [
+                'steps' => [
+                    TransitionPathPayload::STEP_SKILL_OVERLAP,
+                    TransitionPathPayload::STEP_TASK_OVERLAP,
+                    TransitionPathPayload::STEP_TOOL_OVERLAP,
+                ],
+                'rationale_codes' => [
+                    TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET,
+                    TransitionPathPayload::RATIONALE_PUBLISH_READY_TARGET,
+                ],
+                'tradeoff_codes' => [
+                    TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED,
+                ],
+                'delta' => [
+                    TransitionPathPayload::DELTA_ENTRY_EDUCATION => [
+                        'source_value' => "Bachelor's degree",
+                        'target_value' => "Master's degree",
+                        'direction' => TransitionPathPayload::DELTA_DIRECTION_HIGHER,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
+            ->assertOk()
+            ->assertJsonPath('transition_path.path_type', 'stable_upside')
+            ->assertJsonPath('transition_path.target_job.canonical_slug', 'registered-nurses')
+            ->assertJsonPath('transition_path.rationale_codes.0', TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET)
+            ->assertJsonPath('transition_path.tradeoff_codes.0', TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED)
+            ->assertJsonPath('transition_path.bridge_steps_90d.0.step_key', TransitionPathPayload::STEP_SKILL_OVERLAP)
+            ->assertJsonPath('transition_path.bridge_steps_90d.0.time_horizon', \App\Services\Career\Transition\CareerTransitionContractBuilder::TIME_HORIZON_DAYS_0_30)
+            ->assertJsonStructure([
+                'transition_path' => [
+                    'path_type',
+                    'steps',
+                    'delta',
+                    'target_job',
+                    'score_summary',
+                    'trust_summary',
+                    'why_this_path',
+                    'what_is_lost',
+                    'bridge_steps_90d',
+                    'rationale_codes',
+                    'tradeoff_codes',
+                ],
+            ])
+            ->assertJsonMissingPath('transition_path.bundle_kind')
+            ->assertJsonMissingPath('transition_path.bundle_version')
+            ->assertJsonMissingPath('transition_path.seo_contract')
+            ->assertJsonMissingPath('transition_path.provenance_meta');
+
+        $this->assertContains(
+            data_get($response->json(), 'transition_path.bridge_steps_90d.0.time_horizon'),
+            [
+                \App\Services\Career\Transition\CareerTransitionContractBuilder::TIME_HORIZON_DAYS_0_30,
+                \App\Services\Career\Transition\CareerTransitionContractBuilder::TIME_HORIZON_DAYS_31_60,
+                \App\Services\Career\Transition\CareerTransitionContractBuilder::TIME_HORIZON_DAYS_61_90,
+            ],
+        );
+    }
+
     public function test_it_returns_conservative_not_found_when_subject_meta_bundle_is_unavailable(): void
     {
         $chain = CareerFoundationFixture::seedHighTrustCompleteChain();
@@ -153,5 +232,108 @@ final class CareerRecommendationDetailApiTest extends TestCase
             'compile_run_id' => $compileRun->id,
             'import_run_id' => $importRun->id,
         ]);
+    }
+
+    private function compileRecommendationChainBySlug(string $slug): RecommendationSnapshot
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-recommendation-transition-'.$slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'materialization' => 'career_first_wave',
+                    'recommendation_subject_meta' => [
+                        'type_code' => 'INTJ-A',
+                        'canonical_type_code' => 'INTJ',
+                        'display_title' => 'INTJ-A Career Match',
+                        'public_route_slug' => 'intj',
+                    ],
+                ],
+            ),
+        ]);
+
+        return app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+    }
+
+    private function seedTargetOccupation(string $slug, string $title): Occupation
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+        $chain['occupation']->update([
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+        ]);
+
+        return $chain['occupation']->fresh();
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $occupations
+     */
+    private function mockReadinessSummary(array $occupations): void
+    {
+        $lookup = Mockery::mock(CareerTransitionPreviewReadinessLookup::class);
+        foreach ($occupations as $row) {
+            $lookup->shouldReceive('bySlug')
+                ->with((string) ($row['canonical_slug'] ?? ''))
+                ->andReturn($row);
+        }
+        $lookup->shouldReceive('bySlug')->andReturn(null);
+
+        $this->app->instance(CareerTransitionPreviewReadinessLookup::class, $lookup);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readinessRow(
+        string $canonicalSlug,
+        string $status,
+        bool $indexEligible,
+        string $indexState,
+        string $reviewerStatus,
+    ): array {
+        return [
+            'occupation_uuid' => 'uuid-'.$canonicalSlug,
+            'canonical_slug' => $canonicalSlug,
+            'canonical_title_en' => $canonicalSlug,
+            'status' => $status,
+            'blocker_type' => null,
+            'remediation_class' => null,
+            'authority_override_supplied' => false,
+            'review_required' => false,
+            'crosswalk_mode' => 'exact',
+            'reviewer_status' => $reviewerStatus,
+            'index_state' => $indexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => [$status],
+        ];
     }
 }

--- a/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
+++ b/backend/tests/Feature/Career/CareerTransitionPreviewApiTest.php
@@ -72,6 +72,11 @@ final class CareerTransitionPreviewApiTest extends TestCase
             ->assertJsonPath('delta.entry_education_delta.source_value', "Bachelor's degree")
             ->assertJsonPath('delta.entry_education_delta.target_value', "Master's degree")
             ->assertJsonPath('delta.entry_education_delta.direction', TransitionPathPayload::DELTA_DIRECTION_HIGHER)
+            ->assertJsonPath('rationale_codes.0', TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET)
+            ->assertJsonPath('rationale_codes.1', TransitionPathPayload::RATIONALE_PUBLISH_READY_TARGET)
+            ->assertJsonPath('tradeoff_codes.0', TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED)
+            ->assertJsonPath('bridge_steps_90d.0.step_key', TransitionPathPayload::STEP_SKILL_OVERLAP)
+            ->assertJsonPath('bridge_steps_90d.0.time_horizon', \App\Services\Career\Transition\CareerTransitionContractBuilder::TIME_HORIZON_DAYS_0_30)
             ->assertJsonStructure([
                 'path_type',
                 'steps',
@@ -84,14 +89,19 @@ final class CareerTransitionPreviewApiTest extends TestCase
                     'confidence_score' => ['value', 'integrity_state', 'band'],
                 ],
                 'trust_summary' => ['allow_transition_recommendation', 'reviewer_status', 'reason_codes'],
+                'why_this_path',
+                'what_is_lost',
+                'bridge_steps_90d' => [[
+                    'step_key',
+                    'title',
+                    'description',
+                    'time_horizon',
+                ]],
+                'rationale_codes',
+                'tradeoff_codes',
                 'seo_contract' => ['canonical_path', 'canonical_target', 'index_state', 'index_eligible', 'reason_codes'],
                 'provenance_meta' => ['recommendation_snapshot_id', 'transition_path_id', 'compiler_version', 'compile_run_id'],
-            ])
-            ->assertJsonMissingPath('why_this_path')
-            ->assertJsonMissingPath('what_is_lost')
-            ->assertJsonMissingPath('bridge_steps_90d')
-            ->assertJsonMissingPath('rationale_codes')
-            ->assertJsonMissingPath('tradeoff_codes');
+            ]);
 
         /** @var array<string, mixed> $payload */
         $payload = $response->json();

--- a/backend/tests/Unit/Services/Career/CareerTransitionContractBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTransitionContractBuilderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Transition\TransitionPathPayload;
+use App\Services\Career\Transition\CareerTransitionContractBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class CareerTransitionContractBuilderTest extends TestCase
+{
+    public function test_it_builds_additive_transition_contract_fields_from_normalized_payload(): void
+    {
+        $payload = TransitionPathPayload::from([
+            'steps' => [
+                TransitionPathPayload::STEP_SKILL_OVERLAP,
+                TransitionPathPayload::STEP_TASK_OVERLAP,
+                TransitionPathPayload::STEP_TOOL_OVERLAP,
+            ],
+            'rationale_codes' => [
+                TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET,
+                TransitionPathPayload::RATIONALE_PUBLISH_READY_TARGET,
+            ],
+            'tradeoff_codes' => [
+                TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED,
+                TransitionPathPayload::TRADEOFF_HIGHER_TRAINING_REQUIRED,
+            ],
+        ]);
+
+        $contract = app(CareerTransitionContractBuilder::class)->build($payload);
+
+        $this->assertSame([
+            TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET,
+            TransitionPathPayload::RATIONALE_PUBLISH_READY_TARGET,
+        ], $contract['rationale_codes'] ?? null);
+        $this->assertSame([
+            TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED,
+            TransitionPathPayload::TRADEOFF_HIGHER_TRAINING_REQUIRED,
+        ], $contract['tradeoff_codes'] ?? null);
+        $this->assertIsString($contract['why_this_path'] ?? null);
+        $this->assertIsString($contract['what_is_lost'] ?? null);
+        $this->assertSame([
+            'days_0_30',
+            'days_31_60',
+            'days_61_90',
+        ], array_column($contract['bridge_steps_90d'] ?? [], 'time_horizon'));
+        $this->assertSame([
+            TransitionPathPayload::STEP_SKILL_OVERLAP,
+            TransitionPathPayload::STEP_TASK_OVERLAP,
+            TransitionPathPayload::STEP_TOOL_OVERLAP,
+        ], array_column($contract['bridge_steps_90d'] ?? [], 'step_key'));
+    }
+
+    public function test_it_omits_fields_when_payload_has_no_stable_transition_explainability_truth(): void
+    {
+        $payload = TransitionPathPayload::from([
+            'steps' => [],
+            'rationale_codes' => [],
+            'tradeoff_codes' => [],
+        ]);
+
+        $this->assertSame([], app(CareerTransitionContractBuilder::class)->build($payload));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTransitionPreviewBundleBuilderTest.php
@@ -64,9 +64,13 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
         $this->assertSame($snapshot->id, data_get($payload, 'provenance_meta.recommendation_snapshot_id'));
         $this->assertNotNull(data_get($payload, 'score_summary.mobility_score.value'));
         $this->assertNull(data_get($payload, 'delta'));
-        $this->assertNull(data_get($payload, 'why_this_path'));
-        $this->assertNull(data_get($payload, 'what_is_lost'));
-        $this->assertNull(data_get($payload, 'bridge_steps_90d'));
+        $this->assertArrayNotHasKey('why_this_path', $payload);
+        $this->assertArrayNotHasKey('what_is_lost', $payload);
+        $this->assertSame([
+            \App\Services\Career\Transition\CareerTransitionContractBuilder::TIME_HORIZON_DAYS_0_30,
+            \App\Services\Career\Transition\CareerTransitionContractBuilder::TIME_HORIZON_DAYS_31_60,
+            \App\Services\Career\Transition\CareerTransitionContractBuilder::TIME_HORIZON_DAYS_61_90,
+        ], array_column((array) ($payload['bridge_steps_90d'] ?? []), 'time_horizon'));
     }
 
     public function test_it_excludes_blocked_override_eligible_targets(): void
@@ -188,7 +192,7 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
 
         $expectedKeys = array_values(array_filter(
             CareerTransitionPreviewBundle::publicTopLevelKeys(),
-            static fn (string $key): bool => $key !== 'steps'
+            static fn (string $key): bool => ! in_array($key, ['steps', 'bridge_steps_90d'], true)
         ));
         $this->assertSame($expectedKeys, array_keys($payload));
         $this->assertSame('stable_upside', $payload['path_type'] ?? null);
@@ -200,11 +204,16 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
                 'direction' => 'higher',
             ],
         ], $payload['delta'] ?? null);
-        $this->assertArrayNotHasKey('why_this_path', $payload);
-        $this->assertArrayNotHasKey('what_is_lost', $payload);
+        $this->assertSame([
+            TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET,
+            TransitionPathPayload::RATIONALE_PUBLISH_READY_TARGET,
+        ], $payload['rationale_codes'] ?? null);
+        $this->assertSame([
+            TransitionPathPayload::TRADEOFF_HIGHER_ENTRY_EDUCATION_REQUIRED,
+        ], $payload['tradeoff_codes'] ?? null);
+        $this->assertIsString($payload['why_this_path'] ?? null);
+        $this->assertIsString($payload['what_is_lost'] ?? null);
         $this->assertArrayNotHasKey('bridge_steps_90d', $payload);
-        $this->assertArrayNotHasKey('rationale_codes', $payload);
-        $this->assertArrayNotHasKey('tradeoff_codes', $payload);
     }
 
     public function test_it_omits_delta_when_internal_truth_is_missing_or_unrankable(): void
@@ -245,8 +254,14 @@ final class CareerTransitionPreviewBundleBuilderTest extends TestCase
         $payload = app(CareerTransitionPreviewBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
 
         $this->assertArrayNotHasKey('delta', $payload);
-        $this->assertArrayNotHasKey('rationale_codes', $payload);
-        $this->assertArrayNotHasKey('tradeoff_codes', $payload);
+        $this->assertSame([
+            TransitionPathPayload::RATIONALE_SAME_FAMILY_TARGET,
+        ], $payload['rationale_codes'] ?? null);
+        $this->assertSame([
+            TransitionPathPayload::TRADEOFF_HIGHER_WORK_EXPERIENCE_REQUIRED,
+        ], $payload['tradeoff_codes'] ?? null);
+        $this->assertIsString($payload['why_this_path'] ?? null);
+        $this->assertIsString($payload['what_is_lost'] ?? null);
     }
 
     public function test_it_excludes_paths_with_invalid_non_array_payload_shape(): void


### PR DESCRIPTION
## What Changed
- Added a dedicated transition contract builder to produce additive structured explainability fields from backend-owned transition truth:
  - `why_this_path`
  - `what_is_lost`
  - `bridge_steps_90d`
  - `rationale_codes`
  - `tradeoff_codes`
- Expanded transition preview bundle DTO + builder to expose the new fields while preserving existing stable fields.
- Expanded recommendation detail bundle DTO + builder to include additive `transition_path` (built from the same transition source), with preview wrapper metadata removed.
- Added/updated unit and feature tests to lock:
  - additive field presence
  - omission behavior when truth is unavailable
  - constrained enum/value behavior
  - old field compatibility

## Why
Current transition payload remained preview-oriented and lacked stable structured fields needed for direct frontend consumption. This PR completes the contract in a conservative additive way without introducing new recommendation algorithms or cross-surface drift.

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Transition/*.php app/DTO/Career/CareerTransition*.php tests/Unit/Services/Career/CareerTransitionContractBuilderTest.php tests/Feature/Career/CareerRecommendation*.php tests/Feature/Career/CareerTransitionPreview*.php`
- `php artisan test tests/Unit/Services/Career/CareerTransitionContractBuilderTest.php`
- `php artisan test tests/Feature/Career/CareerRecommendation*.php tests/Feature/Career/CareerTransitionPreview*.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally Deferred
- No frontend changes.
- No transition algorithm invention.
- No `suggested_action` expansion.
- No family hub transition payload expansion.
