### PR TITLE
PR-B67: Career promotion-candidate rule narrowing

### DIFF
--- a/backend/app/DTO/Career/CareerFirstWavePromotionCandidateAuthority.php
+++ b/backend/app/DTO/Career/CareerFirstWavePromotionCandidateAuthority.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWavePromotionCandidateAuthority
+{
+    /**
+     * @param  array{auto_nominate:int,manual_review_only:int,not_eligible:int}  $counts
+     * @param  list<CareerFirstWavePromotionCandidateMember>  $members
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'engine_kind' => 'career_first_wave_promotion_candidate_engine',
+            'engine_version' => 'career.promotion_candidate.first_wave.v1',
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'members' => array_map(
+                static fn (CareerFirstWavePromotionCandidateMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFirstWavePromotionCandidateMember.php
+++ b/backend/app/DTO/Career/CareerFirstWavePromotionCandidateMember.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFirstWavePromotionCandidateMember
+{
+    /**
+     * @param  list<string>  $decisionReasons
+     * @param  array{
+     *   index_eligible:bool,
+     *   confidence_score:?int,
+     *   reviewer_status:?string,
+     *   allow_strong_claim:bool,
+     *   crosswalk_mode:?string,
+     *   blocked_governance_status:?string,
+     *   next_step_links_count:int,
+     *   trust_freshness:array{review_due_known:bool,review_staleness_state:string}
+     * }  $decisionEvidence
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly string $currentIndexState,
+        public readonly string $publicIndexState,
+        public readonly string $engineDecision,
+        public readonly bool $autoNominationEligible,
+        public readonly bool $manualReviewOnly,
+        public readonly array $decisionReasons,
+        public readonly array $decisionEvidence,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'member_kind' => 'career_job_detail',
+            'canonical_slug' => $this->canonicalSlug,
+            'current_index_state' => $this->currentIndexState,
+            'public_index_state' => $this->publicIndexState,
+            'engine_decision' => $this->engineDecision,
+            'auto_nomination_eligible' => $this->autoNominationEligible,
+            'manual_review_only' => $this->manualReviewOnly,
+            'decision_reasons' => $this->decisionReasons,
+            'decision_evidence' => $this->decisionEvidence,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWavePromotionCandidateEngine.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWavePromotionCandidateEngine.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Domain\Career\IndexStateValue;
+use App\DTO\Career\CareerFirstWavePromotionCandidateAuthority;
+use App\DTO\Career\CareerFirstWavePromotionCandidateMember;
+
+final class CareerFirstWavePromotionCandidateEngine
+{
+    public const SCOPE = 'career_first_wave_10';
+
+    public const DECISION_AUTO_NOMINATE = 'auto_nominate';
+
+    public const DECISION_MANUAL_REVIEW_ONLY = 'manual_review_only';
+
+    public const DECISION_NOT_ELIGIBLE = 'not_eligible';
+
+    private const CONFIDENCE_THRESHOLD = 70;
+
+    private const MIN_NEXT_STEP_LINKS = 2;
+
+    /**
+     * @var array<string, true>
+     */
+    private const AUTO_CROSSWALK_MODES = [
+        'exact' => true,
+        'trust_inheritance' => true,
+    ];
+
+    /**
+     * @var array<string, true>
+     */
+    private const NOT_ELIGIBLE_CROSSWALK_MODES = [
+        'local_heavy_interpretation' => true,
+        'family_proxy' => true,
+        'unmapped' => true,
+    ];
+
+    /**
+     * @param  list<array<string, mixed>>  $subjects
+     */
+    public function build(array $subjects, string $scope = self::SCOPE): CareerFirstWavePromotionCandidateAuthority
+    {
+        $counts = [
+            self::DECISION_AUTO_NOMINATE => 0,
+            self::DECISION_MANUAL_REVIEW_ONLY => 0,
+            self::DECISION_NOT_ELIGIBLE => 0,
+        ];
+        $members = [];
+
+        foreach ($subjects as $subject) {
+            if (! is_array($subject)) {
+                continue;
+            }
+
+            $slug = $this->normalizeNullableString($subject['canonical_slug'] ?? null);
+            if ($slug === null) {
+                continue;
+            }
+
+            $member = $this->evaluate($slug, $subject);
+            $counts[$member->engineDecision]++;
+            $members[] = $member;
+        }
+
+        return new CareerFirstWavePromotionCandidateAuthority(
+            scope: $scope,
+            counts: $counts,
+            members: $members,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $subject
+     */
+    private function evaluate(string $canonicalSlug, array $subject): CareerFirstWavePromotionCandidateMember
+    {
+        $currentIndexState = $this->normalizeLifecycleState(
+            (string) ($subject['current_index_state'] ?? $subject['lifecycle_state'] ?? ''),
+        );
+        $publicIndexState = $this->normalizePublicIndexState((string) ($subject['public_index_state'] ?? ''));
+        $indexEligible = (bool) ($subject['index_eligible'] ?? false);
+        $confidenceScore = is_numeric($subject['confidence_score'] ?? null) ? (int) round((float) $subject['confidence_score']) : null;
+        $reviewerStatus = $this->normalizeNullableString($subject['reviewer_status'] ?? null);
+        $allowStrongClaim = (bool) ($subject['allow_strong_claim'] ?? false);
+        $crosswalkMode = $this->normalizeNullableString($subject['crosswalk_mode'] ?? null);
+        $blockedGovernanceStatus = $this->normalizeNullableString($subject['blocked_governance_status'] ?? null);
+        $nextStepLinksCount = is_numeric($subject['next_step_links_count'] ?? null) ? max(0, (int) $subject['next_step_links_count']) : 0;
+        $trustFreshness = is_array($subject['trust_freshness'] ?? null) ? $subject['trust_freshness'] : [];
+        $trustStalenessState = $this->normalizeNullableString($trustFreshness['review_staleness_state'] ?? null) ?? 'unknown_due_date';
+
+        $decisionEvidence = [
+            'index_eligible' => $indexEligible,
+            'confidence_score' => $confidenceScore,
+            'reviewer_status' => $reviewerStatus,
+            'allow_strong_claim' => $allowStrongClaim,
+            'crosswalk_mode' => $crosswalkMode,
+            'blocked_governance_status' => $blockedGovernanceStatus,
+            'next_step_links_count' => $nextStepLinksCount,
+            'trust_freshness' => [
+                'review_due_known' => (bool) ($trustFreshness['review_due_known'] ?? false),
+                'review_staleness_state' => $trustStalenessState,
+            ],
+        ];
+
+        $isConfidenceEligible = $confidenceScore !== null && $confidenceScore >= self::CONFIDENCE_THRESHOLD;
+        $isReviewerApproved = $reviewerStatus === 'approved';
+        $isCrosswalkAutoSafe = $crosswalkMode !== null && isset(self::AUTO_CROSSWALK_MODES[$crosswalkMode]);
+        $isNotEligibleCrosswalk = $crosswalkMode !== null && isset(self::NOT_ELIGIBLE_CROSSWALK_MODES[$crosswalkMode]);
+
+        $decision = self::DECISION_MANUAL_REVIEW_ONLY;
+        $decisionReasons = [];
+
+        if (! $indexEligible) {
+            $decision = self::DECISION_NOT_ELIGIBLE;
+            $decisionReasons[] = 'index_eligible_false';
+        } else {
+            $decisionReasons[] = 'index_eligible_true';
+        }
+
+        if ($currentIndexState !== CareerIndexLifecycleState::NOINDEX) {
+            $decision = self::DECISION_NOT_ELIGIBLE;
+            $decisionReasons[] = 'currently_not_noindex';
+        } else {
+            $decisionReasons[] = 'currently_noindex';
+        }
+
+        if (! $isConfidenceEligible) {
+            $decision = self::DECISION_NOT_ELIGIBLE;
+            $decisionReasons[] = 'confidence_below_threshold';
+        } else {
+            $decisionReasons[] = 'confidence_at_or_above_threshold';
+        }
+
+        if (! $allowStrongClaim) {
+            $decision = self::DECISION_NOT_ELIGIBLE;
+            $decisionReasons[] = 'strong_claim_blocked';
+        } else {
+            $decisionReasons[] = 'strong_claim_allowed';
+        }
+
+        if ($blockedGovernanceStatus !== null) {
+            $decision = self::DECISION_NOT_ELIGIBLE;
+            $decisionReasons[] = 'governance_blocked';
+        } else {
+            $decisionReasons[] = 'not_governance_blocked';
+        }
+
+        if ($nextStepLinksCount < self::MIN_NEXT_STEP_LINKS) {
+            $decision = self::DECISION_NOT_ELIGIBLE;
+            $decisionReasons[] = 'next_step_links_insufficient';
+        } else {
+            $decisionReasons[] = 'next_step_links_sufficient';
+        }
+
+        if ($isNotEligibleCrosswalk) {
+            $decision = self::DECISION_NOT_ELIGIBLE;
+            $decisionReasons[] = 'crosswalk_not_supported';
+        }
+
+        if ($decision !== self::DECISION_NOT_ELIGIBLE) {
+            if (! $isReviewerApproved) {
+                $decisionReasons[] = 'reviewer_not_approved_manual_review';
+                $decision = self::DECISION_MANUAL_REVIEW_ONLY;
+            } elseif ($crosswalkMode === 'functional_equivalent') {
+                $decisionReasons[] = 'functional_equivalent_requires_manual_review';
+                $decision = self::DECISION_MANUAL_REVIEW_ONLY;
+            } elseif ($trustStalenessState === 'review_due') {
+                $decisionReasons[] = 'trust_review_due_manual_review';
+                $decision = self::DECISION_MANUAL_REVIEW_ONLY;
+            } elseif ($isCrosswalkAutoSafe) {
+                $decisionReasons[] = 'reviewer_approved';
+                $decisionReasons[] = 'safe_crosswalk';
+                $decision = self::DECISION_AUTO_NOMINATE;
+            } else {
+                $decisionReasons[] = 'crosswalk_requires_manual_review';
+                $decision = self::DECISION_MANUAL_REVIEW_ONLY;
+            }
+        }
+
+        return new CareerFirstWavePromotionCandidateMember(
+            canonicalSlug: $canonicalSlug,
+            currentIndexState: $currentIndexState,
+            publicIndexState: $publicIndexState,
+            engineDecision: $decision,
+            autoNominationEligible: $decision === self::DECISION_AUTO_NOMINATE,
+            manualReviewOnly: $decision === self::DECISION_MANUAL_REVIEW_ONLY,
+            decisionReasons: array_values(array_unique($decisionReasons)),
+            decisionEvidence: $decisionEvidence,
+        );
+    }
+
+    private function normalizeLifecycleState(string $state): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match ($normalized) {
+            CareerIndexLifecycleState::NOINDEX,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE,
+            CareerIndexLifecycleState::INDEXED,
+            CareerIndexLifecycleState::DEMOTED => $normalized,
+            default => CareerIndexLifecycleState::NOINDEX,
+        };
+    }
+
+    private function normalizePublicIndexState(string $state): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match ($normalized) {
+            IndexStateValue::INDEXABLE,
+            IndexStateValue::TRUST_LIMITED,
+            IndexStateValue::NOINDEX => $normalized,
+            default => IndexStateValue::NOINDEX,
+        };
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($value));
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T00:41:58Z",
+  "updated_at": "2026-04-16T00:43:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1836,10 +1836,10 @@
     "PR-B67": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b67-career-promotion-candidate-rule-narrowing",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "118fc62591b8208b5361d7b6444326892d6865ad",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/914",
       "checks": {
         "local": [
           {
@@ -1863,9 +1863,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24485820686/job/71560386547"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24485810828/job/71560356598"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24485820686/job/71560390401"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24485810828/job/71560361866"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene checks failed on PR-B67; local validation passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T00:27:05Z",
+  "updated_at": "2026-04-16T00:41:58Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1782,9 +1782,9 @@
     "PR-B66": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open_checks_failed",
+      "status": "merged",
       "branch": "codex/pr-b66-career-index-policy-engine-formalization",
-      "commit_sha": "7edc96b3402997dd7c464dab08302dc446e73fef",
+      "commit_sha": "96c0d606c8b866b0ee690b2efef6492b7367fc82",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/913",
       "checks": {
         "local": [
@@ -1827,7 +1827,45 @@
           }
         ]
       },
-      "failure_reason": "GitHub hygiene check failed on first CI run; rerun is queued.",
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-16T00:29:06Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B67": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b67-career-promotion-candidate-rule-narrowing",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWavePromotionCandidateEngine.php app/DTO/Career/CareerFirstWavePromotionCandidate*.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1093,6 +1093,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B67
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b67-career-promotion-candidate-rule-narrowing
+    base: main
+    depends_on: ["PR-B66"]
+    mode: execute
+    scope: >
+      Career promotion-candidate rule narrowing.
+      Add a conservative internal-only first-wave career_job_detail promotion candidate
+      authority/engine that formalizes auto_nominate/manual_review_only/not_eligible decisions
+      from existing backend truth, keeps trust freshness evidence-only, excludes family-hub
+      from primary members, and avoids demand/novelty/canonical-conflict inputs.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWavePromotionCandidateEngine.php app/DTO/Career/CareerFirstWavePromotionCandidate*.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php"
+      - "php artisan test tests/Feature/OpenApiDiffTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFirstWavePromotionCandidateEngine;
+use App\Domain\Career\Publish\CareerIndexLifecycleState;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerFirstWavePromotionCandidateEngineTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_conservative_first_wave_promotion_candidate_decisions_and_counts(): void
+    {
+        $payload = app(CareerFirstWavePromotionCandidateEngine::class)->build([
+            [
+                'canonical_slug' => 'registered-nurses',
+                'current_index_state' => CareerIndexLifecycleState::NOINDEX,
+                'public_index_state' => 'noindex',
+                'index_eligible' => true,
+                'confidence_score' => 81,
+                'reviewer_status' => 'approved',
+                'allow_strong_claim' => true,
+                'crosswalk_mode' => 'exact',
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 3,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_scheduled',
+                ],
+            ],
+            [
+                'canonical_slug' => 'software-developers',
+                'current_index_state' => CareerIndexLifecycleState::NOINDEX,
+                'public_index_state' => 'noindex',
+                'index_eligible' => true,
+                'confidence_score' => 79,
+                'reviewer_status' => 'approved',
+                'allow_strong_claim' => true,
+                'crosswalk_mode' => 'functional_equivalent',
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 3,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_scheduled',
+                ],
+            ],
+            [
+                'canonical_slug' => 'management-analysts',
+                'current_index_state' => CareerIndexLifecycleState::NOINDEX,
+                'public_index_state' => 'noindex',
+                'index_eligible' => true,
+                'confidence_score' => 82,
+                'reviewer_status' => 'approved',
+                'allow_strong_claim' => true,
+                'crosswalk_mode' => 'trust_inheritance',
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 2,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_due',
+                ],
+            ],
+            [
+                'canonical_slug' => 'data-scientists',
+                'current_index_state' => CareerIndexLifecycleState::NOINDEX,
+                'public_index_state' => 'noindex',
+                'index_eligible' => false,
+                'confidence_score' => 86,
+                'reviewer_status' => 'approved',
+                'allow_strong_claim' => true,
+                'crosswalk_mode' => 'exact',
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 2,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_scheduled',
+                ],
+            ],
+            [
+                'canonical_slug' => 'web-developers',
+                'current_index_state' => CareerIndexLifecycleState::INDEXED,
+                'public_index_state' => 'indexable',
+                'index_eligible' => true,
+                'confidence_score' => 87,
+                'reviewer_status' => 'approved',
+                'allow_strong_claim' => true,
+                'crosswalk_mode' => 'exact',
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 2,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_scheduled',
+                ],
+            ],
+            [
+                'canonical_slug' => 'ux-designers',
+                'current_index_state' => CareerIndexLifecycleState::NOINDEX,
+                'public_index_state' => 'noindex',
+                'index_eligible' => true,
+                'confidence_score' => 66,
+                'reviewer_status' => 'approved',
+                'allow_strong_claim' => true,
+                'crosswalk_mode' => 'exact',
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 3,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_scheduled',
+                ],
+            ],
+        ])->toArray();
+
+        $members = collect($payload['members'] ?? [])->keyBy('canonical_slug');
+
+        $this->assertSame('career_first_wave_promotion_candidate_engine', $payload['engine_kind']);
+        $this->assertSame('career.promotion_candidate.first_wave.v1', $payload['engine_version']);
+        $this->assertSame(CareerFirstWavePromotionCandidateEngine::SCOPE, $payload['scope']);
+        $this->assertSame([
+            CareerFirstWavePromotionCandidateEngine::DECISION_AUTO_NOMINATE => 1,
+            CareerFirstWavePromotionCandidateEngine::DECISION_MANUAL_REVIEW_ONLY => 2,
+            CareerFirstWavePromotionCandidateEngine::DECISION_NOT_ELIGIBLE => 3,
+        ], $payload['counts']);
+
+        $auto = $members->get('registered-nurses');
+        $this->assertIsArray($auto);
+        $this->assertSame('career_job_detail', $auto['member_kind']);
+        $this->assertSame(CareerFirstWavePromotionCandidateEngine::DECISION_AUTO_NOMINATE, $auto['engine_decision']);
+        $this->assertTrue((bool) ($auto['auto_nomination_eligible'] ?? false));
+        $this->assertFalse((bool) ($auto['manual_review_only'] ?? true));
+        $this->assertContains('index_eligible_true', $auto['decision_reasons']);
+        $this->assertContains('confidence_at_or_above_threshold', $auto['decision_reasons']);
+        $this->assertContains('reviewer_approved', $auto['decision_reasons']);
+        $this->assertContains('safe_crosswalk', $auto['decision_reasons']);
+        $this->assertContains('currently_noindex', $auto['decision_reasons']);
+
+        $functionalEquivalent = $members->get('software-developers');
+        $this->assertIsArray($functionalEquivalent);
+        $this->assertSame(CareerFirstWavePromotionCandidateEngine::DECISION_MANUAL_REVIEW_ONLY, $functionalEquivalent['engine_decision']);
+        $this->assertContains('functional_equivalent_requires_manual_review', $functionalEquivalent['decision_reasons']);
+
+        $reviewDue = $members->get('management-analysts');
+        $this->assertIsArray($reviewDue);
+        $this->assertSame(CareerFirstWavePromotionCandidateEngine::DECISION_MANUAL_REVIEW_ONLY, $reviewDue['engine_decision']);
+        $this->assertContains('trust_review_due_manual_review', $reviewDue['decision_reasons']);
+        $this->assertSame('review_due', data_get($reviewDue, 'decision_evidence.trust_freshness.review_staleness_state'));
+
+        $notEligibleFromIndex = $members->get('data-scientists');
+        $this->assertIsArray($notEligibleFromIndex);
+        $this->assertSame(CareerFirstWavePromotionCandidateEngine::DECISION_NOT_ELIGIBLE, $notEligibleFromIndex['engine_decision']);
+        $this->assertContains('index_eligible_false', $notEligibleFromIndex['decision_reasons']);
+
+        $notEligibleFromCurrentState = $members->get('web-developers');
+        $this->assertIsArray($notEligibleFromCurrentState);
+        $this->assertSame(CareerFirstWavePromotionCandidateEngine::DECISION_NOT_ELIGIBLE, $notEligibleFromCurrentState['engine_decision']);
+        $this->assertContains('currently_not_noindex', $notEligibleFromCurrentState['decision_reasons']);
+
+        $notEligibleFromConfidence = $members->get('ux-designers');
+        $this->assertIsArray($notEligibleFromConfidence);
+        $this->assertSame(CareerFirstWavePromotionCandidateEngine::DECISION_NOT_ELIGIBLE, $notEligibleFromConfidence['engine_decision']);
+        $this->assertContains('confidence_below_threshold', $notEligibleFromConfidence['decision_reasons']);
+
+        $this->assertArrayNotHasKey('demand_signal', $auto);
+        $this->assertArrayNotHasKey('novelty_score', $auto);
+        $this->assertArrayNotHasKey('canonical_conflict', $auto);
+    }
+
+    public function test_it_keeps_trust_freshness_as_decision_evidence_without_hard_blocking_review_due(): void
+    {
+        $payload = app(CareerFirstWavePromotionCandidateEngine::class)->build([
+            [
+                'canonical_slug' => 'registered-nurses',
+                'current_index_state' => CareerIndexLifecycleState::NOINDEX,
+                'public_index_state' => 'noindex',
+                'index_eligible' => true,
+                'confidence_score' => 81,
+                'reviewer_status' => 'approved',
+                'allow_strong_claim' => true,
+                'crosswalk_mode' => 'trust_inheritance',
+                'blocked_governance_status' => null,
+                'next_step_links_count' => 2,
+                'trust_freshness' => [
+                    'review_due_known' => true,
+                    'review_staleness_state' => 'review_due',
+                ],
+            ],
+        ])->toArray();
+
+        $member = $payload['members'][0] ?? [];
+
+        $this->assertSame(CareerFirstWavePromotionCandidateEngine::DECISION_MANUAL_REVIEW_ONLY, $member['engine_decision'] ?? null);
+        $this->assertContains('trust_review_due_manual_review', $member['decision_reasons'] ?? []);
+        $this->assertNotContains('trust_review_due_hard_block', $member['decision_reasons'] ?? []);
+        $this->assertSame('review_due', data_get($member, 'decision_evidence.trust_freshness.review_staleness_state'));
+    }
+}


