### PR TITLE
PR-B70: Crosswalk / editorial operations baseline

### DIFF
--- a/backend/app/Console/Commands/CareerCrosswalkOps.php
+++ b/backend/app/Console/Commands/CareerCrosswalkOps.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Operations\CareerCrosswalkOverrideResolver;
+use App\Domain\Career\Operations\CareerCrosswalkReviewQueueService;
+use App\Domain\Career\Operations\CareerEditorialPatchAuthorityService;
+use App\Domain\Career\Production\CareerAssetBatchManifestBuilder;
+use App\Domain\Career\Publish\CareerFirstWaveLaunchReadinessAuditV2Service;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class CareerCrosswalkOps extends Command
+{
+    protected $signature = 'career:crosswalk-ops
+        {--mode=build-review-queue : build-review-queue|validate-patches|resolve-overrides|snapshot}
+        {--manifest= : Optional batch manifest path for batch origin/publish track context}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Run internal crosswalk/editorial operations baseline actions.';
+
+    public function handle(
+        CareerEditorialPatchAuthorityService $patchAuthorityService,
+        CareerCrosswalkReviewQueueService $reviewQueueService,
+        CareerCrosswalkOverrideResolver $overrideResolver,
+        CareerFirstWaveLaunchReadinessAuditV2Service $auditService,
+        CareerAssetBatchManifestBuilder $manifestBuilder,
+    ): int {
+        $mode = strtolower(trim((string) $this->option('mode')));
+        if (! in_array($mode, ['build-review-queue', 'validate-patches', 'resolve-overrides', 'snapshot'], true)) {
+            $this->error(sprintf('Unsupported --mode [%s].', (string) $this->option('mode')));
+
+            return self::FAILURE;
+        }
+
+        $patchAuthority = $patchAuthorityService->build()->toArray();
+        $patches = (array) ($patchAuthority['patches'] ?? []);
+        $approvedPatchesBySlug = $this->approvedPatchesBySlug($patches);
+        $subjects = (array) (($auditService->build()->toArray())['members'] ?? []);
+        $batchContextBySlug = $this->batchContextBySlug(
+            trim((string) $this->option('manifest')),
+            $manifestBuilder,
+        );
+
+        $result = match ($mode) {
+            'build-review-queue' => [
+                'mode' => $mode,
+                'review_queue' => $reviewQueueService->build(
+                    subjects: $subjects,
+                    approvedPatchesBySlug: $approvedPatchesBySlug,
+                    batchContextBySlug: $batchContextBySlug,
+                )->toArray(),
+            ],
+            'validate-patches' => [
+                'mode' => $mode,
+                'patch_validation' => $patchAuthorityService->validate($patches),
+            ],
+            'resolve-overrides' => [
+                'mode' => $mode,
+                'resolved_crosswalk' => $overrideResolver->resolve(
+                    subjects: $subjects,
+                    approvedPatchesBySlug: $approvedPatchesBySlug,
+                ),
+            ],
+            default => [
+                'mode' => $mode,
+                'patch_authority' => $patchAuthority,
+                'patch_validation' => $patchAuthorityService->validate($patches),
+                'review_queue' => $reviewQueueService->build(
+                    subjects: $subjects,
+                    approvedPatchesBySlug: $approvedPatchesBySlug,
+                    batchContextBySlug: $batchContextBySlug,
+                )->toArray(),
+                'resolved_crosswalk' => $overrideResolver->resolve(
+                    subjects: $subjects,
+                    approvedPatchesBySlug: $approvedPatchesBySlug,
+                ),
+            ],
+        };
+
+        $hasPatchValidation = array_key_exists('patch_validation', $result);
+        $failed = $hasPatchValidation && (bool) data_get($result, 'patch_validation.passed') === false;
+        $status = $failed ? 'failed' : 'ok';
+        $result['status'] = $status;
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($result, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+
+            return $failed ? self::FAILURE : self::SUCCESS;
+        }
+
+        $this->line('mode='.$mode);
+        $this->line('status='.$status);
+        $this->line('patch_count='.(string) count($patches));
+        if (isset($result['patch_validation'])) {
+            $this->line(sprintf(
+                'patch_validation=%s',
+                (bool) data_get($result, 'patch_validation.passed', false) ? 'passed' : 'failed'
+            ));
+        }
+        if (isset($result['review_queue'])) {
+            $this->line('review_queue_total='.(string) data_get($result, 'review_queue.counts.total', 0));
+        }
+        if (isset($result['resolved_crosswalk'])) {
+            $this->line('override_applied='.(string) data_get($result, 'resolved_crosswalk.counts.override_applied', 0));
+        }
+
+        return $failed ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     * @return array<string, array<string, mixed>>
+     */
+    private function approvedPatchesBySlug(array $patches): array
+    {
+        $grouped = [];
+        foreach ($patches as $patch) {
+            if (! is_array($patch)) {
+                continue;
+            }
+
+            $status = strtolower(trim((string) ($patch['patch_status'] ?? '')));
+            $slug = trim((string) ($patch['subject_slug'] ?? ''));
+            if ($status !== 'approved' || $slug === '') {
+                continue;
+            }
+
+            $grouped[$slug][] = $patch;
+        }
+
+        $approved = [];
+        foreach ($grouped as $slug => $items) {
+            usort($items, function (array $a, array $b): int {
+                $at = strtotime((string) ($a['reviewed_at'] ?? $a['created_at'] ?? '')) ?: 0;
+                $bt = strtotime((string) ($b['reviewed_at'] ?? $b['created_at'] ?? '')) ?: 0;
+
+                return $bt <=> $at;
+            });
+            $approved[$slug] = $items[0];
+        }
+
+        return $approved;
+    }
+
+    /**
+     * @return array<string, array{batch_origin:?string,publish_track:?string,family_slug:?string}>
+     */
+    private function batchContextBySlug(string $manifestPath, CareerAssetBatchManifestBuilder $manifestBuilder): array
+    {
+        if ($manifestPath === '') {
+            return [];
+        }
+
+        try {
+            $manifest = $manifestBuilder->fromPath($manifestPath);
+        } catch (RuntimeException) {
+            return [];
+        }
+
+        $context = [];
+        foreach ($manifest->members as $member) {
+            $context[$member->canonicalSlug] = [
+                'batch_origin' => $manifest->batchKey,
+                'publish_track' => $member->expectedPublishTrack,
+                'family_slug' => $member->familySlug,
+            ];
+        }
+
+        return $context;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -9,6 +9,7 @@ use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerCompileAuthorityWave;
+use App\Console\Commands\CareerCrosswalkOps;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerExportFirstWaveRolloutBundleArtifacts;
 use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
@@ -134,6 +135,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPostCommitFailed::class,
         CareerImportAuthorityWave::class,
         CareerCompileAuthorityWave::class,
+        CareerCrosswalkOps::class,
         CareerRunAssetBatch::class,
         CareerExportFirstWaveRolloutBundleArtifacts::class,
         CareerExportFirstWaveReleaseArtifacts::class,

--- a/backend/app/DTO/Career/CareerCrosswalkReviewQueue.php
+++ b/backend/app/DTO/Career/CareerCrosswalkReviewQueue.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerCrosswalkReviewQueue
+{
+    /**
+     * @param  list<CareerCrosswalkReviewQueueItem>  $items
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $items,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'queue_kind' => 'career_crosswalk_review_queue',
+            'queue_version' => 'career.crosswalk.review_queue.v1',
+            'scope' => $this->scope,
+            'counts' => [
+                'total' => count($this->items),
+                'local_heavy_interpretation' => count(array_filter(
+                    $this->items,
+                    static fn (CareerCrosswalkReviewQueueItem $item): bool => $item->currentCrosswalkMode === 'local_heavy_interpretation',
+                )),
+                'family_proxy' => count(array_filter(
+                    $this->items,
+                    static fn (CareerCrosswalkReviewQueueItem $item): bool => $item->currentCrosswalkMode === 'family_proxy',
+                )),
+                'functional_equivalent' => count(array_filter(
+                    $this->items,
+                    static fn (CareerCrosswalkReviewQueueItem $item): bool => $item->currentCrosswalkMode === 'functional_equivalent',
+                )),
+            ],
+            'items' => array_map(
+                static fn (CareerCrosswalkReviewQueueItem $item): array => $item->toArray(),
+                $this->items,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerCrosswalkReviewQueueItem.php
+++ b/backend/app/DTO/Career/CareerCrosswalkReviewQueueItem.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerCrosswalkReviewQueueItem
+{
+    /**
+     * @param  list<string>  $queueReasons
+     * @param  list<string>  $blockingFlags
+     */
+    public function __construct(
+        public readonly string $subjectSlug,
+        public readonly string $currentCrosswalkMode,
+        public readonly array $queueReasons,
+        public readonly ?string $candidateTargetKind,
+        public readonly ?string $candidateTargetSlug,
+        public readonly bool $requiresEditorialPatch,
+        public readonly ?string $batchOrigin,
+        public readonly ?string $publishTrack,
+        public readonly array $blockingFlags,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'subject_slug' => $this->subjectSlug,
+            'current_crosswalk_mode' => $this->currentCrosswalkMode,
+            'queue_reason' => $this->queueReasons,
+            'candidate_target_kind' => $this->candidateTargetKind,
+            'candidate_target_slug' => $this->candidateTargetSlug,
+            'requires_editorial_patch' => $this->requiresEditorialPatch,
+            'batch_origin' => $this->batchOrigin,
+            'publish_track' => $this->publishTrack,
+            'blocking_flags' => $this->blockingFlags,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerEditorialPatchAuthority.php
+++ b/backend/app/DTO/Career/CareerEditorialPatchAuthority.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerEditorialPatchAuthority
+{
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     */
+    public function __construct(
+        public readonly string $scope,
+        public readonly array $patches,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'authority_kind' => 'career_editorial_patch_authority',
+            'authority_version' => 'career.editorial_patch.authority.v1',
+            'scope' => $this->scope,
+            'count' => count($this->patches),
+            'patches' => $this->patches,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Operations/CareerCrosswalkOverrideResolver.php
+++ b/backend/app/Domain/Career/Operations/CareerCrosswalkOverrideResolver.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Operations;
+
+final class CareerCrosswalkOverrideResolver
+{
+    /**
+     * @param  list<array<string, mixed>>  $subjects
+     * @param  array<string, array<string, mixed>>  $approvedPatchesBySlug
+     * @return array<string, mixed>
+     */
+    public function resolve(array $subjects, array $approvedPatchesBySlug): array
+    {
+        $resolved = [];
+        $counts = [
+            'total' => 0,
+            'override_applied' => 0,
+            'kept_original' => 0,
+        ];
+
+        foreach ($subjects as $subject) {
+            if (! is_array($subject)) {
+                continue;
+            }
+
+            $slug = trim((string) ($subject['canonical_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $counts['total']++;
+            $originalMode = strtolower(trim((string) ($subject['crosswalk_mode'] ?? '')));
+            $patch = $approvedPatchesBySlug[$slug] ?? null;
+
+            $resolvedMode = $originalMode;
+            $targetKind = 'occupation';
+            $targetSlug = $slug;
+            $appliedPatchKey = null;
+
+            if (is_array($patch)) {
+                $override = $this->normalizeNullableString($patch['crosswalk_mode_override'] ?? null);
+                if ($override !== null) {
+                    $resolvedMode = strtolower($override);
+                }
+                $targetKind = $this->normalizeTargetKind($patch['target_kind'] ?? null);
+                $targetSlug = $this->normalizeNullableString($patch['target_slug'] ?? null) ?? $slug;
+                $appliedPatchKey = $this->normalizeNullableString($patch['patch_key'] ?? null);
+                $counts['override_applied']++;
+            } else {
+                $counts['kept_original']++;
+            }
+
+            $resolved[] = [
+                'subject_kind' => 'career_job_detail',
+                'subject_slug' => $slug,
+                'original_crosswalk_mode' => $originalMode,
+                'resolved_crosswalk_mode' => $resolvedMode,
+                'resolved_target_kind' => $targetKind,
+                'resolved_target_slug' => $targetSlug,
+                'override_applied' => $appliedPatchKey !== null,
+                'applied_patch_key' => $appliedPatchKey,
+            ];
+        }
+
+        return [
+            'resolver_kind' => 'career_crosswalk_override_resolver',
+            'resolver_version' => 'career.crosswalk.override_resolver.v1',
+            'counts' => $counts,
+            'resolved' => $resolved,
+        ];
+    }
+
+    private function normalizeTargetKind(mixed $value): string
+    {
+        $normalized = strtolower(trim((string) $value));
+
+        return in_array($normalized, ['occupation', 'family'], true)
+            ? $normalized
+            : 'occupation';
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Domain/Career/Operations/CareerCrosswalkReviewQueueService.php
+++ b/backend/app/Domain/Career/Operations/CareerCrosswalkReviewQueueService.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Operations;
+
+use App\DTO\Career\CareerCrosswalkReviewQueue;
+use App\DTO\Career\CareerCrosswalkReviewQueueItem;
+
+final class CareerCrosswalkReviewQueueService
+{
+    /**
+     * @var array<string, true>
+     */
+    private const QUEUE_MODES = [
+        'local_heavy_interpretation' => true,
+        'family_proxy' => true,
+        'functional_equivalent' => true,
+    ];
+
+    /**
+     * @param  list<array<string, mixed>>  $subjects
+     * @param  array<string, array<string, mixed>>  $approvedPatchesBySlug
+     * @param  array<string, array{batch_origin:?string,publish_track:?string,family_slug:?string}>  $batchContextBySlug
+     */
+    public function build(
+        array $subjects,
+        array $approvedPatchesBySlug = [],
+        array $batchContextBySlug = [],
+        string $scope = 'career_crosswalk_editorial_ops',
+    ): CareerCrosswalkReviewQueue {
+        $items = [];
+
+        foreach ($subjects as $subject) {
+            if (! is_array($subject)) {
+                continue;
+            }
+
+            $slug = trim((string) ($subject['canonical_slug'] ?? ''));
+            $mode = strtolower(trim((string) ($subject['crosswalk_mode'] ?? '')));
+            if ($slug === '' || ! isset(self::QUEUE_MODES[$mode])) {
+                continue;
+            }
+
+            $batchContext = $batchContextBySlug[$slug] ?? [
+                'batch_origin' => null,
+                'publish_track' => null,
+                'family_slug' => null,
+            ];
+            $approvedPatch = $approvedPatchesBySlug[$slug] ?? null;
+
+            $candidateTargetKind = is_array($approvedPatch)
+                ? $this->normalizeNullableString($approvedPatch['target_kind'] ?? null)
+                : ($mode === 'family_proxy' ? 'family' : 'occupation');
+            $candidateTargetSlug = is_array($approvedPatch)
+                ? $this->normalizeNullableString($approvedPatch['target_slug'] ?? null)
+                : ($mode === 'family_proxy'
+                    ? $this->normalizeNullableString($batchContext['family_slug'] ?? null)
+                    : $slug);
+
+            $queueReasons = match ($mode) {
+                'local_heavy_interpretation' => ['local_heavy_requires_editorial_patch'],
+                'family_proxy' => ['family_proxy_requires_editorial_patch'],
+                default => ['functional_equivalent_requires_editorial_review'],
+            };
+
+            $blockingFlags = [];
+            $readinessStatus = strtolower(trim((string) ($subject['readiness_status'] ?? '')));
+            if ($readinessStatus !== '' && $readinessStatus !== 'publish_ready') {
+                $blockingFlags[] = 'not_publish_ready';
+            }
+            if (trim((string) ($subject['blocked_governance_status'] ?? '')) !== '') {
+                $blockingFlags[] = 'governance_blocked';
+            }
+            if (! is_array($approvedPatch)) {
+                $blockingFlags[] = 'approved_patch_missing';
+            }
+
+            $items[] = new CareerCrosswalkReviewQueueItem(
+                subjectSlug: $slug,
+                currentCrosswalkMode: $mode,
+                queueReasons: $queueReasons,
+                candidateTargetKind: $candidateTargetKind,
+                candidateTargetSlug: $candidateTargetSlug,
+                requiresEditorialPatch: true,
+                batchOrigin: $this->normalizeNullableString($batchContext['batch_origin'] ?? null),
+                publishTrack: $this->normalizeNullableString($batchContext['publish_track'] ?? null),
+                blockingFlags: array_values(array_unique($blockingFlags)),
+            );
+        }
+
+        return new CareerCrosswalkReviewQueue(
+            scope: $scope,
+            items: $items,
+        );
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Domain/Career/Operations/CareerEditorialPatchAuthorityService.php
+++ b/backend/app/Domain/Career/Operations/CareerEditorialPatchAuthorityService.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Operations;
+
+use App\DTO\Career\CareerEditorialPatchAuthority;
+use App\Models\EditorialPatch;
+
+final class CareerEditorialPatchAuthorityService
+{
+    /**
+     * @var array<string, true>
+     */
+    private const ALLOWED_PATCH_STATUSES = [
+        'draft' => true,
+        'queued' => true,
+        'approved' => true,
+        'rejected' => true,
+        'superseded' => true,
+        'completed' => true,
+        'not_required' => true,
+    ];
+
+    public function build(string $scope = 'career_crosswalk_editorial_ops'): CareerEditorialPatchAuthority
+    {
+        $patches = EditorialPatch::query()
+            ->with('occupation:id,canonical_slug')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn (EditorialPatch $patch): array => $this->normalizePatch($patch))
+            ->values()
+            ->all();
+
+        return new CareerEditorialPatchAuthority(
+            scope: $scope,
+            patches: $patches,
+        );
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     * @return array<string, mixed>
+     */
+    public function validate(array $patches): array
+    {
+        $errors = [];
+        $activeApprovedBySubject = [];
+
+        foreach ($patches as $patch) {
+            if (! is_array($patch)) {
+                continue;
+            }
+
+            $patchKey = trim((string) ($patch['patch_key'] ?? ''));
+            $subjectSlug = trim((string) ($patch['subject_slug'] ?? ''));
+            $status = strtolower(trim((string) ($patch['patch_status'] ?? '')));
+            $targetKind = trim((string) ($patch['target_kind'] ?? ''));
+            $targetSlug = trim((string) ($patch['target_slug'] ?? ''));
+
+            if ($patchKey === '') {
+                $errors[] = 'patch_key_missing';
+            }
+            if ($subjectSlug === '') {
+                $errors[] = sprintf('patch[%s]:subject_slug_missing', $patchKey !== '' ? $patchKey : 'unknown');
+            }
+            if (! isset(self::ALLOWED_PATCH_STATUSES[$status])) {
+                $errors[] = sprintf('patch[%s]:status_invalid', $patchKey !== '' ? $patchKey : 'unknown');
+            }
+
+            if ($targetKind !== '' && ! in_array($targetKind, ['occupation', 'family'], true)) {
+                $errors[] = sprintf('patch[%s]:target_kind_invalid', $patchKey !== '' ? $patchKey : 'unknown');
+            }
+
+            if ($targetKind !== '' && $targetSlug === '') {
+                $errors[] = sprintf('patch[%s]:target_slug_missing', $patchKey !== '' ? $patchKey : 'unknown');
+            }
+
+            if ($status === 'approved' && $subjectSlug !== '') {
+                if (isset($activeApprovedBySubject[$subjectSlug])) {
+                    $errors[] = sprintf('subject[%s]:multiple_approved_patches', $subjectSlug);
+                }
+                $activeApprovedBySubject[$subjectSlug] = $patchKey !== '' ? $patchKey : 'unknown';
+            }
+        }
+
+        return [
+            'passed' => $errors === [],
+            'errors' => array_values(array_unique($errors)),
+            'counts' => [
+                'total' => count($patches),
+                'approved' => count(array_filter(
+                    $patches,
+                    static fn (array $patch): bool => strtolower(trim((string) ($patch['patch_status'] ?? ''))) === 'approved',
+                )),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizePatch(EditorialPatch $patch): array
+    {
+        $notes = is_array($patch->notes) ? $patch->notes : [];
+        $status = strtolower(trim((string) ($patch->status ?? 'draft')));
+
+        if (! isset(self::ALLOWED_PATCH_STATUSES[$status])) {
+            $status = 'draft';
+        }
+
+        $subjectSlug = trim((string) ($patch->occupation?->canonical_slug ?? ''));
+        $targetKind = strtolower(trim((string) ($notes['target_kind'] ?? '')));
+        if (! in_array($targetKind, ['occupation', 'family'], true)) {
+            $targetKind = 'occupation';
+        }
+
+        $targetSlug = trim((string) ($notes['target_slug'] ?? $subjectSlug));
+        $crosswalkModeOverride = $this->normalizeNullableString($notes['crosswalk_mode_override'] ?? null);
+
+        return [
+            'patch_key' => (string) $patch->id,
+            'patch_version' => trim((string) ($patch->patch_version ?? '')) !== '' ? (string) $patch->patch_version : 'v1',
+            'patch_status' => $status,
+            'subject_kind' => 'career_job_detail',
+            'subject_slug' => $subjectSlug,
+            'target_kind' => $targetKind,
+            'target_slug' => $targetSlug,
+            'crosswalk_mode_override' => $crosswalkModeOverride,
+            'review_notes' => $this->normalizeNullableString($notes['review_notes'] ?? null),
+            'created_by' => $this->normalizeNullableString($notes['created_by'] ?? null),
+            'reviewed_by' => $this->normalizeNullableString($notes['reviewed_by'] ?? null),
+            'created_at' => optional($patch->created_at)->toISOString(),
+            'reviewed_at' => $this->normalizeNullableString($notes['reviewed_at'] ?? null)
+                ?? (($status === 'approved' || $status === 'rejected' || $status === 'superseded')
+                    ? optional($patch->updated_at)->toISOString()
+                    : null),
+        ];
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T01:39:25Z",
+  "updated_at": "2026-04-16T02:18:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1965,9 +1965,9 @@
     "PR-B69": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "github_checks_failed",
+      "status": "merged",
       "branch": "codex/pr-b69-career-asset-batch-pipeline-batch1-2-production-line",
-      "commit_sha": "2022025951aec2c9e88ef653b5afe83e35e12a9f",
+      "commit_sha": "bc84adaf1b7fab042f92552c5cd91c92294d49f6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/916",
       "checks": {
         "local": [
@@ -2015,7 +2015,45 @@
           }
         ]
       },
-      "failure_reason": "GitHub hygiene checks failed immediately on PR-B69 and MBTI verify jobs were skipped; local validation is green but required remote checks are not green.",
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-16T01:41:11Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B70": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-b70-crosswalk-editorial-operations-baseline",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Operations/*.php app/DTO/Career/CareerCrosswalk*.php app/DTO/Career/CareerEditorialPatchAuthority.php app/Console/Commands/CareerCrosswalkOps.php tests/Unit/Services/Career/CareerCrosswalkReviewQueueServiceTest.php tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php tests/Feature/Console/CareerCrosswalkOpsCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerCrosswalkReviewQueueServiceTest.php tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/CareerCrosswalkOpsCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T02:18:00Z",
+  "updated_at": "2026-04-16T02:25:30Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2024,10 +2024,10 @@
     "PR-B70": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "pr_open",
       "branch": "codex/pr-b70-crosswalk-editorial-operations-baseline",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "213ccb0fa188108713fe6c8cbbe9174b890a421c",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/917",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1179,6 +1179,34 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B70
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b70-crosswalk-editorial-operations-baseline
+    base: main
+    depends_on: ["PR-B69"]
+    mode: execute
+    scope: >
+      Crosswalk / editorial operations baseline.
+      Add internal-only patch/versioning authority, review queue contract, and
+      override resolution baseline for local_heavy_interpretation/family_proxy with
+      CLI entrypoints, while reusing existing backend truth and keeping public surfaces unchanged.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Operations/*.php app/DTO/Career/CareerCrosswalk*.php app/DTO/Career/CareerEditorialPatchAuthority.php app/Console/Commands/CareerCrosswalkOps.php tests/Unit/Services/Career/CareerCrosswalkReviewQueueServiceTest.php tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php tests/Feature/Console/CareerCrosswalkOpsCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerCrosswalkReviewQueueServiceTest.php tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php"
+      - "php artisan test tests/Feature/Console/CareerCrosswalkOpsCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Console/CareerCrosswalkOpsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerCrosswalkOpsCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\EditorialPatch;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerCrosswalkOpsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_snapshot_mode_outputs_internal_queue_validation_and_override_summary(): void
+    {
+        $fixture = CareerFoundationFixture::seedMinimalChain();
+
+        $fixture['editorialPatch']->forceFill([
+            'status' => 'approved',
+            'patch_version' => 'v1',
+            'notes' => [
+                'target_kind' => 'occupation',
+                'target_slug' => $fixture['occupation']->canonical_slug,
+                'crosswalk_mode_override' => 'exact',
+            ],
+        ])->save();
+
+        $exitCode = Artisan::call('career:crosswalk-ops', [
+            '--mode' => 'snapshot',
+            '--json' => true,
+        ]);
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('snapshot', $payload['mode'] ?? null);
+        $this->assertSame('ok', $payload['status'] ?? null);
+        $this->assertArrayHasKey('patch_authority', $payload);
+        $this->assertArrayHasKey('patch_validation', $payload);
+        $this->assertArrayHasKey('review_queue', $payload);
+        $this->assertArrayHasKey('resolved_crosswalk', $payload);
+        $this->assertTrue((bool) data_get($payload, 'patch_validation.passed'));
+    }
+
+    public function test_validate_patches_mode_returns_failure_when_patch_contract_is_invalid(): void
+    {
+        $fixture = CareerFoundationFixture::seedMinimalChain();
+
+        $subjectSlug = (string) $fixture['occupation']->canonical_slug;
+        $occupationId = (string) $fixture['occupation']->id;
+
+        EditorialPatch::query()->create([
+            'occupation_id' => $occupationId,
+            'required' => true,
+            'status' => 'approved',
+            'patch_version' => 'v1',
+            'notes' => [
+                'target_kind' => 'occupation',
+                'target_slug' => $subjectSlug,
+                'crosswalk_mode_override' => 'exact',
+            ],
+        ]);
+
+        EditorialPatch::query()->create([
+            'occupation_id' => $occupationId,
+            'required' => true,
+            'status' => 'approved',
+            'patch_version' => 'v2',
+            'notes' => [
+                'target_kind' => 'occupation',
+                'target_slug' => $subjectSlug,
+                'crosswalk_mode_override' => 'exact',
+            ],
+        ]);
+
+        $exitCode = Artisan::call('career:crosswalk-ops', [
+            '--mode' => 'validate-patches',
+            '--json' => true,
+        ]);
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('failed', $payload['status'] ?? null);
+        $this->assertFalse((bool) data_get($payload, 'patch_validation.passed'));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Operations\CareerCrosswalkOverrideResolver;
+use Tests\TestCase;
+
+final class CareerCrosswalkOverrideResolverTest extends TestCase
+{
+    public function test_it_applies_only_approved_patch_overrides_and_keeps_original_truth_otherwise(): void
+    {
+        $resolved = app(CareerCrosswalkOverrideResolver::class)->resolve(
+            subjects: [
+                [
+                    'canonical_slug' => 'registered-nurses',
+                    'crosswalk_mode' => 'local_heavy_interpretation',
+                ],
+                [
+                    'canonical_slug' => 'software-developers',
+                    'crosswalk_mode' => 'family_proxy',
+                ],
+                [
+                    'canonical_slug' => 'data-scientists',
+                    'crosswalk_mode' => 'exact',
+                ],
+            ],
+            approvedPatchesBySlug: [
+                'registered-nurses' => [
+                    'patch_key' => 'patch-rn-v2',
+                    'target_kind' => 'occupation',
+                    'target_slug' => 'registered-nurses',
+                    'crosswalk_mode_override' => 'exact',
+                ],
+                'software-developers' => [
+                    'patch_key' => 'patch-sw-v1',
+                    'target_kind' => 'family',
+                    'target_slug' => 'software-engineering-family',
+                    'crosswalk_mode_override' => 'trust_inheritance',
+                ],
+            ],
+        );
+
+        $this->assertSame('career_crosswalk_override_resolver', $resolved['resolver_kind']);
+        $this->assertSame('career.crosswalk.override_resolver.v1', $resolved['resolver_version']);
+        $this->assertSame(3, data_get($resolved, 'counts.total'));
+        $this->assertSame(2, data_get($resolved, 'counts.override_applied'));
+        $this->assertSame(1, data_get($resolved, 'counts.kept_original'));
+
+        $items = collect($resolved['resolved'] ?? [])->keyBy('subject_slug');
+
+        $rn = $items->get('registered-nurses');
+        $this->assertIsArray($rn);
+        $this->assertSame('local_heavy_interpretation', $rn['original_crosswalk_mode']);
+        $this->assertSame('exact', $rn['resolved_crosswalk_mode']);
+        $this->assertSame('occupation', $rn['resolved_target_kind']);
+        $this->assertTrue((bool) $rn['override_applied']);
+        $this->assertSame('patch-rn-v2', $rn['applied_patch_key']);
+
+        $sw = $items->get('software-developers');
+        $this->assertIsArray($sw);
+        $this->assertSame('family_proxy', $sw['original_crosswalk_mode']);
+        $this->assertSame('trust_inheritance', $sw['resolved_crosswalk_mode']);
+        $this->assertSame('family', $sw['resolved_target_kind']);
+        $this->assertSame('software-engineering-family', $sw['resolved_target_slug']);
+
+        $ds = $items->get('data-scientists');
+        $this->assertIsArray($ds);
+        $this->assertSame('exact', $ds['resolved_crosswalk_mode']);
+        $this->assertFalse((bool) $ds['override_applied']);
+        $this->assertNull($ds['applied_patch_key']);
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerCrosswalkReviewQueueServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCrosswalkReviewQueueServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Operations\CareerCrosswalkReviewQueueService;
+use Tests\TestCase;
+
+final class CareerCrosswalkReviewQueueServiceTest extends TestCase
+{
+    public function test_it_builds_review_queue_items_for_local_heavy_family_proxy_and_functional_equivalent(): void
+    {
+        $queue = app(CareerCrosswalkReviewQueueService::class)->build(
+            subjects: [
+                [
+                    'canonical_slug' => 'registered-nurses',
+                    'crosswalk_mode' => 'local_heavy_interpretation',
+                    'readiness_status' => 'blocked_override_eligible',
+                    'blocked_governance_status' => null,
+                ],
+                [
+                    'canonical_slug' => 'software-developers',
+                    'crosswalk_mode' => 'family_proxy',
+                    'readiness_status' => 'publish_ready',
+                    'blocked_governance_status' => null,
+                ],
+                [
+                    'canonical_slug' => 'data-scientists',
+                    'crosswalk_mode' => 'functional_equivalent',
+                    'readiness_status' => 'candidate_review',
+                    'blocked_governance_status' => 'blocked_not_safely_remediable',
+                ],
+                [
+                    'canonical_slug' => 'management-analysts',
+                    'crosswalk_mode' => 'exact',
+                    'readiness_status' => 'publish_ready',
+                    'blocked_governance_status' => null,
+                ],
+            ],
+            approvedPatchesBySlug: [
+                'software-developers' => [
+                    'patch_key' => 'patch-software',
+                    'target_kind' => 'family',
+                    'target_slug' => 'software-engineering-family',
+                    'crosswalk_mode_override' => 'trust_inheritance',
+                ],
+            ],
+            batchContextBySlug: [
+                'registered-nurses' => [
+                    'batch_origin' => 'batch-1',
+                    'publish_track' => 'hold',
+                    'family_slug' => 'healthcare-support',
+                ],
+                'software-developers' => [
+                    'batch_origin' => 'batch-2',
+                    'publish_track' => 'candidate',
+                    'family_slug' => 'software-engineering-family',
+                ],
+            ],
+        )->toArray();
+
+        $this->assertSame('career_crosswalk_review_queue', $queue['queue_kind']);
+        $this->assertSame('career.crosswalk.review_queue.v1', $queue['queue_version']);
+        $this->assertSame(3, data_get($queue, 'counts.total'));
+        $this->assertSame(1, data_get($queue, 'counts.local_heavy_interpretation'));
+        $this->assertSame(1, data_get($queue, 'counts.family_proxy'));
+        $this->assertSame(1, data_get($queue, 'counts.functional_equivalent'));
+
+        $items = collect($queue['items'] ?? [])->keyBy('subject_slug');
+
+        $localHeavy = $items->get('registered-nurses');
+        $this->assertIsArray($localHeavy);
+        $this->assertContains('local_heavy_requires_editorial_patch', $localHeavy['queue_reason']);
+        $this->assertContains('not_publish_ready', $localHeavy['blocking_flags']);
+        $this->assertContains('approved_patch_missing', $localHeavy['blocking_flags']);
+        $this->assertSame('batch-1', $localHeavy['batch_origin']);
+        $this->assertSame('hold', $localHeavy['publish_track']);
+
+        $familyProxy = $items->get('software-developers');
+        $this->assertIsArray($familyProxy);
+        $this->assertSame('family', $familyProxy['candidate_target_kind']);
+        $this->assertSame('software-engineering-family', $familyProxy['candidate_target_slug']);
+        $this->assertNotContains('approved_patch_missing', $familyProxy['blocking_flags']);
+
+        $functional = $items->get('data-scientists');
+        $this->assertIsArray($functional);
+        $this->assertContains('functional_equivalent_requires_editorial_review', $functional['queue_reason']);
+        $this->assertContains('governance_blocked', $functional['blocking_flags']);
+    }
+}


### PR DESCRIPTION
## What Changed
- Added internal editorial patch authority formalization in backend operations layer:
  - `CareerEditorialPatchAuthorityService`
  - `CareerEditorialPatchAuthority` DTO
- Added backend review queue contract for crosswalk editorial operations:
  - `CareerCrosswalkReviewQueueService`
  - `CareerCrosswalkReviewQueue` / `CareerCrosswalkReviewQueueItem` DTOs
- Added backend override resolver for approved patch application:
  - `CareerCrosswalkOverrideResolver`
- Added internal CLI entrypoint:
  - `career:crosswalk-ops`
  - modes: `build-review-queue`, `validate-patches`, `resolve-overrides`, `snapshot`
  - options: `--manifest`, `--json`
- Registered command in console kernel.
- Added tests:
  - `CareerCrosswalkReviewQueueServiceTest`
  - `CareerCrosswalkOverrideResolverTest`
  - `CareerCrosswalkOpsCommandTest`
- Updated train manifest/state entries for PR-B70 and recorded local validations.

## Why
- Formalize crosswalk/editorial operations as backend-owned, internal-only truth.
- Provide auditable patch/versioning and review queue contracts before full backoffice UI.
- Ensure `local_heavy_interpretation` / `family_proxy` cases are handled conservatively with explicit review + approved override flow.
- Keep all patch merge logic in backend authority layer, not in consumer/frontend layers.

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Operations/*.php app/DTO/Career/CareerCrosswalk*.php app/DTO/Career/CareerEditorialPatchAuthority.php app/Console/Commands/CareerCrosswalkOps.php tests/Unit/Services/Career/CareerCrosswalkReviewQueueServiceTest.php tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php tests/Feature/Console/CareerCrosswalkOpsCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerCrosswalkReviewQueueServiceTest.php tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php`
- `php artisan test tests/Feature/Console/CareerCrosswalkOpsCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerAssetBatchPipelineTest.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchManifestServiceTest.php`

## Intentionally Deferred
- No frontend/backoffice UI work.
- No public API / OpenAPI changes.
- No expansion into unrelated attribution/rollout semantics.
- No automatic upgrade of `local_heavy_interpretation`/`family_proxy` without approved patch.
