### PR TITLE
PR-B66: Career index policy engine formalization

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWaveIndexPolicyAuthority.php
+++ b/backend/app/DTO/Career/CareerFirstWaveIndexPolicyAuthority.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveIndexPolicyAuthority
+{
+    /**
+     * @param  array{noindex:int,promotion_candidate:int,indexed:int,demoted:int}  $counts
+     * @param  list<CareerFirstWaveIndexPolicyMember>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'policy_kind' => 'career_first_wave_index_policy_authority',
+            'policy_version' => 'career.index_policy.first_wave.v1',
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'members' => array_map(
+                static fn (CareerFirstWaveIndexPolicyMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWaveIndexPolicyMember.php
+++ b/backend/app/DTO/Career/CareerFirstWaveIndexPolicyMember.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWaveIndexPolicyMember
+{
+    /**
+     * @param  list<string>  $policyReasons
+     * @param  array{
+     *   confidence_score:?int,
+     *   reviewer_status:?string,
+     *   crosswalk_mode:?string,
+     *   allow_strong_claim:bool,
+     *   blocked_governance_status:?string,
+     *   next_step_links_count:int,
+     *   trust_freshness:array{review_due_known:bool,review_staleness_state:string}
+     * }  $policyEvidence
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $currentIndexState,
+        public readonly string $publicIndexState,
+        public readonly bool $indexEligible,
+        public readonly string $policyState,
+        public readonly array $policyReasons,
+        public readonly array $policyEvidence,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'member_kind' => 'career_job_detail',
+            'canonical_slug' => $this->canonicalSlug,
+            'current_index_state' => $this->currentIndexState,
+            'public_index_state' => $this->publicIndexState,
+            'index_eligible' => $this->indexEligible,
+            'policy_state' => $this->policyState,
+            'policy_reasons' => $this->policyReasons,
+            'policy_evidence' => $this->policyEvidence,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveIndexPolicyEngine.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveIndexPolicyEngine.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Domain\Career\IndexStateValue;
+use App\DTO\Career\CareerFirstWaveIndexPolicyAuthority;
+use App\DTO\Career\CareerFirstWaveIndexPolicyMember;
+
+final class CareerFirstWaveIndexPolicyEngine
+{
+    public const SCOPE = 'career_first_wave_10';
+
+    /**
+     * @param  list<array<string, mixed>>  $subjects
+     */
+    public function build(array $subjects, string $scope = self::SCOPE): CareerFirstWaveIndexPolicyAuthority
+    {
+        $counts = [
+            CareerIndexLifecycleState::NOINDEX => 0,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE => 0,
+            CareerIndexLifecycleState::INDEXED => 0,
+            CareerIndexLifecycleState::DEMOTED => 0,
+        ];
+        $members = [];
+
+        foreach ($subjects as $subject) {
+            if (! is_array($subject)) {
+                continue;
+            }
+
+            $slug = $this->normalizeNullableString($subject['canonical_slug'] ?? null);
+            if ($slug === null) {
+                continue;
+            }
+
+            $member = $this->evaluate($slug, $subject);
+            $counts[$member->policyState]++;
+            $members[] = $member;
+        }
+
+        return new CareerFirstWaveIndexPolicyAuthority(
+            scope: $scope,
+            counts: $counts,
+            members: $members,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $subject
+     */
+    private function evaluate(string $canonicalSlug, array $subject): CareerFirstWaveIndexPolicyMember
+    {
+        $currentIndexState = $this->normalizePolicyState(
+            (string) ($subject['current_index_state'] ?? $subject['lifecycle_state'] ?? ''),
+        );
+        $indexEligible = (bool) ($subject['index_eligible'] ?? false);
+        $publicIndexState = $this->normalizePublicIndexState((string) ($subject['public_index_state'] ?? ''));
+        $reviewerStatus = $this->normalizeNullableString($subject['reviewer_status'] ?? null);
+        $crosswalkMode = $this->normalizeNullableString($subject['crosswalk_mode'] ?? null);
+        $allowStrongClaim = (bool) ($subject['allow_strong_claim'] ?? false);
+        $confidenceScore = is_numeric($subject['confidence_score'] ?? null) ? (int) round((float) $subject['confidence_score']) : null;
+        $blockedGovernanceStatus = $this->normalizeNullableString($subject['blocked_governance_status'] ?? null);
+        $nextStepLinksCount = is_numeric($subject['next_step_links_count'] ?? null) ? max(0, (int) $subject['next_step_links_count']) : 0;
+
+        $trustFreshness = is_array($subject['trust_freshness'] ?? null) ? $subject['trust_freshness'] : [];
+        $policyEvidence = [
+            'confidence_score' => $confidenceScore,
+            'reviewer_status' => $reviewerStatus,
+            'crosswalk_mode' => $crosswalkMode,
+            'allow_strong_claim' => $allowStrongClaim,
+            'blocked_governance_status' => $blockedGovernanceStatus,
+            'next_step_links_count' => $nextStepLinksCount,
+            'trust_freshness' => [
+                'review_due_known' => (bool) ($trustFreshness['review_due_known'] ?? false),
+                'review_staleness_state' => $this->normalizeNullableString($trustFreshness['review_staleness_state'] ?? null) ?? 'unknown',
+            ],
+        ];
+
+        $policyState = $this->resolvePolicyState($currentIndexState, $indexEligible, $publicIndexState);
+
+        $policyReasons = [];
+        $reviewApproved = in_array($reviewerStatus, ['approved', 'reviewed'], true);
+        $policyReasons[] = $reviewApproved ? 'reviewer_approved' : 'reviewer_not_approved';
+
+        if ($crosswalkMode !== null) {
+            $policyReasons[] = match ($crosswalkMode) {
+                'exact', 'trust_inheritance', 'direct_match' => 'safe_crosswalk',
+                'unmapped' => 'crosswalk_unmapped',
+                'family_proxy' => 'crosswalk_family_proxy',
+                'local_heavy_interpretation' => 'crosswalk_local_heavy_interpretation',
+                default => 'crosswalk_mode_candidate_only',
+            };
+        }
+
+        $policyReasons[] = $allowStrongClaim ? 'strong_claim_allowed' : 'strong_claim_blocked';
+
+        if ($blockedGovernanceStatus !== null) {
+            $policyReasons[] = 'blocked_governance';
+        }
+
+        if ($nextStepLinksCount > 0) {
+            $policyReasons[] = 'next_step_links_present';
+        } else {
+            $policyReasons[] = 'insufficient_next_step_links';
+        }
+
+        if ($confidenceScore !== null && $confidenceScore < 60) {
+            $policyReasons[] = 'confidence_below_threshold';
+        }
+
+        if (! $indexEligible) {
+            $policyReasons[] = 'not_index_eligible';
+        }
+
+        if ($publicIndexState === IndexStateValue::TRUST_LIMITED) {
+            $policyReasons[] = 'trust_limited';
+        }
+
+        switch ($policyState) {
+            case CareerIndexLifecycleState::INDEXED:
+                $policyReasons[] = 'indexed_ready';
+                break;
+            case CareerIndexLifecycleState::PROMOTION_CANDIDATE:
+                $policyReasons[] = 'publish_gate_candidate';
+                break;
+            case CareerIndexLifecycleState::DEMOTED:
+                if (! $reviewApproved) {
+                    $policyReasons[] = 'demoted_review_regression';
+                }
+                if (! $indexEligible || $publicIndexState !== IndexStateValue::INDEXABLE) {
+                    $policyReasons[] = 'demoted_trust_regression';
+                }
+                break;
+            default:
+                $policyReasons[] = 'publish_gate_hold';
+                break;
+        }
+
+        return new CareerFirstWaveIndexPolicyMember(
+            canonicalSlug: $canonicalSlug,
+            currentIndexState: $currentIndexState,
+            publicIndexState: $publicIndexState,
+            indexEligible: $indexEligible,
+            policyState: $policyState,
+            policyReasons: array_values(array_unique($policyReasons)),
+            policyEvidence: $policyEvidence,
+        );
+    }
+
+    private function resolvePolicyState(string $currentIndexState, bool $indexEligible, string $publicIndexState): string
+    {
+        if (in_array($currentIndexState, [
+            CareerIndexLifecycleState::NOINDEX,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE,
+            CareerIndexLifecycleState::INDEXED,
+            CareerIndexLifecycleState::DEMOTED,
+        ], true)) {
+            return $currentIndexState;
+        }
+
+        if ($indexEligible && $publicIndexState === IndexStateValue::INDEXABLE) {
+            return CareerIndexLifecycleState::INDEXED;
+        }
+
+        return CareerIndexLifecycleState::NOINDEX;
+    }
+
+    private function normalizePolicyState(string $state): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match ($normalized) {
+            CareerIndexLifecycleState::NOINDEX,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE,
+            CareerIndexLifecycleState::INDEXED,
+            CareerIndexLifecycleState::DEMOTED => $normalized,
+            default => CareerIndexLifecycleState::NOINDEX,
+        };
+    }
+
+    private function normalizePublicIndexState(string $state): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match ($normalized) {
+            IndexStateValue::INDEXABLE,
+            IndexStateValue::TRUST_LIMITED,
+            IndexStateValue::NOINDEX => $normalized,
+            default => IndexStateValue::NOINDEX,
+        };
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($value));
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchManifestService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchManifestService.php
@@ -7,6 +7,7 @@ namespace App\Domain\Career\Publish;
 use App\DTO\Career\CareerFirstWaveLaunchManifest;
 use App\DTO\Career\CareerFirstWaveLaunchManifestMember;
 use App\DTO\Career\CareerFirstWaveLaunchReadinessAuditMember;
+use App\DTO\Career\CareerFirstWaveIndexPolicyMember;
 use App\Services\Career\Bundles\CareerFamilyHubBundleBuilder;
 use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
 use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
@@ -20,6 +21,7 @@ final class CareerFirstWaveLaunchManifestService
         private readonly CareerJobDetailBundleBuilder $jobDetailBundleBuilder,
         private readonly CareerFamilyHubBundleBuilder $familyHubBundleBuilder,
         private readonly CareerStructuredDataBuilder $structuredDataBuilder,
+        private readonly CareerFirstWaveIndexPolicyEngine $indexPolicyEngine,
     ) {}
 
     public function build(): CareerFirstWaveLaunchManifest
