### PR TITLE
PR-B78X: Career crosswalk/editorial ops console baseline (backend)

### DIFF
--- a/backend/app/Domain/Career/Operations/CareerCrosswalkOverrideReadModelService.php
+++ b/backend/app/Domain/Career/Operations/CareerCrosswalkOverrideReadModelService.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Operations;
+
+use App\Models\Occupation;
+
+final class CareerCrosswalkOverrideReadModelService
+{
+    public function __construct(
+        private readonly CareerEditorialPatchAuthorityService $patchAuthorityService,
+        private readonly CareerCrosswalkOverrideResolver $overrideResolver,
+    ) {}
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function forSubject(string $subjectSlug): ?array
+    {
+        $slug = trim($subjectSlug);
+        if ($slug === '') {
+            return null;
+        }
+
+        $occupation = Occupation::query()
+            ->select(['id', 'canonical_slug', 'canonical_title_en', 'crosswalk_mode'])
+            ->where('canonical_slug', $slug)
+            ->first();
+        if (! $occupation instanceof Occupation) {
+            return null;
+        }
+
+        $subject = [
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'canonical_title_en' => (string) ($occupation->canonical_title_en ?? ''),
+            'crosswalk_mode' => (string) ($occupation->crosswalk_mode ?? ''),
+        ];
+
+        $patches = (array) (($this->patchAuthorityService->build()->toArray())['patches'] ?? []);
+        $approvedBySlug = [];
+        foreach ($patches as $patch) {
+            if (! is_array($patch)) {
+                continue;
+            }
+            if (trim((string) ($patch['subject_slug'] ?? '')) !== $slug) {
+                continue;
+            }
+            if (strtolower(trim((string) ($patch['patch_status'] ?? ''))) !== 'approved') {
+                continue;
+            }
+            $approvedBySlug[$slug] = $patch;
+        }
+
+        $resolved = $this->overrideResolver->resolve([$subject], $approvedBySlug);
+        $resolvedItem = is_array(($resolved['resolved'][0] ?? null)) ? $resolved['resolved'][0] : null;
+        if (! is_array($resolvedItem)) {
+            return null;
+        }
+
+        return [
+            'override_kind' => 'career_crosswalk_override_read_model',
+            'override_version' => 'career.crosswalk.override.read_model.v1',
+            'subject_slug' => $slug,
+            'canonical_title_en' => (string) ($occupation->canonical_title_en ?? ''),
+            'original_crosswalk_mode' => $resolvedItem['original_crosswalk_mode'] ?? null,
+            'resolved_crosswalk_mode' => $resolvedItem['resolved_crosswalk_mode'] ?? null,
+            'resolved_target_kind' => $resolvedItem['resolved_target_kind'] ?? null,
+            'resolved_target_slug' => $resolvedItem['resolved_target_slug'] ?? null,
+            'override_applied' => (bool) ($resolvedItem['override_applied'] ?? false),
+            'applied_patch_key' => $resolvedItem['applied_patch_key'] ?? null,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Operations/CareerCrosswalkReviewQueueReadModelService.php
+++ b/backend/app/Domain/Career/Operations/CareerCrosswalkReviewQueueReadModelService.php
@@ -1,0 +1,445 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Operations;
+
+use App\Domain\Career\Production\CareerAssetBatchManifestBuilder;
+use App\Models\Occupation;
+use RuntimeException;
+
+final class CareerCrosswalkReviewQueueReadModelService
+{
+    /**
+     * @var array<string, int>
+     */
+    private const MODE_RISK_PRIORITY = [
+        'local_heavy_interpretation' => 400,
+        'unmapped' => 300,
+        'family_proxy' => 200,
+        'functional_equivalent' => 100,
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const DEFAULT_BATCH_MANIFEST_PATHS = [
+        'docs/career/batches/batch_2_manifest.json',
+        'docs/career/batches/batch_3_manifest.json',
+        'docs/career/batches/batch_4_manifest.json',
+    ];
+
+    public function __construct(
+        private readonly CareerEditorialPatchAuthorityService $patchAuthorityService,
+        private readonly CareerCrosswalkReviewQueueService $reviewQueueService,
+        private readonly CareerAssetBatchManifestBuilder $manifestBuilder,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $filters
+     * @return array<string, mixed>
+     */
+    public function list(array $filters = []): array
+    {
+        $subjects = $this->subjects();
+        $subjectsBySlug = $this->subjectsBySlug($subjects);
+        $slugs = array_keys($subjectsBySlug);
+        $familySlugBySlug = $this->familySlugBySlug($slugs);
+
+        $patches = (array) (($this->patchAuthorityService->build()->toArray())['patches'] ?? []);
+        $latestPatchBySlug = $this->latestPatchBySlug($patches);
+        $approvedPatchBySlug = $this->approvedPatchBySlug($patches);
+        $batchContextBySlug = $this->batchContextBySlug();
+
+        $queue = $this->reviewQueueService->build(
+            subjects: $subjects,
+            approvedPatchesBySlug: $approvedPatchBySlug,
+            batchContextBySlug: $batchContextBySlug,
+        )->toArray();
+
+        $items = array_map(function (array $item) use ($subjectsBySlug, $familySlugBySlug, $latestPatchBySlug): array {
+            $slug = trim((string) ($item['subject_slug'] ?? ''));
+            $subject = $subjectsBySlug[$slug] ?? [];
+            $latestPatch = $latestPatchBySlug[$slug] ?? null;
+            $latestStatus = is_array($latestPatch) ? strtolower(trim((string) ($latestPatch['patch_status'] ?? ''))) : null;
+
+            return [
+                'subject_slug' => $slug,
+                'canonical_title_en' => $this->nullableString($subject['canonical_title_en'] ?? null),
+                'family_slug' => $familySlugBySlug[$slug] ?? null,
+                'current_crosswalk_mode' => $this->nullableString($item['current_crosswalk_mode'] ?? null),
+                'candidate_target_kind' => $this->nullableString($item['candidate_target_kind'] ?? null),
+                'candidate_target_slug' => $this->nullableString($item['candidate_target_slug'] ?? null),
+                'queue_reason' => $this->normalizeStringArray($item['queue_reason'] ?? []),
+                'requires_editorial_patch' => (bool) ($item['requires_editorial_patch'] ?? false),
+                'batch_origin' => $this->nullableString($item['batch_origin'] ?? null),
+                'publish_track' => $this->nullableString($item['publish_track'] ?? null),
+                'blocking_flags' => $this->normalizeStringArray($item['blocking_flags'] ?? []),
+                'has_approved_patch' => $latestStatus === 'approved',
+                'latest_patch_key' => is_array($latestPatch) ? $this->nullableString($latestPatch['patch_key'] ?? null) : null,
+                'latest_patch_status' => $latestStatus,
+                'latest_patch_version' => is_array($latestPatch) ? $this->nullableString($latestPatch['patch_version'] ?? null) : null,
+                'latest_patch_created_at' => is_array($latestPatch) ? $this->nullableString($latestPatch['created_at'] ?? null) : null,
+            ];
+        }, (array) ($queue['items'] ?? []));
+
+        $filtered = $this->applyFilters($items, $filters);
+        $sorted = $this->applySorting($filtered, (string) ($filters['sort'] ?? 'risk'));
+
+        return [
+            'queue_kind' => 'career_crosswalk_review_queue_read_model',
+            'queue_version' => 'career.crosswalk.review_queue.read_model.v1',
+            'scope' => (string) ($queue['scope'] ?? 'career_crosswalk_editorial_ops'),
+            'filters_applied' => $this->normalizeFilterEcho($filters),
+            'counts' => [
+                'total' => count($sorted),
+                'local_heavy_interpretation' => $this->countByMode($sorted, 'local_heavy_interpretation'),
+                'family_proxy' => $this->countByMode($sorted, 'family_proxy'),
+                'functional_equivalent' => $this->countByMode($sorted, 'functional_equivalent'),
+                'unmapped' => $this->countByMode($sorted, 'unmapped'),
+                'requires_editorial_patch' => count(array_filter(
+                    $sorted,
+                    static fn (array $item): bool => (bool) ($item['requires_editorial_patch'] ?? false)
+                )),
+                'has_approved_patch' => count(array_filter(
+                    $sorted,
+                    static fn (array $item): bool => (bool) ($item['has_approved_patch'] ?? false)
+                )),
+            ],
+            'items' => array_values($sorted),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function subjects(): array
+    {
+        return Occupation::query()
+            ->with('indexStates:id,occupation_id,index_state,index_eligible,changed_at,updated_at')
+            ->orderBy('canonical_slug')
+            ->get(['id', 'canonical_slug', 'canonical_title_en', 'crosswalk_mode'])
+            ->map(function (Occupation $occupation): array {
+                $indexState = $occupation->indexStates->sortByDesc(
+                    static fn ($row): int => strtotime((string) ($row->changed_at ?? $row->updated_at ?? '')) ?: 0
+                )->first();
+
+                $readinessStatus = 'blocked_override_eligible';
+                if ($indexState !== null && ($indexState->index_state ?? null) === 'indexable') {
+                    $readinessStatus = 'publish_ready';
+                }
+
+                return [
+                    'canonical_slug' => (string) $occupation->canonical_slug,
+                    'canonical_title_en' => (string) ($occupation->canonical_title_en ?? ''),
+                    'crosswalk_mode' => (string) ($occupation->crosswalk_mode ?? ''),
+                    'readiness_status' => $readinessStatus,
+                    'blocked_governance_status' => null,
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function item(string $slug, array $filters = []): ?array
+    {
+        $normalized = trim($slug);
+        if ($normalized === '') {
+            return null;
+        }
+
+        $payload = $this->list($filters);
+        foreach ((array) ($payload['items'] ?? []) as $item) {
+            if (trim((string) ($item['subject_slug'] ?? '')) === $normalized) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $subjects
+     * @return array<string, array<string, mixed>>
+     */
+    private function subjectsBySlug(array $subjects): array
+    {
+        $result = [];
+        foreach ($subjects as $subject) {
+            if (! is_array($subject)) {
+                continue;
+            }
+            $slug = trim((string) ($subject['canonical_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+            $result[$slug] = $subject;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, string>
+     */
+    private function familySlugBySlug(array $slugs): array
+    {
+        if ($slugs === []) {
+            return [];
+        }
+
+        return Occupation::query()
+            ->with('family:id,canonical_slug')
+            ->whereIn('canonical_slug', $slugs)
+            ->get(['id', 'family_id', 'canonical_slug'])
+            ->mapWithKeys(static function (Occupation $occupation): array {
+                $slug = trim((string) ($occupation->canonical_slug ?? ''));
+                $familySlug = trim((string) ($occupation->family?->canonical_slug ?? ''));
+                if ($slug === '' || $familySlug === '') {
+                    return [];
+                }
+
+                return [$slug => $familySlug];
+            })
+            ->all();
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     * @return array<string, array<string, mixed>>
+     */
+    private function latestPatchBySlug(array $patches): array
+    {
+        $grouped = [];
+        foreach ($patches as $patch) {
+            if (! is_array($patch)) {
+                continue;
+            }
+            $slug = trim((string) ($patch['subject_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+            $grouped[$slug][] = $patch;
+        }
+
+        $latest = [];
+        foreach ($grouped as $slug => $items) {
+            usort($items, static function (array $a, array $b): int {
+                $aTime = strtotime((string) ($a['reviewed_at'] ?? $a['created_at'] ?? '')) ?: 0;
+                $bTime = strtotime((string) ($b['reviewed_at'] ?? $b['created_at'] ?? '')) ?: 0;
+                if ($aTime !== $bTime) {
+                    return $bTime <=> $aTime;
+                }
+
+                return strcmp((string) ($b['patch_version'] ?? ''), (string) ($a['patch_version'] ?? ''));
+            });
+
+            $latest[$slug] = $items[0];
+        }
+
+        return $latest;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     * @return array<string, array<string, mixed>>
+     */
+    private function approvedPatchBySlug(array $patches): array
+    {
+        $approved = [];
+        foreach ($this->latestPatchBySlug($patches) as $slug => $patch) {
+            $status = strtolower(trim((string) ($patch['patch_status'] ?? '')));
+            if ($status === 'approved') {
+                $approved[$slug] = $patch;
+            }
+        }
+
+        return $approved;
+    }
+
+    /**
+     * @return array<string, array{batch_origin:?string,publish_track:?string,family_slug:?string}>
+     */
+    private function batchContextBySlug(): array
+    {
+        $context = [];
+
+        foreach (self::DEFAULT_BATCH_MANIFEST_PATHS as $path) {
+            try {
+                $manifest = $this->manifestBuilder->fromPath($path);
+            } catch (RuntimeException) {
+                continue;
+            }
+
+            foreach ($manifest->members as $member) {
+                if (! isset($context[$member->canonicalSlug])) {
+                    $context[$member->canonicalSlug] = [
+                        'batch_origin' => $manifest->batchKey,
+                        'publish_track' => $member->expectedPublishTrack,
+                        'family_slug' => $member->familySlug,
+                    ];
+                }
+            }
+        }
+
+        return $context;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @param  array<string, mixed>  $filters
+     * @return list<array<string, mixed>>
+     */
+    private function applyFilters(array $items, array $filters): array
+    {
+        $crosswalkMode = $this->nullableString($filters['crosswalk_mode'] ?? null);
+        $publishTrack = $this->nullableString($filters['publish_track'] ?? null);
+        $batchOrigin = $this->nullableString($filters['batch_origin'] ?? null);
+        $queueReason = $this->nullableString($filters['queue_reason'] ?? null);
+        $requiresEditorialPatch = $this->toNullableBool($filters['requires_editorial_patch'] ?? null);
+
+        return array_values(array_filter($items, function (array $item) use (
+            $crosswalkMode,
+            $publishTrack,
+            $batchOrigin,
+            $queueReason,
+            $requiresEditorialPatch
+        ): bool {
+            if ($crosswalkMode !== null && strtolower((string) ($item['current_crosswalk_mode'] ?? '')) !== strtolower($crosswalkMode)) {
+                return false;
+            }
+            if ($publishTrack !== null && strtolower((string) ($item['publish_track'] ?? '')) !== strtolower($publishTrack)) {
+                return false;
+            }
+            if ($batchOrigin !== null && strtolower((string) ($item['batch_origin'] ?? '')) !== strtolower($batchOrigin)) {
+                return false;
+            }
+            if ($queueReason !== null) {
+                $reasons = array_map('strtolower', (array) ($item['queue_reason'] ?? []));
+                if (! in_array(strtolower($queueReason), $reasons, true)) {
+                    return false;
+                }
+            }
+            if ($requiresEditorialPatch !== null && (bool) ($item['requires_editorial_patch'] ?? false) !== $requiresEditorialPatch) {
+                return false;
+            }
+
+            return true;
+        }));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return list<array<string, mixed>>
+     */
+    private function applySorting(array $items, string $sort): array
+    {
+        $normalized = strtolower(trim($sort));
+        if (! in_array($normalized, ['slug', 'newest', 'risk'], true)) {
+            $normalized = 'risk';
+        }
+
+        usort($items, function (array $left, array $right) use ($normalized): int {
+            if ($normalized === 'slug') {
+                return strcmp(
+                    (string) ($left['subject_slug'] ?? ''),
+                    (string) ($right['subject_slug'] ?? ''),
+                );
+            }
+
+            if ($normalized === 'newest') {
+                $leftTime = strtotime((string) ($left['latest_patch_created_at'] ?? '')) ?: 0;
+                $rightTime = strtotime((string) ($right['latest_patch_created_at'] ?? '')) ?: 0;
+                if ($leftTime !== $rightTime) {
+                    return $rightTime <=> $leftTime;
+                }
+            }
+
+            $leftRisk = self::MODE_RISK_PRIORITY[(string) ($left['current_crosswalk_mode'] ?? '')] ?? 0;
+            $rightRisk = self::MODE_RISK_PRIORITY[(string) ($right['current_crosswalk_mode'] ?? '')] ?? 0;
+            if ($leftRisk !== $rightRisk) {
+                return $rightRisk <=> $leftRisk;
+            }
+
+            return strcmp(
+                (string) ($left['subject_slug'] ?? ''),
+                (string) ($right['subject_slug'] ?? ''),
+            );
+        });
+
+        return array_values($items);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function countByMode(array $items, string $mode): int
+    {
+        return count(array_filter($items, static fn (array $item): bool => (string) ($item['current_crosswalk_mode'] ?? '') === $mode));
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     * @return array<string, mixed>
+     */
+    private function normalizeFilterEcho(array $filters): array
+    {
+        return [
+            'crosswalk_mode' => $this->nullableString($filters['crosswalk_mode'] ?? null),
+            'requires_editorial_patch' => $this->toNullableBool($filters['requires_editorial_patch'] ?? null),
+            'publish_track' => $this->nullableString($filters['publish_track'] ?? null),
+            'batch_origin' => $this->nullableString($filters['batch_origin'] ?? null),
+            'queue_reason' => $this->nullableString($filters['queue_reason'] ?? null),
+            'sort' => $this->nullableString($filters['sort'] ?? null) ?? 'risk',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeStringArray(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(array_map(
+            fn (mixed $item): string => trim((string) $item),
+            $value,
+        ))));
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function toNullableBool(mixed $value): ?bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($value));
+        if (in_array($normalized, ['1', 'true', 'yes'], true)) {
+            return true;
+        }
+        if (in_array($normalized, ['0', 'false', 'no'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Domain/Career/Operations/CareerCrosswalkReviewQueueService.php
+++ b/backend/app/Domain/Career/Operations/CareerCrosswalkReviewQueueService.php
@@ -16,6 +16,7 @@ final class CareerCrosswalkReviewQueueService
         'local_heavy_interpretation' => true,
         'family_proxy' => true,
         'functional_equivalent' => true,
+        'unmapped' => true,
     ];
 
     /**
@@ -61,7 +62,8 @@ final class CareerCrosswalkReviewQueueService
             $queueReasons = match ($mode) {
                 'local_heavy_interpretation' => ['local_heavy_requires_editorial_patch'],
                 'family_proxy' => ['family_proxy_requires_editorial_patch'],
-                default => ['functional_equivalent_requires_editorial_review'],
+                'functional_equivalent' => ['functional_equivalent_requires_editorial_review'],
+                default => ['unmapped_requires_editorial_patch'],
             };
 
             $blockingFlags = [];

--- a/backend/app/Domain/Career/Operations/CareerEditorialPatchHistoryReadModelService.php
+++ b/backend/app/Domain/Career/Operations/CareerEditorialPatchHistoryReadModelService.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Operations;
+
+final class CareerEditorialPatchHistoryReadModelService
+{
+    public function __construct(
+        private readonly CareerEditorialPatchAuthorityService $patchAuthorityService,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function forSubject(string $subjectSlug): array
+    {
+        $slug = trim($subjectSlug);
+        $patches = (array) (($this->patchAuthorityService->build()->toArray())['patches'] ?? []);
+
+        $items = array_values(array_filter($patches, static fn (array $patch): bool => trim((string) ($patch['subject_slug'] ?? '')) === $slug));
+
+        usort($items, function (array $left, array $right): int {
+            $leftVersion = $this->versionRank((string) ($left['patch_version'] ?? 'v0'));
+            $rightVersion = $this->versionRank((string) ($right['patch_version'] ?? 'v0'));
+            if ($leftVersion !== $rightVersion) {
+                return $rightVersion <=> $leftVersion;
+            }
+
+            $leftTime = strtotime((string) ($left['created_at'] ?? '')) ?: 0;
+            $rightTime = strtotime((string) ($right['created_at'] ?? '')) ?: 0;
+
+            return $rightTime <=> $leftTime;
+        });
+
+        $latest = $items[0] ?? null;
+
+        return [
+            'history_kind' => 'career_editorial_patch_history',
+            'history_version' => 'career.editorial_patch.history.v1',
+            'subject_slug' => $slug,
+            'count' => count($items),
+            'latest_patch' => is_array($latest) ? $latest : null,
+            'status_counts' => [
+                'draft' => $this->countByStatus($items, 'draft'),
+                'queued' => $this->countByStatus($items, 'queued'),
+                'approved' => $this->countByStatus($items, 'approved'),
+                'rejected' => $this->countByStatus($items, 'rejected'),
+                'superseded' => $this->countByStatus($items, 'superseded'),
+            ],
+            'patches' => array_map(function (array $patch, int $index): array {
+                return array_merge($patch, [
+                    'is_latest' => $index === 0,
+                ]);
+            }, $items, array_keys($items)),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     */
+    private function countByStatus(array $patches, string $status): int
+    {
+        return count(array_filter(
+            $patches,
+            static fn (array $patch): bool => strtolower(trim((string) ($patch['patch_status'] ?? ''))) === $status
+        ));
+    }
+
+    private function versionRank(string $version): int
+    {
+        $normalized = strtolower(trim($version));
+        if (preg_match('/^v(\d+)$/', $normalized, $matches) === 1) {
+            return (int) ($matches[1] ?? 0);
+        }
+
+        return 0;
+    }
+}

--- a/backend/app/Domain/Career/Operations/CareerEditorialPatchMutationService.php
+++ b/backend/app/Domain/Career/Operations/CareerEditorialPatchMutationService.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Operations;
+
+use App\Models\EditorialPatch;
+use App\Models\Occupation;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class CareerEditorialPatchMutationService
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function create(array $payload): array
+    {
+        $subjectSlug = trim((string) ($payload['subject_slug'] ?? ''));
+        $targetKind = $this->normalizeTargetKind($payload['target_kind'] ?? null);
+        $targetSlug = trim((string) ($payload['target_slug'] ?? ''));
+        $modeOverride = trim((string) ($payload['crosswalk_mode_override'] ?? ''));
+        $reviewNotes = trim((string) ($payload['review_notes'] ?? ''));
+        $createdBy = trim((string) ($payload['created_by'] ?? ''));
+
+        if ($subjectSlug === '') {
+            throw new RuntimeException('subject_slug_required');
+        }
+        if ($targetSlug === '') {
+            throw new RuntimeException('target_slug_required');
+        }
+        if ($modeOverride === '') {
+            throw new RuntimeException('crosswalk_mode_override_required');
+        }
+
+        $occupation = Occupation::query()
+            ->where('canonical_slug', $subjectSlug)
+            ->first();
+        if (! $occupation instanceof Occupation) {
+            throw new RuntimeException('subject_slug_not_found');
+        }
+
+        $nextVersion = $this->nextVersion($occupation->id);
+        $now = now()->toISOString();
+
+        $patch = EditorialPatch::query()->create([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => (string) $occupation->id,
+            'required' => true,
+            'status' => 'draft',
+            'patch_version' => $nextVersion,
+            'notes' => [
+                'target_kind' => $targetKind,
+                'target_slug' => $targetSlug,
+                'crosswalk_mode_override' => $modeOverride,
+                'review_notes' => $reviewNotes === '' ? null : $reviewNotes,
+                'created_by' => $createdBy === '' ? null : $createdBy,
+                'created_at' => $now,
+            ],
+        ]);
+
+        return $this->normalize($patch->fresh('occupation'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function approve(string $patchKey, ?string $reviewNotes = null, ?string $reviewedBy = null): array
+    {
+        $patch = EditorialPatch::query()->with('occupation')->find($patchKey);
+        if (! $patch instanceof EditorialPatch) {
+            throw new RuntimeException('patch_not_found');
+        }
+
+        DB::transaction(function () use ($patch, $reviewNotes, $reviewedBy): void {
+            EditorialPatch::query()
+                ->where('occupation_id', $patch->occupation_id)
+                ->where('id', '!=', $patch->id)
+                ->where('status', 'approved')
+                ->get()
+                ->each(function (EditorialPatch $approved) use ($patch): void {
+                    $notes = is_array($approved->notes) ? $approved->notes : [];
+                    $notes['superseded_by'] = (string) $patch->id;
+                    $approved->forceFill([
+                        'status' => 'superseded',
+                        'notes' => $notes,
+                    ])->save();
+                });
+
+            $notes = is_array($patch->notes) ? $patch->notes : [];
+            $notes['review_notes'] = $reviewNotes !== null && trim($reviewNotes) !== ''
+                ? trim($reviewNotes)
+                : ($notes['review_notes'] ?? null);
+            $notes['reviewed_by'] = $reviewedBy !== null && trim($reviewedBy) !== ''
+                ? trim($reviewedBy)
+                : ($notes['reviewed_by'] ?? null);
+            $notes['reviewed_at'] = now()->toISOString();
+
+            $patch->forceFill([
+                'status' => 'approved',
+                'notes' => $notes,
+            ])->save();
+        });
+
+        return $this->normalize($patch->fresh('occupation'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function reject(string $patchKey, ?string $reviewNotes = null, ?string $reviewedBy = null): array
+    {
+        $patch = EditorialPatch::query()->with('occupation')->find($patchKey);
+        if (! $patch instanceof EditorialPatch) {
+            throw new RuntimeException('patch_not_found');
+        }
+
+        $notes = is_array($patch->notes) ? $patch->notes : [];
+        $notes['review_notes'] = $reviewNotes !== null && trim($reviewNotes) !== ''
+            ? trim($reviewNotes)
+            : ($notes['review_notes'] ?? null);
+        $notes['reviewed_by'] = $reviewedBy !== null && trim($reviewedBy) !== ''
+            ? trim($reviewedBy)
+            : ($notes['reviewed_by'] ?? null);
+        $notes['reviewed_at'] = now()->toISOString();
+
+        $patch->forceFill([
+            'status' => 'rejected',
+            'notes' => $notes,
+        ])->save();
+
+        return $this->normalize($patch->fresh('occupation'));
+    }
+
+    private function normalizeTargetKind(mixed $value): string
+    {
+        $normalized = strtolower(trim((string) $value));
+
+        return in_array($normalized, ['occupation', 'family'], true) ? $normalized : 'occupation';
+    }
+
+    private function nextVersion(string $occupationId): string
+    {
+        $latest = EditorialPatch::query()
+            ->where('occupation_id', $occupationId)
+            ->orderByDesc('created_at')
+            ->first();
+        if (! $latest instanceof EditorialPatch) {
+            return 'v1';
+        }
+
+        $current = strtolower(trim((string) ($latest->patch_version ?? 'v0')));
+        if (preg_match('/^v(\d+)$/', $current, $matches) !== 1) {
+            return 'v1';
+        }
+
+        return 'v'.(((int) ($matches[1] ?? 0)) + 1);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalize(EditorialPatch $patch): array
+    {
+        $notes = is_array($patch->notes) ? $patch->notes : [];
+
+        return [
+            'patch_key' => (string) $patch->id,
+            'patch_version' => trim((string) ($patch->patch_version ?? '')) !== '' ? (string) $patch->patch_version : 'v1',
+            'patch_status' => strtolower(trim((string) ($patch->status ?? 'draft'))),
+            'subject_kind' => 'career_job_detail',
+            'subject_slug' => trim((string) ($patch->occupation?->canonical_slug ?? '')),
+            'target_kind' => $this->normalizeTargetKind($notes['target_kind'] ?? null),
+            'target_slug' => trim((string) ($notes['target_slug'] ?? '')),
+            'crosswalk_mode_override' => trim((string) ($notes['crosswalk_mode_override'] ?? '')),
+            'review_notes' => trim((string) ($notes['review_notes'] ?? '')) !== '' ? trim((string) $notes['review_notes']) : null,
+            'created_by' => trim((string) ($notes['created_by'] ?? '')) !== '' ? trim((string) $notes['created_by']) : null,
+            'reviewed_by' => trim((string) ($notes['reviewed_by'] ?? '')) !== '' ? trim((string) $notes['reviewed_by']) : null,
+            'created_at' => optional($patch->created_at)->toISOString(),
+            'reviewed_at' => trim((string) ($notes['reviewed_at'] ?? '')) !== '' ? trim((string) $notes['reviewed_at']) : null,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Internal/Career/CareerCrosswalkOverrideController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Internal/Career/CareerCrosswalkOverrideController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Internal\Career;
+
+use App\Domain\Career\Operations\CareerCrosswalkOverrideReadModelService;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\Internal\CareerCrosswalkOverrideResource;
+
+final class CareerCrosswalkOverrideController extends Controller
+{
+    public function __construct(
+        private readonly CareerCrosswalkOverrideReadModelService $readModelService,
+    ) {}
+
+    public function show(string $slug): CareerCrosswalkOverrideResource
+    {
+        $summary = $this->readModelService->forSubject($slug);
+        abort_if(! is_array($summary), 404, 'career_crosswalk_override_not_found');
+
+        return new CareerCrosswalkOverrideResource($summary);
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Internal/Career/CareerCrosswalkPatchController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Internal/Career/CareerCrosswalkPatchController.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Internal\Career;
+
+use App\Domain\Career\Operations\CareerEditorialPatchHistoryReadModelService;
+use App\Domain\Career\Operations\CareerEditorialPatchMutationService;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\Internal\CareerCrosswalkPatchHistoryResource;
+use App\Http\Resources\Career\Internal\CareerCrosswalkPatchMutationResource;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use RuntimeException;
+
+final class CareerCrosswalkPatchController extends Controller
+{
+    public function __construct(
+        private readonly CareerEditorialPatchHistoryReadModelService $historyReadModelService,
+        private readonly CareerEditorialPatchMutationService $mutationService,
+    ) {}
+
+    public function history(string $slug): CareerCrosswalkPatchHistoryResource
+    {
+        return new CareerCrosswalkPatchHistoryResource($this->historyReadModelService->forSubject($slug));
+    }
+
+    public function store(Request $request): CareerCrosswalkPatchMutationResource
+    {
+        $payload = $request->validate([
+            'subject_kind' => ['required', Rule::in(['career_job_detail'])],
+            'subject_slug' => ['required', 'string'],
+            'target_kind' => ['required', Rule::in(['occupation', 'family'])],
+            'target_slug' => ['required', 'string'],
+            'crosswalk_mode_override' => ['required', 'string'],
+            'review_notes' => ['nullable', 'string'],
+        ]);
+
+        try {
+            $patch = $this->mutationService->create(array_merge($payload, [
+                'created_by' => (string) ($request->attributes->get('fm_admin_user_id') ?? ''),
+            ]));
+        } catch (RuntimeException $exception) {
+            abort(422, $exception->getMessage());
+        }
+
+        return new CareerCrosswalkPatchMutationResource([
+            'mutation_kind' => 'career_crosswalk_patch_create',
+            'status' => 'ok',
+            'patch' => $patch,
+        ]);
+    }
+
+    public function approve(string $patchKey, Request $request): CareerCrosswalkPatchMutationResource
+    {
+        $payload = $request->validate([
+            'review_notes' => ['nullable', 'string'],
+        ]);
+
+        try {
+            $patch = $this->mutationService->approve(
+                patchKey: $patchKey,
+                reviewNotes: is_string($payload['review_notes'] ?? null) ? $payload['review_notes'] : null,
+                reviewedBy: (string) ($request->attributes->get('fm_admin_user_id') ?? ''),
+            );
+        } catch (RuntimeException $exception) {
+            abort(422, $exception->getMessage());
+        }
+
+        return new CareerCrosswalkPatchMutationResource([
+            'mutation_kind' => 'career_crosswalk_patch_approve',
+            'status' => 'ok',
+            'patch' => $patch,
+        ]);
+    }
+
+    public function reject(string $patchKey, Request $request): CareerCrosswalkPatchMutationResource
+    {
+        $payload = $request->validate([
+            'review_notes' => ['nullable', 'string'],
+        ]);
+
+        try {
+            $patch = $this->mutationService->reject(
+                patchKey: $patchKey,
+                reviewNotes: is_string($payload['review_notes'] ?? null) ? $payload['review_notes'] : null,
+                reviewedBy: (string) ($request->attributes->get('fm_admin_user_id') ?? ''),
+            );
+        } catch (RuntimeException $exception) {
+            abort(422, $exception->getMessage());
+        }
+
+        return new CareerCrosswalkPatchMutationResource([
+            'mutation_kind' => 'career_crosswalk_patch_reject',
+            'status' => 'ok',
+            'patch' => $patch,
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Internal/Career/CareerCrosswalkReviewQueueController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Internal/Career/CareerCrosswalkReviewQueueController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Internal\Career;
+
+use App\Domain\Career\Operations\CareerCrosswalkReviewQueueReadModelService;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Career\Internal\CareerCrosswalkReviewQueueItemResource;
+use App\Http\Resources\Career\Internal\CareerCrosswalkReviewQueueResource;
+use Illuminate\Http\Request;
+
+final class CareerCrosswalkReviewQueueController extends Controller
+{
+    public function __construct(
+        private readonly CareerCrosswalkReviewQueueReadModelService $readModelService,
+    ) {}
+
+    public function index(Request $request): CareerCrosswalkReviewQueueResource
+    {
+        return new CareerCrosswalkReviewQueueResource($this->readModelService->list($this->filters($request)));
+    }
+
+    public function show(string $slug, Request $request): CareerCrosswalkReviewQueueItemResource
+    {
+        $item = $this->readModelService->item($slug, $this->filters($request));
+        abort_if(! is_array($item), 404, 'career_crosswalk_queue_item_not_found');
+
+        return new CareerCrosswalkReviewQueueItemResource($item);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function filters(Request $request): array
+    {
+        return [
+            'crosswalk_mode' => $request->query('crosswalk_mode'),
+            'requires_editorial_patch' => $request->query('requires_editorial_patch'),
+            'publish_track' => $request->query('publish_track'),
+            'batch_origin' => $request->query('batch_origin'),
+            'queue_reason' => $request->query('queue_reason'),
+            'sort' => $request->query('sort'),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/Career/Internal/CareerCrosswalkOverrideResource.php
+++ b/backend/app/Http/Resources/Career/Internal/CareerCrosswalkOverrideResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career\Internal;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class CareerCrosswalkOverrideResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return is_array($this->resource) ? $this->resource : [];
+    }
+}

--- a/backend/app/Http/Resources/Career/Internal/CareerCrosswalkPatchHistoryResource.php
+++ b/backend/app/Http/Resources/Career/Internal/CareerCrosswalkPatchHistoryResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career\Internal;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class CareerCrosswalkPatchHistoryResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return is_array($this->resource) ? $this->resource : [];
+    }
+}

--- a/backend/app/Http/Resources/Career/Internal/CareerCrosswalkPatchMutationResource.php
+++ b/backend/app/Http/Resources/Career/Internal/CareerCrosswalkPatchMutationResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career\Internal;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class CareerCrosswalkPatchMutationResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return is_array($this->resource) ? $this->resource : [];
+    }
+}

--- a/backend/app/Http/Resources/Career/Internal/CareerCrosswalkReviewQueueItemResource.php
+++ b/backend/app/Http/Resources/Career/Internal/CareerCrosswalkReviewQueueItemResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career\Internal;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class CareerCrosswalkReviewQueueItemResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return is_array($this->resource) ? $this->resource : [];
+    }
+}

--- a/backend/app/Http/Resources/Career/Internal/CareerCrosswalkReviewQueueResource.php
+++ b/backend/app/Http/Resources/Career/Internal/CareerCrosswalkReviewQueueResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Career\Internal;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class CareerCrosswalkReviewQueueResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return is_array($this->resource) ? $this->resource : [];
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2272,6 +2272,36 @@
       "merged_at": "",
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-B78X": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-b78x-crosswalk-editorial-ops-console-baseline",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Operations/*.php app/Http/Controllers/API/V0_5/Internal/Career/*.php app/Http/Resources/Career/Internal/*.php tests/Unit/Services/Career/*Crosswalk*Test.php tests/Feature/Internal/Career/*Crosswalk*Test.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/*Crosswalk*Test.php tests/Feature/Internal/Career/*Crosswalk*Test.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2276,10 +2276,10 @@
     "PR-B78X": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open_checks_failed",
       "branch": "codex/pr-b78x-crosswalk-editorial-ops-console-baseline",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "a97c21af0e64065288bcd5cd5f9318fd7dff28f2",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/923",
       "checks": {
         "local": [
           {
@@ -2295,9 +2295,16 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "CI / hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24501733333/job/71609969428",
+            "reason": "The job was not started because recent account payments have failed or spending limit needs to be increased."
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "github_checks_failed_billing_block",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1315,6 +1315,31 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B78X
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b78x-crosswalk-editorial-ops-console-baseline
+    base: main
+    depends_on: ["PR-B77X"]
+    mode: execute
+    scope: >
+      Career crosswalk/editorial ops console baseline (backend).
+      Add internal read-model services and internal-only crosswalk ops endpoints
+      for review queue, patch history, override summary, and patch create/approve/reject actions.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Domain/Career/Operations/*.php app/Http/Controllers/API/V0_5/Internal/Career/*.php app/Http/Resources/Career/Internal/*.php tests/Unit/Services/Career/*Crosswalk*Test.php tests/Feature/Internal/Career/*Crosswalk*Test.php"
+      - "php artisan test tests/Unit/Services/Career/*Crosswalk*Test.php tests/Feature/Internal/Career/*Crosswalk*Test.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -52,6 +52,9 @@ use App\Http\Controllers\API\V0_5\Career\CareerRecommendationIndexController;
 use App\Http\Controllers\API\V0_5\Career\CareerRuntimeConfigController;
 use App\Http\Controllers\API\V0_5\Career\CareerSearchController;
 use App\Http\Controllers\API\V0_5\Career\CareerTransitionPreviewController;
+use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkOverrideController;
+use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkPatchController;
+use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkReviewQueueController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
 use App\Http\Controllers\API\V0_5\Cms\CareerGuideController;
 use App\Http\Controllers\API\V0_5\Cms\CareerJobController;
@@ -482,5 +485,18 @@ Route::prefix('v0.5')->group(function () {
     ])->group(function () {
         Route::post('/cms/articles/{id}/publish', [ArticleController::class, 'publish']);
         Route::post('/cms/articles/{id}/unpublish', [ArticleController::class, 'unpublish']);
+    });
+
+    Route::middleware([
+        ...$cmsAdminMiddleware,
+        EnsureCmsAdminAuthorized::class.':write',
+    ])->prefix('internal/career/crosswalk')->group(function () {
+        Route::get('/review-queue', [CareerCrosswalkReviewQueueController::class, 'index']);
+        Route::get('/review-queue/{slug}', [CareerCrosswalkReviewQueueController::class, 'show']);
+        Route::get('/patches/{slug}', [CareerCrosswalkPatchController::class, 'history']);
+        Route::get('/override/{slug}', [CareerCrosswalkOverrideController::class, 'show']);
+        Route::post('/patches', [CareerCrosswalkPatchController::class, 'store']);
+        Route::post('/patches/{patchKey}/approve', [CareerCrosswalkPatchController::class, 'approve']);
+        Route::post('/patches/{patchKey}/reject', [CareerCrosswalkPatchController::class, 'reject']);
     });
 });

--- a/backend/tests/Feature/Internal/Career/CareerCrosswalkOpsApiTest.php
+++ b/backend/tests/Feature/Internal/Career/CareerCrosswalkOpsApiTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Internal\Career;
+
+use App\Models\AdminUser;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerCrosswalkOpsApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_review_queue_requires_internal_admin_auth(): void
+    {
+        $response = $this->getJson('/api/v0.5/internal/career/crosswalk/review-queue');
+
+        $response->assertStatus(401)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'UNAUTHORIZED');
+    }
+
+    public function test_internal_crosswalk_endpoints_support_queue_patch_and_override_flow(): void
+    {
+        $fixture = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'ops-flow-role',
+            'crosswalk_mode' => 'local_heavy_interpretation',
+        ]);
+        $slug = (string) $fixture['occupation']->canonical_slug;
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+
+        $queueResponse = $this->withSession(['ops_org_id' => 31])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/internal/career/crosswalk/review-queue');
+
+        $queueResponse->assertOk()
+            ->assertJsonPath('queue_kind', 'career_crosswalk_review_queue_read_model');
+
+        $createResponse = $this->withSession(['ops_org_id' => 31])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/internal/career/crosswalk/patches', [
+                'subject_kind' => 'career_job_detail',
+                'subject_slug' => $slug,
+                'target_kind' => 'occupation',
+                'target_slug' => $slug,
+                'crosswalk_mode_override' => 'exact',
+                'review_notes' => 'ops console patch create',
+            ]);
+
+        $createResponse->assertOk()
+            ->assertJsonPath('mutation_kind', 'career_crosswalk_patch_create')
+            ->assertJsonPath('patch.subject_slug', $slug)
+            ->assertJsonPath('patch.patch_status', 'draft');
+
+        $patchKey = (string) $createResponse->json('patch.patch_key');
+        $this->assertNotSame('', $patchKey);
+
+        $approveResponse = $this->withSession(['ops_org_id' => 31])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/internal/career/crosswalk/patches/'.$patchKey.'/approve', [
+                'review_notes' => 'approve from ops console',
+            ]);
+
+        $approveResponse->assertOk()
+            ->assertJsonPath('mutation_kind', 'career_crosswalk_patch_approve')
+            ->assertJsonPath('patch.patch_status', 'approved');
+
+        $historyResponse = $this->withSession(['ops_org_id' => 31])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/internal/career/crosswalk/patches/'.$slug);
+        $historyResponse->assertOk()
+            ->assertJsonPath('history_kind', 'career_editorial_patch_history')
+            ->assertJson(fn ($json) => $json->where('status_counts.approved', 1)->etc());
+
+        $overrideResponse = $this->withSession(['ops_org_id' => 31])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/internal/career/crosswalk/override/'.$slug);
+        $overrideResponse->assertOk()
+            ->assertJsonPath('override_kind', 'career_crosswalk_override_read_model')
+            ->assertJsonPath('override_applied', true)
+            ->assertJsonPath('resolved_crosswalk_mode', 'exact');
+
+        $rejectResponse = $this->withSession(['ops_org_id' => 31])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/internal/career/crosswalk/patches/'.$patchKey.'/reject', [
+                'review_notes' => 'reject after approval should still set rejected',
+            ]);
+
+        $rejectResponse->assertOk()
+            ->assertJsonPath('mutation_kind', 'career_crosswalk_patch_reject')
+            ->assertJsonPath('patch.patch_status', 'rejected');
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        if ($permissions === []) {
+            return $admin;
+        }
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null]
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerCrosswalkPatchMutationServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCrosswalkPatchMutationServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Operations\CareerEditorialPatchMutationService;
+use App\Models\EditorialPatch;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerCrosswalkPatchMutationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_patch_and_preserves_version_chain(): void
+    {
+        $fixture = CareerFoundationFixture::seedMinimalChain();
+        $slug = (string) $fixture['occupation']->canonical_slug;
+
+        $service = app(CareerEditorialPatchMutationService::class);
+        $created = $service->create([
+            'subject_slug' => $slug,
+            'target_kind' => 'occupation',
+            'target_slug' => $slug,
+            'crosswalk_mode_override' => 'exact',
+            'review_notes' => 'initial patch',
+            'created_by' => 'ops-admin-1',
+        ]);
+
+        $this->assertSame('draft', $created['patch_status']);
+        $this->assertSame('v1', $created['patch_version']);
+        $this->assertDatabaseHas('editorial_patches', [
+            'id' => $created['patch_key'],
+            'status' => 'draft',
+            'occupation_id' => (string) $fixture['occupation']->id,
+        ]);
+    }
+
+    public function test_it_approves_and_supersedes_previous_approved_patch(): void
+    {
+        $fixture = CareerFoundationFixture::seedMinimalChain();
+        $slug = (string) $fixture['occupation']->canonical_slug;
+
+        $first = EditorialPatch::query()->create([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => (string) $fixture['occupation']->id,
+            'required' => true,
+            'status' => 'approved',
+            'patch_version' => 'v1',
+            'notes' => [
+                'target_kind' => 'occupation',
+                'target_slug' => $slug,
+                'crosswalk_mode_override' => 'exact',
+            ],
+        ]);
+
+        $service = app(CareerEditorialPatchMutationService::class);
+        $created = $service->create([
+            'subject_slug' => $slug,
+            'target_kind' => 'family',
+            'target_slug' => (string) $fixture['family']->canonical_slug,
+            'crosswalk_mode_override' => 'trust_inheritance',
+            'review_notes' => 'new approved patch',
+            'created_by' => 'ops-admin-2',
+        ]);
+
+        $approved = $service->approve($created['patch_key'], 'approve patch', 'ops-reviewer-1');
+        $this->assertSame('approved', $approved['patch_status']);
+
+        $this->assertDatabaseHas('editorial_patches', [
+            'id' => (string) $first->id,
+            'status' => 'superseded',
+        ]);
+    }
+
+    public function test_it_rejects_patch(): void
+    {
+        $fixture = CareerFoundationFixture::seedMinimalChain();
+        $slug = (string) $fixture['occupation']->canonical_slug;
+        $service = app(CareerEditorialPatchMutationService::class);
+
+        $created = $service->create([
+            'subject_slug' => $slug,
+            'target_kind' => 'occupation',
+            'target_slug' => $slug,
+            'crosswalk_mode_override' => 'exact',
+            'review_notes' => 'reject-me',
+            'created_by' => 'ops-admin-3',
+        ]);
+
+        $rejected = $service->reject($created['patch_key'], 'not enough evidence', 'ops-reviewer-2');
+        $this->assertSame('rejected', $rejected['patch_status']);
+        $this->assertDatabaseHas('editorial_patches', [
+            'id' => $created['patch_key'],
+            'status' => 'rejected',
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerCrosswalkReadModelsTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCrosswalkReadModelsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Models\EditorialPatch;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerCrosswalkReadModelsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_review_queue_read_model_exposes_enriched_fields_for_high_risk_modes(): void
+    {
+        $localHeavy = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'local-heavy-role',
+            'crosswalk_mode' => 'local_heavy_interpretation',
+        ]);
+        $familyProxy = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'family-proxy-role',
+            'crosswalk_mode' => 'family_proxy',
+        ]);
+        CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'unmapped-role',
+            'crosswalk_mode' => 'unmapped',
+        ]);
+
+        $familyProxy['editorialPatch']->forceFill([
+            'status' => 'approved',
+            'patch_version' => 'v1',
+            'notes' => [
+                'target_kind' => 'family',
+                'target_slug' => $familyProxy['family']->canonical_slug,
+                'crosswalk_mode_override' => 'trust_inheritance',
+            ],
+        ])->save();
+
+        $payload = app(\App\Domain\Career\Operations\CareerCrosswalkReviewQueueReadModelService::class)
+            ->list(['sort' => 'risk']);
+
+        $this->assertSame('career_crosswalk_review_queue_read_model', $payload['queue_kind']);
+        $this->assertGreaterThanOrEqual(3, data_get($payload, 'counts.total'));
+        $this->assertGreaterThanOrEqual(1, data_get($payload, 'counts.local_heavy_interpretation'));
+        $this->assertGreaterThanOrEqual(1, data_get($payload, 'counts.family_proxy'));
+        $this->assertGreaterThanOrEqual(1, data_get($payload, 'counts.unmapped'));
+
+        $items = collect($payload['items'] ?? [])->keyBy('subject_slug');
+        $localHeavyItem = $items->get('local-heavy-role');
+        $this->assertIsArray($localHeavyItem);
+        $this->assertSame('local_heavy_interpretation', $localHeavyItem['current_crosswalk_mode']);
+        $this->assertTrue((bool) $localHeavyItem['requires_editorial_patch']);
+        $this->assertContains('local_heavy_requires_editorial_patch', $localHeavyItem['queue_reason']);
+
+        $familyItem = $items->get('family-proxy-role');
+        $this->assertIsArray($familyItem);
+        $this->assertSame('family_proxy', $familyItem['current_crosswalk_mode']);
+        $this->assertTrue((bool) $familyItem['has_approved_patch']);
+        $this->assertSame('approved', $familyItem['latest_patch_status']);
+        $this->assertSame('family', $familyItem['candidate_target_kind']);
+
+        $unmappedItem = $items->get('unmapped-role');
+        $this->assertIsArray($unmappedItem);
+        $this->assertContains('unmapped_requires_editorial_patch', $unmappedItem['queue_reason']);
+    }
+
+    public function test_patch_history_read_model_returns_version_chain_and_latest_patch(): void
+    {
+        $fixture = CareerFoundationFixture::seedMinimalChain();
+        $slug = (string) $fixture['occupation']->canonical_slug;
+
+        EditorialPatch::query()->create([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => (string) $fixture['occupation']->id,
+            'required' => true,
+            'status' => 'rejected',
+            'patch_version' => 'v1',
+            'notes' => [
+                'target_kind' => 'occupation',
+                'target_slug' => $slug,
+                'crosswalk_mode_override' => 'exact',
+            ],
+        ]);
+
+        EditorialPatch::query()->create([
+            'id' => (string) Str::uuid(),
+            'occupation_id' => (string) $fixture['occupation']->id,
+            'required' => true,
+            'status' => 'approved',
+            'patch_version' => 'v2',
+            'notes' => [
+                'target_kind' => 'occupation',
+                'target_slug' => $slug,
+                'crosswalk_mode_override' => 'trust_inheritance',
+            ],
+        ]);
+
+        $payload = app(\App\Domain\Career\Operations\CareerEditorialPatchHistoryReadModelService::class)
+            ->forSubject($slug);
+
+        $this->assertSame('career_editorial_patch_history', $payload['history_kind']);
+        $this->assertSame(3, $payload['count']); // includes fixture patch row
+        $this->assertIsArray($payload['latest_patch']);
+        $this->assertSame('approved', data_get($payload, 'latest_patch.patch_status'));
+        $this->assertSame('v2', data_get($payload, 'latest_patch.patch_version'));
+        $this->assertGreaterThanOrEqual(1, data_get($payload, 'status_counts.rejected'));
+    }
+
+    public function test_override_read_model_reflects_approved_patch_resolution(): void
+    {
+        $fixture = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'override-read-role',
+            'crosswalk_mode' => 'local_heavy_interpretation',
+        ]);
+
+        $fixture['editorialPatch']->forceFill([
+            'status' => 'approved',
+            'patch_version' => 'v1',
+            'notes' => [
+                'target_kind' => 'occupation',
+                'target_slug' => 'override-read-role',
+                'crosswalk_mode_override' => 'exact',
+            ],
+        ])->save();
+
+        $payload = app(\App\Domain\Career\Operations\CareerCrosswalkOverrideReadModelService::class)
+            ->forSubject('override-read-role');
+
+        $this->assertIsArray($payload);
+        $this->assertSame('career_crosswalk_override_read_model', $payload['override_kind']);
+        $this->assertTrue((bool) $payload['override_applied']);
+        $this->assertSame('local_heavy_interpretation', $payload['original_crosswalk_mode']);
+        $this->assertSame('exact', $payload['resolved_crosswalk_mode']);
+    }
+}


### PR DESCRIPTION
## What changed
- Added internal-only crosswalk ops read-model services for queue, patch history, and override summary.
- Added internal API endpoints for review queue list/detail, patch history, override summary, and patch create/approve/reject actions.
- Added patch mutation service with version-chain handling, approved supersede behavior, and reject path.
- Extended review queue semantics to include `unmapped` mode so high-risk cases are visible in ops flows.
- Added unit/feature coverage for read-models, patch mutation chain behavior, and internal endpoint flow.

## Why
B70 established backend ops authority/CLI baseline, but internal UI needed stable read/write contracts. This PR exposes minimal, internal-only endpoints and projections so ops workflows can use backend-owned truth instead of ad-hoc merges.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Domain/Career/Operations/*.php app/Http/Controllers/API/V0_5/Internal/Career/*.php app/Http/Resources/Career/Internal/*.php tests/Unit/Services/Career/*Crosswalk*Test.php tests/Feature/Internal/Career/*Crosswalk*Test.php`
- `php artisan test tests/Unit/Services/Career/*Crosswalk*Test.php tests/Feature/Internal/Career/*Crosswalk*Test.php`

## Intentionally deferred
- Full backoffice/editorial CMS UI.
- Public API exposure or OpenAPI contract expansion.
- Bulk import/reporting workflows beyond minimal patch create/review actions.
