### PR TITLE
PR-B69: Career asset batch pipeline / batch-1~2 production line

### DIFF
--- a/backend/app/Console/Commands/CareerRunAssetBatch.php
+++ b/backend/app/Console/Commands/CareerRunAssetBatch.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Production\CareerAssetBatchPipeline;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class CareerRunAssetBatch extends Command
+{
+    protected $signature = 'career:run-asset-batch
+        {--manifest= : Path to batch manifest JSON}
+        {--mode=full : validate|compile-trust|publish-candidate|regression|full}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Run Career asset batch pipeline with staged validate/compile-trust/publish-candidate/regression modes.';
+
+    public function handle(CareerAssetBatchPipeline $pipeline): int
+    {
+        $manifest = trim((string) $this->option('manifest'));
+        if ($manifest === '') {
+            $this->error('--manifest is required.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $result = $pipeline->run($manifest, (string) $this->option('mode'));
+        } catch (RuntimeException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($result, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+
+            return ($result['status'] ?? 'aborted') === 'completed' ? self::SUCCESS : self::FAILURE;
+        }
+
+        $this->line('status='.(string) ($result['status'] ?? 'aborted'));
+        $this->line('mode='.(string) ($result['mode'] ?? ''));
+        $this->line('batch_key='.(string) data_get($result, 'manifest.batch_key', ''));
+        $this->line('member_count='.(string) data_get($result, 'manifest.member_count', 0));
+
+        foreach ((array) ($result['stages'] ?? []) as $name => $stage) {
+            $this->line(sprintf(
+                'stage[%s]=%s%s',
+                (string) $name,
+                ((bool) data_get($stage, 'passed', false)) ? 'passed' : 'failed',
+                ((bool) data_get($stage, 'skipped', false)) ? ' (skipped)' : '',
+            ));
+        }
+
+        return ($result['status'] ?? 'aborted') === 'completed' ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -9,6 +9,7 @@ use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerCompileAuthorityWave;
+use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerExportFirstWaveRolloutBundleArtifacts;
 use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutWavePlanArtifact;
@@ -133,6 +134,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPostCommitFailed::class,
         CareerImportAuthorityWave::class,
         CareerCompileAuthorityWave::class,
+        CareerRunAssetBatch::class,
         CareerExportFirstWaveRolloutBundleArtifacts::class,
         CareerExportFirstWaveReleaseArtifacts::class,
         CareerExportFirstWaveRolloutWavePlanArtifact::class,

--- a/backend/app/DTO/Career/CareerAssetBatchManifest.php
+++ b/backend/app/DTO/Career/CareerAssetBatchManifest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerAssetBatchManifest
+{
+    /**
+     * @param  list<CareerAssetBatchManifestMember>  $members
+     */
+    public function __construct(
+        public readonly string $batchKind,
+        public readonly string $batchVersion,
+        public readonly string $batchKey,
+        public readonly string $scope,
+        public readonly int $memberCount,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'batch_kind' => $this->batchKind,
+            'batch_version' => $this->batchVersion,
+            'batch_key' => $this->batchKey,
+            'scope' => $this->scope,
+            'member_count' => $this->memberCount,
+            'members' => array_map(
+                static fn (CareerAssetBatchManifestMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerAssetBatchManifestMember.php
+++ b/backend/app/DTO/Career/CareerAssetBatchManifestMember.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerAssetBatchManifestMember
+{
+    public function __construct(
+        public readonly string $occupationUuid,
+        public readonly string $canonicalSlug,
+        public readonly string $canonicalTitleEn,
+        public readonly string $familySlug,
+        public readonly string $crosswalkMode,
+        public readonly string $batchRole,
+        public readonly bool $stableSeed,
+        public readonly bool $candidateSeed,
+        public readonly bool $holdSeed,
+        public readonly string $expectedPublishTrack,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'member_kind' => 'career_job_detail',
+            'occupation_uuid' => $this->occupationUuid,
+            'canonical_slug' => $this->canonicalSlug,
+            'canonical_title_en' => $this->canonicalTitleEn,
+            'family_slug' => $this->familySlug,
+            'crosswalk_mode' => $this->crosswalkMode,
+            'batch_role' => $this->batchRole,
+            'stable_seed' => $this->stableSeed,
+            'candidate_seed' => $this->candidateSeed,
+            'hold_seed' => $this->holdSeed,
+            'expected_publish_track' => $this->expectedPublishTrack,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Production/CareerAssetBatchManifestBuilder.php
+++ b/backend/app/Domain/Career/Production/CareerAssetBatchManifestBuilder.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Production;
+
+use App\DTO\Career\CareerAssetBatchManifest;
+use App\DTO\Career\CareerAssetBatchManifestMember;
+use RuntimeException;
+
+final class CareerAssetBatchManifestBuilder
+{
+    public const BATCH_KIND_1 = 'career_asset_batch_1';
+
+    public const BATCH_KIND_2 = 'career_asset_batch_2';
+
+    public function fromPath(string $path): CareerAssetBatchManifest
+    {
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! is_file($resolved)) {
+            throw new RuntimeException(sprintf('Career asset batch manifest not found at [%s].', $resolved));
+        }
+
+        $decoded = json_decode((string) file_get_contents($resolved), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException(sprintf('Career asset batch manifest must be valid JSON: [%s].', $resolved));
+        }
+
+        $members = $decoded['members'] ?? null;
+        if (! is_array($members)) {
+            throw new RuntimeException('Career asset batch manifest must contain a members array.');
+        }
+
+        $batchKind = $this->requiredString($decoded, 'batch_kind');
+        $batchVersion = $this->requiredString($decoded, 'batch_version');
+        $batchKey = $this->requiredString($decoded, 'batch_key');
+        $scope = $this->requiredString($decoded, 'scope');
+        $memberCount = (int) ($decoded['member_count'] ?? 0);
+
+        if ($memberCount < 1) {
+            throw new RuntimeException('Career asset batch manifest member_count must be greater than zero.');
+        }
+
+        if ($memberCount !== count($members)) {
+            throw new RuntimeException('Career asset batch manifest member_count must equal members length.');
+        }
+
+        $normalizedMembers = array_map(
+            fn (mixed $row): CareerAssetBatchManifestMember => $this->normalizeMember($row),
+            $members,
+        );
+
+        return new CareerAssetBatchManifest(
+            batchKind: $batchKind,
+            batchVersion: $batchVersion,
+            batchKey: $batchKey,
+            scope: $scope,
+            memberCount: $memberCount,
+            members: $normalizedMembers,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function requiredString(array $payload, string $field): string
+    {
+        $value = trim((string) ($payload[$field] ?? ''));
+        if ($value === '') {
+            throw new RuntimeException(sprintf('Career asset batch manifest missing required field [%s].', $field));
+        }
+
+        return $value;
+    }
+
+    private function toBool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return ((int) $value) === 1;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+
+            return in_array($normalized, ['1', 'true', 'yes'], true);
+        }
+
+        return false;
+    }
+
+    private function normalizeMember(mixed $row): CareerAssetBatchManifestMember
+    {
+        if (! is_array($row)) {
+            throw new RuntimeException('Career asset batch manifest member rows must be objects.');
+        }
+
+        return new CareerAssetBatchManifestMember(
+            occupationUuid: $this->requiredString($row, 'occupation_uuid'),
+            canonicalSlug: $this->requiredString($row, 'canonical_slug'),
+            canonicalTitleEn: $this->requiredString($row, 'canonical_title_en'),
+            familySlug: $this->requiredString($row, 'family_slug'),
+            crosswalkMode: $this->requiredString($row, 'crosswalk_mode'),
+            batchRole: $this->requiredString($row, 'batch_role'),
+            stableSeed: $this->toBool($row['stable_seed'] ?? false),
+            candidateSeed: $this->toBool($row['candidate_seed'] ?? false),
+            holdSeed: $this->toBool($row['hold_seed'] ?? false),
+            expectedPublishTrack: $this->requiredString($row, 'expected_publish_track'),
+        );
+    }
+}

--- a/backend/app/Domain/Career/Production/CareerAssetBatchPipeline.php
+++ b/backend/app/Domain/Career/Production/CareerAssetBatchPipeline.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Production;
+
+use App\Domain\Career\Publish\CareerFirstWaveLaunchReadinessAuditV2Service;
+use App\Domain\Career\Publish\CareerFirstWavePromotionCandidateEngine;
+use App\Domain\Career\Publish\CareerTrustFreshnessAuthorityService;
+use RuntimeException;
+
+final class CareerAssetBatchPipeline
+{
+    public const MODE_VALIDATE = 'validate';
+
+    public const MODE_COMPILE_TRUST = 'compile-trust';
+
+    public const MODE_PUBLISH_CANDIDATE = 'publish-candidate';
+
+    public const MODE_REGRESSION = 'regression';
+
+    public const MODE_FULL = 'full';
+
+    public function __construct(
+        private readonly CareerAssetBatchManifestBuilder $manifestBuilder,
+        private readonly CareerAssetBatchValidator $validator,
+        private readonly CareerAssetBatchTrustCompiler $trustCompiler,
+        private readonly CareerAssetBatchPublishCandidateService $publishCandidateService,
+        private readonly CareerAssetBatchRegressionRunner $regressionRunner,
+        private readonly CareerFirstWaveLaunchReadinessAuditV2Service $auditV2Service,
+        private readonly CareerTrustFreshnessAuthorityService $trustFreshnessAuthorityService,
+        private readonly CareerFirstWavePromotionCandidateEngine $promotionCandidateEngine,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function run(string $manifestPath, string $mode = self::MODE_FULL): array
+    {
+        $normalizedMode = $this->normalizeMode($mode);
+        $manifest = $this->manifestBuilder->fromPath($manifestPath);
+
+        $truthBySlug = $this->truthBySlug();
+        $stages = [];
+
+        $validate = $this->validator->validate($manifest, $truthBySlug);
+        $stages['validate'] = $validate;
+
+        if ($normalizedMode === self::MODE_VALIDATE) {
+            return $this->result(
+                (bool) ($validate['passed'] ?? false) ? 'completed' : 'aborted',
+                $normalizedMode,
+                $manifest->toArray(),
+                $stages,
+            );
+        }
+
+        if (! (bool) $validate['passed']) {
+            $stages['compile_trust'] = $this->skippedStage('compile_trust', 'validation_failed');
+            $stages['publish_candidate'] = $this->skippedStage('publish_candidate', 'validation_failed');
+            $stages['regression'] = $this->skippedStage('regression', 'validation_failed');
+
+            return $this->result('aborted', $normalizedMode, $manifest->toArray(), $stages);
+        }
+
+        $trustFreshnessBySlug = $this->trustFreshnessBySlug();
+        $compileTrust = $this->trustCompiler->compile($manifest, $trustFreshnessBySlug);
+        $stages['compile_trust'] = $compileTrust;
+
+        if ($normalizedMode === self::MODE_COMPILE_TRUST) {
+            return $this->result('completed', $normalizedMode, $manifest->toArray(), $stages);
+        }
+
+        if (! (bool) $compileTrust['passed']) {
+            $stages['publish_candidate'] = $this->skippedStage('publish_candidate', 'trust_compile_failed');
+            $stages['regression'] = $this->skippedStage('regression', 'trust_compile_failed');
+
+            return $this->result('aborted', $normalizedMode, $manifest->toArray(), $stages);
+        }
+
+        $promotionBySlug = $this->promotionBySlug($truthBySlug, $manifest->scope);
+        $publishCandidate = $this->publishCandidateService->project(
+            $manifest,
+            $truthBySlug,
+            $promotionBySlug,
+        );
+        $stages['publish_candidate'] = $publishCandidate;
+
+        if ($normalizedMode === self::MODE_PUBLISH_CANDIDATE) {
+            return $this->result('completed', $normalizedMode, $manifest->toArray(), $stages);
+        }
+
+        $regression = $this->regressionRunner->run($manifest, $truthBySlug);
+        $stages['regression'] = $regression;
+
+        return $this->result(
+            (bool) ($regression['passed'] ?? false) ? 'completed' : 'aborted',
+            $normalizedMode,
+            $manifest->toArray(),
+            $stages,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function result(string $status, string $mode, array $manifest, array $stages): array
+    {
+        return [
+            'pipeline_kind' => 'career_asset_batch_pipeline',
+            'pipeline_version' => 'career.asset_batch_pipeline.v1',
+            'status' => $status,
+            'mode' => $mode,
+            'manifest' => $manifest,
+            'stages' => $stages,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function skippedStage(string $stage, string $reason): array
+    {
+        return [
+            'stage' => $stage,
+            'passed' => false,
+            'skipped' => true,
+            'reason' => $reason,
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function truthBySlug(): array
+    {
+        $audit = $this->auditV2Service->build();
+        $truthBySlug = [];
+
+        foreach ($audit->members as $member) {
+            $truthBySlug[$member->canonicalSlug] = [
+                'canonical_slug' => $member->canonicalSlug,
+                'occupation_uuid' => $member->occupationUuid,
+                'canonical_title_en' => $member->canonicalTitleEn,
+                'launch_tier' => $member->launchTier,
+                'readiness_status' => $member->readinessStatus,
+                'lifecycle_state' => $member->lifecycleState,
+                'public_index_state' => $member->publicIndexState,
+                'index_eligible' => $member->indexEligible,
+                'reviewer_status' => $member->reviewerStatus,
+                'crosswalk_mode' => $member->crosswalkMode,
+                'allow_strong_claim' => $member->allowStrongClaim,
+                'confidence_score' => $member->confidenceScore,
+                'blocked_governance_status' => $member->blockedGovernanceStatus,
+                'next_step_links_count' => $member->nextStepLinksCount,
+                'trust_freshness' => is_array($member->trustFreshness) ? $member->trustFreshness : [],
+            ];
+        }
+
+        return $truthBySlug;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function trustFreshnessBySlug(): array
+    {
+        $authority = $this->trustFreshnessAuthorityService->build();
+        $freshnessBySlug = [];
+
+        foreach ($authority->members as $member) {
+            $freshnessBySlug[$member->canonicalSlug] = [
+                'review_due_known' => $member->reviewDueKnown,
+                'review_staleness_state' => $member->reviewStalenessState,
+                'reviewer_status' => $member->reviewerStatus,
+                'reviewed_at' => $member->reviewedAt,
+                'next_review_due_at' => $member->nextReviewDueAt,
+            ];
+        }
+
+        return $freshnessBySlug;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $truthBySlug
+     * @return array<string, array<string, mixed>>
+     */
+    private function promotionBySlug(array $truthBySlug, string $scope): array
+    {
+        $authority = $this->promotionCandidateEngine->build(array_values($truthBySlug), $scope)->toArray();
+        $promotionBySlug = [];
+
+        foreach ((array) ($authority['members'] ?? []) as $member) {
+            if (! is_array($member)) {
+                continue;
+            }
+
+            $slug = trim((string) ($member['canonical_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $promotionBySlug[$slug] = $member;
+        }
+
+        return $promotionBySlug;
+    }
+
+    private function normalizeMode(string $mode): string
+    {
+        $normalized = strtolower(trim($mode));
+
+        return match ($normalized) {
+            self::MODE_VALIDATE,
+            self::MODE_COMPILE_TRUST,
+            self::MODE_PUBLISH_CANDIDATE,
+            self::MODE_REGRESSION,
+            self::MODE_FULL => $normalized,
+            default => throw new RuntimeException(sprintf(
+                'Unsupported batch mode [%s]. Allowed modes: %s',
+                $mode,
+                implode(', ', [
+                    self::MODE_VALIDATE,
+                    self::MODE_COMPILE_TRUST,
+                    self::MODE_PUBLISH_CANDIDATE,
+                    self::MODE_REGRESSION,
+                    self::MODE_FULL,
+                ]),
+            )),
+        };
+    }
+}

--- a/backend/app/Domain/Career/Production/CareerAssetBatchPublishCandidateService.php
+++ b/backend/app/Domain/Career/Production/CareerAssetBatchPublishCandidateService.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Production;
+
+use App\Domain\Career\Publish\CareerFirstWavePromotionCandidateEngine;
+use App\DTO\Career\CareerAssetBatchManifest;
+
+final class CareerAssetBatchPublishCandidateService
+{
+    /**
+     * @param  array<string, array<string, mixed>>  $truthBySlug
+     * @param  array<string, array<string, mixed>>  $promotionBySlug
+     * @return array<string, mixed>
+     */
+    public function project(
+        CareerAssetBatchManifest $manifest,
+        array $truthBySlug,
+        array $promotionBySlug,
+    ): array {
+        $candidateReadySet = [];
+        $holdBackSet = [];
+        $rejectionSet = [];
+        $members = [];
+        $trackSummary = [
+            'stable' => 0,
+            'candidate' => 0,
+            'hold' => 0,
+        ];
+        $decisionCounts = [
+            CareerFirstWavePromotionCandidateEngine::DECISION_AUTO_NOMINATE => 0,
+            CareerFirstWavePromotionCandidateEngine::DECISION_MANUAL_REVIEW_ONLY => 0,
+            CareerFirstWavePromotionCandidateEngine::DECISION_NOT_ELIGIBLE => 0,
+        ];
+
+        foreach ($manifest->members as $member) {
+            $truth = $truthBySlug[$member->canonicalSlug] ?? null;
+            $promotion = $promotionBySlug[$member->canonicalSlug] ?? null;
+
+            if (! is_array($truth)) {
+                $decision = CareerFirstWavePromotionCandidateEngine::DECISION_NOT_ELIGIBLE;
+                $reasons = ['missing_backend_truth'];
+            } else {
+                $decision = (string) ($promotion['engine_decision'] ?? CareerFirstWavePromotionCandidateEngine::DECISION_NOT_ELIGIBLE);
+                $reasons = is_array($promotion['decision_reasons'] ?? null)
+                    ? array_values($promotion['decision_reasons'])
+                    : ['promotion_decision_missing'];
+            }
+
+            if (! isset($decisionCounts[$decision])) {
+                $decision = CareerFirstWavePromotionCandidateEngine::DECISION_NOT_ELIGIBLE;
+                $reasons[] = 'promotion_decision_unknown';
+            }
+
+            $decisionCounts[$decision]++;
+
+            if ($decision === CareerFirstWavePromotionCandidateEngine::DECISION_AUTO_NOMINATE) {
+                $candidateReadySet[] = $member->canonicalSlug;
+                $trackSummary[$member->expectedPublishTrack] = ($trackSummary[$member->expectedPublishTrack] ?? 0) + 1;
+            } elseif ($decision === CareerFirstWavePromotionCandidateEngine::DECISION_MANUAL_REVIEW_ONLY) {
+                $holdBackSet[] = $member->canonicalSlug;
+                $trackSummary['hold']++;
+            } else {
+                $rejectionSet[] = [
+                    'canonical_slug' => $member->canonicalSlug,
+                    'reasons' => array_values(array_unique($reasons)),
+                ];
+                $trackSummary['hold']++;
+            }
+
+            $members[] = [
+                'canonical_slug' => $member->canonicalSlug,
+                'engine_decision' => $decision,
+                'decision_reasons' => array_values(array_unique($reasons)),
+                'expected_publish_track' => $member->expectedPublishTrack,
+            ];
+        }
+
+        return [
+            'stage' => 'publish_candidate',
+            'passed' => true,
+            'counts' => $decisionCounts,
+            'candidate_ready_set' => array_values($candidateReadySet),
+            'hold_back_set' => array_values($holdBackSet),
+            'rejection_set' => $rejectionSet,
+            'publish_track_summary' => $trackSummary,
+            'members' => $members,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Production/CareerAssetBatchRegressionRunner.php
+++ b/backend/app/Domain/Career/Production/CareerAssetBatchRegressionRunner.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Production;
+
+use App\Domain\Career\Publish\CareerFirstWaveIndexPolicyEngine;
+use App\Domain\Career\Publish\CareerFirstWaveLaunchManifestService;
+use App\Domain\Career\Publish\CareerFirstWaveRolloutWavePlanService;
+use App\DTO\Career\CareerAssetBatchManifest;
+use Throwable;
+
+final class CareerAssetBatchRegressionRunner
+{
+    public function __construct(
+        private readonly CareerFirstWaveLaunchManifestService $launchManifestService,
+        private readonly CareerFirstWaveRolloutWavePlanService $rolloutWavePlanService,
+        private readonly CareerFirstWaveIndexPolicyEngine $indexPolicyEngine,
+    ) {}
+
+    /**
+     * @param  array<string, array<string, mixed>>  $truthBySlug
+     * @return array<string, mixed>
+     */
+    public function run(CareerAssetBatchManifest $manifest, array $truthBySlug): array
+    {
+        $checks = [];
+
+        try {
+            $launchManifest = $this->launchManifestService->build()->toArray();
+            $launchTotal = (int) data_get($launchManifest, 'counts.total', 0);
+            $checks[] = [
+                'check' => 'first_wave_launch_manifest_baseline',
+                'passed' => $launchTotal === 10,
+                'details' => [
+                    'first_wave_total' => $launchTotal,
+                ],
+            ];
+        } catch (Throwable $e) {
+            $checks[] = [
+                'check' => 'first_wave_launch_manifest_baseline',
+                'passed' => false,
+                'details' => ['error' => $e->getMessage()],
+            ];
+        }
+
+        try {
+            $rolloutPlan = $this->rolloutWavePlanService->build()->toArray();
+            $checks[] = [
+                'check' => 'rollout_wave_plan_compatibility',
+                'passed' => trim((string) ($rolloutPlan['scope'] ?? '')) !== '',
+                'details' => [
+                    'scope' => (string) ($rolloutPlan['scope'] ?? ''),
+                ],
+            ];
+        } catch (Throwable $e) {
+            $checks[] = [
+                'check' => 'rollout_wave_plan_compatibility',
+                'passed' => false,
+                'details' => ['error' => $e->getMessage()],
+            ];
+        }
+
+        try {
+            $policy = $this->indexPolicyEngine->build(array_values($truthBySlug), $manifest->scope)->toArray();
+            $checks[] = [
+                'check' => 'index_policy_engine_compatibility',
+                'passed' => is_array($policy['members'] ?? null),
+                'details' => [
+                    'members' => count((array) ($policy['members'] ?? [])),
+                ],
+            ];
+        } catch (Throwable $e) {
+            $checks[] = [
+                'check' => 'index_policy_engine_compatibility',
+                'passed' => false,
+                'details' => ['error' => $e->getMessage()],
+            ];
+        }
+
+        $passed = collect($checks)->every(static fn (array $check): bool => (bool) ($check['passed'] ?? false));
+
+        return [
+            'stage' => 'regression',
+            'passed' => $passed,
+            'checks' => $checks,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Production/CareerAssetBatchTrustCompiler.php
+++ b/backend/app/Domain/Career/Production/CareerAssetBatchTrustCompiler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Production;
+
+use App\DTO\Career\CareerAssetBatchManifest;
+
+final class CareerAssetBatchTrustCompiler
+{
+    /**
+     * @param  array<string, array<string, mixed>>  $trustFreshnessBySlug
+     * @return array<string, mixed>
+     */
+    public function compile(CareerAssetBatchManifest $manifest, array $trustFreshnessBySlug): array
+    {
+        $members = [];
+        $compileSuccess = 0;
+        $compileFailed = 0;
+        $trustReady = 0;
+        $trustMissing = 0;
+
+        foreach ($manifest->members as $member) {
+            $freshness = $trustFreshnessBySlug[$member->canonicalSlug] ?? null;
+            $hasFreshness = is_array($freshness);
+
+            if ($hasFreshness) {
+                $compileSuccess++;
+                $trustReady++;
+            } else {
+                $compileFailed++;
+                $trustMissing++;
+            }
+
+            $members[] = [
+                'canonical_slug' => $member->canonicalSlug,
+                'compile_success' => $hasFreshness,
+                'trust_state' => $hasFreshness ? 'trust_ready' : 'trust_missing',
+                'trust_evidence' => $hasFreshness ? [
+                    'review_due_known' => (bool) ($freshness['review_due_known'] ?? false),
+                    'review_staleness_state' => (string) ($freshness['review_staleness_state'] ?? 'unknown_due_date'),
+                    'reviewer_status' => $freshness['reviewer_status'] ?? null,
+                ] : null,
+            ];
+        }
+
+        return [
+            'stage' => 'compile_trust',
+            'passed' => $compileFailed === 0,
+            'counts' => [
+                'total' => count($members),
+                'compile_success' => $compileSuccess,
+                'compile_failed' => $compileFailed,
+                'trust_ready' => $trustReady,
+                'trust_missing' => $trustMissing,
+            ],
+            'members' => $members,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Production/CareerAssetBatchValidator.php
+++ b/backend/app/Domain/Career/Production/CareerAssetBatchValidator.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Production;
+
+use App\DTO\Career\CareerAssetBatchManifest;
+
+final class CareerAssetBatchValidator
+{
+    /**
+     * @var array<string, true>
+     */
+    private const ALLOWED_CROSSWALK_MODES = [
+        'exact' => true,
+        'trust_inheritance' => true,
+        'functional_equivalent' => true,
+        'direct_match' => true,
+        'family_proxy' => true,
+        'local_heavy_interpretation' => true,
+        'unmapped' => true,
+    ];
+
+    /**
+     * @var array<string, true>
+     */
+    private const ALLOWED_BATCH_ROLES = [
+        'stable_seed' => true,
+        'candidate_seed' => true,
+        'hold_seed' => true,
+    ];
+
+    /**
+     * @var array<string, true>
+     */
+    private const ALLOWED_PUBLISH_TRACKS = [
+        'stable' => true,
+        'candidate' => true,
+        'hold' => true,
+    ];
+
+    /**
+     * @param  array<string, array<string, mixed>>  $truthBySlug
+     * @return array<string, mixed>
+     */
+    public function validate(CareerAssetBatchManifest $manifest, array $truthBySlug): array
+    {
+        $seenSlugs = [];
+        $seenIds = [];
+        $members = [];
+
+        foreach ($manifest->members as $member) {
+            $errors = [];
+            $slug = $member->canonicalSlug;
+            $occupationId = $member->occupationUuid;
+
+            if (isset($seenSlugs[$slug])) {
+                $errors[] = 'duplicate_canonical_slug';
+            }
+            if (isset($seenIds[$occupationId])) {
+                $errors[] = 'duplicate_occupation_uuid';
+            }
+
+            $seenSlugs[$slug] = true;
+            $seenIds[$occupationId] = true;
+
+            if (! isset(self::ALLOWED_CROSSWALK_MODES[$member->crosswalkMode])) {
+                $errors[] = 'unsupported_crosswalk_mode';
+            }
+
+            if (! isset(self::ALLOWED_BATCH_ROLES[$member->batchRole])) {
+                $errors[] = 'unsupported_batch_role';
+            }
+
+            if (! isset(self::ALLOWED_PUBLISH_TRACKS[$member->expectedPublishTrack])) {
+                $errors[] = 'unsupported_expected_publish_track';
+            }
+
+            if ($member->batchRole === 'stable_seed' && ! $member->stableSeed) {
+                $errors[] = 'stable_seed_role_mismatch';
+            }
+            if ($member->batchRole === 'candidate_seed' && ! $member->candidateSeed) {
+                $errors[] = 'candidate_seed_role_mismatch';
+            }
+            if ($member->batchRole === 'hold_seed' && ! $member->holdSeed) {
+                $errors[] = 'hold_seed_role_mismatch';
+            }
+
+            if (! isset($truthBySlug[$slug])) {
+                $errors[] = 'missing_backend_truth';
+            }
+
+            $members[] = [
+                'canonical_slug' => $slug,
+                'valid' => $errors === [],
+                'errors' => $errors,
+            ];
+        }
+
+        $errors = [];
+        if ($manifest->batchKind === CareerAssetBatchManifestBuilder::BATCH_KIND_1 && $manifest->memberCount !== 10) {
+            $errors[] = 'batch_1_member_count_must_equal_10';
+        }
+        if ($manifest->batchKind === CareerAssetBatchManifestBuilder::BATCH_KIND_2 && $manifest->memberCount !== 30) {
+            $errors[] = 'batch_2_member_count_must_equal_30';
+        }
+
+        return [
+            'stage' => 'validate',
+            'passed' => $errors === [] && collect($members)->every(static fn (array $row): bool => (bool) $row['valid']),
+            'errors' => $errors,
+            'counts' => [
+                'total' => count($members),
+                'valid' => collect($members)->where('valid', true)->count(),
+                'invalid' => collect($members)->where('valid', false)->count(),
+            ],
+            'members' => $members,
+        ];
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T01:07:47Z",
+  "updated_at": "2026-04-16T01:38:16Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1916,10 +1916,10 @@
     "PR-B68": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "merged",
       "branch": "codex/pr-b68-career-dataset-article-structured-data-completion",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "ef4b9356ab7c103159d91d0931b922da2f280f02",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/915",
       "checks": {
         "local": [
           {
@@ -1940,6 +1940,55 @@
           },
           {
             "command": "php artisan test tests/Feature/OpenApiDiffTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24486532023/job/71562611296"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24486532023/job/71562615728"
+          }
+        ]
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-16T01:14:45Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B69": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-b69-career-asset-batch-pipeline-batch1-2-production-line",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Production/*.php app/DTO/Career/CareerAssetBatchManifest.php app/Console/Commands/CareerRunAssetBatch.php tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php tests/Feature/Console/CareerRunAssetBatchCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/CareerRunAssetBatchCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php",
             "status": "passed"
           }
         ],

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T01:38:16Z",
+  "updated_at": "2026-04-16T01:39:25Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1965,10 +1965,10 @@
     "PR-B69": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b69-career-asset-batch-pipeline-batch1-2-production-line",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "2022025951aec2c9e88ef653b5afe83e35e12a9f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/916",
       "checks": {
         "local": [
           {
@@ -1992,9 +1992,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24487382570/job/71565178259"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24487373150/job/71565148798"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24487382570/job/71565182254"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24487373150/job/71565152961"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene checks failed immediately on PR-B69 and MBTI verify jobs were skipped; local validation is green but required remote checks are not green.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1150,6 +1150,35 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B69
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b69-career-asset-batch-pipeline-batch1-2-production-line
+    base: main
+    depends_on: ["PR-B68"]
+    mode: execute
+    scope: >
+      Career asset batch pipeline / batch-1~2 production line.
+      Introduce an internal-only reusable batch pipeline with explicit manifest,
+      staged validate/compile-trust/publish-candidate/regression flow, and a single
+      CLI entrypoint to run Batch 1 (10) and framework-compatible Batch 2 (30)
+      orchestration without inventing truth outside existing backend authorities.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Production/*.php app/DTO/Career/CareerAssetBatchManifest.php app/Console/Commands/CareerRunAssetBatch.php tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php tests/Feature/Console/CareerRunAssetBatchCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php"
+      - "php artisan test tests/Feature/Console/CareerRunAssetBatchCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Console/CareerRunAssetBatchCommandTest.php
+++ b/backend/tests/Feature/Console/CareerRunAssetBatchCommandTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\Production\CareerAssetBatchManifestBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerRunAssetBatchCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var list<string>
+     */
+    private array $manifestPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->manifestPaths as $path) {
+            File::delete($path);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_runs_full_batch_pipeline_for_batch_1_manifest(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $manifestPath = $this->createBatchManifest(
+            CareerAssetBatchManifestBuilder::BATCH_KIND_1,
+            10,
+            0,
+        );
+
+        $this->artisan('career:run-asset-batch', [
+            '--manifest' => $manifestPath,
+            '--mode' => 'full',
+        ])
+            ->expectsOutputToContain('status=completed')
+            ->expectsOutputToContain('mode=full')
+            ->expectsOutputToContain('stage[validate]=passed')
+            ->expectsOutputToContain('stage[compile_trust]=passed')
+            ->expectsOutputToContain('stage[publish_candidate]=passed')
+            ->expectsOutputToContain('stage[regression]=passed')
+            ->assertExitCode(0);
+    }
+
+    public function test_command_supports_batch_2_validate_mode_with_json_output(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $manifestPath = $this->createBatchManifest(
+            CareerAssetBatchManifestBuilder::BATCH_KIND_2,
+            10,
+            20,
+        );
+
+        $exitCode = Artisan::call('career:run-asset-batch', [
+            '--manifest' => $manifestPath,
+            '--mode' => 'validate',
+            '--json' => true,
+        ]);
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertSame('career_asset_batch_pipeline', $payload['pipeline_kind'] ?? null);
+        $this->assertSame('aborted', $payload['status'] ?? null);
+        $this->assertSame('validate', $payload['mode'] ?? null);
+        $this->assertSame(30, data_get($payload, 'manifest.member_count'));
+        $this->assertSame(20, data_get($payload, 'stages.validate.counts.invalid'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    private function createBatchManifest(string $batchKind, int $truthMembers, int $syntheticMembers): string
+    {
+        $firstWave = json_decode((string) file_get_contents(base_path('docs/career/first_wave_manifest.json')), true);
+        $occupations = array_slice((array) ($firstWave['occupations'] ?? []), 0, $truthMembers);
+
+        $members = [];
+        foreach ($occupations as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $track = $this->normalizeTrack((string) ($row['wave_classification'] ?? 'hold'));
+            $members[] = [
+                'occupation_uuid' => (string) ($row['occupation_uuid'] ?? ''),
+                'canonical_slug' => (string) ($row['canonical_slug'] ?? ''),
+                'canonical_title_en' => (string) ($row['canonical_title_en'] ?? ''),
+                'family_slug' => 'family-'.(string) ($row['canonical_slug'] ?? ''),
+                'crosswalk_mode' => (string) ($row['crosswalk_mode'] ?? 'exact'),
+                'batch_role' => $track.'_seed',
+                'stable_seed' => $track === 'stable',
+                'candidate_seed' => $track === 'candidate',
+                'hold_seed' => $track === 'hold',
+                'expected_publish_track' => $track,
+            ];
+        }
+
+        for ($i = 1; $i <= $syntheticMembers; $i++) {
+            $members[] = [
+                'occupation_uuid' => sprintf('10000000-0000-0000-0000-%012d', $i),
+                'canonical_slug' => sprintf('batch-two-command-%02d', $i),
+                'canonical_title_en' => sprintf('Batch Two Command %02d', $i),
+                'family_slug' => 'batch-two-family',
+                'crosswalk_mode' => 'exact',
+                'batch_role' => 'hold_seed',
+                'stable_seed' => false,
+                'candidate_seed' => false,
+                'hold_seed' => true,
+                'expected_publish_track' => 'hold',
+            ];
+        }
+
+        $payload = [
+            'batch_kind' => $batchKind,
+            'batch_version' => 'career.asset_batch.manifest.v1',
+            'batch_key' => $batchKind.'-command-test',
+            'scope' => $batchKind === CareerAssetBatchManifestBuilder::BATCH_KIND_1
+                ? 'career_batch_1_first_wave_10'
+                : 'career_batch_2_first_wave_30_framework',
+            'member_count' => count($members),
+            'members' => $members,
+        ];
+
+        $path = storage_path('app/private/testing/'.$payload['batch_key'].'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, (string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        $this->manifestPaths[] = $path;
+
+        return $path;
+    }
+
+    private function normalizeTrack(string $waveClassification): string
+    {
+        $normalized = strtolower(trim($waveClassification));
+
+        return match ($normalized) {
+            'stable' => 'stable',
+            'candidate' => 'candidate',
+            default => 'hold',
+        };
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Production\CareerAssetBatchManifestBuilder;
+use App\Domain\Career\Production\CareerAssetBatchPipeline;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerAssetBatchPipelineTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var list<string>
+     */
+    private array $manifestPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->manifestPaths as $path) {
+            File::delete($path);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_it_runs_batch_1_full_pipeline_with_validate_compile_publish_and_regression(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $manifestPath = $this->createBatchManifest(
+            CareerAssetBatchManifestBuilder::BATCH_KIND_1,
+            10,
+            0,
+        );
+
+        $result = app(CareerAssetBatchPipeline::class)->run($manifestPath, CareerAssetBatchPipeline::MODE_FULL);
+
+        $this->assertSame('career_asset_batch_pipeline', $result['pipeline_kind'] ?? null);
+        $this->assertSame('completed', $result['status'] ?? null);
+        $this->assertSame(CareerAssetBatchPipeline::MODE_FULL, $result['mode'] ?? null);
+        $this->assertSame(10, data_get($result, 'manifest.member_count'));
+        $this->assertTrue((bool) data_get($result, 'stages.validate.passed'));
+        $this->assertTrue((bool) data_get($result, 'stages.compile_trust.passed'));
+        $this->assertTrue((bool) data_get($result, 'stages.publish_candidate.passed'));
+        $this->assertTrue((bool) data_get($result, 'stages.regression.passed'));
+    }
+
+    public function test_it_supports_batch_2_manifest_shape_for_30_members_and_fails_fast_on_missing_truth(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $manifestPath = $this->createBatchManifest(
+            CareerAssetBatchManifestBuilder::BATCH_KIND_2,
+            10,
+            20,
+        );
+
+        $result = app(CareerAssetBatchPipeline::class)->run($manifestPath, CareerAssetBatchPipeline::MODE_VALIDATE);
+
+        $this->assertSame('aborted', $result['status'] ?? null);
+        $this->assertSame(CareerAssetBatchPipeline::MODE_VALIDATE, $result['mode'] ?? null);
+        $this->assertSame(30, data_get($result, 'manifest.member_count'));
+        $this->assertSame(30, data_get($result, 'stages.validate.counts.total'));
+        $this->assertSame(20, data_get($result, 'stages.validate.counts.invalid'));
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    private function createBatchManifest(string $batchKind, int $truthMembers, int $syntheticMembers): string
+    {
+        $firstWave = json_decode((string) file_get_contents(base_path('docs/career/first_wave_manifest.json')), true);
+        $occupations = array_slice((array) ($firstWave['occupations'] ?? []), 0, $truthMembers);
+
+        $members = [];
+        foreach ($occupations as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $track = $this->normalizeTrack((string) ($row['wave_classification'] ?? 'hold'));
+            $members[] = [
+                'occupation_uuid' => (string) ($row['occupation_uuid'] ?? ''),
+                'canonical_slug' => (string) ($row['canonical_slug'] ?? ''),
+                'canonical_title_en' => (string) ($row['canonical_title_en'] ?? ''),
+                'family_slug' => 'family-'.(string) ($row['canonical_slug'] ?? ''),
+                'crosswalk_mode' => (string) ($row['crosswalk_mode'] ?? 'exact'),
+                'batch_role' => $track.'_seed',
+                'stable_seed' => $track === 'stable',
+                'candidate_seed' => $track === 'candidate',
+                'hold_seed' => $track === 'hold',
+                'expected_publish_track' => $track,
+            ];
+        }
+
+        for ($i = 1; $i <= $syntheticMembers; $i++) {
+            $members[] = [
+                'occupation_uuid' => sprintf('00000000-0000-0000-0000-%012d', $i),
+                'canonical_slug' => sprintf('batch-two-synthetic-%02d', $i),
+                'canonical_title_en' => sprintf('Batch Two Synthetic %02d', $i),
+                'family_slug' => 'batch-two-family',
+                'crosswalk_mode' => 'exact',
+                'batch_role' => 'hold_seed',
+                'stable_seed' => false,
+                'candidate_seed' => false,
+                'hold_seed' => true,
+                'expected_publish_track' => 'hold',
+            ];
+        }
+
+        $payload = [
+            'batch_kind' => $batchKind,
+            'batch_version' => 'career.asset_batch.manifest.v1',
+            'batch_key' => $batchKind.'-test',
+            'scope' => $batchKind === CareerAssetBatchManifestBuilder::BATCH_KIND_1
+                ? 'career_batch_1_first_wave_10'
+                : 'career_batch_2_first_wave_30_framework',
+            'member_count' => count($members),
+            'members' => $members,
+        ];
+
+        $path = storage_path('app/private/testing/'.$payload['batch_key'].'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, (string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        $this->manifestPaths[] = $path;
+
+        return $path;
+    }
+
+    private function normalizeTrack(string $waveClassification): string
+    {
+        $normalized = strtolower(trim($waveClassification));
+
+        return match ($normalized) {
+            'stable' => 'stable',
+            'candidate' => 'candidate',
+            default => 'hold',
+        };
+    }
+}


### PR DESCRIPTION
## What Changed
- Added a new internal-only batch production pipeline for Career assets:
  - `CareerAssetBatchPipeline`
  - `CareerAssetBatchManifestBuilder`
  - `CareerAssetBatchValidator`
  - `CareerAssetBatchTrustCompiler`
  - `CareerAssetBatchPublishCandidateService`
  - `CareerAssetBatchRegressionRunner`
- Added explicit batch manifest contract DTOs:
  - `CareerAssetBatchManifest`
  - `CareerAssetBatchManifestMember`
- Added unified CLI entrypoint:
  - `career:run-asset-batch`
  - modes: `validate`, `compile-trust`, `publish-candidate`, `regression`, `full`
- Wired command registration in `app/Console/Kernel.php`.
- Added focused tests:
  - `CareerAssetBatchPipelineTest`
  - `CareerRunAssetBatchCommandTest`
- Updated train ledger for PR-B69.

## Why
- Formalize a reusable and auditable batch production line from the first-wave 10 baseline.
- Keep truth/score/trust/claim owned by existing backend engines and only orchestrate pipeline stages.
- Provide safe scale path from Batch 1 (10) to Batch 2 (30 framework) without bypassing validate/trust/publish gates.

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Production/*.php app/DTO/Career/CareerAssetBatchManifest.php app/Console/Commands/CareerRunAssetBatch.php tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php tests/Feature/Console/CareerRunAssetBatchCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php`
- `php artisan test tests/Feature/Console/CareerRunAssetBatchCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php`

## Intentionally Deferred
- No frontend changes.
- No OpenAPI/public API expansion.
- No 342 full-batch production execution.
- No family-hub primary member expansion.
- No new score/trust/crosswalk truth invention.