@@ -56,10 +58,34 @@ final class CareerFirstWaveLaunchManifestService
             'hold' => [],
             'blocked' => [],
         ];
+        $policyAuthority = $this->indexPolicyEngine->build(array_map(
+            function (CareerFirstWaveLaunchReadinessAuditMember $member): array {
+                return [
+                    'canonical_slug' => $member->canonicalSlug,
+                    'current_index_state' => $member->lifecycleState,
+                    'public_index_state' => $member->publicIndexState,
+                    'index_eligible' => $member->indexEligible,
+                    'reviewer_status' => $member->reviewerStatus,
+                    'crosswalk_mode' => $member->crosswalkMode,
+                    'allow_strong_claim' => $member->allowStrongClaim,
+                    'confidence_score' => $member->confidenceScore,
+                    'blocked_governance_status' => $member->blockedGovernanceStatus,
+                    'next_step_links_count' => $member->nextStepLinksCount,
+                    'trust_freshness' => $member->trustFreshness ?? [],
+                ];
+            },
+            $audit->members,
+        ), $audit->scope);
+        $policyBySlug = [];
+        foreach ($policyAuthority->members as $policyMember) {
+            $policyBySlug[$policyMember->canonicalSlug] = $policyMember;
+        }
+
         $members = [];
 
         foreach ($audit->members as $auditMember) {
-            $group = $this->classifyGroup($auditMember);
+            $policyMember = $policyBySlug[$auditMember->canonicalSlug] ?? null;
+            $group = $this->classifyGroup($auditMember, $policyMember);
             $supportingRoute = $this->buildSupportingRoutes($auditMember);
             $smokeMatrix = $this->buildSmokeMatrix(
                 auditMember: $auditMember,
@@ -76,8 +102,8 @@ final class CareerFirstWaveLaunchManifestService
                 canonicalTitleEn: $auditMember->canonicalTitleEn,
                 launchTier: $auditMember->launchTier,
                 readinessStatus: $auditMember->readinessStatus,
-                lifecycleState: $auditMember->lifecycleState,
-                publicIndexState: $auditMember->publicIndexState,
+                lifecycleState: $policyMember?->policyState ?? $auditMember->lifecycleState,
+                publicIndexState: $policyMember?->publicIndexState ?? $auditMember->publicIndexState,
                 blockers: $auditMember->blockers,
                 trustFreshness: is_array($auditMember->trustFreshness) ? $auditMember->trustFreshness : [],
                 supportingRoutes: $supportingRoute,
@@ -160,7 +186,10 @@ final class CareerFirstWaveLaunchManifestService
         ];
     }
 
