### PR TITLE
PR-B74X: Career dataset publicization / publication metadata authority

### DIFF
--- a/backend/app/DTO/Career/CareerDatasetPublicationMetadata.php
+++ b/backend/app/DTO/Career/CareerDatasetPublicationMetadata.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerDatasetPublicationMetadata
+{
+    /**
+     * @param  array{name:string,url:string}  $publisher
+     * @param  array{name:string,url:string,summary:string}  $license
+     * @param  array{summary:string,allowed_for_public_display:bool,allowed_for_download:bool}  $usage
+     * @param  array{
+     *   access_mode:string,
+     *   download_url:string,
+     *   format:list<string>,
+     *   methodology_url:string,
+     *   documentation_url:string
+     * }  $distribution
+     */
+    public function __construct(
+        public readonly string $datasetKey,
+        public readonly string $datasetScope,
+        public readonly array $publisher,
+        public readonly array $license,
+        public readonly array $usage,
+        public readonly array $distribution,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'authority_kind' => 'career_dataset_publication_metadata',
+            'authority_version' => 'career.dataset_publication.v1',
+            'dataset_key' => $this->datasetKey,
+            'dataset_scope' => $this->datasetScope,
+            'publisher' => $this->publisher,
+            'license' => $this->license,
+            'usage' => $this->usage,
+            'distribution' => $this->distribution,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerPublicDatasetContract.php
+++ b/backend/app/DTO/Career/CareerPublicDatasetContract.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerPublicDatasetContract
+{
+    /**
+     * @param  array<string, mixed>  $publication
+     * @param  array<string, mixed>  $collectionSummary
+     * @param  array<string, mixed>  $filters
+     */
+    public function __construct(
+        public readonly string $datasetKey,
+        public readonly string $datasetScope,
+        public readonly string $datasetName,
+        public readonly string $datasetNameZh,
+        public readonly array $publication,
+        public readonly array $collectionSummary,
+        public readonly array $filters,
+        public readonly string $methodUrl,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'contract_kind' => 'career_public_dataset_hub',
+            'contract_version' => 'career.dataset_public_contract.v1',
+            'dataset_key' => $this->datasetKey,
+            'dataset_scope' => $this->datasetScope,
+            'dataset_name' => $this->datasetName,
+            'dataset_name_zh' => $this->datasetNameZh,
+            'publication' => $this->publication,
+            'collection_summary' => $this->collectionSummary,
+            'filters' => $this->filters,
+            'method_url' => $this->methodUrl,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerPublicDatasetMethodContract.php
+++ b/backend/app/DTO/Career/CareerPublicDatasetMethodContract.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerPublicDatasetMethodContract
+{
+    /**
+     * @param  list<string>  $included
+     * @param  list<string>  $excluded
+     * @param  list<string>  $boundaryNotes
+     */
+    public function __construct(
+        public readonly string $datasetKey,
+        public readonly string $datasetScope,
+        public readonly string $methodUrl,
+        public readonly string $hubUrl,
+        public readonly string $title,
+        public readonly string $summary,
+        public readonly string $sourceSummary,
+        public readonly string $reviewDisciplineSummary,
+        public readonly array $included,
+        public readonly array $excluded,
+        public readonly array $boundaryNotes,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'contract_kind' => 'career_public_dataset_method',
+            'contract_version' => 'career.dataset_public_method.v1',
+            'dataset_key' => $this->datasetKey,
+            'dataset_scope' => $this->datasetScope,
+            'method_url' => $this->methodUrl,
+            'hub_url' => $this->hubUrl,
+            'title' => $this->title,
+            'summary' => $this->summary,
+            'source_summary' => $this->sourceSummary,
+            'review_discipline_summary' => $this->reviewDisciplineSummary,
+            'included' => $this->included,
+            'excluded' => $this->excluded,
+            'boundary_notes' => $this->boundaryNotes,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerDatasetHubController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerDatasetHubController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerDatasetHubResource;
+use App\Services\Career\Dataset\CareerPublicDatasetContractBuilder;
+
+final class CareerDatasetHubController extends Controller
+{
+    public function __construct(
+        private readonly CareerPublicDatasetContractBuilder $contractBuilder,
+    ) {}
+
+    public function show(): CareerDatasetHubResource
+    {
+        return new CareerDatasetHubResource($this->contractBuilder->buildHubContract());
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerDatasetMethodController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerDatasetMethodController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerDatasetMethodResource;
+use App\Services\Career\Dataset\CareerPublicDatasetContractBuilder;
+
+final class CareerDatasetMethodController extends Controller
+{
+    public function __construct(
+        private readonly CareerPublicDatasetContractBuilder $contractBuilder,
+    ) {}
+
+    public function show(): CareerDatasetMethodResource
+    {
+        return new CareerDatasetMethodResource($this->contractBuilder->buildMethodContract());
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerDatasetHubResource.php
+++ b/backend/app/Http/Resources/Career/CareerDatasetHubResource.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerPublicDatasetContract;
+use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerPublicDatasetContract
+ */
+final class CareerDatasetHubResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerPublicDatasetContract $contract */
+        $contract = $this->resource;
+        $payload = $contract->toArray();
+
+        return array_merge($payload, [
+            'structured_data' => $this->buildStructuredData($payload),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $contract
+     * @return array<string, mixed>
+     */
+    private function buildStructuredData(array $contract): array
+    {
+        $publication = (array) ($contract['publication'] ?? []);
+        $distribution = (array) ($publication['distribution'] ?? []);
+
+        $structuredPayload = [
+            'dataset_name' => $contract['dataset_name'] ?? null,
+            'description' => (string) data_get($contract, 'collection_summary.member_kind', 'career_job_detail').' public dataset hub',
+            'url' => $distribution['documentation_url'] ?? null,
+            'license' => $publication['license'] ?? null,
+            'publisher' => $publication['publisher'] ?? null,
+            'distribution' => $distribution,
+            'keywords' => ['career', 'dataset', 'occupations'],
+        ];
+
+        $structured = app(CareerStructuredDataBuilder::class)->build('career_dataset_hub', $structuredPayload);
+        $fragments = is_array($structured['fragments'] ?? null) ? $structured['fragments'] : [];
+
+        return [
+            'dataset' => is_array($fragments['dataset'] ?? null) ? $fragments['dataset'] : [],
+            'breadcrumb_list' => is_array($fragments['breadcrumb_list'] ?? null) ? $fragments['breadcrumb_list'] : [],
+        ];
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerDatasetMethodResource.php
+++ b/backend/app/Http/Resources/Career/CareerDatasetMethodResource.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerPublicDatasetMethodContract;
+use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerPublicDatasetMethodContract
+ */
+final class CareerDatasetMethodResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerPublicDatasetMethodContract $contract */
+        $contract = $this->resource;
+        $payload = $contract->toArray();
+
+        return array_merge($payload, [
+            'structured_data' => $this->buildStructuredData($payload),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $contract
+     * @return array<string, mixed>
+     */
+    private function buildStructuredData(array $contract): array
+    {
+        $structured = app(CareerStructuredDataBuilder::class)->build('career_dataset_method', [
+            'title' => $contract['title'] ?? null,
+            'summary' => $contract['summary'] ?? null,
+            'url' => $contract['method_url'] ?? null,
+        ]);
+        $fragments = is_array($structured['fragments'] ?? null) ? $structured['fragments'] : [];
+
+        return [
+            'article' => is_array($fragments['article'] ?? null) ? $fragments['article'] : [],
+            'breadcrumb_list' => is_array($fragments['breadcrumb_list'] ?? null) ? $fragments['breadcrumb_list'] : [],
+        ];
+    }
+}

--- a/backend/app/Services/Career/Dataset/CareerDatasetPublicationMetadataService.php
+++ b/backend/app/Services/Career/Dataset/CareerDatasetPublicationMetadataService.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Dataset;
+
+use App\DTO\Career\CareerDatasetPublicationMetadata;
+
+final class CareerDatasetPublicationMetadataService
+{
+    public const DATASET_KEY = 'career_first_wave_job_detail_dataset';
+
+    public const DATASET_SCOPE = 'career_first_wave_10';
+
+    public function build(): CareerDatasetPublicationMetadata
+    {
+        return new CareerDatasetPublicationMetadata(
+            datasetKey: self::DATASET_KEY,
+            datasetScope: self::DATASET_SCOPE,
+            publisher: [
+                'name' => 'FermatMind',
+                'url' => 'https://www.fermatmind.com',
+            ],
+            license: [
+                'name' => 'Proprietary Dataset License',
+                'url' => 'https://www.fermatmind.com/datasets/occupations/license',
+                'summary' => 'Public display allowed. Redistribution and mirrored republication require explicit permission.',
+            ],
+            usage: [
+                'summary' => 'Public viewing and on-site exploration allowed; redistribution, bulk extraction, and mirrored republication require explicit permission.',
+                'allowed_for_public_display' => true,
+                'allowed_for_download' => true,
+            ],
+            distribution: [
+                'access_mode' => 'landing_page_and_download',
+                'download_url' => 'https://www.fermatmind.com/datasets/occupations/download',
+                'format' => ['json', 'csv'],
+                'methodology_url' => 'https://www.fermatmind.com/datasets/occupations/method',
+                'documentation_url' => 'https://www.fermatmind.com/datasets/occupations',
+            ],
+        );
+    }
+}

--- a/backend/app/Services/Career/Dataset/CareerPublicDatasetContractBuilder.php
+++ b/backend/app/Services/Career/Dataset/CareerPublicDatasetContractBuilder.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Dataset;
+
+use App\DTO\Career\CareerPublicDatasetContract;
+use App\DTO\Career\CareerPublicDatasetMethodContract;
+
+final class CareerPublicDatasetContractBuilder
+{
+    public function __construct(
+        private readonly CareerDatasetPublicationMetadataService $publicationMetadataService,
+        private readonly CareerFirstWaveDatasetAuthorityBuilder $datasetAuthorityBuilder,
+    ) {}
+
+    public function buildHubContract(): CareerPublicDatasetContract
+    {
+        $publication = $this->publicationMetadataService->build()->toArray();
+        $authority = $this->datasetAuthorityBuilder->build()->toArray();
+
+        $counts = (array) data_get($authority, 'aggregate.counts', []);
+        $collectionSummary = [
+            'member_kind' => (string) data_get($authority, 'aggregate.member_kind', 'career_job_detail'),
+            'member_count' => (int) data_get($authority, 'aggregate.member_count', 0),
+            'stable_count' => (int) ($counts['stable'] ?? 0),
+            'candidate_count' => (int) ($counts['candidate'] ?? 0),
+            'hold_count' => (int) ($counts['hold'] ?? 0),
+            'discoverable_count' => (int) ($counts['discoverable'] ?? 0),
+            'excluded_count' => (int) ($counts['excluded'] ?? 0),
+            'manifest_version' => (string) data_get($authority, 'descriptor.manifest_version', 'unknown'),
+            'selection_policy_version' => (string) data_get($authority, 'descriptor.selection_policy_version', 'unknown'),
+        ];
+
+        return new CareerPublicDatasetContract(
+            datasetKey: (string) data_get($authority, 'descriptor.dataset_key', CareerDatasetPublicationMetadataService::DATASET_KEY),
+            datasetScope: (string) data_get($authority, 'descriptor.dataset_scope', CareerDatasetPublicationMetadataService::DATASET_SCOPE),
+            datasetName: 'FermatMind Career Occupations Dataset (First Wave)',
+            datasetNameZh: '费马测试职业数据库（首批职业集）',
+            publication: $publication,
+            collectionSummary: $collectionSummary,
+            filters: [
+                'family' => true,
+                'publish_track' => true,
+                'index_posture' => true,
+            ],
+            methodUrl: (string) data_get($publication, 'distribution.methodology_url', 'https://www.fermatmind.com/datasets/occupations/method'),
+        );
+    }
+
+    public function buildMethodContract(): CareerPublicDatasetMethodContract
+    {
+        $publication = $this->publicationMetadataService->build()->toArray();
+        $authority = $this->datasetAuthorityBuilder->build()->toArray();
+
+        return new CareerPublicDatasetMethodContract(
+            datasetKey: (string) data_get($authority, 'descriptor.dataset_key', CareerDatasetPublicationMetadataService::DATASET_KEY),
+            datasetScope: (string) data_get($authority, 'descriptor.dataset_scope', CareerDatasetPublicationMetadataService::DATASET_SCOPE),
+            methodUrl: (string) data_get($publication, 'distribution.methodology_url', 'https://www.fermatmind.com/datasets/occupations/method'),
+            hubUrl: (string) data_get($publication, 'distribution.documentation_url', 'https://www.fermatmind.com/datasets/occupations'),
+            title: 'Occupations dataset method',
+            summary: 'This dataset is compiled from backend-owned occupation authority, launch policy, and trust manifests under a conservative publication boundary.',
+            sourceSummary: 'Included records come from career_job_detail members in the first-wave authority scope and are materialized through import/compile runs.',
+            reviewDisciplineSummary: 'Updates follow validate, trust compile, and publish-candidate discipline. Internal review queue states are not published in this method contract.',
+            included: [
+                'career_job_detail first-wave members only',
+                'public-safe publication metadata (publisher, license, usage, distribution)',
+                'high-level launch and index posture summaries',
+            ],
+            excluded: [
+                'family hub as primary dataset members',
+                'raw internal evidence refs and review queue internals',
+                'internal storage/source paths and debug-only provenance fields',
+            ],
+            boundaryNotes: [
+                'Dataset scope is currently limited to career_first_wave_10.',
+                'Crosswalk and editorial overrides remain backend-owned and are not exposed as raw operational records.',
+                'This page is a public method summary, not an internal authority dump.',
+            ],
+        );
+    }
+}

--- a/backend/app/Services/Career/StructuredData/CareerDatasetStructuredDataBuilder.php
+++ b/backend/app/Services/Career/StructuredData/CareerDatasetStructuredDataBuilder.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\StructuredData;
+
+final class CareerDatasetStructuredDataBuilder
+{
+    public function __construct(
+        private readonly CareerStructuredDataOutputPolicy $outputPolicy,
+        private readonly CareerBreadcrumbBuilder $breadcrumbBuilder,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>|null
+     */
+    public function build(string $routeKind, array $payload): ?array
+    {
+        if ($this->outputPolicy->allows($routeKind, CareerStructuredDataOutputPolicy::SCHEMA_DATASET)) {
+            return $this->buildDataset($routeKind, $payload);
+        }
+
+        if ($this->outputPolicy->allows($routeKind, CareerStructuredDataOutputPolicy::SCHEMA_ARTICLE)) {
+            return $this->buildMethodArticle($routeKind, $payload);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>|null
+     */
+    private function buildDataset(string $routeKind, array $payload): ?array
+    {
+        $name = $this->normalizeString($payload['dataset_name'] ?? null);
+        $url = $this->normalizeString($payload['url'] ?? null);
+        if ($name === null || $url === null) {
+            return null;
+        }
+
+        $distribution = (array) ($payload['distribution'] ?? []);
+        $downloadUrl = $this->normalizeString($distribution['download_url'] ?? null);
+        $license = (array) ($payload['license'] ?? []);
+        $publisher = (array) ($payload['publisher'] ?? []);
+
+        $fragment = [
+            '@context' => 'https://schema.org',
+            '@type' => 'Dataset',
+            '@id' => $url.'#dataset',
+            'name' => $name,
+            'url' => $url,
+            'description' => $this->normalizeString($payload['description'] ?? null),
+            'license' => $this->normalizeString($license['url'] ?? null),
+            'keywords' => is_array($payload['keywords'] ?? null) ? array_values(array_filter((array) $payload['keywords'])) : [],
+        ];
+
+        if ($publisherName = $this->normalizeString($publisher['name'] ?? null)) {
+            $fragment['publisher'] = [
+                '@type' => 'Organization',
+                'name' => $publisherName,
+                'url' => $this->normalizeString($publisher['url'] ?? null),
+            ];
+        }
+
+        if ($downloadUrl !== null) {
+            $fragment['distribution'] = [[
+                '@type' => 'DataDownload',
+                'contentUrl' => $downloadUrl,
+                'encodingFormat' => implode(',', (array) ($distribution['format'] ?? [])),
+            ]];
+        }
+
+        $breadcrumbNodes = [
+            ['name' => 'Datasets', 'path' => '/datasets/occupations'],
+            ['name' => $name, 'path' => $url],
+        ];
+
+        return [
+            'route_kind' => $routeKind,
+            'canonical_path' => $url,
+            'canonical_title' => $name,
+            'breadcrumb_nodes' => $breadcrumbNodes,
+            'fragments' => [
+                'dataset' => array_filter($fragment, static fn (mixed $value): bool => $value !== null),
+                'breadcrumb_list' => $this->breadcrumbBuilder->buildBreadcrumbList($breadcrumbNodes),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>|null
+     */
+    private function buildMethodArticle(string $routeKind, array $payload): ?array
+    {
+        $headline = $this->normalizeString($payload['title'] ?? null);
+        $url = $this->normalizeString($payload['url'] ?? null);
+        if ($headline === null || $url === null) {
+            return null;
+        }
+
+        $fragment = [
+            '@context' => 'https://schema.org',
+            '@type' => 'Article',
+            '@id' => $url.'#method',
+            'url' => $url,
+            'mainEntityOfPage' => $url,
+            'headline' => $headline,
+            'description' => $this->normalizeString($payload['summary'] ?? null),
+        ];
+
+        $breadcrumbNodes = [
+            ['name' => 'Datasets', 'path' => '/datasets/occupations'],
+            ['name' => 'Method', 'path' => $url],
+        ];
+
+        return [
+            'route_kind' => $routeKind,
+            'canonical_path' => $url,
+            'canonical_title' => $headline,
+            'breadcrumb_nodes' => $breadcrumbNodes,
+            'fragments' => [
+                'article' => array_filter($fragment, static fn (mixed $value): bool => $value !== null),
+                'breadcrumb_list' => $this->breadcrumbBuilder->buildBreadcrumbList($breadcrumbNodes),
+            ],
+        ];
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/Career/StructuredData/CareerStructuredDataBuilder.php
+++ b/backend/app/Services/Career/StructuredData/CareerStructuredDataBuilder.php
@@ -13,6 +13,7 @@ final class CareerStructuredDataBuilder
         private readonly CareerJobDetailStructuredDataBuilder $jobDetailBuilder,
         private readonly CareerFamilyHubStructuredDataBuilder $familyHubBuilder,
         private readonly CareerArticleStructuredDataBuilder $articleBuilder,
+        private readonly CareerDatasetStructuredDataBuilder $datasetBuilder,
         private readonly CareerStructuredDataOutputPolicy $outputPolicy,
     ) {}
 
@@ -21,6 +22,19 @@ final class CareerStructuredDataBuilder
      */
     public function build(string $routeKind, mixed $payload): ?array
     {
+        if (
+            $this->outputPolicy->allows($routeKind, CareerStructuredDataOutputPolicy::SCHEMA_DATASET)
+            || in_array(
+                $routeKind,
+                ['career_dataset_method'],
+                true
+            )
+        ) {
+            return is_array($payload)
+                ? $this->datasetBuilder->build($routeKind, $payload)
+                : null;
+        }
+
         if ($this->outputPolicy->allows($routeKind, CareerStructuredDataOutputPolicy::SCHEMA_ARTICLE)) {
             return is_array($payload)
                 ? $this->articleBuilder->build($routeKind, $payload)

--- a/backend/app/Services/Career/StructuredData/CareerStructuredDataOutputPolicy.php
+++ b/backend/app/Services/Career/StructuredData/CareerStructuredDataOutputPolicy.php
@@ -37,6 +37,14 @@ final class CareerStructuredDataOutputPolicy
                 self::SCHEMA_ARTICLE,
                 self::SCHEMA_BREADCRUMB_LIST,
             ],
+            'career_dataset_hub' => [
+                self::SCHEMA_DATASET,
+                self::SCHEMA_BREADCRUMB_LIST,
+            ],
+            'career_dataset_method' => [
+                self::SCHEMA_ARTICLE,
+                self::SCHEMA_BREADCRUMB_LIST,
+            ],
             default => [],
         };
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2136,6 +2136,23 @@
       "merged_at": "",
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-B74X": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-b74x-career-dataset-publication-metadata-authority-public-contract",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2140,15 +2140,49 @@
     "PR-B74X": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "pr_open",
       "branch": "codex/pr-b74x-career-dataset-publication-metadata-authority-public-contract",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "ed1bd43a780859e8252b52442830a65c1490ee3b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/920",
       "checks": {
-        "local": [],
-        "github": []
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Dataset/*.php app/DTO/Career/CareerPublicDataset*.php app/DTO/Career/CareerDatasetPublicationMetadata.php app/Services/Career/StructuredData/*.php tests/Unit/Services/Career/*Dataset*.php tests/Feature/Career/*Dataset*.php tests/Feature/SEO/*Dataset*.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/*Dataset*.php tests/Feature/Career/*Dataset*.php tests/Feature/SEO/*Dataset*.php",
+            "status": "passed"
+          }
+        ],
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24491840199/job/71578277373"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24491828874/job/71578244998"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24491840199/job/71578281289"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details": "https://github.com/fermatmind/fap-api/actions/runs/24491828874/job/71578249008"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub hygiene checks failed before logs were available from the runs; local validation is fully green and the PR is waiting on remote CI status.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1237,6 +1237,32 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B74X
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b74x-career-dataset-publication-metadata-authority-public-contract
+    base: main
+    depends_on: ["PR-B71X"]
+    mode: execute
+    scope: >
+      Career dataset publicization / publication metadata authority.
+      Add dedicated Career publication metadata authority and a public-safe
+      dataset hub/method contract, then wire Dataset JSON-LD only for
+      dataset hub surfaces under strict route-kind allow/deny boundaries.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Dataset/*.php app/DTO/Career/CareerPublicDataset*.php app/DTO/Career/CareerDatasetPublicationMetadata.php app/Services/Career/StructuredData/*.php tests/Unit/Services/Career/*Dataset*.php tests/Feature/Career/*Dataset*.php tests/Feature/SEO/*Dataset*.php"
+      - "php artisan test tests/Unit/Services/Career/*Dataset*.php tests/Feature/Career/*Dataset*.php tests/Feature/SEO/*Dataset*.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -31,6 +31,8 @@ use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Career\CareerAliasResolutionController;
 use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
+use App\Http\Controllers\API\V0_5\Career\CareerDatasetHubController;
+use App\Http\Controllers\API\V0_5\Career\CareerDatasetMethodController;
 use App\Http\Controllers\API\V0_5\Career\CareerFamilyHubController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveDiscoverabilityManifestController;
 use App\Http\Controllers\API\V0_5\Career\CareerFirstWaveLaunchTierController;
@@ -431,6 +433,8 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/recommendations/mbti/{type}/explainability', [CareerRecommendationExplainabilityController::class, 'show']);
     Route::get('/career/transition-preview', [CareerTransitionPreviewController::class, 'show']);
     Route::get('/career/search', [CareerSearchController::class, 'index']);
+    Route::get('/career/datasets/occupations', [CareerDatasetHubController::class, 'show']);
+    Route::get('/career/datasets/occupations/method', [CareerDatasetMethodController::class, 'show']);
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);

--- a/backend/tests/Feature/Career/CareerDatasetPublicApiTest.php
+++ b/backend/tests/Feature/Career/CareerDatasetPublicApiTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerDatasetPublicApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_public_dataset_hub_contract_with_dataset_structured_data(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $this->getJson('/api/v0.5/career/datasets/occupations')
+            ->assertOk()
+            ->assertJsonPath('contract_kind', 'career_public_dataset_hub')
+            ->assertJsonPath('contract_version', 'career.dataset_public_contract.v1')
+            ->assertJsonPath('dataset_key', 'career_first_wave_job_detail_dataset')
+            ->assertJsonPath('dataset_scope', 'career_first_wave_10')
+            ->assertJsonPath('publication.publisher.name', 'FermatMind')
+            ->assertJsonPath('publication.license.name', 'Proprietary Dataset License')
+            ->assertJsonPath('publication.usage.allowed_for_public_display', true)
+            ->assertJsonPath('publication.usage.allowed_for_download', true)
+            ->assertJsonPath('publication.distribution.download_url', 'https://www.fermatmind.com/datasets/occupations/download')
+            ->assertJsonPath('method_url', 'https://www.fermatmind.com/datasets/occupations/method')
+            ->assertJsonPath('structured_data.dataset.@type', 'Dataset')
+            ->assertJsonPath('structured_data.breadcrumb_list.@type', 'BreadcrumbList')
+            ->assertJsonMissingPath('structured_data.article');
+    }
+
+    public function test_it_returns_public_dataset_method_contract_with_article_structured_data(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $this->getJson('/api/v0.5/career/datasets/occupations/method')
+            ->assertOk()
+            ->assertJsonPath('contract_kind', 'career_public_dataset_method')
+            ->assertJsonPath('contract_version', 'career.dataset_public_method.v1')
+            ->assertJsonPath('dataset_key', 'career_first_wave_job_detail_dataset')
+            ->assertJsonPath('dataset_scope', 'career_first_wave_10')
+            ->assertJsonPath('method_url', 'https://www.fermatmind.com/datasets/occupations/method')
+            ->assertJsonPath('hub_url', 'https://www.fermatmind.com/datasets/occupations')
+            ->assertJsonPath('structured_data.article.@type', 'Article')
+            ->assertJsonPath('structured_data.breadcrumb_list.@type', 'BreadcrumbList')
+            ->assertJsonMissingPath('structured_data.dataset');
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Feature/SEO/CareerDatasetStructuredDataPolicyTest.php
+++ b/backend/tests/Feature/SEO/CareerDatasetStructuredDataPolicyTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use App\Services\Career\StructuredData\CareerStructuredDataOutputPolicy;
+use Tests\TestCase;
+
+final class CareerDatasetStructuredDataPolicyTest extends TestCase
+{
+    public function test_dataset_schema_is_only_allowed_for_dataset_hub_route_kind(): void
+    {
+        $policy = app(CareerStructuredDataOutputPolicy::class);
+
+        $this->assertTrue($policy->allows('career_dataset_hub', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
+        $this->assertFalse($policy->allows('career_dataset_method', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
+        $this->assertFalse($policy->allows('career_job_detail', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
+        $this->assertFalse($policy->allows('career_family_hub', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
+        $this->assertFalse($policy->allows('career_recommendation_detail', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
+        $this->assertFalse($policy->allows('career_search', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
+        $this->assertFalse($policy->allows('career_alias_resolution', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerDatasetPublicationMetadataServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerDatasetPublicationMetadataServiceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Dataset\CareerDatasetPublicationMetadataService;
+use Tests\TestCase;
+
+final class CareerDatasetPublicationMetadataServiceTest extends TestCase
+{
+    public function test_it_builds_dedicated_career_owned_publication_metadata_authority(): void
+    {
+        $payload = app(CareerDatasetPublicationMetadataService::class)->build()->toArray();
+
+        $this->assertSame('career_dataset_publication_metadata', $payload['authority_kind']);
+        $this->assertSame('career.dataset_publication.v1', $payload['authority_version']);
+        $this->assertSame('career_first_wave_job_detail_dataset', $payload['dataset_key']);
+        $this->assertSame('career_first_wave_10', $payload['dataset_scope']);
+        $this->assertSame('FermatMind', data_get($payload, 'publisher.name'));
+        $this->assertSame('https://www.fermatmind.com', data_get($payload, 'publisher.url'));
+        $this->assertSame('Proprietary Dataset License', data_get($payload, 'license.name'));
+        $this->assertSame(
+            'https://www.fermatmind.com/datasets/occupations/license',
+            data_get($payload, 'license.url')
+        );
+        $this->assertTrue((bool) data_get($payload, 'usage.allowed_for_public_display'));
+        $this->assertTrue((bool) data_get($payload, 'usage.allowed_for_download'));
+        $this->assertSame('landing_page_and_download', data_get($payload, 'distribution.access_mode'));
+        $this->assertSame(
+            'https://www.fermatmind.com/datasets/occupations/download',
+            data_get($payload, 'distribution.download_url')
+        );
+        $this->assertSame(
+            'https://www.fermatmind.com/datasets/occupations/method',
+            data_get($payload, 'distribution.methodology_url')
+        );
+        $this->assertSame(
+            'https://www.fermatmind.com/datasets/occupations',
+            data_get($payload, 'distribution.documentation_url')
+        );
+        $this->assertSame(['json', 'csv'], data_get($payload, 'distribution.format'));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerDatasetStructuredDataBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerDatasetStructuredDataBuilderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\StructuredData\CareerDatasetStructuredDataBuilder;
+use Tests\TestCase;
+
+final class CareerDatasetStructuredDataBuilderTest extends TestCase
+{
+    public function test_it_builds_dataset_json_ld_for_dataset_hub_route_only(): void
+    {
+        $payload = app(CareerDatasetStructuredDataBuilder::class)->build('career_dataset_hub', [
+            'dataset_name' => 'FermatMind Career Occupations Dataset (First Wave)',
+            'description' => 'Public dataset hub',
+            'url' => 'https://www.fermatmind.com/datasets/occupations',
+            'license' => [
+                'url' => 'https://www.fermatmind.com/datasets/occupations/license',
+            ],
+            'publisher' => [
+                'name' => 'FermatMind',
+                'url' => 'https://www.fermatmind.com',
+            ],
+            'distribution' => [
+                'download_url' => 'https://www.fermatmind.com/datasets/occupations/download',
+                'format' => ['json', 'csv'],
+            ],
+            'keywords' => ['career', 'dataset'],
+        ]);
+
+        $this->assertNotNull($payload);
+        $this->assertSame('Dataset', data_get($payload, 'fragments.dataset.@type'));
+        $this->assertSame(
+            'https://www.fermatmind.com/datasets/occupations/download',
+            data_get($payload, 'fragments.dataset.distribution.0.contentUrl')
+        );
+        $this->assertSame('BreadcrumbList', data_get($payload, 'fragments.breadcrumb_list.@type'));
+    }
+
+    public function test_it_builds_method_article_json_ld_only_for_dataset_method_route(): void
+    {
+        $payload = app(CareerDatasetStructuredDataBuilder::class)->build('career_dataset_method', [
+            'title' => 'Occupations dataset method',
+            'summary' => 'Method contract.',
+            'url' => 'https://www.fermatmind.com/datasets/occupations/method',
+        ]);
+
+        $this->assertNotNull($payload);
+        $this->assertSame('Article', data_get($payload, 'fragments.article.@type'));
+        $this->assertSame('BreadcrumbList', data_get($payload, 'fragments.breadcrumb_list.@type'));
+    }
+
+    public function test_it_denies_dataset_schema_for_non_dataset_routes(): void
+    {
+        $this->assertNull(app(CareerDatasetStructuredDataBuilder::class)->build('career_job_detail', [
+            'dataset_name' => 'Should not render',
+            'url' => 'https://www.fermatmind.com/datasets/occupations',
+        ]));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerPublicDatasetContractBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerPublicDatasetContractBuilderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Dataset\CareerPublicDatasetContractBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class CareerPublicDatasetContractBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_public_safe_dataset_hub_contract_from_backend_authority(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $contract = app(CareerPublicDatasetContractBuilder::class)->buildHubContract()->toArray();
+
+        $this->assertSame('career_public_dataset_hub', $contract['contract_kind']);
+        $this->assertSame('career.dataset_public_contract.v1', $contract['contract_version']);
+        $this->assertSame('career_first_wave_job_detail_dataset', $contract['dataset_key']);
+        $this->assertSame('career_first_wave_10', $contract['dataset_scope']);
+        $this->assertSame('FermatMind', data_get($contract, 'publication.publisher.name'));
+        $this->assertSame('Proprietary Dataset License', data_get($contract, 'publication.license.name'));
+        $this->assertSame(
+            'https://www.fermatmind.com/datasets/occupations/download',
+            data_get($contract, 'publication.distribution.download_url')
+        );
+        $this->assertSame(
+            'https://www.fermatmind.com/datasets/occupations/method',
+            data_get($contract, 'method_url')
+        );
+        $this->assertSame(10, data_get($contract, 'collection_summary.member_count'));
+        $this->assertSame(6, data_get($contract, 'collection_summary.stable_count'));
+        $this->assertSame(4, data_get($contract, 'collection_summary.hold_count'));
+        $this->assertTrue((bool) data_get($contract, 'filters.family'));
+        $this->assertTrue((bool) data_get($contract, 'filters.publish_track'));
+        $this->assertTrue((bool) data_get($contract, 'filters.index_posture'));
+        $this->assertArrayNotHasKey('source_path', $contract);
+    }
+
+    public function test_it_builds_a_public_safe_dataset_method_contract(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $contract = app(CareerPublicDatasetContractBuilder::class)->buildMethodContract()->toArray();
+
+        $this->assertSame('career_public_dataset_method', $contract['contract_kind']);
+        $this->assertSame('career.dataset_public_method.v1', $contract['contract_version']);
+        $this->assertSame('career_first_wave_job_detail_dataset', $contract['dataset_key']);
+        $this->assertSame('career_first_wave_10', $contract['dataset_scope']);
+        $this->assertSame('https://www.fermatmind.com/datasets/occupations/method', $contract['method_url']);
+        $this->assertSame('https://www.fermatmind.com/datasets/occupations', $contract['hub_url']);
+        $this->assertNotEmpty($contract['included']);
+        $this->assertNotEmpty($contract['excluded']);
+        $this->assertNotEmpty($contract['boundary_notes']);
+        $this->assertArrayNotHasKey('evidence_refs', $contract);
+        $this->assertArrayNotHasKey('review_queue', $contract);
+    }
+
+    private function materializeCurrentFirstWaveFixture(): void
+    {
+        $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [
+            '--source' => base_path('tests/Fixtures/Career/authority_wave/first_wave_readiness_summary_subset.csv'),
+            '--materialize-missing' => true,
+            '--compile-missing' => true,
+            '--repair-safe-partials' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
@@ -156,4 +156,40 @@ final class CareerStructuredDataBuilderTest extends TestCase
         $this->assertArrayNotHasKey('dataset', (array) data_get($articlePayload, 'fragments'));
         $this->assertArrayNotHasKey('dataset', (array) data_get($guidePayload, 'fragments'));
     }
+
+    public function test_it_builds_dataset_and_method_structured_data_only_for_dataset_routes(): void
+    {
+        $builder = app(CareerStructuredDataBuilder::class);
+
+        $hubPayload = $builder->build('career_dataset_hub', [
+            'dataset_name' => 'FermatMind Career Occupations Dataset (First Wave)',
+            'description' => 'Public dataset hub',
+            'url' => 'https://www.fermatmind.com/datasets/occupations',
+            'publisher' => [
+                'name' => 'FermatMind',
+                'url' => 'https://www.fermatmind.com',
+            ],
+            'license' => [
+                'url' => 'https://www.fermatmind.com/datasets/occupations/license',
+            ],
+            'distribution' => [
+                'download_url' => 'https://www.fermatmind.com/datasets/occupations/download',
+                'format' => ['json', 'csv'],
+            ],
+        ]);
+        $methodPayload = $builder->build('career_dataset_method', [
+            'title' => 'Occupations dataset method',
+            'summary' => 'Method summary',
+            'url' => 'https://www.fermatmind.com/datasets/occupations/method',
+        ]);
+
+        $this->assertSame('Dataset', data_get($hubPayload, 'fragments.dataset.@type'));
+        $this->assertSame('BreadcrumbList', data_get($hubPayload, 'fragments.breadcrumb_list.@type'));
+        $this->assertSame('Article', data_get($methodPayload, 'fragments.article.@type'));
+        $this->assertSame('BreadcrumbList', data_get($methodPayload, 'fragments.breadcrumb_list.@type'));
+        $this->assertNull($builder->build('career_recommendation_detail', [
+            'title' => 'Should not render',
+            'url' => 'https://www.fermatmind.com/datasets/occupations/method',
+        ]));
+    }
 }

--- a/backend/tests/Unit/Services/Career/CareerStructuredDataOutputPolicyTest.php
+++ b/backend/tests/Unit/Services/Career/CareerStructuredDataOutputPolicyTest.php
@@ -33,11 +33,21 @@ final class CareerStructuredDataOutputPolicyTest extends TestCase
             [CareerStructuredDataOutputPolicy::SCHEMA_ARTICLE, CareerStructuredDataOutputPolicy::SCHEMA_BREADCRUMB_LIST],
             $policy->allowedSchemaFamiliesFor('article_public_detail'),
         );
+        $this->assertSame(
+            [CareerStructuredDataOutputPolicy::SCHEMA_DATASET, CareerStructuredDataOutputPolicy::SCHEMA_BREADCRUMB_LIST],
+            $policy->allowedSchemaFamiliesFor('career_dataset_hub'),
+        );
+        $this->assertSame(
+            [CareerStructuredDataOutputPolicy::SCHEMA_ARTICLE, CareerStructuredDataOutputPolicy::SCHEMA_BREADCRUMB_LIST],
+            $policy->allowedSchemaFamiliesFor('career_dataset_method'),
+        );
 
         $this->assertFalse($policy->allows('career_job_detail', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
         $this->assertFalse($policy->allows('career_family_hub', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
         $this->assertFalse($policy->allows('career_guide_public_detail', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
         $this->assertFalse($policy->allows('career_recommendation_detail', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
+        $this->assertFalse($policy->allows('career_search', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
+        $this->assertFalse($policy->allows('career_alias_resolution', CareerStructuredDataOutputPolicy::SCHEMA_DATASET));
         $this->assertFalse($policy->allows('career_search', CareerStructuredDataOutputPolicy::SCHEMA_ARTICLE));
         $this->assertFalse($policy->allows('career_alias_resolution', CareerStructuredDataOutputPolicy::SCHEMA_ARTICLE));
     }


### PR DESCRIPTION
## What changed
- Added dedicated backend-owned publication metadata authority (`CareerDatasetPublicationMetadataService` + DTO) for publisher/license/usage/distribution truth.
- Added public-safe dataset contract builders (`CareerPublicDatasetContractBuilder`) for dataset hub and method surfaces.
- Added public v0.5 endpoints:
  - `GET /api/v0.5/career/datasets/occupations`
  - `GET /api/v0.5/career/datasets/occupations/method`
- Added structured-data routing support:
  - `career_dataset_hub` => `Dataset + BreadcrumbList`
  - `career_dataset_method` => `Article + BreadcrumbList`
  - Kept Dataset denied on job/family/search/resolve/recommendation surfaces.
- Added/updated backend unit+feature tests for publication metadata, public contracts, structured-data policy, and new API resources.
- Added train entries for `PR-B74X` in manifest/state.

## Why
B48 was blocked by missing dedicated publication metadata truth. This PR formalizes that truth and exposes a public-safe dataset contract without leaking internal-only authority internals.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Dataset/*.php app/DTO/Career/CareerPublicDataset*.php app/DTO/Career/CareerDatasetPublicationMetadata.php app/Services/Career/StructuredData/*.php tests/Unit/Services/Career/*Dataset*.php tests/Feature/Career/*Dataset*.php tests/Feature/SEO/*Dataset*.php`
- `php artisan test tests/Unit/Services/Career/*Dataset*.php tests/Feature/Career/*Dataset*.php tests/Feature/SEO/*Dataset*.php`

## Intentionally deferred
- No frontend changes in this backend PR.
- No OpenAPI/public API surface outside the two additive career dataset endpoints.
- No dataset publicization on job/family/search/resolve/recommendation surfaces.
