### PR TITLE
PR-B76X: Career feedback + time-travel system baseline (backend)

### DIFF
--- a/backend/app/DTO/Career/CareerFeedbackRecord.php
+++ b/backend/app/DTO/Career/CareerFeedbackRecord.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFeedbackRecord
+{
+    public function __construct(
+        public readonly string $feedbackUuid,
+        public readonly string $subjectKind,
+        public readonly ?string $subjectSlug,
+        public readonly ?int $burnoutCheckin,
+        public readonly ?int $careerSatisfaction,
+        public readonly ?int $switchUrgency,
+        public readonly ?string $contextSnapshotUuid,
+        public readonly ?string $projectionUuid,
+        public readonly ?string $recommendationSnapshotUuid,
+        public readonly ?string $createdAt,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'feedback_uuid' => $this->feedbackUuid,
+            'subject_kind' => $this->subjectKind,
+            'subject_slug' => $this->subjectSlug,
+            'burnout_checkin' => $this->burnoutCheckin,
+            'career_satisfaction' => $this->careerSatisfaction,
+            'switch_urgency' => $this->switchUrgency,
+            'context_snapshot_uuid' => $this->contextSnapshotUuid,
+            'projection_uuid' => $this->projectionUuid,
+            'recommendation_snapshot_uuid' => $this->recommendationSnapshotUuid,
+            'created_at' => $this->createdAt,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerJobDetailBundle.php
+++ b/backend/app/DTO/Career/CareerJobDetailBundle.php
@@ -21,6 +21,7 @@ final class CareerJobDetailBundle
      * @param  array<string, mixed>  $integritySummary
      * @param  array<string, mixed>  $seoContract
      * @param  array<string, mixed>  $provenanceMeta
+     * @param  array<string, mixed>  $lifecycleCompanion
      */
     public function __construct(
         public readonly array $identity,
@@ -37,6 +38,7 @@ final class CareerJobDetailBundle
         public readonly array $integritySummary,
         public readonly array $seoContract,
         public readonly array $provenanceMeta,
+        public readonly array $lifecycleCompanion,
     ) {}
 
     /**
@@ -61,6 +63,7 @@ final class CareerJobDetailBundle
             'integrity_summary' => $this->integritySummary,
             'seo_contract' => $this->seoContract,
             'provenance_meta' => $this->provenanceMeta,
+            'lifecycle_companion' => $this->lifecycleCompanion,
         ];
     }
 }

--- a/backend/app/DTO/Career/CareerProjectionDeltaSummary.php
+++ b/backend/app/DTO/Career/CareerProjectionDeltaSummary.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerProjectionDeltaSummary
+{
+    /**
+     * @param  array<string, mixed>  $scoreDeltas
+     * @param  array<string, mixed>  $feedbackDeltas
+     * @param  array<string, mixed>  $claimPermissionsChanged
+     */
+    public function __construct(
+        public readonly bool $deltaAvailable,
+        public readonly ?string $previousProjectionUuid,
+        public readonly ?string $currentProjectionUuid,
+        public readonly array $scoreDeltas,
+        public readonly array $feedbackDeltas,
+        public readonly bool $transitionChanged,
+        public readonly bool $targetJobsChanged,
+        public readonly array $claimPermissionsChanged,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'delta_available' => $this->deltaAvailable,
+            'previous_projection_uuid' => $this->previousProjectionUuid,
+            'current_projection_uuid' => $this->currentProjectionUuid,
+            'score_deltas' => $this->scoreDeltas,
+            'feedback_deltas' => $this->feedbackDeltas,
+            'transition_changed' => $this->transitionChanged,
+            'target_jobs_changed' => $this->targetJobsChanged,
+            'claim_permissions_changed' => $this->claimPermissionsChanged,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerProjectionTimeline.php
+++ b/backend/app/DTO/Career/CareerProjectionTimeline.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerProjectionTimeline
+{
+    /**
+     * @param  list<CareerProjectionTimelineEntry>  $entries
+     */
+    public function __construct(
+        public readonly string $timelineKind,
+        public readonly string $timelineVersion,
+        public readonly ?string $currentProjectionUuid,
+        public readonly ?string $currentRecommendationSnapshotUuid,
+        public readonly array $entries,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'timeline_kind' => $this->timelineKind,
+            'timeline_version' => $this->timelineVersion,
+            'current_projection_uuid' => $this->currentProjectionUuid,
+            'current_recommendation_snapshot_uuid' => $this->currentRecommendationSnapshotUuid,
+            'entries' => array_map(
+                static fn (CareerProjectionTimelineEntry $entry): array => $entry->toArray(),
+                $this->entries
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerProjectionTimelineEntry.php
+++ b/backend/app/DTO/Career/CareerProjectionTimelineEntry.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerProjectionTimelineEntry
+{
+    public function __construct(
+        public readonly string $projectionUuid,
+        public readonly string $recommendationSnapshotUuid,
+        public readonly ?string $contextSnapshotUuid,
+        public readonly ?string $feedbackUuid,
+        public readonly string $entryKind,
+        public readonly string $entryLabel,
+        public readonly ?string $createdAt,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'projection_uuid' => $this->projectionUuid,
+            'recommendation_snapshot_uuid' => $this->recommendationSnapshotUuid,
+            'context_snapshot_uuid' => $this->contextSnapshotUuid,
+            'feedback_uuid' => $this->feedbackUuid,
+            'entry_kind' => $this->entryKind,
+            'entry_label' => $this->entryLabel,
+            'created_at' => $this->createdAt,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
+++ b/backend/app/DTO/Career/CareerRecommendationDetailBundle.php
@@ -20,6 +20,9 @@ final class CareerRecommendationDetailBundle
      * @param  array<string, mixed>  $seoContract
      * @param  array<string, mixed>  $provenanceMeta
      * @param  array<string, mixed>|null  $transitionPath
+     * @param  array<string, mixed>|null  $feedbackCheckin
+     * @param  array<string, mixed>  $projectionTimeline
+     * @param  array<string, mixed>  $projectionDeltaSummary
      */
     public function __construct(
         public readonly array $identity,
@@ -33,6 +36,9 @@ final class CareerRecommendationDetailBundle
         public readonly array $trustManifest,
         public readonly array $matchedJobs,
         public readonly ?array $transitionPath,
+        public readonly ?array $feedbackCheckin,
+        public readonly array $projectionTimeline,
+        public readonly array $projectionDeltaSummary,
         public readonly array $seoContract,
         public readonly array $provenanceMeta,
     ) {}
@@ -56,6 +62,9 @@ final class CareerRecommendationDetailBundle
             'trust_manifest' => $this->trustManifest,
             'matched_jobs' => $this->matchedJobs,
             'transition_path' => $this->transitionPath,
+            'feedback_checkin' => $this->feedbackCheckin,
+            'projection_timeline' => $this->projectionTimeline,
+            'projection_delta_summary' => $this->projectionDeltaSummary,
             'seo_contract' => $this->seoContract,
             'provenance_meta' => $this->provenanceMeta,
         ];

--- a/backend/app/Domain/Career/Feedback/CareerFeedbackTimelineAuthorityService.php
+++ b/backend/app/Domain/Career/Feedback/CareerFeedbackTimelineAuthorityService.php
@@ -1,0 +1,484 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Feedback;
+
+use App\DTO\Career\CareerFeedbackRecord as CareerFeedbackRecordDto;
+use App\DTO\Career\CareerProjectionDeltaSummary;
+use App\DTO\Career\CareerProjectionTimeline;
+use App\DTO\Career\CareerProjectionTimelineEntry;
+use App\Models\CareerFeedbackRecord;
+use App\Models\ContextSnapshot;
+use App\Models\ProfileProjection;
+use App\Models\ProjectionLineage;
+use App\Models\RecommendationSnapshot;
+use App\Models\TransitionPath;
+use Illuminate\Support\Facades\DB;
+
+final class CareerFeedbackTimelineAuthorityService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildForRecommendationSnapshot(?RecommendationSnapshot $snapshot): array
+    {
+        if (! $snapshot instanceof RecommendationSnapshot || ! $snapshot->profileProjection) {
+            return $this->emptyPayload();
+        }
+
+        $timeline = $this->buildTimeline($snapshot);
+        $delta = $this->buildDeltaSummary($snapshot, $timeline);
+        $latestFeedback = $this->findFeedbackByRecommendationSnapshotId($snapshot->id);
+
+        return [
+            'feedback_checkin' => $latestFeedback?->toArray(),
+            'projection_timeline' => $timeline->toArray(),
+            'projection_delta_summary' => $delta->toArray(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildCompanionForJobSnapshot(?RecommendationSnapshot $snapshot): array
+    {
+        if (! $snapshot instanceof RecommendationSnapshot) {
+            return [];
+        }
+
+        $payload = $this->buildForRecommendationSnapshot($snapshot);
+        $timeline = is_array($payload['projection_timeline'] ?? null) ? $payload['projection_timeline'] : [];
+        $entries = is_array($timeline['entries'] ?? null) ? $timeline['entries'] : [];
+        $timeline['entries'] = array_slice($entries, -4);
+
+        return [
+            'timeline' => $timeline,
+            'delta_summary' => is_array($payload['projection_delta_summary'] ?? null) ? $payload['projection_delta_summary'] : [],
+            'latest_feedback' => is_array($payload['feedback_checkin'] ?? null) ? $payload['feedback_checkin'] : null,
+        ];
+    }
+
+    public function resolveCurrentSnapshotByType(string $type): ?RecommendationSnapshot
+    {
+        $requestedType = strtoupper(trim($type));
+        if ($requestedType === '') {
+            return null;
+        }
+        $canonicalType = strtoupper(strtok($requestedType, '-') ?: $requestedType);
+
+        /** @var RecommendationSnapshot|null $snapshot */
+        $snapshot = RecommendationSnapshot::query()
+            ->with(['profileProjection', 'contextSnapshot'])
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', function ($query) use ($requestedType, $canonicalType): void {
+                $query->where(function ($inner) use ($requestedType, $canonicalType): void {
+                    $inner->where('projection_payload->recommendation_subject_meta->type_code', $requestedType)
+                        ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $requestedType)
+                        ->orWhere('projection_payload->recommendation_subject_meta->canonical_type_code', $canonicalType);
+                });
+            })
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        return $snapshot;
+    }
+
+    public function appendFeedbackRefresh(RecommendationSnapshot $snapshot, array $input): RecommendationSnapshot
+    {
+        /** @var RecommendationSnapshot $createdSnapshot */
+        $createdSnapshot = DB::transaction(function () use ($snapshot, $input): RecommendationSnapshot {
+            $context = $snapshot->contextSnapshot;
+            $projection = $snapshot->profileProjection;
+            if (! $context instanceof ContextSnapshot || ! $projection instanceof ProfileProjection) {
+                return $snapshot;
+            }
+
+            $burnoutCheckin = $this->normalizeScaleValue($input['burnout_checkin'] ?? null);
+            $careerSatisfaction = $this->normalizeScaleValue($input['career_satisfaction'] ?? null);
+            $switchUrgency = $this->normalizeScaleValue($input['switch_urgency'] ?? null);
+
+            $newContext = ContextSnapshot::query()->create([
+                'identity_id' => $context->identity_id,
+                'visitor_id' => $context->visitor_id,
+                'captured_at' => now(),
+                'current_occupation_id' => $context->current_occupation_id,
+                'employment_status' => $context->employment_status,
+                'monthly_comp_band' => $context->monthly_comp_band,
+                'burnout_level' => $this->scaleToDecimal($burnoutCheckin) ?? $context->burnout_level,
+                'switch_urgency' => $this->scaleToDecimal($switchUrgency) ?? $context->switch_urgency,
+                'risk_tolerance' => $context->risk_tolerance,
+                'geo_region' => $context->geo_region,
+                'family_constraint_level' => $context->family_constraint_level,
+                'manager_track_preference' => $context->manager_track_preference,
+                'time_horizon_months' => $context->time_horizon_months,
+                'context_payload' => array_merge(
+                    is_array($context->context_payload) ? $context->context_payload : [],
+                    [
+                        'feedback_checkin' => [
+                            'burnout_checkin' => $burnoutCheckin,
+                            'career_satisfaction' => $careerSatisfaction,
+                            'switch_urgency' => $switchUrgency,
+                        ],
+                    ],
+                ),
+                'compile_run_id' => $context->compile_run_id,
+            ]);
+
+            $newProjection = ProfileProjection::query()->create([
+                'identity_id' => $projection->identity_id,
+                'visitor_id' => $projection->visitor_id,
+                'context_snapshot_id' => $newContext->id,
+                'projection_version' => $projection->projection_version,
+                'psychometric_axis_coverage' => $projection->psychometric_axis_coverage,
+                'projection_payload' => array_merge(
+                    is_array($projection->projection_payload) ? $projection->projection_payload : [],
+                    [
+                        'lifecycle_feedback' => [
+                            'burnout_checkin' => $burnoutCheckin,
+                            'career_satisfaction' => $careerSatisfaction,
+                            'switch_urgency' => $switchUrgency,
+                        ],
+                    ],
+                ),
+                'compile_run_id' => $projection->compile_run_id,
+            ]);
+
+            ProjectionLineage::query()->create([
+                'parent_projection_id' => $projection->id,
+                'child_projection_id' => $newProjection->id,
+                'trigger_context_snapshot_id' => $newContext->id,
+                'trigger_assessment_id' => null,
+                'lineage_reason' => 'context_refresh',
+                'diff_summary' => [
+                    'feedback_refresh' => true,
+                    'burnout_checkin' => $burnoutCheckin,
+                    'career_satisfaction' => $careerSatisfaction,
+                    'switch_urgency' => $switchUrgency,
+                ],
+            ]);
+
+            $newPayload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
+            $newPayload['feedback_checkin'] = [
+                'burnout_checkin' => $burnoutCheckin,
+                'career_satisfaction' => $careerSatisfaction,
+                'switch_urgency' => $switchUrgency,
+            ];
+
+            $newRecommendationSnapshot = RecommendationSnapshot::query()->create([
+                'profile_projection_id' => $newProjection->id,
+                'context_snapshot_id' => $newContext->id,
+                'occupation_id' => $snapshot->occupation_id,
+                'snapshot_payload' => $newPayload,
+                'compiled_at' => now(),
+                'compiler_version' => $snapshot->compiler_version,
+                'truth_metric_id' => $snapshot->truth_metric_id,
+                'trust_manifest_id' => $snapshot->trust_manifest_id,
+                'index_state_id' => $snapshot->index_state_id,
+                'compile_run_id' => $snapshot->compile_run_id,
+            ]);
+
+            CareerFeedbackRecord::query()->create([
+                'subject_kind' => 'recommendation_type',
+                'subject_slug' => strtolower(trim((string) ($input['subject_slug'] ?? ''))),
+                'burnout_checkin' => $burnoutCheckin,
+                'career_satisfaction' => $careerSatisfaction,
+                'switch_urgency' => $switchUrgency,
+                'context_snapshot_id' => $newContext->id,
+                'profile_projection_id' => $newProjection->id,
+                'recommendation_snapshot_id' => $newRecommendationSnapshot->id,
+            ]);
+
+            return $newRecommendationSnapshot;
+        });
+
+        return $createdSnapshot->fresh(['profileProjection', 'contextSnapshot']) ?? $createdSnapshot;
+    }
+
+    private function buildTimeline(RecommendationSnapshot $snapshot): CareerProjectionTimeline
+    {
+        $projectionIds = $this->resolveProjectionChain($snapshot->profile_projection_id);
+        $entries = [];
+        $firstProjectionId = $projectionIds[0] ?? null;
+
+        foreach ($projectionIds as $projectionId) {
+            /** @var RecommendationSnapshot|null $timelineSnapshot */
+            $timelineSnapshot = RecommendationSnapshot::query()
+                ->where('profile_projection_id', $projectionId)
+                ->where('occupation_id', $snapshot->occupation_id)
+                ->orderByDesc('created_at')
+                ->first();
+
+            if (! $timelineSnapshot instanceof RecommendationSnapshot) {
+                continue;
+            }
+
+            $feedback = $this->findFeedbackByRecommendationSnapshotId($timelineSnapshot->id);
+            $entryKind = $feedback instanceof CareerFeedbackRecordDto
+                ? 'feedback_refresh'
+                : (($projectionId === $firstProjectionId) ? 'initial' : 'feedback_refresh');
+            $entryLabel = $entryKind === 'initial' ? 'Initial recommendation snapshot' : 'Feedback refresh snapshot';
+
+            $entries[] = new CareerProjectionTimelineEntry(
+                projectionUuid: (string) $timelineSnapshot->profile_projection_id,
+                recommendationSnapshotUuid: (string) $timelineSnapshot->id,
+                contextSnapshotUuid: is_string($timelineSnapshot->context_snapshot_id) ? $timelineSnapshot->context_snapshot_id : null,
+                feedbackUuid: $feedback?->feedbackUuid,
+                entryKind: $entryKind,
+                entryLabel: $entryLabel,
+                createdAt: optional($timelineSnapshot->created_at)->toISOString(),
+            );
+        }
+
+        return new CareerProjectionTimeline(
+            timelineKind: 'career_projection_timeline',
+            timelineVersion: 'career.timeline.v1',
+            currentProjectionUuid: is_string($snapshot->profile_projection_id) ? $snapshot->profile_projection_id : null,
+            currentRecommendationSnapshotUuid: (string) $snapshot->id,
+            entries: $entries,
+        );
+    }
+
+    private function buildDeltaSummary(
+        RecommendationSnapshot $snapshot,
+        CareerProjectionTimeline $timeline,
+    ): CareerProjectionDeltaSummary {
+        $entries = $timeline->entries;
+        if (count($entries) < 2) {
+            return new CareerProjectionDeltaSummary(
+                deltaAvailable: false,
+                previousProjectionUuid: null,
+                currentProjectionUuid: is_string($snapshot->profile_projection_id) ? $snapshot->profile_projection_id : null,
+                scoreDeltas: [],
+                feedbackDeltas: [],
+                transitionChanged: false,
+                targetJobsChanged: false,
+                claimPermissionsChanged: [],
+            );
+        }
+
+        $currentEntry = $entries[count($entries) - 1];
+        $previousEntry = $entries[count($entries) - 2];
+
+        /** @var RecommendationSnapshot|null $previousSnapshot */
+        $previousSnapshot = RecommendationSnapshot::query()->find($previousEntry->recommendationSnapshotUuid);
+        if (! $previousSnapshot instanceof RecommendationSnapshot) {
+            return new CareerProjectionDeltaSummary(
+                deltaAvailable: false,
+                previousProjectionUuid: null,
+                currentProjectionUuid: is_string($snapshot->profile_projection_id) ? $snapshot->profile_projection_id : null,
+                scoreDeltas: [],
+                feedbackDeltas: [],
+                transitionChanged: false,
+                targetJobsChanged: false,
+                claimPermissionsChanged: [],
+            );
+        }
+
+        $currentPayload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
+        $previousPayload = is_array($previousSnapshot->snapshot_payload) ? $previousSnapshot->snapshot_payload : [];
+
+        $scoreDeltas = [
+            'fit_score' => $this->scoreDelta($previousPayload, $currentPayload, 'fit_score'),
+            'strain_score' => $this->scoreDelta($previousPayload, $currentPayload, 'strain_score'),
+            'ai_survival_score' => $this->scoreDelta($previousPayload, $currentPayload, 'ai_survival_score'),
+            'mobility_score' => $this->scoreDelta($previousPayload, $currentPayload, 'mobility_score'),
+            'confidence_score' => $this->scoreDelta($previousPayload, $currentPayload, 'confidence_score'),
+        ];
+
+        $currentFeedback = $this->feedbackValuesFromPayload($currentPayload);
+        $previousFeedback = $this->feedbackValuesFromPayload($previousPayload);
+
+        $currentTransitionTarget = TransitionPath::query()
+            ->where('recommendation_snapshot_id', $snapshot->id)
+            ->orderByDesc('created_at')
+            ->value('to_occupation_id');
+        $previousTransitionTarget = TransitionPath::query()
+            ->where('recommendation_snapshot_id', $previousSnapshot->id)
+            ->orderByDesc('created_at')
+            ->value('to_occupation_id');
+
+        return new CareerProjectionDeltaSummary(
+            deltaAvailable: true,
+            previousProjectionUuid: $previousEntry->projectionUuid,
+            currentProjectionUuid: $currentEntry->projectionUuid,
+            scoreDeltas: $scoreDeltas,
+            feedbackDeltas: [
+                'burnout_checkin' => $this->deltaValue($previousFeedback['burnout_checkin'], $currentFeedback['burnout_checkin']),
+                'career_satisfaction' => $this->deltaValue($previousFeedback['career_satisfaction'], $currentFeedback['career_satisfaction']),
+                'switch_urgency' => $this->deltaValue($previousFeedback['switch_urgency'], $currentFeedback['switch_urgency']),
+            ],
+            transitionChanged: $currentTransitionTarget !== $previousTransitionTarget,
+            targetJobsChanged: $snapshot->occupation_id !== $previousSnapshot->occupation_id,
+            claimPermissionsChanged: [
+                'allow_strong_claim' => $this->claimChanged($previousPayload, $currentPayload, 'allow_strong_claim'),
+                'allow_salary_comparison' => $this->claimChanged($previousPayload, $currentPayload, 'allow_salary_comparison'),
+                'allow_ai_strategy' => $this->claimChanged($previousPayload, $currentPayload, 'allow_ai_strategy'),
+                'allow_transition_recommendation' => $this->claimChanged($previousPayload, $currentPayload, 'allow_transition_recommendation'),
+            ],
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveProjectionChain(?string $currentProjectionId): array
+    {
+        if (! is_string($currentProjectionId) || $currentProjectionId === '') {
+            return [];
+        }
+
+        $chain = [];
+        $cursor = $currentProjectionId;
+        while (is_string($cursor) && $cursor !== '') {
+            $chain[] = $cursor;
+            /** @var ProjectionLineage|null $lineage */
+            $lineage = ProjectionLineage::query()
+                ->where('child_projection_id', $cursor)
+                ->first();
+            $parentId = is_string($lineage?->parent_projection_id) ? $lineage->parent_projection_id : null;
+            if ($parentId === null) {
+                break;
+            }
+            $cursor = $parentId;
+        }
+
+        return array_reverse($chain);
+    }
+
+    private function scoreDelta(array $previousPayload, array $currentPayload, string $scoreKey): array
+    {
+        $previous = $this->extractScore($previousPayload, $scoreKey);
+        $current = $this->extractScore($currentPayload, $scoreKey);
+
+        return [
+            'previous' => $previous,
+            'current' => $current,
+            'delta' => $this->deltaValue($previous, $current),
+        ];
+    }
+
+    private function extractScore(array $payload, string $scoreKey): ?float
+    {
+        $bundle = is_array($payload['score_bundle'] ?? null) ? $payload['score_bundle'] : [];
+        $score = is_array($bundle[$scoreKey] ?? null) ? $bundle[$scoreKey] : [];
+        $value = $score['value'] ?? null;
+
+        return is_numeric($value) ? (float) $value : null;
+    }
+
+    /**
+     * @return array{burnout_checkin: int|null, career_satisfaction: int|null, switch_urgency: int|null}
+     */
+    private function feedbackValuesFromPayload(array $payload): array
+    {
+        $feedback = is_array($payload['feedback_checkin'] ?? null) ? $payload['feedback_checkin'] : [];
+
+        return [
+            'burnout_checkin' => $this->normalizeScaleValue($feedback['burnout_checkin'] ?? null),
+            'career_satisfaction' => $this->normalizeScaleValue($feedback['career_satisfaction'] ?? null),
+            'switch_urgency' => $this->normalizeScaleValue($feedback['switch_urgency'] ?? null),
+        ];
+    }
+
+    private function claimChanged(array $previousPayload, array $currentPayload, string $key): bool
+    {
+        $previousClaims = is_array($previousPayload['claim_permissions'] ?? null) ? $previousPayload['claim_permissions'] : [];
+        $currentClaims = is_array($currentPayload['claim_permissions'] ?? null) ? $currentPayload['claim_permissions'] : [];
+
+        return ($previousClaims[$key] ?? null) !== ($currentClaims[$key] ?? null);
+    }
+
+    private function deltaValue(?float $previous, ?float $current): ?float
+    {
+        if ($previous === null || $current === null) {
+            return null;
+        }
+
+        return round($current - $previous, 2);
+    }
+
+    private function normalizeScaleValue(mixed $value): ?int
+    {
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = (int) $value;
+        if ($normalized < 1 || $normalized > 5) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    private function scaleToDecimal(?int $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return round(($value - 1) / 4, 2);
+    }
+
+    private function findFeedbackByRecommendationSnapshotId(string $recommendationSnapshotId): ?CareerFeedbackRecordDto
+    {
+        /** @var CareerFeedbackRecord|null $record */
+        $record = CareerFeedbackRecord::query()
+            ->where('recommendation_snapshot_id', $recommendationSnapshotId)
+            ->latest('created_at')
+            ->first();
+
+        if (! $record instanceof CareerFeedbackRecord) {
+            return null;
+        }
+
+        return new CareerFeedbackRecordDto(
+            feedbackUuid: (string) $record->id,
+            subjectKind: (string) $record->subject_kind,
+            subjectSlug: is_string($record->subject_slug) ? $record->subject_slug : null,
+            burnoutCheckin: is_numeric($record->burnout_checkin) ? (int) $record->burnout_checkin : null,
+            careerSatisfaction: is_numeric($record->career_satisfaction) ? (int) $record->career_satisfaction : null,
+            switchUrgency: is_numeric($record->switch_urgency) ? (int) $record->switch_urgency : null,
+            contextSnapshotUuid: is_string($record->context_snapshot_id) ? $record->context_snapshot_id : null,
+            projectionUuid: is_string($record->profile_projection_id) ? $record->profile_projection_id : null,
+            recommendationSnapshotUuid: is_string($record->recommendation_snapshot_id) ? $record->recommendation_snapshot_id : null,
+            createdAt: optional($record->created_at)->toISOString(),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function emptyPayload(): array
+    {
+        return [
+            'feedback_checkin' => null,
+            'projection_timeline' => [
+                'timeline_kind' => 'career_projection_timeline',
+                'timeline_version' => 'career.timeline.v1',
+                'current_projection_uuid' => null,
+                'current_recommendation_snapshot_uuid' => null,
+                'entries' => [],
+            ],
+            'projection_delta_summary' => [
+                'delta_available' => false,
+                'previous_projection_uuid' => null,
+                'current_projection_uuid' => null,
+                'score_deltas' => [],
+                'feedback_deltas' => [],
+                'transition_changed' => false,
+                'target_jobs_changed' => false,
+                'claim_permissions_changed' => [],
+            ],
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Feedback/CareerFeedbackTimelineAuthorityService.php
+++ b/backend/app/Domain/Career/Feedback/CareerFeedbackTimelineAuthorityService.php
@@ -186,6 +186,8 @@ final class CareerFeedbackTimelineAuthorityService
                 'compile_run_id' => $snapshot->compile_run_id,
             ]);
 
+            $this->cloneTransitionPaths($snapshot, $newRecommendationSnapshot);
+
             CareerFeedbackRecord::query()->create([
                 'subject_kind' => 'recommendation_type',
                 'subject_slug' => strtolower(trim((string) ($input['subject_slug'] ?? ''))),
@@ -201,6 +203,25 @@ final class CareerFeedbackTimelineAuthorityService
         });
 
         return $createdSnapshot->fresh(['profileProjection', 'contextSnapshot']) ?? $createdSnapshot;
+    }
+
+    private function cloneTransitionPaths(
+        RecommendationSnapshot $sourceSnapshot,
+        RecommendationSnapshot $targetSnapshot,
+    ): void {
+        $paths = TransitionPath::query()
+            ->where('recommendation_snapshot_id', $sourceSnapshot->id)
+            ->get();
+
+        foreach ($paths as $path) {
+            TransitionPath::query()->create([
+                'recommendation_snapshot_id' => $targetSnapshot->id,
+                'from_occupation_id' => $path->from_occupation_id,
+                'to_occupation_id' => $path->to_occupation_id,
+                'path_type' => $path->path_type,
+                'path_payload' => $path->path_payload,
+            ]);
+        }
     }
 
     private function buildTimeline(RecommendationSnapshot $snapshot): CareerProjectionTimeline

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerRecommendationFeedbackController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerRecommendationFeedbackController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Domain\Career\Feedback\CareerFeedbackTimelineAuthorityService;
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class CareerRecommendationFeedbackController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerFeedbackTimelineAuthorityService $feedbackTimelineAuthorityService,
+    ) {}
+
+    public function store(Request $request, string $type): JsonResponse
+    {
+        $validated = $request->validate([
+            'burnout_checkin' => ['nullable', 'integer', 'between:1,5'],
+            'career_satisfaction' => ['nullable', 'integer', 'between:1,5'],
+            'switch_urgency' => ['nullable', 'integer', 'between:1,5'],
+        ]);
+
+        $snapshot = $this->feedbackTimelineAuthorityService->resolveCurrentSnapshotByType($type);
+        if ($snapshot === null) {
+            return $this->notFoundResponse('career recommendation detail bundle unavailable.');
+        }
+
+        $createdSnapshot = $this->feedbackTimelineAuthorityService->appendFeedbackRefresh($snapshot, [
+            ...$validated,
+            'subject_slug' => strtolower(trim($type)),
+        ]);
+
+        $payload = $this->feedbackTimelineAuthorityService->buildForRecommendationSnapshot($createdSnapshot);
+
+        return response()->json([
+            'ok' => true,
+            'data' => $payload,
+        ]);
+    }
+}
+

--- a/backend/app/Models/CareerFeedbackRecord.php
+++ b/backend/app/Models/CareerFeedbackRecord.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CareerFeedbackRecord extends CareerImmutableFoundationModel
+{
+    protected $table = 'career_feedback_records';
+
+    protected $casts = [
+        'burnout_checkin' => 'integer',
+        'career_satisfaction' => 'integer',
+        'switch_urgency' => 'integer',
+        'created_at' => 'datetime',
+    ];
+
+    public function contextSnapshot(): BelongsTo
+    {
+        return $this->belongsTo(ContextSnapshot::class, 'context_snapshot_id', 'id');
+    }
+
+    public function profileProjection(): BelongsTo
+    {
+        return $this->belongsTo(ProfileProjection::class, 'profile_projection_id', 'id');
+    }
+
+    public function recommendationSnapshot(): BelongsTo
+    {
+        return $this->belongsTo(RecommendationSnapshot::class, 'recommendation_snapshot_id', 'id');
+    }
+}
+

--- a/backend/app/Models/ContextSnapshot.php
+++ b/backend/app/Models/ContextSnapshot.php
@@ -38,6 +38,11 @@ class ContextSnapshot extends CareerImmutableFoundationModel
         return $this->hasMany(RecommendationSnapshot::class, 'context_snapshot_id', 'id');
     }
 
+    public function feedbackRecords(): HasMany
+    {
+        return $this->hasMany(CareerFeedbackRecord::class, 'context_snapshot_id', 'id');
+    }
+
     public function compileRun(): BelongsTo
     {
         return $this->belongsTo(CareerCompileRun::class, 'compile_run_id', 'id');

--- a/backend/app/Models/ProfileProjection.php
+++ b/backend/app/Models/ProfileProjection.php
@@ -38,6 +38,11 @@ class ProfileProjection extends CareerImmutableFoundationModel
         return $this->hasMany(RecommendationSnapshot::class, 'profile_projection_id', 'id');
     }
 
+    public function feedbackRecords(): HasMany
+    {
+        return $this->hasMany(CareerFeedbackRecord::class, 'profile_projection_id', 'id');
+    }
+
     public function compileRun(): BelongsTo
     {
         return $this->belongsTo(CareerCompileRun::class, 'compile_run_id', 'id');

--- a/backend/app/Models/RecommendationSnapshot.php
+++ b/backend/app/Models/RecommendationSnapshot.php
@@ -56,4 +56,9 @@ class RecommendationSnapshot extends CareerImmutableFoundationModel
     {
         return $this->hasMany(TransitionPath::class, 'recommendation_snapshot_id', 'id');
     }
+
+    public function feedbackRecords(): HasMany
+    {
+        return $this->hasMany(CareerFeedbackRecord::class, 'recommendation_snapshot_id', 'id');
+    }
 }

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\Feedback\CareerFeedbackTimelineAuthorityService;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerJobDetailBundle;
 use App\Models\Occupation;
@@ -16,6 +17,7 @@ final class CareerJobDetailBundleBuilder
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly CareerWhiteBoxScorePayloadBuilder $whiteBoxScorePayloadBuilder,
+        private readonly CareerFeedbackTimelineAuthorityService $feedbackTimelineAuthorityService,
     ) {}
 
     public function buildBySlug(string $slug): ?CareerJobDetailBundle
@@ -204,6 +206,7 @@ final class CareerJobDetailBundleBuilder
                 'source_trace_id' => $truthMetric?->source_trace_id,
                 'compile_refs' => $this->normalizeArray($payload['compile_refs'] ?? []),
             ],
+            lifecycleCompanion: $this->feedbackTimelineAuthorityService->buildCompanionForJobSnapshot($snapshot),
         );
     }
 

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\Feedback\CareerFeedbackTimelineAuthorityService;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerRecommendationDetailBundle;
 use App\DTO\Career\CareerTransitionPreviewBundle;
@@ -19,6 +20,7 @@ final class CareerRecommendationDetailBundleBuilder
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly CareerWhiteBoxScorePayloadBuilder $whiteBoxScorePayloadBuilder,
         private readonly CareerTransitionPreviewBundleBuilder $transitionPreviewBundleBuilder,
+        private readonly CareerFeedbackTimelineAuthorityService $feedbackTimelineAuthorityService,
     ) {}
 
     public function buildByType(string $type): ?CareerRecommendationDetailBundle
@@ -58,6 +60,7 @@ final class CareerRecommendationDetailBundleBuilder
         $warnings = $this->normalizeArray($payload['warnings'] ?? []);
         $routeSubject = $this->routeSubject($subjectMeta, $requestedType);
         $transitionPath = $this->recommendationTransitionPath($routeSubject);
+        $lifecycle = $this->feedbackTimelineAuthorityService->buildForRecommendationSnapshot($snapshot);
 
         return new CareerRecommendationDetailBundle(
             identity: [
@@ -101,6 +104,9 @@ final class CareerRecommendationDetailBundleBuilder
             ],
             matchedJobs: $this->buildMatchedJobs($snapshots),
             transitionPath: $transitionPath,
+            feedbackCheckin: is_array($lifecycle['feedback_checkin'] ?? null) ? $lifecycle['feedback_checkin'] : null,
+            projectionTimeline: is_array($lifecycle['projection_timeline'] ?? null) ? $lifecycle['projection_timeline'] : [],
+            projectionDeltaSummary: is_array($lifecycle['projection_delta_summary'] ?? null) ? $lifecycle['projection_delta_summary'] : [],
             seoContract: $this->buildSeoContract($snapshot, $routeSubject),
             provenanceMeta: [
                 'content_version' => $trustManifest?->content_version,

--- a/backend/database/migrations/2026_04_16_000100_create_career_feedback_records_table.php
+++ b/backend/database/migrations/2026_04_16_000100_create_career_feedback_records_table.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('career_feedback_records')) {
+            return;
+        }
+
+        Schema::create('career_feedback_records', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('subject_kind', 64);
+            $table->string('subject_slug', 128)->nullable();
+            $table->unsignedTinyInteger('burnout_checkin')->nullable();
+            $table->unsignedTinyInteger('career_satisfaction')->nullable();
+            $table->unsignedTinyInteger('switch_urgency')->nullable();
+            $table->foreignUuid('context_snapshot_id')->nullable();
+            $table->foreignUuid('profile_projection_id')->nullable();
+            $table->foreignUuid('recommendation_snapshot_id')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['subject_kind', 'subject_slug', 'created_at'], 'career_feedback_subject_idx');
+            $table->index(['recommendation_snapshot_id', 'created_at'], 'career_feedback_recommendation_idx');
+
+            $table->foreign('context_snapshot_id')
+                ->references('id')
+                ->on('context_snapshots')
+                ->nullOnDelete();
+            $table->foreign('profile_projection_id')
+                ->references('id')
+                ->on('profile_projections')
+                ->nullOnDelete();
+            $table->foreign('recommendation_snapshot_id')
+                ->references('id')
+                ->on('recommendation_snapshots')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};
+

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T05:10:00Z",
+  "updated_at": "2026-04-16T15:28:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2183,6 +2183,40 @@
         ]
       },
       "failure_reason": "GitHub hygiene checks failed before logs were available from the runs; local validation is fully green and the PR is waiting on remote CI status.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B76X": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-b76x-career-feedback-time-travel-baseline",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Feedback/*.php app/DTO/Career/CareerFeedback*.php app/DTO/Career/CareerProjection*.php tests/Unit/Services/Career/*Feedback*.php tests/Unit/Services/Career/*Timeline*.php tests/Feature/Career/*Recommendation*.php tests/Feature/Career/*JobDetail*.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/*Feedback*.php tests/Unit/Services/Career/*Timeline*.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Career/*Recommendation*.php tests/Feature/Career/*JobDetail*.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1263,6 +1263,33 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B76X
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b76x-career-feedback-time-travel-baseline
+    base: main
+    depends_on: ["PR-B74X"]
+    mode: execute
+    scope: >
+      Career feedback + time-travel system baseline (backend).
+      Add append-only feedback check-in authority and projection timeline/delta read
+      contract on career recommendation/job detail bundles without changing public API
+      families outside career detail surfaces.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Feedback/*.php app/DTO/Career/CareerFeedback*.php app/DTO/Career/CareerProjection*.php tests/Unit/Services/Career/*Feedback*.php tests/Unit/Services/Career/*Timeline*.php tests/Feature/Career/*Recommendation*.php tests/Feature/Career/*JobDetail*.php"
+      - "php artisan test tests/Unit/Services/Career/*Feedback*.php tests/Unit/Services/Career/*Timeline*.php"
+      - "php artisan test tests/Feature/Career/*Recommendation*.php tests/Feature/Career/*JobDetail*.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -47,6 +47,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerJobExplainabilityController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobListController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationExplainabilityController;
+use App\Http\Controllers\API\V0_5\Career\CareerRecommendationFeedbackController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationIndexController;
 use App\Http\Controllers\API\V0_5\Career\CareerSearchController;
 use App\Http\Controllers\API\V0_5\Career\CareerTransitionPreviewController;
@@ -431,6 +432,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/recommendations/mbti', [CareerRecommendationIndexController::class, 'index']);
     Route::get('/career/recommendations/mbti/{type}', [CareerRecommendationDetailController::class, 'show']);
     Route::get('/career/recommendations/mbti/{type}/explainability', [CareerRecommendationExplainabilityController::class, 'show']);
+    Route::post('/career/recommendations/mbti/{type}/feedback', [CareerRecommendationFeedbackController::class, 'store']);
     Route::get('/career/transition-preview', [CareerTransitionPreviewController::class, 'show']);
     Route::get('/career/search', [CareerSearchController::class, 'index']);
     Route::get('/career/datasets/occupations', [CareerDatasetHubController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -99,6 +99,7 @@ final class CareerJobDetailApiTest extends TestCase
                     'breadcrumb_list',
                 ],
                 'provenance_meta' => ['compiler_version', 'compile_refs'],
+                'lifecycle_companion',
             ])
             ->assertJsonMissingPath('white_box_scores.fit_score.formula_ref')
             ->assertJsonMissingPath('white_box_scores.fit_score.critical_missing_fields');

--- a/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
@@ -62,6 +62,17 @@ final class CareerRecommendationDetailApiTest extends TestCase
                     'seo_contract' => ['canonical_path', 'canonical_target', 'index_state', 'index_eligible', 'reason_codes'],
                     'trust_summary' => ['reviewer_status'],
                 ]],
+                'feedback_checkin',
+                'projection_timeline' => [
+                    'timeline_kind',
+                    'timeline_version',
+                    'entries',
+                ],
+                'projection_delta_summary' => [
+                    'delta_available',
+                    'score_deltas',
+                    'feedback_deltas',
+                ],
                 'seo_contract',
                 'provenance_meta' => ['compiler_version', 'compile_refs'],
             ])

--- a/backend/tests/Feature/Career/CareerRecommendationFeedbackApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationFeedbackApiTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\ContextSnapshot;
+use App\Models\ProfileProjection;
+use App\Models\RecommendationSnapshot;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerRecommendationFeedbackApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_appends_feedback_as_new_lifecycle_state_and_keeps_previous_snapshots_immutable(): void
+    {
+        $snapshot = $this->compileRecommendationChainBySlug('feedback-api-case');
+        $beforeSnapshotCount = RecommendationSnapshot::query()->count();
+        $beforeProjectionCount = ProfileProjection::query()->count();
+        $beforeContextCount = ContextSnapshot::query()->count();
+
+        $response = $this->postJson('/api/v0.5/career/recommendations/mbti/intj/feedback', [
+            'burnout_checkin' => 5,
+            'career_satisfaction' => 2,
+            'switch_urgency' => 4,
+        ])->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('data.feedback_checkin.burnout_checkin', 5)
+            ->assertJsonPath('data.feedback_checkin.career_satisfaction', 2)
+            ->assertJsonPath('data.feedback_checkin.switch_urgency', 4)
+            ->assertJsonPath('data.projection_delta_summary.delta_available', true);
+
+        $this->assertSame($beforeSnapshotCount + 1, RecommendationSnapshot::query()->count());
+        $this->assertSame($beforeProjectionCount + 1, ProfileProjection::query()->count());
+        $this->assertSame($beforeContextCount + 1, ContextSnapshot::query()->count());
+        $this->assertNotNull(RecommendationSnapshot::query()->find($snapshot->id));
+
+        $entries = (array) data_get($response->json(), 'data.projection_timeline.entries', []);
+        $this->assertGreaterThanOrEqual(2, count($entries));
+    }
+
+    public function test_it_returns_not_found_when_feedback_target_type_is_unavailable(): void
+    {
+        $this->postJson('/api/v0.5/career/recommendations/mbti/non-existent-type/feedback', [
+            'burnout_checkin' => 3,
+            'career_satisfaction' => 3,
+            'switch_urgency' => 3,
+        ])->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    private function compileRecommendationChainBySlug(string $slug): RecommendationSnapshot
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-recommendation-feedback-'.$slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'materialization' => 'career_first_wave',
+                    'recommendation_subject_meta' => [
+                        'type_code' => 'INTJ-A',
+                        'canonical_type_code' => 'INTJ',
+                        'display_title' => 'INTJ-A Career Match',
+                        'public_route_slug' => 'intj',
+                    ],
+                ],
+            ),
+        ]);
+
+        return app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+    }
+}

--- a/backend/tests/Feature/Career/CareerRecommendationFeedbackApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationFeedbackApiTest.php
@@ -9,6 +9,7 @@ use App\Models\CareerImportRun;
 use App\Models\ContextSnapshot;
 use App\Models\ProfileProjection;
 use App\Models\RecommendationSnapshot;
+use App\Models\TransitionPath;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
@@ -21,9 +22,19 @@ final class CareerRecommendationFeedbackApiTest extends TestCase
     public function test_it_appends_feedback_as_new_lifecycle_state_and_keeps_previous_snapshots_immutable(): void
     {
         $snapshot = $this->compileRecommendationChainBySlug('feedback-api-case');
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $snapshot->occupation_id,
+            'path_type' => 'bridge',
+            'path_payload' => [
+                'steps' => [],
+            ],
+        ]);
         $beforeSnapshotCount = RecommendationSnapshot::query()->count();
         $beforeProjectionCount = ProfileProjection::query()->count();
         $beforeContextCount = ContextSnapshot::query()->count();
+        $beforePathCount = TransitionPath::query()->count();
 
         $response = $this->postJson('/api/v0.5/career/recommendations/mbti/intj/feedback', [
             'burnout_checkin' => 5,
@@ -34,11 +45,13 @@ final class CareerRecommendationFeedbackApiTest extends TestCase
             ->assertJsonPath('data.feedback_checkin.burnout_checkin', 5)
             ->assertJsonPath('data.feedback_checkin.career_satisfaction', 2)
             ->assertJsonPath('data.feedback_checkin.switch_urgency', 4)
-            ->assertJsonPath('data.projection_delta_summary.delta_available', true);
+            ->assertJsonPath('data.projection_delta_summary.delta_available', true)
+            ->assertJsonPath('data.projection_delta_summary.transition_changed', false);
 
         $this->assertSame($beforeSnapshotCount + 1, RecommendationSnapshot::query()->count());
         $this->assertSame($beforeProjectionCount + 1, ProfileProjection::query()->count());
         $this->assertSame($beforeContextCount + 1, ContextSnapshot::query()->count());
+        $this->assertSame($beforePathCount + 1, TransitionPath::query()->count());
         $this->assertNotNull(RecommendationSnapshot::query()->find($snapshot->id));
 
         $entries = (array) data_get($response->json(), 'data.projection_timeline.entries', []);

--- a/backend/tests/Unit/Services/Career/CareerFeedbackTimelineAuthorityServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFeedbackTimelineAuthorityServiceTest.php
@@ -8,6 +8,7 @@ use App\Domain\Career\Feedback\CareerFeedbackTimelineAuthorityService;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\RecommendationSnapshot;
+use App\Models\TransitionPath;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
@@ -20,6 +21,16 @@ final class CareerFeedbackTimelineAuthorityServiceTest extends TestCase
     public function test_it_builds_timeline_and_appends_feedback_refresh_without_mutating_previous_snapshot(): void
     {
         $snapshot = $this->compileRecommendationChainBySlug('feedback-timeline-unit');
+        $beforeTransitionPathCount = TransitionPath::query()->count();
+        TransitionPath::query()->create([
+            'recommendation_snapshot_id' => $snapshot->id,
+            'from_occupation_id' => $snapshot->occupation_id,
+            'to_occupation_id' => $snapshot->occupation_id,
+            'path_type' => 'bridge',
+            'path_payload' => [
+                'steps' => [],
+            ],
+        ]);
         $service = app(CareerFeedbackTimelineAuthorityService::class);
 
         $before = $service->buildForRecommendationSnapshot($snapshot);
@@ -43,7 +54,9 @@ final class CareerFeedbackTimelineAuthorityServiceTest extends TestCase
         $this->assertSame(2, data_get($after, 'feedback_checkin.career_satisfaction'));
         $this->assertSame(5, data_get($after, 'feedback_checkin.switch_urgency'));
         $this->assertSame(true, data_get($after, 'projection_delta_summary.delta_available'));
+        $this->assertSame(false, data_get($after, 'projection_delta_summary.transition_changed'));
         $this->assertGreaterThanOrEqual(2, count((array) data_get($after, 'projection_timeline.entries', [])));
+        $this->assertSame($beforeTransitionPathCount + 2, TransitionPath::query()->count());
     }
 
     private function compileRecommendationChainBySlug(string $slug): RecommendationSnapshot

--- a/backend/tests/Unit/Services/Career/CareerFeedbackTimelineAuthorityServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFeedbackTimelineAuthorityServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Feedback\CareerFeedbackTimelineAuthorityService;
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\RecommendationSnapshot;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerFeedbackTimelineAuthorityServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_timeline_and_appends_feedback_refresh_without_mutating_previous_snapshot(): void
+    {
+        $snapshot = $this->compileRecommendationChainBySlug('feedback-timeline-unit');
+        $service = app(CareerFeedbackTimelineAuthorityService::class);
+
+        $before = $service->buildForRecommendationSnapshot($snapshot);
+        $this->assertSame('career_projection_timeline', data_get($before, 'projection_timeline.timeline_kind'));
+        $this->assertGreaterThanOrEqual(1, count((array) data_get($before, 'projection_timeline.entries', [])));
+
+        $beforeSnapshotCount = RecommendationSnapshot::query()->count();
+        $afterSnapshot = $service->appendFeedbackRefresh($snapshot, [
+            'subject_slug' => 'intj',
+            'burnout_checkin' => 4,
+            'career_satisfaction' => 2,
+            'switch_urgency' => 5,
+        ]);
+
+        $this->assertNotSame($snapshot->id, $afterSnapshot->id);
+        $this->assertSame($beforeSnapshotCount + 1, RecommendationSnapshot::query()->count());
+        $this->assertSame($snapshot->id, RecommendationSnapshot::query()->find($snapshot->id)?->id);
+
+        $after = $service->buildForRecommendationSnapshot($afterSnapshot);
+        $this->assertSame(4, data_get($after, 'feedback_checkin.burnout_checkin'));
+        $this->assertSame(2, data_get($after, 'feedback_checkin.career_satisfaction'));
+        $this->assertSame(5, data_get($after, 'feedback_checkin.switch_urgency'));
+        $this->assertSame(true, data_get($after, 'projection_delta_summary.delta_available'));
+        $this->assertGreaterThanOrEqual(2, count((array) data_get($after, 'projection_timeline.entries', [])));
+    }
+
+    private function compileRecommendationChainBySlug(string $slug): RecommendationSnapshot
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-feedback-timeline-'.$slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                [
+                    'materialization' => 'career_first_wave',
+                    'recommendation_subject_meta' => [
+                        'type_code' => 'INTJ-A',
+                        'canonical_type_code' => 'INTJ',
+                        'display_title' => 'INTJ-A Career Match',
+                        'public_route_slug' => 'intj',
+                    ],
+                ],
+            ),
+        ]);
+
+        return app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## What Changed
- Added `CareerFeedbackTimelineAuthorityService` lifecycle append/read baseline for recommendation snapshots.
- Added structured lifecycle payload outputs: `feedback_checkin`, `projection_timeline`, `projection_delta_summary` on recommendation detail bundles.
- Added lightweight `lifecycle_companion` output on job detail bundles.
- Added feedback write API: `POST /api/v0.5/career/recommendations/mbti/{type}/feedback`.
- Added persistence for feedback records via `career_feedback_records` migration/model.
- Added append-only lineage wiring: new feedback creates new context/projection/recommendation snapshots and lineage entry.
- Re-review fix: clone `transition_paths` from previous snapshot to new feedback-refresh snapshot to avoid transition loss and false `transition_changed`.

## Why
- Establish backend-owned time-travel baseline without overwriting historical snapshots/projections.
- Keep lifecycle deltas/timeline strictly structured and replayable for frontend consumption.
- Preserve transition continuity after feedback refresh.

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Feedback/*.php app/DTO/Career/CareerFeedback*.php app/DTO/Career/CareerProjection*.php tests/Unit/Services/Career/*Feedback*.php tests/Unit/Services/Career/*Timeline*.php tests/Feature/Career/*Recommendation*.php tests/Feature/Career/*JobDetail*.php`
- `php artisan test tests/Unit/Services/Career/*Feedback*.php tests/Unit/Services/Career/*Timeline*.php`
- `php artisan test tests/Feature/Career/*Recommendation*.php tests/Feature/Career/*JobDetail*.php`

## Intentionally Deferred
- No frontend/UI changes in this PR.
- No algorithm rewrite, no paid strategy package, no analytics dashboard.
- No family-hub lifecycle surface.