-    private function classifyGroup(CareerFirstWaveLaunchReadinessAuditMember $member): string
+    private function classifyGroup(
+        CareerFirstWaveLaunchReadinessAuditMember $member,
+        ?CareerFirstWaveIndexPolicyMember $policyMember = null,
+    ): string
     {
         if (
             $member->blockedGovernanceStatus !== null
@@ -175,7 +204,7 @@ final class CareerFirstWaveLaunchManifestService
 
         if (
             $member->launchTier === WaveClassification::CANDIDATE
-            || $member->lifecycleState === CareerIndexLifecycleState::PROMOTION_CANDIDATE
+            || ($policyMember?->policyState ?? $member->lifecycleState) === CareerIndexLifecycleState::PROMOTION_CANDIDATE
         ) {
             return 'candidate';
         }

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\Career\Publish;
 
 use App\Domain\Career\IndexStateValue;
+use App\DTO\Career\CareerFirstWaveIndexPolicyMember;
 use App\DTO\Career\CareerFirstWaveLifecycleSummary;
 
 final class CareerFirstWaveLifecycleSummaryService
@@ -16,6 +17,7 @@ final class CareerFirstWaveLifecycleSummaryService
     public function __construct(
         private readonly FirstWaveManifestReader $manifestReader,
         private readonly FirstWavePublishReadyValidator $validator,
+        private readonly CareerFirstWaveIndexPolicyEngine $indexPolicyEngine,
     ) {}
 
     public function build(): CareerFirstWaveLifecycleSummary
@@ -37,14 +39,8 @@ final class CareerFirstWaveLifecycleSummaryService
             $rowsBySlug[$slug] = $row;
         }
 
-        $counts = [
-            'total' => 0,
-            CareerIndexLifecycleState::NOINDEX => 0,
-            CareerIndexLifecycleState::PROMOTION_CANDIDATE => 0,
-            CareerIndexLifecycleState::INDEXED => 0,
-            CareerIndexLifecycleState::DEMOTED => 0,
-        ];
-        $occupations = [];
+        $subjects = [];
+        $manifestRowsBySlug = [];
 
         foreach ((array) ($manifest['occupations'] ?? []) as $occupation) {
             if (! is_array($occupation)) {
@@ -56,31 +52,48 @@ final class CareerFirstWaveLifecycleSummaryService
                 continue;
             }
 
+            $manifestRowsBySlug[$slug] = $occupation;
             $row = $rowsBySlug[$slug] ?? [];
-            $lifecycleState = $this->normalizeLifecycleState((string) ($row['index_state'] ?? ''));
             $indexEligible = (bool) ($row['index_eligible'] ?? false);
             $publicIndexState = IndexStateValue::publicFacing((string) ($row['index_state'] ?? ''), $indexEligible);
-            $reviewerStatus = $this->normalizeNullableString($row['reviewer_status'] ?? null);
-            $trustStatus = strtolower(trim((string) ($row['trust_status'] ?? '')));
-
-            $counts['total']++;
-            $counts[$lifecycleState]++;
-
-            $occupations[] = [
-                'occupation_uuid' => (string) ($occupation['occupation_uuid'] ?? ''),
+            $subjects[] = [
                 'canonical_slug' => $slug,
-                'canonical_title_en' => (string) ($occupation['canonical_title_en'] ?? ''),
-                'lifecycle_state' => $lifecycleState,
+                'current_index_state' => (string) ($row['index_state'] ?? ''),
                 'public_index_state' => $publicIndexState,
                 'index_eligible' => $indexEligible,
-                'reviewer_status' => $reviewerStatus,
-                'reason_codes' => $this->curateReasonCodes(
-                    lifecycleState: $lifecycleState,
-                    publicIndexState: $publicIndexState,
-                    indexEligible: $indexEligible,
-                    reviewerStatus: $reviewerStatus,
-                    trustStatus: $trustStatus,
-                ),
+                'reviewer_status' => $row['reviewer_status'] ?? null,
+                'crosswalk_mode' => $row['crosswalk_mode'] ?? null,
+                'allow_strong_claim' => (bool) ($row['allow_strong_claim'] ?? false),
+                'confidence_score' => $row['confidence_score'] ?? null,
+                'blocked_governance_status' => $row['blocked_governance_status'] ?? null,
+                'next_step_links_count' => $row['next_step_links_count'] ?? 0,
+                'trust_status' => $row['trust_status'] ?? null,
+            ];
+        }
+
+        $authority = $this->indexPolicyEngine->build($subjects, self::SCOPE);
+
+        $counts = [
+            'total' => count($authority->members),
+            CareerIndexLifecycleState::NOINDEX => $authority->counts[CareerIndexLifecycleState::NOINDEX] ?? 0,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE => $authority->counts[CareerIndexLifecycleState::PROMOTION_CANDIDATE] ?? 0,
+            CareerIndexLifecycleState::INDEXED => $authority->counts[CareerIndexLifecycleState::INDEXED] ?? 0,
+            CareerIndexLifecycleState::DEMOTED => $authority->counts[CareerIndexLifecycleState::DEMOTED] ?? 0,
+        ];
+        $occupations = [];
+
+        foreach ($authority->members as $member) {
+            $manifestRow = $manifestRowsBySlug[$member->canonicalSlug] ?? [];
+
+            $occupations[] = [
+                'occupation_uuid' => (string) ($manifestRow['occupation_uuid'] ?? ''),
+                'canonical_slug' => $member->canonicalSlug,
+                'canonical_title_en' => (string) ($manifestRow['canonical_title_en'] ?? ''),
+                'lifecycle_state' => $member->policyState,
+                'public_index_state' => $member->publicIndexState,
+                'index_eligible' => $member->indexEligible,
+                'reviewer_status' => $member->policyEvidence['reviewer_status'] ?? null,
+                'reason_codes' => $this->projectLifecycleReasonCodes($member),
             ];
         }
 
@@ -92,83 +105,48 @@ final class CareerFirstWaveLifecycleSummaryService
         );
     }
 
