### PR TITLE
PR-B79X: Career conversion attribution baseline (backend taxonomy)

### DIFF
--- a/backend/app/Services/Analytics/CareerAttributionEventMapper.php
+++ b/backend/app/Services/Analytics/CareerAttributionEventMapper.php
@@ -23,6 +23,8 @@ final class CareerAttributionEventMapper
         'career_job_index_result_click',
         'career_family_hub_child_click',
         'career_job_detail_cta_click',
+        'career_shortlist_add',
+        'career_support_link_click',
         'career_recommendation_result_click',
         'career_recommendation_matched_job_click',
         'career_transition_preview_view',
@@ -154,6 +156,14 @@ final class CareerAttributionEventMapper
         $subjectKey = $this->normalizeSubjectKey($payload['subject_key'] ?? null, $subjectKind);
         $blockedClaimKind = $this->normalizeBlockedClaimKind($eventCode, $payload['blocked_claim_kind'] ?? null);
         $this->validateClaimBlockedEventScope($eventCode, $sourcePageType, $routeFamily, $subjectKind);
+        $this->validateConversionEventScope(
+            $eventCode,
+            $sourcePageType,
+            $routeFamily,
+            $subjectKind,
+            $queryMode,
+            (string) ($payload['target_action'] ?? '')
+        );
 
         $meta = [
             'entry_surface' => $this->normalizeOptionalString($payload['entry_surface'] ?? null, 128) ?? 'unknown',
@@ -185,6 +195,113 @@ final class CareerAttributionEventMapper
                 'scale_code_v2' => 'CAREER',
             ],
         ];
