### PR TITLE
hotfix: fix CareerGuideSeoService parse error breaking healthz+sitemap

### DIFF
--- a/backend/app/Services/Cms/CareerGuideSeoService.php
+++ b/backend/app/Services/Cms/CareerGuideSeoService.php
@@ -19,6 +19,10 @@ final class CareerGuideSeoService
         'zh-CN',
     ];
 
+    public function __construct(
+        private readonly CareerArticleStructuredDataBuilder $careerArticleStructuredDataBuilder,
+    ) {}
+
     public function generateSeoMeta(int $guideId): CareerGuideSeoMeta
     {
         if ($guideId <= 0) {
@@ -328,6 +332,3 @@ final class CareerGuideSeoService
         return $normalized;
     }
 }
-    public function __construct(
-        private readonly CareerArticleStructuredDataBuilder $careerArticleStructuredDataBuilder,
-    ) {}


### PR DESCRIPTION
## What changed
- Moved `CareerGuideSeoService` constructor back inside class body
- Removed stray constructor declaration left after class closing brace

## Why
- Production verification failed with ParseError at `backend/app/Services/Cms/CareerGuideSeoService.php:331`
- This parse error caused `/api/healthz` and `/sitemap.xml` requests to fail in runtime verification

## Validation
- `php -l backend/app/Services/Cms/CareerGuideSeoService.php`
- `cd backend && bash scripts/pr24_verify_sitemap.sh`

## Deferred
- None