-    private function normalizeLifecycleState(string $state): string
-    {
-        $normalized = strtolower(trim($state));
-
-        return match ($normalized) {
-            CareerIndexLifecycleState::NOINDEX,
-            CareerIndexLifecycleState::PROMOTION_CANDIDATE,
-            CareerIndexLifecycleState::INDEXED,
-            CareerIndexLifecycleState::DEMOTED => $normalized,
-            default => CareerIndexLifecycleState::NOINDEX,
-        };
-    }
-
     /**
      * @return list<string>
      */
-    private function curateReasonCodes(
-        string $lifecycleState,
-        string $publicIndexState,
-        bool $indexEligible,
-        ?string $reviewerStatus,
-        string $trustStatus,
-    ): array {
+    private function projectLifecycleReasonCodes(CareerFirstWaveIndexPolicyMember $member): array
+    {
         $reasonCodes = [];
-        $reviewApproved = in_array($reviewerStatus, ['approved', 'reviewed'], true);
+        $has = array_flip($member->policyReasons);
 
-        switch ($lifecycleState) {
+        switch ($member->policyState) {
             case CareerIndexLifecycleState::INDEXED:
                 $reasonCodes[] = 'indexed_ready';
                 break;
-
             case CareerIndexLifecycleState::PROMOTION_CANDIDATE:
                 $reasonCodes[] = 'publish_gate_candidate';
-                if (! $reviewApproved) {
-                    $reasonCodes[] = 'review_pending';
-                }
                 break;
-
             case CareerIndexLifecycleState::DEMOTED:
-                if (! $reviewApproved) {
+                if (isset($has['demoted_review_regression'])) {
                     $reasonCodes[] = 'demoted_review_regression';
                 }
-                if (! $indexEligible || $publicIndexState !== IndexStateValue::INDEXABLE) {
+                if (isset($has['demoted_trust_regression'])) {
                     $reasonCodes[] = 'demoted_trust_regression';
                 }
                 break;
-
             default:
-                if ($trustStatus === WaveClassification::HOLD) {
+                if (isset($has['publish_gate_hold'])) {
                     $reasonCodes[] = 'publish_gate_hold';
                 }
                 break;
         }
 
-        if (! $indexEligible && $lifecycleState !== CareerIndexLifecycleState::INDEXED) {
+        if (isset($has['not_index_eligible']) && $member->policyState !== CareerIndexLifecycleState::INDEXED) {
             $reasonCodes[] = 'not_index_eligible';
         }
 
-        if ($publicIndexState === IndexStateValue::TRUST_LIMITED) {
+        if (isset($has['trust_limited'])) {
             $reasonCodes[] = 'trust_limited';
         }
 
-        if ($reasonCodes === [] && $lifecycleState === CareerIndexLifecycleState::NOINDEX) {
+        if ($reasonCodes === [] && $member->policyState === CareerIndexLifecycleState::NOINDEX) {
             $reasonCodes[] = 'not_index_eligible';
         }
 
         return array_values(array_unique($reasonCodes));
-    }
-
-    private function normalizeNullableString(mixed $value): ?string
-    {
-        if (! is_string($value)) {
-            return null;
-        }
-
-        $normalized = trim($value);
-
-        return $normalized !== '' ? $normalized : null;
     }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-15T23:56:47Z",
+  "updated_at": "2026-04-16T00:25:41Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1733,9 +1733,9 @@
     "PR-B65": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "github_checks_failed",
+      "status": "merged",
       "branch": "codex/pr-b65-career-transition-engine-contract-expansion",
-      "commit_sha": "74a5beaf99783a476cd034cc50d4bd11bd767003",
+      "commit_sha": "d2915e1edaf43811ea0dc49f0a71de983027f117",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/912",
       "checks": {
         "local": [
@@ -1773,7 +1773,45 @@
           }
         ]
       },
-      "failure_reason": "GitHub Actions hygiene job failed immediately on PR-B65; local validation passed, but required remote checks are not green.",
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-15T23:58:03Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B66": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b66-career-index-policy-engine-formalization",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveIndexPolicyEngine.php app/DTO/Career/CareerFirstWaveIndexPolicy*.php tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T00:25:41Z",
+  "updated_at": "2026-04-16T00:27:05Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1782,10 +1782,10 @@
     "PR-B66": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b66-career-index-policy-engine-formalization",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "7edc96b3402997dd7c464dab08302dc446e73fef",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/913",
       "checks": {
         "local": [
           {
@@ -1809,9 +1809,25 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24485372348/job/71558931698"
+          },
+          {
+            "name": "hygiene",
+            "status": "queued",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24485382634/job/71558966323"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24485372348/job/71558936274"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene check failed on first CI run; rerun is queued.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1064,6 +1064,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B66
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b66-career-index-policy-engine-formalization
+    base: main
+    depends_on: ["PR-B65"]
+    mode: execute
+    scope: >
+      Career index policy engine formalization.
+      Consolidate first-wave career_job_detail index policy truth into a single backend-owned
+      authority/engine for noindex, promotion_candidate, indexed, and demoted states with
+      reason/evidence outputs, while keeping trust_freshness evidence-only and excluding family-hub
+      from primary members.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveIndexPolicyEngine.php app/DTO/Career/CareerFirstWaveIndexPolicy*.php tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWaveIndexPolicyEngine;
+use App\Domain\Career\Publish\CareerIndexLifecycleState;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerFirstWaveIndexPolicyEngineTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_first_wave_index_policy_authority_with_formalized_states_counts_reasons_and_evidence(): void
+    {
+        $authority = app(CareerFirstWaveIndexPolicyEngine::class)->build([
+            [
+                'canonical_slug' => 'registered-nurses',
+                'current_index_state' => CareerIndexLifecycleState::INDEXED,
+                'public_index_state' => 'indexable',
+                'index_eligible' => true,
+                'reviewer_status' => 'approved',
+                'crosswalk_mode' => 'exact',
+                'allow_strong_claim' => true,
+                'confidence_score' => 81,
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 3,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_scheduled',
+                ],
+            ],
+            [
+                'canonical_slug' => 'software-developers',
+                'current_index_state' => CareerIndexLifecycleState::NOINDEX,
+                'public_index_state' => 'noindex',
+                'index_eligible' => false,
+                'reviewer_status' => 'pending',
+                'crosswalk_mode' => 'unmapped',
+                'allow_strong_claim' => false,
+                'confidence_score' => 55,
+                'blocked_governance_status' => 'blocked_not_safely_remediable',
+                'next_step_links_count' => 0,
+                'trust_freshness' => [
+                    'review_due_known' => false,
+                    'review_staleness_state' => 'unknown_due_date',
+                ],
+            ],
+            [
+                'canonical_slug' => 'management-analysts',
+                'current_index_state' => CareerIndexLifecycleState::DEMOTED,
+                'public_index_state' => 'trust_limited',
+                'index_eligible' => false,
+                'reviewer_status' => 'changes_required',
+                'crosswalk_mode' => 'local_heavy_interpretation',
+                'allow_strong_claim' => true,
+                'confidence_score' => 64,
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 2,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_due',
+                ],
+            ],
+            [
+                'canonical_slug' => 'data-scientists',
+                'current_index_state' => CareerIndexLifecycleState::PROMOTION_CANDIDATE,
+                'public_index_state' => 'trust_limited',
+                'index_eligible' => false,
+                'reviewer_status' => 'reviewed',
+                'crosswalk_mode' => 'direct_match',
+                'allow_strong_claim' => true,
+                'confidence_score' => 73,
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 1,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_due',
+                ],
+            ],
+        ]);
+
+        $payload = $authority->toArray();
+        $members = collect($payload['members'] ?? [])->keyBy('canonical_slug');
+
+        $this->assertSame('career_first_wave_index_policy_authority', $payload['policy_kind']);
+        $this->assertSame('career.index_policy.first_wave.v1', $payload['policy_version']);
+        $this->assertSame(CareerFirstWaveIndexPolicyEngine::SCOPE, $payload['scope']);
+        $this->assertSame([
+            CareerIndexLifecycleState::NOINDEX => 1,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE => 1,
+            CareerIndexLifecycleState::INDEXED => 1,
+            CareerIndexLifecycleState::DEMOTED => 1,
+        ], $payload['counts']);
+
+        $indexed = $members->get('registered-nurses');
+        $this->assertIsArray($indexed);
+        $this->assertSame('career_job_detail', $indexed['member_kind']);
+        $this->assertSame(CareerIndexLifecycleState::INDEXED, $indexed['policy_state']);
+        $this->assertSame('indexable', $indexed['public_index_state']);
+        $this->assertContains('reviewer_approved', $indexed['policy_reasons']);
+        $this->assertContains('safe_crosswalk', $indexed['policy_reasons']);
+        $this->assertContains('strong_claim_allowed', $indexed['policy_reasons']);
+        $this->assertContains('next_step_links_present', $indexed['policy_reasons']);
+        $this->assertContains('indexed_ready', $indexed['policy_reasons']);
+        $this->assertSame(81, data_get($indexed, 'policy_evidence.confidence_score'));
+        $this->assertSame('approved', data_get($indexed, 'policy_evidence.reviewer_status'));
+        $this->assertTrue((bool) data_get($indexed, 'policy_evidence.trust_freshness.review_due_known'));
+        $this->assertSame('review_scheduled', data_get($indexed, 'policy_evidence.trust_freshness.review_staleness_state'));
+
+        $noindex = $members->get('software-developers');
+        $this->assertIsArray($noindex);
+        $this->assertSame(CareerIndexLifecycleState::NOINDEX, $noindex['policy_state']);
+        $this->assertContains('reviewer_not_approved', $noindex['policy_reasons']);
+        $this->assertContains('crosswalk_unmapped', $noindex['policy_reasons']);
+        $this->assertContains('strong_claim_blocked', $noindex['policy_reasons']);
+        $this->assertContains('blocked_governance', $noindex['policy_reasons']);
+        $this->assertContains('insufficient_next_step_links', $noindex['policy_reasons']);
+        $this->assertContains('confidence_below_threshold', $noindex['policy_reasons']);
+        $this->assertContains('publish_gate_hold', $noindex['policy_reasons']);
+        $this->assertSame('unknown_due_date', data_get($noindex, 'policy_evidence.trust_freshness.review_staleness_state'));
+
+        $demoted = $members->get('management-analysts');
+        $this->assertIsArray($demoted);
+        $this->assertSame(CareerIndexLifecycleState::DEMOTED, $demoted['policy_state']);
+        $this->assertContains('demoted_review_regression', $demoted['policy_reasons']);
+        $this->assertContains('demoted_trust_regression', $demoted['policy_reasons']);
+
+        $candidate = $members->get('data-scientists');
+        $this->assertIsArray($candidate);
+        $this->assertSame(CareerIndexLifecycleState::PROMOTION_CANDIDATE, $candidate['policy_state']);
+        $this->assertContains('publish_gate_candidate', $candidate['policy_reasons']);
+        $this->assertContains('trust_limited', $candidate['policy_reasons']);
+    }
+
+    public function test_it_keeps_trust_freshness_as_evidence_only_without_changing_policy_state(): void
+    {
+        $authority = app(CareerFirstWaveIndexPolicyEngine::class)->build([
+            [
+                'canonical_slug' => 'data-scientists',
+                'current_index_state' => CareerIndexLifecycleState::INDEXED,
+                'public_index_state' => 'indexable',
+                'index_eligible' => true,
+                'reviewer_status' => 'approved',
+                'crosswalk_mode' => 'exact',
+                'allow_strong_claim' => true,
+                'confidence_score' => 82,
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 2,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_due',
+                ],
+            ],
+        ])->toArray();
+
+        $member = $authority['members'][0] ?? [];
+
+        $this->assertSame(CareerIndexLifecycleState::INDEXED, $member['policy_state'] ?? null);
+        $this->assertSame('review_due', data_get($member, 'policy_evidence.trust_freshness.review_staleness_state'));
+        $this->assertNotContains('review_due', $member['policy_reasons'] ?? []);
+        $this->assertNotContains('unknown_due_date', $member['policy_reasons'] ?? []);
+    }
+}


### PR DESCRIPTION
## What Changed
- Added a unified backend index policy authority:
  - `CareerFirstWaveIndexPolicyEngine`
  - `CareerFirstWaveIndexPolicyAuthority`
  - `CareerFirstWaveIndexPolicyMember`
- Formalized first-wave `career_job_detail` policy states into one engine:
  - `noindex`
  - `promotion_candidate`
  - `indexed`
  - `demoted`
- Formalized policy outputs per member:
  - `policy_state`
  - `policy_reasons`
  - `policy_evidence`
- Kept trust freshness evidence-only (`review_due_known`, `review_staleness_state`) and did not promote it to a new blocker.
- Refactored existing consumers to reuse engine truth instead of duplicating logic:
  - `CareerFirstWaveLifecycleSummaryService`
  - `CareerFirstWaveLaunchManifestService`
- Added focused unit coverage for engine behavior and trust-freshness boundary.
- Updated train manifest/state entries for `PR-B66` and synced B65 merged state.

## Why
Index policy truth was previously spread across lifecycle/manifest/publish-gate paths. This PR consolidates policy semantics into one backend-owned authority to prevent drift while preserving existing lifecycle/manifest behavior.

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveIndexPolicyEngine.php app/DTO/Career/CareerFirstWaveIndexPolicy*.php tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally Deferred
- Any new index-policy inputs not already stabilized (`demand_signal`, `novelty_score`, `canonical_conflict`).
- Any family-hub promotion into primary policy members.
- Any frontend/public API/OpenAPI expansion.
