### PR TITLE
PR-B77X: Career threshold config + experiment authority (backend)

### DIFF
--- a/backend/app/DTO/Career/CareerThresholdExperimentAuthority.php
+++ b/backend/app/DTO/Career/CareerThresholdExperimentAuthority.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerThresholdExperimentAuthority
+{
+    public function __construct(
+        public readonly CareerThresholdExperimentSnapshot $snapshot,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'authority_kind' => 'career_threshold_experiment_authority',
+            'authority_version' => 'career.threshold_experiment.v1',
+            ...$this->snapshot->toArray(),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerThresholdExperimentSnapshot.php
+++ b/backend/app/DTO/Career/CareerThresholdExperimentSnapshot.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerThresholdExperimentSnapshot
+{
+    /**
+     * @param  array<string, mixed>  $thresholds
+     * @param  array<string, mixed>  $experiments
+     */
+    public function __construct(
+        public readonly string $snapshotKey,
+        public readonly array $thresholds,
+        public readonly array $experiments,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'snapshot_key' => $this->snapshotKey,
+            'thresholds' => $this->thresholds,
+            'experiments' => $this->experiments,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveIndexPolicyEngine.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveIndexPolicyEngine.php
@@ -7,10 +7,15 @@ namespace App\Domain\Career\Publish;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerFirstWaveIndexPolicyAuthority;
 use App\DTO\Career\CareerFirstWaveIndexPolicyMember;
+use App\Services\Career\Config\CareerThresholdExperimentAuthorityService;
 
 final class CareerFirstWaveIndexPolicyEngine
 {
     public const SCOPE = 'career_first_wave_10';
+
+    public function __construct(
+        private readonly CareerThresholdExperimentAuthorityService $runtimeConfigAuthority,
+    ) {}
 
     /**
      * @param  list<array<string, mixed>>  $subjects
@@ -106,7 +111,7 @@ final class CareerFirstWaveIndexPolicyEngine
             $policyReasons[] = 'insufficient_next_step_links';
         }
 
-        if ($confidenceScore !== null && $confidenceScore < 60) {
+        if ($confidenceScore !== null && $confidenceScore < $this->runtimeConfigAuthority->confidencePublishMin()) {
             $policyReasons[] = 'confidence_below_threshold';
         }
 

--- a/backend/app/Domain/Career/Publish/CareerFirstWavePromotionCandidateEngine.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWavePromotionCandidateEngine.php
@@ -7,6 +7,7 @@ namespace App\Domain\Career\Publish;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerFirstWavePromotionCandidateAuthority;
 use App\DTO\Career\CareerFirstWavePromotionCandidateMember;
+use App\Services\Career\Config\CareerThresholdExperimentAuthorityService;
 
 final class CareerFirstWavePromotionCandidateEngine
 {
@@ -17,10 +18,6 @@ final class CareerFirstWavePromotionCandidateEngine
     public const DECISION_MANUAL_REVIEW_ONLY = 'manual_review_only';
 
     public const DECISION_NOT_ELIGIBLE = 'not_eligible';
-
-    private const CONFIDENCE_THRESHOLD = 70;
-
-    private const MIN_NEXT_STEP_LINKS = 2;
 
     /**
      * @var array<string, true>
@@ -38,6 +35,10 @@ final class CareerFirstWavePromotionCandidateEngine
         'family_proxy' => true,
         'unmapped' => true,
     ];
+
+    public function __construct(
+        private readonly CareerThresholdExperimentAuthorityService $runtimeConfigAuthority,
+    ) {}
 
     /**
      * @param  list<array<string, mixed>>  $subjects
@@ -106,10 +107,12 @@ final class CareerFirstWavePromotionCandidateEngine
             ],
         ];
 
-        $isConfidenceEligible = $confidenceScore !== null && $confidenceScore >= self::CONFIDENCE_THRESHOLD;
+        $isConfidenceEligible = $confidenceScore !== null
+            && $confidenceScore >= $this->runtimeConfigAuthority->confidencePromotionCandidateMin();
         $isReviewerApproved = $reviewerStatus === 'approved';
         $isCrosswalkAutoSafe = $crosswalkMode !== null && isset(self::AUTO_CROSSWALK_MODES[$crosswalkMode]);
         $isNotEligibleCrosswalk = $crosswalkMode !== null && isset(self::NOT_ELIGIBLE_CROSSWALK_MODES[$crosswalkMode]);
+        $strongClaimRequired = $this->runtimeConfigAuthority->promotionStrongClaimRequired();
 
         $decision = self::DECISION_MANUAL_REVIEW_ONLY;
         $decisionReasons = [];
@@ -135,7 +138,7 @@ final class CareerFirstWavePromotionCandidateEngine
             $decisionReasons[] = 'confidence_at_or_above_threshold';
         }
 
-        if (! $allowStrongClaim) {
+        if ($strongClaimRequired && ! $allowStrongClaim) {
             $decision = self::DECISION_NOT_ELIGIBLE;
             $decisionReasons[] = 'strong_claim_blocked';
         } else {
@@ -149,7 +152,7 @@ final class CareerFirstWavePromotionCandidateEngine
             $decisionReasons[] = 'not_governance_blocked';
         }
 
-        if ($nextStepLinksCount < self::MIN_NEXT_STEP_LINKS) {
+        if ($nextStepLinksCount < $this->runtimeConfigAuthority->promotionNextStepLinksMin()) {
             $decision = self::DECISION_NOT_ELIGIBLE;
             $decisionReasons[] = 'next_step_links_insufficient';
         } else {

--- a/backend/app/Domain/Career/Scoring/WarningMatrix.php
+++ b/backend/app/Domain/Career/Scoring/WarningMatrix.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace App\Domain\Career\Scoring;
 
 use App\Domain\Career\IndexStateValue;
+use App\Services\Career\Config\CareerThresholdExperimentAuthorityService;
 
 final class WarningMatrix
 {
+    public function __construct(
+        private readonly CareerThresholdExperimentAuthorityService $runtimeConfigAuthority,
+    ) {}
+
     /**
      * @param  array<string,mixed>  $context
      * @param  array<string,CareerScoreResult>  $scoreBundle
@@ -48,7 +53,8 @@ final class WarningMatrix
             $blockedClaims[] = 'strong_claim';
         }
 
-        if (ScoreMath::normalizeNullable($context['quality_confidence'] ?? null, 0.7) < 0.72) {
+        $qualityConfidenceThreshold = ((float) $this->runtimeConfigAuthority->warningLowConfidenceThreshold()) / 100.0;
+        if (ScoreMath::normalizeNullable($context['quality_confidence'] ?? null, 0.7) < $qualityConfidenceThreshold) {
             $amberFlags[] = ClaimReasonCode::LOW_QUALITY_CONFIDENCE;
             $blockedClaims[] = 'strong_claim';
         }

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerRuntimeConfigController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerRuntimeConfigController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\CareerRuntimeConfigResource;
+use App\Services\Career\Config\CareerThresholdExperimentAuthorityService;
+
+final class CareerRuntimeConfigController extends Controller
+{
+    public function __construct(
+        private readonly CareerThresholdExperimentAuthorityService $authorityService,
+    ) {}
+
+    public function show(): CareerRuntimeConfigResource
+    {
+        return new CareerRuntimeConfigResource($this->authorityService->buildAuthority());
+    }
+}

--- a/backend/app/Http/Resources/Career/CareerRuntimeConfigResource.php
+++ b/backend/app/Http/Resources/Career/CareerRuntimeConfigResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career;
+
+use App\DTO\Career\CareerThresholdExperimentAuthority;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CareerThresholdExperimentAuthority
+ */
+final class CareerRuntimeConfigResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CareerThresholdExperimentAuthority $authority */
+        $authority = $this->resource;
+
+        return $authority->toArray();
+    }
+}

--- a/backend/app/Services/Career/Config/CareerThresholdExperimentAuthorityService.php
+++ b/backend/app/Services/Career/Config/CareerThresholdExperimentAuthorityService.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Config;
+
+use App\DTO\Career\CareerThresholdExperimentAuthority;
+use App\DTO\Career\CareerThresholdExperimentSnapshot;
+use App\Support\RuntimeConfig;
+
+final class CareerThresholdExperimentAuthorityService
+{
+    public const DEFAULT_SNAPSHOT_KEY = 'career_default_v1';
+
+    public const THRESHOLD_CONFIDENCE_PUBLISH_MIN = 60;
+
+    public const THRESHOLD_CONFIDENCE_PROMOTION_CANDIDATE_MIN = 70;
+
+    public const THRESHOLD_CONFIDENCE_STABLE_MIN = 75;
+
+    public const THRESHOLD_WARNING_LOW_CONFIDENCE = 72;
+
+    public const THRESHOLD_WARNING_HIGH_STRAIN = 70;
+
+    public const THRESHOLD_WARNING_AI_RISK = 65;
+
+    public const THRESHOLD_PROMOTION_NEXT_STEP_LINKS_MIN = 2;
+
+    public const THRESHOLD_PROMOTION_STRONG_CLAIM_REQUIRED = true;
+
+    public function buildAuthority(): CareerThresholdExperimentAuthority
+    {
+        return new CareerThresholdExperimentAuthority(
+            snapshot: new CareerThresholdExperimentSnapshot(
+                snapshotKey: $this->snapshotKey(),
+                thresholds: $this->thresholds(),
+                experiments: $this->experiments(),
+            ),
+        );
+    }
+
+    public function confidencePublishMin(): int
+    {
+        return (int) data_get($this->thresholds(), 'confidence.publish_min', self::THRESHOLD_CONFIDENCE_PUBLISH_MIN);
+    }
+
+    public function confidencePromotionCandidateMin(): int
+    {
+        return (int) data_get(
+            $this->thresholds(),
+            'confidence.promotion_candidate_min',
+            self::THRESHOLD_CONFIDENCE_PROMOTION_CANDIDATE_MIN
+        );
+    }
+
+    public function confidenceStableMin(): int
+    {
+        return (int) data_get($this->thresholds(), 'confidence.stable_min', self::THRESHOLD_CONFIDENCE_STABLE_MIN);
+    }
+
+    public function warningLowConfidenceThreshold(): int
+    {
+        return (int) data_get(
+            $this->thresholds(),
+            'warnings.low_confidence_threshold',
+            self::THRESHOLD_WARNING_LOW_CONFIDENCE
+        );
+    }
+
+    public function warningHighStrainThreshold(): int
+    {
+        return (int) data_get(
+            $this->thresholds(),
+            'warnings.high_strain_threshold',
+            self::THRESHOLD_WARNING_HIGH_STRAIN
+        );
+    }
+
+    public function warningAiRiskThreshold(): int
+    {
+        return (int) data_get($this->thresholds(), 'warnings.ai_risk_threshold', self::THRESHOLD_WARNING_AI_RISK);
+    }
+
+    public function promotionNextStepLinksMin(): int
+    {
+        return (int) data_get(
+            $this->thresholds(),
+            'promotion.next_step_links_min',
+            self::THRESHOLD_PROMOTION_NEXT_STEP_LINKS_MIN
+        );
+    }
+
+    public function promotionStrongClaimRequired(): bool
+    {
+        return (bool) data_get(
+            $this->thresholds(),
+            'promotion.strong_claim_required',
+            self::THRESHOLD_PROMOTION_STRONG_CLAIM_REQUIRED
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function thresholds(): array
+    {
+        $configured = RuntimeConfig::raw('career.threshold_experiment.thresholds');
+        if (is_array($configured)) {
+            return array_replace_recursive($this->defaultThresholds(), $configured);
+        }
+
+        return $this->defaultThresholds();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function experiments(): array
+    {
+        $configured = RuntimeConfig::raw('career.threshold_experiment.experiments');
+        if (is_array($configured)) {
+            return array_replace_recursive($this->defaultExperiments(), $configured);
+        }
+
+        return $this->defaultExperiments();
+    }
+
+    private function snapshotKey(): string
+    {
+        $configured = RuntimeConfig::value('career.threshold_experiment.snapshot_key', self::DEFAULT_SNAPSHOT_KEY);
+        $normalized = is_string($configured) ? trim($configured) : '';
+
+        return $normalized !== '' ? $normalized : self::DEFAULT_SNAPSHOT_KEY;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function defaultThresholds(): array
+    {
+        return [
+            'confidence' => [
+                'publish_min' => self::THRESHOLD_CONFIDENCE_PUBLISH_MIN,
+                'promotion_candidate_min' => self::THRESHOLD_CONFIDENCE_PROMOTION_CANDIDATE_MIN,
+                'stable_min' => self::THRESHOLD_CONFIDENCE_STABLE_MIN,
+            ],
+            'warnings' => [
+                'low_confidence_threshold' => self::THRESHOLD_WARNING_LOW_CONFIDENCE,
+                'high_strain_threshold' => self::THRESHOLD_WARNING_HIGH_STRAIN,
+                'ai_risk_threshold' => self::THRESHOLD_WARNING_AI_RISK,
+            ],
+            'promotion' => [
+                'next_step_links_min' => self::THRESHOLD_PROMOTION_NEXT_STEP_LINKS_MIN,
+                'strong_claim_required' => self::THRESHOLD_PROMOTION_STRONG_CLAIM_REQUIRED,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{enabled: bool, variant: string}>
+     */
+    private function defaultExperiments(): array
+    {
+        return [
+            'career_warning_copy_v1' => [
+                'enabled' => true,
+                'variant' => 'control',
+            ],
+            'career_explorer_primary_path_v1' => [
+                'enabled' => true,
+                'variant' => 'jobs_first',
+            ],
+            'career_transition_emphasis_v1' => [
+                'enabled' => true,
+                'variant' => 'balanced',
+            ],
+        ];
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T15:28:00+08:00",
+  "updated_at": "2026-04-16T07:55:52.360319Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2225,10 +2225,10 @@
     "PR-B77X": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b77x-career-threshold-experiment-authority",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "f82ba907",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/922",
       "checks": {
         "local": [
           {
@@ -2244,9 +2244,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24498764362/job/71599946364"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24498750966/job/71599904494"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24498764362/job/71599956092"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24498750966/job/71599911148"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub checks failed: hygiene jobs failed and verify-mbti jobs skipped on PR #922; local checks passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2221,6 +2221,36 @@
       "merged_at": "",
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-B77X": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-b77x-career-threshold-experiment-authority",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Config/*.php app/DTO/Career/CareerThresholdExperiment*.php app/Http/Controllers/API/V0_5/Career/CareerRuntimeConfigController.php app/Http/Resources/Career/CareerRuntimeConfigResource.php tests/Unit/Services/Career/*Threshold*Test.php tests/Feature/Career/*RuntimeConfig*Test.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/*Threshold*Test.php tests/Feature/Career/*RuntimeConfig*Test.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1290,6 +1290,31 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B77X
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b77x-career-threshold-experiment-authority
+    base: main
+    depends_on: ["PR-B76X"]
+    mode: execute
+    scope: >
+      Career threshold config + experiment authority (backend).
+      Formalize confidence/warning/promotion thresholds and minimal experiment flags
+      into a single backend-owned runtime config authority with additive read contract.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Config/*.php app/DTO/Career/CareerThresholdExperiment*.php app/Http/Controllers/API/V0_5/Career/CareerRuntimeConfigController.php app/Http/Resources/Career/CareerRuntimeConfigResource.php tests/Unit/Services/Career/*Threshold*Test.php tests/Feature/Career/*RuntimeConfig*Test.php"
+      - "php artisan test tests/Unit/Services/Career/*Threshold*Test.php tests/Feature/Career/*RuntimeConfig*Test.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -49,6 +49,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerRecommendationDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationExplainabilityController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationFeedbackController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationIndexController;
+use App\Http\Controllers\API\V0_5\Career\CareerRuntimeConfigController;
 use App\Http\Controllers\API\V0_5\Career\CareerSearchController;
 use App\Http\Controllers\API\V0_5\Career\CareerTransitionPreviewController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
@@ -433,6 +434,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/recommendations/mbti/{type}', [CareerRecommendationDetailController::class, 'show']);
     Route::get('/career/recommendations/mbti/{type}/explainability', [CareerRecommendationExplainabilityController::class, 'show']);
     Route::post('/career/recommendations/mbti/{type}/feedback', [CareerRecommendationFeedbackController::class, 'store']);
+    Route::get('/career/runtime-config', [CareerRuntimeConfigController::class, 'show']);
     Route::get('/career/transition-preview', [CareerTransitionPreviewController::class, 'show']);
     Route::get('/career/search', [CareerSearchController::class, 'index']);
     Route::get('/career/datasets/occupations', [CareerDatasetHubController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerRuntimeConfigApiTest.php
+++ b/backend/tests/Feature/Career/CareerRuntimeConfigApiTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use Tests\TestCase;
+
+final class CareerRuntimeConfigApiTest extends TestCase
+{
+    public function test_it_returns_runtime_threshold_experiment_authority_payload(): void
+    {
+        $this->getJson('/api/v0.5/career/runtime-config')
+            ->assertOk()
+            ->assertJsonPath('authority_kind', 'career_threshold_experiment_authority')
+            ->assertJsonPath('authority_version', 'career.threshold_experiment.v1')
+            ->assertJsonPath('snapshot_key', 'career_default_v1')
+            ->assertJsonPath('thresholds.confidence.publish_min', 60)
+            ->assertJsonPath('thresholds.confidence.promotion_candidate_min', 70)
+            ->assertJsonPath('thresholds.confidence.stable_min', 75)
+            ->assertJsonPath('thresholds.warnings.low_confidence_threshold', 72)
+            ->assertJsonPath('thresholds.warnings.high_strain_threshold', 70)
+            ->assertJsonPath('thresholds.warnings.ai_risk_threshold', 65)
+            ->assertJsonPath('thresholds.promotion.next_step_links_min', 2)
+            ->assertJsonPath('thresholds.promotion.strong_claim_required', true)
+            ->assertJsonPath('experiments.career_warning_copy_v1.enabled', true)
+            ->assertJsonPath('experiments.career_warning_copy_v1.variant', 'control')
+            ->assertJsonPath('experiments.career_explorer_primary_path_v1.variant', 'jobs_first')
+            ->assertJsonPath('experiments.career_transition_emphasis_v1.variant', 'balanced');
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerThresholdExperimentAuthorityServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerThresholdExperimentAuthorityServiceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Config\CareerThresholdExperimentAuthorityService;
+use Tests\TestCase;
+
+final class CareerThresholdExperimentAuthorityServiceTest extends TestCase
+{
+    public function test_it_builds_default_threshold_and_experiment_authority_snapshot(): void
+    {
+        $authority = app(CareerThresholdExperimentAuthorityService::class)->buildAuthority()->toArray();
+
+        $this->assertSame('career_threshold_experiment_authority', $authority['authority_kind'] ?? null);
+        $this->assertSame('career.threshold_experiment.v1', $authority['authority_version'] ?? null);
+        $this->assertSame('career_default_v1', $authority['snapshot_key'] ?? null);
+        $this->assertSame(60, data_get($authority, 'thresholds.confidence.publish_min'));
+        $this->assertSame(70, data_get($authority, 'thresholds.confidence.promotion_candidate_min'));
+        $this->assertSame(75, data_get($authority, 'thresholds.confidence.stable_min'));
+        $this->assertSame(72, data_get($authority, 'thresholds.warnings.low_confidence_threshold'));
+        $this->assertSame(70, data_get($authority, 'thresholds.warnings.high_strain_threshold'));
+        $this->assertSame(65, data_get($authority, 'thresholds.warnings.ai_risk_threshold'));
+        $this->assertSame(2, data_get($authority, 'thresholds.promotion.next_step_links_min'));
+        $this->assertSame(true, data_get($authority, 'thresholds.promotion.strong_claim_required'));
+        $this->assertSame(true, data_get($authority, 'experiments.career_warning_copy_v1.enabled'));
+        $this->assertSame('control', data_get($authority, 'experiments.career_warning_copy_v1.variant'));
+        $this->assertSame('jobs_first', data_get($authority, 'experiments.career_explorer_primary_path_v1.variant'));
+        $this->assertSame('balanced', data_get($authority, 'experiments.career_transition_emphasis_v1.variant'));
+    }
+}


### PR DESCRIPTION
## What Changed
- Added `CareerThresholdExperimentAuthorityService` and DTOs to formalize threshold + experiment authority snapshot.
- Added runtime-config API surface: `GET /api/v0.5/career/runtime-config` via controller/resource.
- Refactored threshold consumption to read from authority in:
  - `CareerFirstWaveIndexPolicyEngine`
  - `CareerFirstWavePromotionCandidateEngine`
  - `WarningMatrix`
- Added/initialized PR train manifest + state entries for `PR-B77X`.
- Added unit/feature tests for authority snapshot and runtime-config API.

## Why
- Remove threshold/experiment config drift across services.
- Establish backend-owned, versioned runtime-config authority for safe frontend consumption.
- Keep existing truth/algorithms intact while unifying configuration source.

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Config/*.php app/DTO/Career/CareerThresholdExperiment*.php app/Http/Controllers/API/V0_5/Career/CareerRuntimeConfigController.php app/Http/Resources/Career/CareerRuntimeConfigResource.php tests/Unit/Services/Career/*Threshold*Test.php tests/Feature/Career/*RuntimeConfig*Test.php`
- `php artisan test tests/Unit/Services/Career/*Threshold*Test.php tests/Feature/Career/*RuntimeConfig*Test.php`

## Intentionally Deferred
- No experiment platform UI/enrollment/analytics pipeline.
- No new algorithmic truth; authority is config-only formalization.
- No unrelated API surface expansion beyond minimal runtime-config endpoint.