### PR DESCRIPTION
## What changed
- Added a new internal-only authority engine for first-wave promotion narrowing:
  - `CareerFirstWavePromotionCandidateEngine`
  - `CareerFirstWavePromotionCandidateAuthority`
  - `CareerFirstWavePromotionCandidateMember`
- Formalized decision states:
  - `auto_nominate`
  - `manual_review_only`
  - `not_eligible`
- Implemented conservative decision rules based only on existing strong backend truth:
  - `index_eligible`
  - `current_index_state`
  - `confidence_score`
  - `reviewer_status`
  - `allow_strong_claim`
  - `crosswalk_mode`
  - `blocked_governance_status`
  - `next_step_links_count`
  - `trust_freshness` (evidence-only)
- Added focused unit tests to lock boundaries:
  - strict auto-nominate gate
  - functional-equivalent manual-only behavior
  - trust freshness evidence-only behavior
  - no weak truth (`demand_signal`, `novelty_score`, `canonical_conflict`)
- Updated train manifest/state for PR-B67 and synced PR-B66 merged status.

## Why
Existing promotion semantics were too broad/scattered for safe automation. This PR adds a conservative, explainable, backend-owned authority that narrows automatic nomination without changing public API, online index state, or rollout/public semantics.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWavePromotionCandidateEngine.php app/DTO/Career/CareerFirstWavePromotionCandidate*.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWaveRolloutWavePlanServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`

## Intentionally deferred
- Any weak/unstable signals (`demand_signal`, `novelty_score`, `canonical_conflict`)
- Any promotion scoring model
- Any family-hub primary member expansion
- Any public API/OpenAPI/frontend scope changes
- Any direct online index-state writeback