+    }
+
+    private function validateConversionEventScope(
+        string $eventCode,
+        string $sourcePageType,
+        string $routeFamily,
+        string $subjectKind,
+        string $queryMode,
+        string $targetActionRaw,
+    ): void {
+        $targetAction = strtolower(trim($targetActionRaw));
+
+        if ($eventCode === 'career_shortlist_add') {
+            if (! in_array($sourcePageType, ['job_detail', 'recommendation_detail'], true)) {
+                throw ValidationException::withMessages([
+                    'payload.source_page_type' => 'payload.source_page_type is not supported for career_shortlist_add.',
+                ]);
+            }
+            if (! in_array($routeFamily, ['job_detail', 'recommendation_detail'], true)) {
+                throw ValidationException::withMessages([
+                    'payload.route_family' => 'payload.route_family is not supported for career_shortlist_add.',
+                ]);
+            }
+            if (($sourcePageType === 'job_detail' && $routeFamily !== 'job_detail')
+                || ($sourcePageType === 'recommendation_detail' && $routeFamily !== 'recommendation_detail')) {
+                throw ValidationException::withMessages([
+                    'payload.route_family' => 'payload.route_family must align with payload.source_page_type for career_shortlist_add.',
+                ]);
+            }
+            if ($subjectKind !== 'job_slug') {
+                throw ValidationException::withMessages([
+                    'payload.subject_kind' => 'payload.subject_kind must be job_slug for career_shortlist_add.',
+                ]);
+            }
+            if ($queryMode !== 'non_query') {
+                throw ValidationException::withMessages([
+                    'payload.query_mode' => 'payload.query_mode must be non_query for career_shortlist_add.',
+                ]);
+            }
+            if ($targetAction !== 'add_shortlist') {
+                throw ValidationException::withMessages([
+                    'payload.target_action' => 'payload.target_action must be add_shortlist for career_shortlist_add.',
+                ]);
+            }
+        }
+
+        if ($eventCode === 'career_job_detail_cta_click') {
+            if ($sourcePageType !== 'job_detail') {
+                throw ValidationException::withMessages([
+                    'payload.source_page_type' => 'payload.source_page_type must be career_job_detail for career_job_detail_cta_click.',
+                ]);
+            }
+            if ($routeFamily !== 'job_detail') {
+                throw ValidationException::withMessages([
+                    'payload.route_family' => 'payload.route_family must be job_detail for career_job_detail_cta_click.',
+                ]);
+            }
+            if ($subjectKind !== 'job_slug') {
+                throw ValidationException::withMessages([
+                    'payload.subject_kind' => 'payload.subject_kind must be job_slug for career_job_detail_cta_click.',
+                ]);
+            }
+            if ($queryMode !== 'non_query') {
+                throw ValidationException::withMessages([
+                    'payload.query_mode' => 'payload.query_mode must be non_query for career_job_detail_cta_click.',
+                ]);
+            }
+            if (! in_array($targetAction, ['open_next_step_link', 'open_transition_cta', 'open_primary_cta'], true)) {
+                throw ValidationException::withMessages([
+                    'payload.target_action' => 'payload.target_action is not supported for career_job_detail_cta_click.',
+                ]);
+            }
+        }
+
+        if ($eventCode === 'career_support_link_click') {
+            if (! in_array($sourcePageType, ['job_detail', 'recommendation_detail'], true)) {
+                throw ValidationException::withMessages([
+                    'payload.source_page_type' => 'payload.source_page_type is not supported for career_support_link_click.',
+                ]);
+            }
+            if (! in_array($routeFamily, ['job_detail', 'recommendation_detail'], true)) {
+                throw ValidationException::withMessages([
+                    'payload.route_family' => 'payload.route_family is not supported for career_support_link_click.',
+                ]);
+            }
+            if (($sourcePageType === 'job_detail' && $routeFamily !== 'job_detail')
+                || ($sourcePageType === 'recommendation_detail' && $routeFamily !== 'recommendation_detail')) {
+                throw ValidationException::withMessages([
+                    'payload.route_family' => 'payload.route_family must align with payload.source_page_type for career_support_link_click.',
+                ]);
+            }
+            if (! in_array($subjectKind, ['job_slug', 'none'], true)) {
+                throw ValidationException::withMessages([
+                    'payload.subject_kind' => 'payload.subject_kind is not supported for career_support_link_click.',
+                ]);
+            }
+            if ($queryMode !== 'non_query') {
+                throw ValidationException::withMessages([
+                    'payload.query_mode' => 'payload.query_mode must be non_query for career_support_link_click.',
+                ]);
+            }
+            if ($targetAction !== 'open_support_link') {
+                throw ValidationException::withMessages([
+                    'payload.target_action' => 'payload.target_action must be open_support_link for career_support_link_click.',
+                ]);
+            }
+        }
     }
 
     /**

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T09:23:55.316865Z",
+  "updated_at": "2026-04-16T09:26:24.672849Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2313,10 +2313,10 @@
     "PR-B79X": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b79x-career-conversion-attribution-taxonomy",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "98ec509e446b196719ccfbee5d6e48805ca405e8",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/924",
       "checks": {
         "local": [
           {
@@ -2332,9 +2332,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502626278/job/71613039201"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502594921/job/71612933619"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502626278/job/71613046208"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502594921/job/71612942879"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions checks failed at workflow startup in CI (hygiene failed, MBTI matrix skipped) while all required local checks passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T09:26:24.672849Z",
+  "updated_at": "2026-04-16T09:27:59.916317Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2336,22 +2336,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502626278/job/71613039201"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502682846/job/71613229138"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502594921/job/71612933619"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502681094/job/71613223698"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502626278/job/71613046208"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502682846/job/71613237137"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502594921/job/71612942879"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24502681094/job/71613231907"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T07:55:52.360319Z",
+  "updated_at": "2026-04-16T09:23:55.316865Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2305,6 +2305,36 @@
         ]
       },
       "failure_reason": "github_checks_failed_billing_block",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B79X": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-b79x-career-conversion-attribution-taxonomy",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1340,6 +1340,31 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B79X
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b79x-career-conversion-attribution-taxonomy
+    base: main
+    depends_on: ["PR-B78X"]
+    mode: execute
+    scope: >
+      Career conversion attribution baseline (backend taxonomy).
+      Add minimal conversion event taxonomy for shortlist add, job detail CTA click,
+      and support-link click with ingest + daily compatibility under existing schema.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php"
+      - "php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php
@@ -161,10 +161,37 @@ final class CareerAttributionDailyBuilderTest extends TestCase
             'query_mode' => 'non_query',
             'blocked_claim_kind' => 'ai_strategy',
         ], 'anon_claim_blocked_none', 'session_claim_blocked_none');
+        $this->insertCareerEvent($orgId, 'career_job_detail_cta_click', $day->copy()->addMinutes(16), [
+            'entry_surface' => 'career_job_detail',
+            'source_page_type' => 'career_job_detail',
+            'target_action' => 'open_next_step_link',
+            'route_family' => 'job_detail',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'registered-nurses',
+            'query_mode' => 'non_query',
+        ], 'anon_job_detail_cta', 'session_job_detail_cta');
+        $this->insertCareerEvent($orgId, 'career_support_link_click', $day->copy()->addMinutes(17), [
+            'entry_surface' => 'career_recommendation_detail',
+            'source_page_type' => 'career_recommendation_detail',
+            'target_action' => 'open_support_link',
+            'route_family' => 'recommendation_detail',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'registered-nurses',
+            'query_mode' => 'non_query',
+        ], 'anon_support_click', 'session_support_click');
+        $this->insertCareerEvent($orgId, 'career_shortlist_add', $day->copy()->addMinutes(18), [
+            'entry_surface' => 'career_recommendation_detail',
+            'source_page_type' => 'career_recommendation_detail',
+            'target_action' => 'add_shortlist',
+            'route_family' => 'recommendation_detail',
+            'subject_kind' => 'job_slug',
+            'subject_key' => 'registered-nurses',
+            'query_mode' => 'non_query',
+        ], 'anon_shortlist_add', 'session_shortlist_add');
 
         $result = app(CareerAttributionDailyBuilder::class)->refresh($day, $day, [$orgId], false);
 
-        $this->assertSame(16, (int) ($result['upserted_rows'] ?? 0));
+        $this->assertSame(19, (int) ($result['upserted_rows'] ?? 0));
 
         $readyRow = DB::table('analytics_career_attribution_daily')
             ->where('day', $day->toDateString())
@@ -339,6 +366,29 @@ final class CareerAttributionDailyBuilderTest extends TestCase
         $this->assertSame('publish_ready', $claimBlockedJobRow->readiness_class);
         $this->assertSame('recommendation_detail', $claimBlockedNoneRow->source_page_type);
         $this->assertSame('unknown', $claimBlockedNoneRow->readiness_class);
+
+        $jobDetailCtaRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_job_detail_cta_click')
+            ->where('subject_key', 'registered-nurses')
+            ->first();
+        $supportLinkRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_support_link_click')
+            ->where('subject_key', 'registered-nurses')
+            ->first();
+        $shortlistRow = DB::table('analytics_career_attribution_daily')
+            ->where('event_name', 'career_shortlist_add')
+            ->where('subject_key', 'registered-nurses')
+            ->first();
+
+        $this->assertNotNull($jobDetailCtaRow);
+        $this->assertNotNull($supportLinkRow);
+        $this->assertNotNull($shortlistRow);
+        $this->assertSame('job_detail', $jobDetailCtaRow->source_page_type);
+        $this->assertSame('recommendation_detail', $supportLinkRow->source_page_type);
+        $this->assertSame('recommendation_detail', $shortlistRow->source_page_type);
+        $this->assertSame('publish_ready', $jobDetailCtaRow->readiness_class);
+        $this->assertSame('publish_ready', $supportLinkRow->readiness_class);
+        $this->assertSame('publish_ready', $shortlistRow->readiness_class);
     }
 
     private function materializeCurrentFirstWaveFixture(): void

--- a/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
@@ -238,6 +238,57 @@ final class CareerAttributionEventIngestTest extends TestCase
                 ],
                 'expected_source_page_type' => 'job_detail',
             ],
+            [
+                'event' => 'career_job_detail_cta_click',
+                'anon' => 'anon_b79_job_detail_cta',
+                'path' => '/en/career/jobs/software-developers',
+                'payload' => [
+                    'entry_surface' => 'career_job_detail',
+                    'source_page_type' => 'career_job_detail',
+                    'target_action' => 'open_next_step_link',
+                    'landing_path' => '/en/career/jobs/software-developers',
+                    'route_family' => 'job_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'job_detail',
+            ],
+            [
+                'event' => 'career_support_link_click',
+                'anon' => 'anon_b79_support_click',
+                'path' => '/en/career/recommendations/mbti/intj-a',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => 'open_support_link',
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'recommendation_detail',
+            ],
+            [
+                'event' => 'career_shortlist_add',
+                'anon' => 'anon_b79_shortlist_add',
+                'path' => '/en/career/recommendations/mbti/intj-a',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => 'add_shortlist',
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+                'expected_source_page_type' => 'recommendation_detail',
+            ],
         ];
 
         foreach ($cases as $case) {
@@ -597,7 +648,6 @@ final class CareerAttributionEventIngestTest extends TestCase
             'career_unknown_event',
             'career_view',
             'career_alias_search',
-            'career_shortlist_add',
             'career_family_hub_ready_surface_exposed',
             'career_family_hub_blocked_surface_exposed',
         ] as $eventName) {
@@ -612,6 +662,70 @@ final class CareerAttributionEventIngestTest extends TestCase
                     'subject_kind' => 'none',
                     'query_mode' => 'non_query',
                 ],
+            ]);
+
+            $response->assertStatus(422);
+        }
+    }
+
+    public function test_ingest_endpoint_rejects_conversion_events_outside_supported_minimal_scope(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $cases = [
+            [
+                'eventName' => 'career_job_detail_cta_click',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => 'open_next_step_link',
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+            ],
+            [
+                'eventName' => 'career_shortlist_add',
+                'payload' => [
+                    'entry_surface' => 'career_job_detail',
+                    'source_page_type' => 'career_job_detail',
+                    'target_action' => 'add_shortlist',
+                    'landing_path' => '/en/career/jobs/software-developers',
+                    'route_family' => 'job_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'query',
+                    'locale' => 'en',
+                ],
+            ],
+            [
+                'eventName' => 'career_support_link_click',
+                'payload' => [
+                    'entry_surface' => 'career_job_detail',
+                    'source_page_type' => 'career_job_detail',
+                    'target_action' => 'open_primary_cta',
+                    'landing_path' => '/en/career/jobs/software-developers',
+                    'route_family' => 'job_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+            ],
+        ];
+
+        foreach ($cases as $index => $case) {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ingest_test_token',
+            ])->postJson('/api/v0.5/career/attribution/events', [
+                'eventName' => $case['eventName'],
+                'anonymousId' => "anon_b79_invalid_{$index}",
+                'path' => '/en/career/jobs/software-developers',
+                'timestamp' => '2026-04-16T10:00:00+08:00',
+                'payload' => $case['payload'],
             ]);
 
             $response->assertStatus(422);


### PR DESCRIPTION
## What Changed
- Added three conversion attribution events to backend mapper allowlist: `career_shortlist_add`, `career_job_detail_cta_click`, `career_support_link_click`.
- Added strict scope validation for these conversion events (source page, route family, subject kind, query mode, and target action constraints).
- Extended ingest feature tests for accepted conversion payloads and rejection cases outside minimal supported scope.
- Extended daily builder feature test to verify daily aggregation coverage for new conversion events.
- Added PR-B79X train manifest/state entries and marked local checks passed.

## Why
This formalizes the minimal backend conversion taxonomy needed by PR-B79X/F47 while keeping attribution scope narrow and aligned to existing ingest/daily infrastructure.

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Analytics/CareerAttributionEventMapper.php app/Services/Analytics/CareerAttributionDailyBuilder.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php`
- `php artisan test tests/Feature/Analytics/CareerAttributionEventIngestTest.php tests/Feature/Analytics/CareerAttributionDailyBuilderTest.php`

## Intentionally Deferred
- Any public analytics endpoint/dashboard/reporting changes.
- Any new shortlist write model or shortlist business flow changes.
- Any conversion expansion outside job/recommendation detail minimal scope.