### PR TITLE
PR-B80: Career full-342 release ledger authority

### DIFF
--- a/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
+++ b/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Publish\CareerFullReleaseLedgerProjectionService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerExportFullReleaseLedger extends Command
+{
+    protected $signature = 'career:export-full-release-ledger
+        {--timestamp= : Optional output directory timestamp segment}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Materialize internal full-342 release ledger authority to storage/app/private/career_release_ledger.';
+
+    public function __construct(
+        private readonly CareerFullReleaseLedgerProjectionService $projectionService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $timestamp = $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null);
+            $rootDir = storage_path('app/private/career_release_ledger');
+            $finalDir = $rootDir.DIRECTORY_SEPARATOR.$timestamp;
+            $tmpDir = $finalDir.'.tmp';
+
+            if (is_dir($finalDir) || is_dir($tmpDir)) {
+                throw new \RuntimeException('release ledger output dir already exists: '.$finalDir);
+            }
+
+            $projected = $this->projectionService->build();
+            $ledger = (array) ($projected[CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME] ?? []);
+            if ($ledger === []) {
+                throw new \RuntimeException('empty full release ledger payload');
+            }
+
+            File::ensureDirectoryExists($tmpDir);
+            $path = $tmpDir.DIRECTORY_SEPARATOR.CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME;
+            $encoded = json_encode($ledger, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                throw new \RuntimeException('failed to encode full release ledger payload');
+            }
+            File::put($path, $encoded.PHP_EOL);
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize release ledger output dir: '.$finalDir);
+            }
+
+            $payload = [
+                'status' => 'materialized',
+                'output_dir' => $finalDir,
+                'artifacts' => [
+                    CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME => $finalDir.DIRECTORY_SEPARATOR.CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME,
+                ],
+                'ledger' => $ledger,
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+                return self::SUCCESS;
+            }
+
+            $this->line('status=materialized');
+            $this->line('output_dir='.$finalDir);
+            $this->line('career-full-release-ledger='.(string) data_get($payload, 'artifacts.career-full-release-ledger.json', ''));
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            $normalized = now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for full release ledger export');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -10,11 +10,12 @@ use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCrosswalkOps;
-use App\Console\Commands\CareerRunAssetBatch;
-use App\Console\Commands\CareerExportFirstWaveRolloutBundleArtifacts;
 use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
+use App\Console\Commands\CareerExportFirstWaveRolloutBundleArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutWavePlanArtifact;
+use App\Console\Commands\CareerExportFullReleaseLedger;
 use App\Console\Commands\CareerImportAuthorityWave;
+use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CiScaleImpact;
 use App\Console\Commands\CommerceCompensatePendingOrders;
 use App\Console\Commands\CommerceReconcile;
@@ -29,9 +30,9 @@ use App\Console\Commands\FapResolvePack;
 use App\Console\Commands\FapSelfCheck;
 use App\Console\Commands\FapValidateReport;
 use App\Console\Commands\FapWeeklyReport;
+use App\Console\Commands\MbtiPrewarm;
 use App\Console\Commands\MbtiUpgradeLegacyPartialUnlocks;
 use App\Console\Commands\MetricsWeeklyValidity;
-use App\Console\Commands\MbtiPrewarm;
 use App\Console\Commands\NormsBig5BootstrapBuild;
 use App\Console\Commands\NormsBig5DriftCheck;
 use App\Console\Commands\NormsBig5MonthlyDriftCheck;
@@ -136,6 +137,7 @@ class Kernel extends ConsoleKernel
         CareerImportAuthorityWave::class,
         CareerCompileAuthorityWave::class,
         CareerCrosswalkOps::class,
+        CareerExportFullReleaseLedger::class,
         CareerRunAssetBatch::class,
         CareerExportFirstWaveRolloutBundleArtifacts::class,
         CareerExportFirstWaveReleaseArtifacts::class,

--- a/backend/app/DTO/Career/CareerFullReleaseLedger.php
+++ b/backend/app/DTO/Career/CareerFullReleaseLedger.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFullReleaseLedger
+{
+    /**
+     * @param  array<string, mixed>  $trackingCounts
+     * @param  array<string, int>  $releaseCounts
+     * @param  array<string, int>  $opsHandoffCounts
+     * @param  list<CareerFullReleaseLedgerMember>  $members
+     */
+    public function __construct(
+        public readonly string $ledgerKind,
+        public readonly string $ledgerVersion,
+        public readonly string $scope,
+        public readonly array $trackingCounts,
+        public readonly array $releaseCounts,
+        public readonly array $opsHandoffCounts,
+        public readonly array $members,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'ledger_kind' => $this->ledgerKind,
+            'ledger_version' => $this->ledgerVersion,
+            'scope' => $this->scope,
+            'counts' => [
+                'tracking_counts' => $this->trackingCounts,
+                'release_counts' => $this->releaseCounts,
+                'ops_handoff_counts' => $this->opsHandoffCounts,
+            ],
+            'members' => array_map(
+                static fn (CareerFullReleaseLedgerMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerFullReleaseLedgerMember.php
+++ b/backend/app/DTO/Career/CareerFullReleaseLedgerMember.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerFullReleaseLedgerMember
+{
+    /**
+     * @param  list<string>  $blockerReasons
+     * @param  array<string, mixed>  $evidenceRefs
+     */
+    public function __construct(
+        public readonly string $memberKind,
+        public readonly string $canonicalSlug,
+        public readonly ?string $canonicalTitleEn,
+        public readonly ?string $batchOrigin,
+        public readonly ?string $currentCrosswalkMode,
+        public readonly string $currentIndexState,
+        public readonly string $publicIndexState,
+        public readonly bool $indexEligible,
+        public readonly string $releaseCohort,
+        public readonly array $blockerReasons,
+        public readonly array $evidenceRefs,
+        public readonly ?string $resolvedTargetKind = null,
+        public readonly ?string $resolvedTargetSlug = null,
+        public readonly ?string $reviewQueueStatus = null,
+        public readonly ?bool $overrideApplied = null,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'member_kind' => $this->memberKind,
+            'canonical_slug' => $this->canonicalSlug,
+            'canonical_title_en' => $this->canonicalTitleEn,
+            'batch_origin' => $this->batchOrigin,
+            'current_crosswalk_mode' => $this->currentCrosswalkMode,
+            'current_index_state' => $this->currentIndexState,
+            'public_index_state' => $this->publicIndexState,
+            'index_eligible' => $this->indexEligible,
+            'release_cohort' => $this->releaseCohort,
+            'blocker_reasons' => $this->blockerReasons,
+            'evidence_refs' => $this->evidenceRefs,
+            'resolved_target_kind' => $this->resolvedTargetKind,
+            'resolved_target_slug' => $this->resolvedTargetSlug,
+            'review_queue_status' => $this->reviewQueueStatus,
+            'override_applied' => $this->overrideApplied,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerProjectionService.php
+++ b/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerProjectionService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+final class CareerFullReleaseLedgerProjectionService
+{
+    public const LEDGER_FILENAME = 'career-full-release-ledger.json';
+
+    public function __construct(
+        private readonly CareerFullReleaseLedgerService $ledgerService,
+    ) {}
+
+    /**
+     * @return array{career-full-release-ledger.json: array<string, mixed>}
+     */
+    public function build(): array
+    {
+        return [
+            self::LEDGER_FILENAME => $this->ledgerService->build()->toArray(),
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerService.php
+++ b/backend/app/Domain/Career/Publish/CareerFullReleaseLedgerService.php
@@ -1,0 +1,633 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Domain\Career\IndexStateValue;
+use App\Domain\Career\Operations\CareerCrosswalkOverrideResolver;
+use App\Domain\Career\Operations\CareerCrosswalkReviewQueueService;
+use App\Domain\Career\Operations\CareerEditorialPatchAuthorityService;
+use App\Domain\Career\Production\CareerAssetBatchManifestBuilder;
+use App\DTO\Career\CareerFullReleaseLedger;
+use App\DTO\Career\CareerFullReleaseLedgerMember;
+use App\Models\Occupation;
+
+final class CareerFullReleaseLedgerService
+{
+    public const LEDGER_KIND = 'career_full_release_ledger';
+
+    public const LEDGER_VERSION = 'career.release_ledger.full_342.v1';
+
+    public const SCOPE = 'career_all_342';
+
+    /**
+     * @var list<string>
+     */
+    private const BATCH_MANIFEST_PATHS = [
+        'docs/career/batches/batch_2_manifest.json',
+        'docs/career/batches/batch_3_manifest.json',
+        'docs/career/batches/batch_4_manifest.json',
+    ];
+
+    /**
+     * @var array<string, true>
+     */
+    private const REVIEW_NEEDED_CROSSWALK_MODES = [
+        'local_heavy_interpretation' => true,
+        'unmapped' => true,
+        'functional_equivalent' => true,
+    ];
+
+    public function __construct(
+        private readonly FirstWaveManifestReader $firstWaveManifestReader,
+        private readonly CareerAssetBatchManifestBuilder $manifestBuilder,
+        private readonly CareerFirstWaveLaunchReadinessAuditService $firstWaveAuditService,
+        private readonly CareerEditorialPatchAuthorityService $patchAuthorityService,
+        private readonly CareerCrosswalkReviewQueueService $reviewQueueService,
+        private readonly CareerCrosswalkOverrideResolver $crosswalkOverrideResolver,
+    ) {}
+
+    public function build(): CareerFullReleaseLedger
+    {
+        $firstWaveManifest = $this->firstWaveManifestReader->read();
+        $firstWaveAuditPayload = $this->safeFirstWaveAudit();
+        $firstWaveAudit = $firstWaveAuditPayload['audit'];
+        $firstWaveAuditAvailable = (bool) ($firstWaveAuditPayload['available'] ?? false);
+        $batchMembers = $this->loadBatchMembers();
+        $trackedMembers = $this->buildTrackedMembers($firstWaveManifest, $batchMembers);
+
+        $auditBySlug = $this->mapBySlug((array) ($firstWaveAudit['members'] ?? []));
+        $batchContextBySlug = $this->buildBatchContextBySlug($trackedMembers);
+        $approvedPatchesBySlug = $this->approvedPatchesBySlug();
+
+        $subjects = $this->buildQueueSubjects($trackedMembers, $auditBySlug);
+        $reviewQueue = $this->reviewQueueService->build(
+            subjects: $subjects,
+            approvedPatchesBySlug: $approvedPatchesBySlug,
+            batchContextBySlug: $batchContextBySlug,
+            scope: self::SCOPE,
+        )->toArray();
+        $reviewQueueBySlug = $this->mapBySlug((array) ($reviewQueue['items'] ?? []), 'subject_slug');
+
+        $resolvedCrosswalk = $this->crosswalkOverrideResolver->resolve($subjects, $approvedPatchesBySlug);
+        $resolvedBySlug = $this->mapBySlug((array) ($resolvedCrosswalk['resolved'] ?? []), 'subject_slug');
+
+        $indexStateBySlug = $this->loadIndexStateBySlug(array_keys($trackedMembers));
+
+        $releaseCounts = [
+            'public_detail_indexable' => 0,
+            'public_detail_conservative' => 0,
+            'explorer_only' => 0,
+            'family_handoff' => 0,
+            'review_needed' => 0,
+            'blocked' => 0,
+        ];
+
+        $opsHandoffCounts = [
+            'review_queue_total' => (int) data_get($reviewQueue, 'counts.total', 0),
+            'family_handoff_total' => 0,
+            'review_needed_total' => 0,
+            'explorer_only_total' => 0,
+            'override_applied_total' => (int) data_get($resolvedCrosswalk, 'counts.override_applied', 0),
+            'unmapped_total' => 0,
+        ];
+
+        $members = [];
+
+        foreach ($trackedMembers as $slug => $tracked) {
+            $auditRow = $auditBySlug[$slug] ?? null;
+            $queueRow = $reviewQueueBySlug[$slug] ?? null;
+            $resolvedRow = $resolvedBySlug[$slug] ?? null;
+            $indexRow = $indexStateBySlug[$slug] ?? null;
+
+            $currentCrosswalkMode = $this->normalizeNullableString($tracked['crosswalk_mode'] ?? null);
+            $currentIndexState = $this->normalizeIndexState((string) ($auditRow['lifecycle_state'] ?? $indexRow['current_index_state'] ?? ''));
+            $indexEligible = (bool) ($auditRow['index_eligible'] ?? $indexRow['index_eligible'] ?? false);
+            $publicIndexState = $this->normalizePublicIndexState(
+                (string) ($auditRow['public_index_state'] ?? $indexRow['public_index_state'] ?? ''),
+                $indexEligible,
+            );
+
+            $blockedGovernanceStatus = $this->normalizeNullableString($auditRow['blocked_governance_status'] ?? null);
+            $readinessStatus = $this->normalizeNullableString($auditRow['readiness_status'] ?? null);
+
+            $releaseCohort = $this->resolveReleaseCohort(
+                firstWaveMember: (bool) ($tracked['first_wave_member'] ?? false),
+                batchOrigin: $this->normalizeNullableString($tracked['batch_origin'] ?? null),
+                crosswalkMode: $currentCrosswalkMode,
+                readinessStatus: $readinessStatus,
+                blockedGovernanceStatus: $blockedGovernanceStatus,
+                publicIndexState: $publicIndexState,
+                queueRow: $queueRow,
+                resolvedRow: $resolvedRow,
+            );
+
+            $blockerReasons = $this->buildBlockerReasons(
+                releaseCohort: $releaseCohort,
+                tracked: $tracked,
+                readinessStatus: $readinessStatus,
+                blockedGovernanceStatus: $blockedGovernanceStatus,
+                publicIndexState: $publicIndexState,
+                queueRow: $queueRow,
+                firstWaveAuditAvailable: $firstWaveAuditAvailable,
+            );
+
+            $releaseCounts[$releaseCohort]++;
+            if ($releaseCohort === 'family_handoff') {
+                $opsHandoffCounts['family_handoff_total']++;
+            }
+            if ($releaseCohort === 'review_needed') {
+                $opsHandoffCounts['review_needed_total']++;
+            }
+            if ($releaseCohort === 'explorer_only') {
+                $opsHandoffCounts['explorer_only_total']++;
+            }
+            if ($currentCrosswalkMode === 'unmapped') {
+                $opsHandoffCounts['unmapped_total']++;
+            }
+
+            $members[] = new CareerFullReleaseLedgerMember(
+                memberKind: 'career_tracked_occupation',
+                canonicalSlug: $slug,
+                canonicalTitleEn: $this->normalizeNullableString($tracked['canonical_title_en'] ?? null),
+                batchOrigin: $this->normalizeNullableString($tracked['batch_origin'] ?? null),
+                currentCrosswalkMode: $currentCrosswalkMode,
+                currentIndexState: $currentIndexState,
+                publicIndexState: $publicIndexState,
+                indexEligible: $indexEligible,
+                releaseCohort: $releaseCohort,
+                blockerReasons: $blockerReasons,
+                evidenceRefs: $this->buildEvidenceRefs($tracked, $queueRow, $resolvedRow),
+                resolvedTargetKind: $this->normalizeNullableString($resolvedRow['resolved_target_kind'] ?? null),
+                resolvedTargetSlug: $this->normalizeNullableString($resolvedRow['resolved_target_slug'] ?? null),
+                reviewQueueStatus: is_array($queueRow) ? 'queued' : null,
+                overrideApplied: is_array($resolvedRow) ? (bool) ($resolvedRow['override_applied'] ?? false) : null,
+            );
+        }
+
+        usort($members, static fn (CareerFullReleaseLedgerMember $left, CareerFullReleaseLedgerMember $right): int => strcmp(
+            $left->canonicalSlug,
+            $right->canonicalSlug,
+        ));
+
+        $expectedTotal = (int) data_get($batchMembers, 'coverage.expected_total_occupations', 0);
+        $trackedTotal = count($trackedMembers);
+        $missing = $expectedTotal > 0 ? max(0, $expectedTotal - $trackedTotal) : 0;
+
+        return new CareerFullReleaseLedger(
+            ledgerKind: self::LEDGER_KIND,
+            ledgerVersion: self::LEDGER_VERSION,
+            scope: self::SCOPE,
+            trackingCounts: [
+                'expected_total_occupations' => $expectedTotal,
+                'tracked_total_occupations' => $trackedTotal,
+                'missing_occupations' => $missing,
+                'tracking_complete' => $expectedTotal > 0 && $missing === 0,
+                'first_wave_members' => count((array) data_get($batchMembers, 'coverage.excluded_first_wave_slugs', [])),
+                'batch_members' => max(0, $trackedTotal - count((array) data_get($batchMembers, 'coverage.excluded_first_wave_slugs', []))),
+                'first_wave_audit_available' => $firstWaveAuditAvailable,
+            ],
+            releaseCounts: $releaseCounts,
+            opsHandoffCounts: $opsHandoffCounts,
+            members: $members,
+        );
+    }
+
+    /**
+     * @return array{audit: array<string, mixed>, available: bool}
+     */
+    private function safeFirstWaveAudit(): array
+    {
+        try {
+            return [
+                'audit' => $this->firstWaveAuditService->build()->toArray(),
+                'available' => true,
+            ];
+        } catch (\Throwable) {
+            return [
+                'audit' => [
+                    'summary_kind' => 'career_first_wave_launch_readiness_audit',
+                    'summary_version' => 'career.launch_readiness.audit.v1',
+                    'scope' => 'career_first_wave_10',
+                    'counts' => [],
+                    'members' => [],
+                ],
+                'available' => false,
+            ];
+        }
+    }
+
+    /**
+     * @return array{members:array<string, array<string, mixed>>,coverage:array<string, mixed>}
+     */
+    private function loadBatchMembers(): array
+    {
+        $members = [];
+
+        foreach (self::BATCH_MANIFEST_PATHS as $path) {
+            $manifest = $this->manifestBuilder->fromPath($path);
+
+            foreach ($manifest->members as $member) {
+                $slug = trim((string) $member->canonicalSlug);
+                if ($slug === '') {
+                    continue;
+                }
+
+                $members[$slug] = [
+                    'canonical_slug' => $slug,
+                    'canonical_title_en' => $member->canonicalTitleEn,
+                    'crosswalk_mode' => $member->crosswalkMode,
+                    'batch_origin' => $manifest->batchKey,
+                    'family_slug' => $member->familySlug,
+                    'expected_publish_track' => $member->expectedPublishTrack,
+                    'first_wave_member' => false,
+                ];
+            }
+        }
+
+        $setPath = base_path('docs/career/batches/b71x_batch_set.json');
+        $setConfig = json_decode((string) file_get_contents($setPath), true);
+
+        return [
+            'members' => $members,
+            'coverage' => is_array($setConfig['coverage_baseline'] ?? null)
+                ? $setConfig['coverage_baseline']
+                : [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $firstWaveManifest
+     * @param  array{members:array<string, array<string, mixed>>,coverage:array<string, mixed>}  $batchMembers
+     * @return array<string, array<string, mixed>>
+     */
+    private function buildTrackedMembers(array $firstWaveManifest, array $batchMembers): array
+    {
+        $tracked = [];
+        $firstWaveBySlug = [];
+
+        foreach ((array) ($firstWaveManifest['occupations'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $firstWaveBySlug[$slug] = [
+                'canonical_slug' => $slug,
+                'canonical_title_en' => $this->normalizeNullableString($row['canonical_title_en'] ?? null),
+                'crosswalk_mode' => $this->normalizeNullableString($row['crosswalk_mode'] ?? null),
+                'batch_origin' => 'first_wave_manifest',
+                'family_slug' => null,
+                'expected_publish_track' => $this->normalizeNullableString($row['wave_classification'] ?? null),
+                'first_wave_member' => true,
+            ];
+        }
+
+        foreach ((array) ($batchMembers['members'] ?? []) as $slug => $row) {
+            $tracked[$slug] = $row;
+        }
+
+        foreach ((array) data_get($batchMembers, 'coverage.excluded_first_wave_slugs', []) as $slugValue) {
+            $slug = trim((string) $slugValue);
+            if ($slug === '' || isset($tracked[$slug])) {
+                continue;
+            }
+
+            $tracked[$slug] = [
+                'canonical_slug' => $slug,
+                'canonical_title_en' => $firstWaveBySlug[$slug]['canonical_title_en'] ?? null,
+                'crosswalk_mode' => $firstWaveBySlug[$slug]['crosswalk_mode'] ?? null,
+                'batch_origin' => 'b71x_excluded_first_wave',
+                'family_slug' => null,
+                'expected_publish_track' => null,
+                'first_wave_member' => true,
+            ];
+        }
+
+        ksort($tracked);
+
+        return $tracked;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $trackedMembers
+     * @return array<string, array{batch_origin:?string,publish_track:?string,family_slug:?string}>
+     */
+    private function buildBatchContextBySlug(array $trackedMembers): array
+    {
+        $context = [];
+
+        foreach ($trackedMembers as $slug => $member) {
+            $context[$slug] = [
+                'batch_origin' => $this->normalizeNullableString($member['batch_origin'] ?? null),
+                'publish_track' => $this->normalizeNullableString($member['expected_publish_track'] ?? null),
+                'family_slug' => $this->normalizeNullableString($member['family_slug'] ?? null),
+            ];
+        }
+
+        return $context;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $trackedMembers
+     * @param  array<string, array<string, mixed>>  $auditBySlug
+     * @return list<array<string, mixed>>
+     */
+    private function buildQueueSubjects(array $trackedMembers, array $auditBySlug): array
+    {
+        $subjects = [];
+
+        foreach ($trackedMembers as $slug => $member) {
+            $audit = $auditBySlug[$slug] ?? [];
+
+            $subjects[] = [
+                'canonical_slug' => $slug,
+                'crosswalk_mode' => $member['crosswalk_mode'] ?? $audit['crosswalk_mode'] ?? 'unmapped',
+                'readiness_status' => $audit['readiness_status'] ?? 'blocked_override_eligible',
+                'blocked_governance_status' => $audit['blocked_governance_status'] ?? null,
+            ];
+        }
+
+        return $subjects;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function approvedPatchesBySlug(): array
+    {
+        $patches = (array) (($this->patchAuthorityService->build()->toArray())['patches'] ?? []);
+        $grouped = [];
+
+        foreach ($patches as $patch) {
+            if (! is_array($patch)) {
+                continue;
+            }
+
+            $slug = trim((string) ($patch['subject_slug'] ?? ''));
+            $status = strtolower(trim((string) ($patch['patch_status'] ?? '')));
+            if ($slug === '' || $status !== 'approved') {
+                continue;
+            }
+
+            $grouped[$slug][] = $patch;
+        }
+
+        $approved = [];
+        foreach ($grouped as $slug => $items) {
+            usort($items, static function (array $left, array $right): int {
+                $leftTime = strtotime((string) ($left['reviewed_at'] ?? $left['created_at'] ?? '')) ?: 0;
+                $rightTime = strtotime((string) ($right['reviewed_at'] ?? $right['created_at'] ?? '')) ?: 0;
+
+                return $rightTime <=> $leftTime;
+            });
+            $approved[$slug] = $items[0];
+        }
+
+        return $approved;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, array{current_index_state:string,public_index_state:string,index_eligible:bool}>
+     */
+    private function loadIndexStateBySlug(array $slugs): array
+    {
+        if ($slugs === []) {
+            return [];
+        }
+
+        return Occupation::query()
+            ->with('indexStates:id,occupation_id,index_state,index_eligible,changed_at,updated_at')
+            ->whereIn('canonical_slug', $slugs)
+            ->get(['id', 'canonical_slug'])
+            ->mapWithKeys(function (Occupation $occupation): array {
+                $indexState = $occupation->indexStates->sortByDesc(
+                    static fn ($row): int => strtotime((string) ($row->changed_at ?? $row->updated_at ?? '')) ?: 0
+                )->first();
+
+                $indexEligible = (bool) ($indexState?->index_eligible ?? false);
+                $currentIndexState = $this->normalizeIndexState((string) ($indexState?->index_state ?? ''));
+
+                return [
+                    (string) $occupation->canonical_slug => [
+                        'current_index_state' => $currentIndexState,
+                        'public_index_state' => $this->normalizePublicIndexState(
+                            (string) ($indexState?->index_state ?? ''),
+                            $indexEligible,
+                        ),
+                        'index_eligible' => $indexEligible,
+                    ],
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $queueRow
+     * @param  array<string, mixed>|null  $resolvedRow
+     */
+    private function resolveReleaseCohort(
+        bool $firstWaveMember,
+        ?string $batchOrigin,
+        ?string $crosswalkMode,
+        ?string $readinessStatus,
+        ?string $blockedGovernanceStatus,
+        string $publicIndexState,
+        ?array $queueRow,
+        ?array $resolvedRow,
+    ): string {
+        if (
+            $blockedGovernanceStatus !== null
+            || in_array((string) $readinessStatus, ['blocked_override_eligible', 'blocked_not_safely_remediable'], true)
+        ) {
+            return 'blocked';
+        }
+
+        if ($firstWaveMember && $readinessStatus === 'publish_ready') {
+            return $publicIndexState === IndexStateValue::INDEXABLE
+                ? 'public_detail_indexable'
+                : 'public_detail_conservative';
+        }
+
+        $candidateTargetKind = strtolower(trim((string) ($queueRow['candidate_target_kind'] ?? '')));
+        $resolvedTargetKind = strtolower(trim((string) ($resolvedRow['resolved_target_kind'] ?? '')));
+
+        if ($candidateTargetKind === 'family' || $resolvedTargetKind === 'family') {
+            return 'family_handoff';
+        }
+
+        if ($crosswalkMode === 'family_proxy') {
+            return 'explorer_only';
+        }
+
+        if ($crosswalkMode !== null && isset(self::REVIEW_NEEDED_CROSSWALK_MODES[$crosswalkMode])) {
+            return 'review_needed';
+        }
+
+        if ($batchOrigin !== null && in_array($batchOrigin, ['batch_2', 'batch_3'], true)) {
+            return 'public_detail_conservative';
+        }
+
+        return 'review_needed';
+    }
+
+    /**
+     * @param  array<string, mixed>  $tracked
+     * @param  array<string, mixed>|null  $queueRow
+     * @return list<string>
+     */
+    private function buildBlockerReasons(
+        string $releaseCohort,
+        array $tracked,
+        ?string $readinessStatus,
+        ?string $blockedGovernanceStatus,
+        string $publicIndexState,
+        ?array $queueRow,
+        bool $firstWaveAuditAvailable,
+    ): array {
+        $reasons = [];
+
+        if ($blockedGovernanceStatus !== null) {
+            $reasons[] = 'blocked_governance';
+        }
+
+        if (($tracked['first_wave_member'] ?? false) !== true) {
+            $reasons[] = 'full_scope_readiness_authority_not_materialized';
+        }
+        if (($tracked['first_wave_member'] ?? false) === true && $firstWaveAuditAvailable === false) {
+            $reasons[] = 'first_wave_readiness_audit_unavailable';
+        }
+
+        if ($releaseCohort === 'public_detail_conservative') {
+            if ($publicIndexState !== IndexStateValue::INDEXABLE) {
+                $reasons[] = 'public_index_not_indexable';
+            }
+            if (($tracked['batch_origin'] ?? null) === 'batch_3') {
+                $reasons[] = 'batch3_default_noindex_conservative';
+            }
+        }
+
+        if ($releaseCohort === 'explorer_only') {
+            $reasons[] = 'family_proxy_explorer_only';
+        }
+
+        if ($releaseCohort === 'family_handoff') {
+            $reasons[] = 'family_handoff_required';
+        }
+
+        if ($releaseCohort === 'review_needed') {
+            $reasons[] = 'review_queue_required';
+            if (is_array($queueRow)) {
+                foreach ((array) ($queueRow['queue_reason'] ?? []) as $reason) {
+                    if (is_string($reason) && trim($reason) !== '') {
+                        $reasons[] = trim($reason);
+                    }
+                }
+            }
+        }
+
+        if ($releaseCohort === 'blocked' && $readinessStatus !== null) {
+            $reasons[] = 'first_wave_readiness_'.$readinessStatus;
+        }
+
+        return array_values(array_unique(array_filter($reasons, static fn (mixed $reason): bool => is_string($reason) && $reason !== '')));
+    }
+
+    /**
+     * @param  array<string, mixed>  $tracked
+     * @param  array<string, mixed>|null  $queueRow
+     * @param  array<string, mixed>|null  $resolvedRow
+     * @return array<string, mixed>
+     */
+    private function buildEvidenceRefs(array $tracked, ?array $queueRow, ?array $resolvedRow): array
+    {
+        return [
+            'tracking_source' => [
+                'kind' => 'career_batch_coverage_set',
+                'path' => 'docs/career/batches/b71x_batch_set.json',
+            ],
+            'batch_manifest' => [
+                'kind' => 'career_asset_batch_manifest',
+                'batch_origin' => $tracked['batch_origin'] ?? null,
+            ],
+            'readiness_authority' => [
+                'kind' => 'career_first_wave_launch_readiness_audit_v2',
+                'scope' => 'career_first_wave_10',
+                'applies_directly' => (bool) ($tracked['first_wave_member'] ?? false),
+            ],
+            'crosswalk_queue' => [
+                'kind' => 'career_crosswalk_review_queue',
+                'queued' => is_array($queueRow),
+            ],
+            'override_resolution' => [
+                'kind' => 'career_crosswalk_override_resolver',
+                'override_applied' => is_array($resolvedRow) ? (bool) ($resolvedRow['override_applied'] ?? false) : false,
+            ],
+        ];
+    }
+
+    private function normalizeIndexState(string $state): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match ($normalized) {
+            CareerIndexLifecycleState::NOINDEX,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE,
+            CareerIndexLifecycleState::INDEXED,
+            CareerIndexLifecycleState::DEMOTED => $normalized,
+            default => CareerIndexLifecycleState::NOINDEX,
+        };
+    }
+
+    private function normalizePublicIndexState(string $state, bool $indexEligible): string
+    {
+        $normalized = strtolower(trim($state));
+
+        if (in_array($normalized, [IndexStateValue::INDEXABLE, IndexStateValue::TRUST_LIMITED, IndexStateValue::NOINDEX], true)) {
+            return $normalized;
+        }
+
+        return IndexStateValue::publicFacing($normalized, $indexEligible);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, array<string, mixed>>
+     */
+    private function mapBySlug(array $rows, string $key = 'canonical_slug'): array
+    {
+        $mapped = [];
+
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row[$key] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $mapped[$slug] = $row;
+        }
+
+        return $mapped;
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T12:43:01Z",
+  "updated_at": "2026-04-16T12:44:50Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2364,10 +2364,10 @@
     "PR-B80": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b80-career-full-342-release-ledger-authority",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "8bf0f9f78bcb7521fbb264daf62069afb6f28d8f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/925",
       "checks": {
         "local": [
           {
@@ -2383,9 +2383,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24510876483/job/71641393509"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24510890697/job/71641443036"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24510876483/job/71641403144"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24510890697/job/71641453307"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions checks failed at workflow startup in CI (hygiene failed, MBTI matrix skipped) while all required local checks passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T09:27:59.916317Z",
+  "updated_at": "2026-04-16T12:43:01Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2356,6 +2356,36 @@
         ]
       },
       "failure_reason": "GitHub Actions checks failed at workflow startup in CI (hygiene failed, MBTI matrix skipped) while all required local checks passed.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B80": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-b80-career-full-342-release-ledger-authority",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/DTO/Career/CareerFullReleaseLedger*.php app/Domain/Career/Publish/CareerFullReleaseLedger*.php app/Console/Commands/CareerExportFullReleaseLedger.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1365,6 +1365,32 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B80
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b80-career-full-342-release-ledger-authority
+    base: main
+    depends_on: ["PR-B79X"]
+    mode: execute
+    scope: >
+      Career full-342 release ledger authority (internal-only).
+      Add backend-owned full-342 release ledger DTO/service/projection + internal export command,
+      consolidating tracked/release/index/review/family-handoff truth into one machine-readable authority
+      without introducing public API/OpenAPI changes or weak-truth fields.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/DTO/Career/CareerFullReleaseLedger*.php app/Domain/Career/Publish/CareerFullReleaseLedger*.php app/Console/Commands/CareerExportFullReleaseLedger.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\Publish\CareerFullReleaseLedgerProjectionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerExportFullReleaseLedgerCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = storage_path('app/private/career_release_ledger');
+        File::deleteDirectory($this->rootDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->rootDir);
+
+        parent::tearDown();
+    }
+
+    public function test_command_materializes_internal_full_release_ledger_and_supports_json_output(): void
+    {
+        $timestamp = 'b80-test-export';
+
+        $exitCode = Artisan::call('career:export-full-release-ledger', [
+            '--timestamp' => $timestamp,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('materialized', $payload['status'] ?? null);
+
+        $artifactPath = $payload['artifacts'][CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME] ?? null;
+        $this->assertIsString($artifactPath);
+        $this->assertFileExists($artifactPath);
+
+        $ledger = json_decode((string) file_get_contents($artifactPath), true);
+        $this->assertIsArray($ledger);
+        $this->assertSame('career_full_release_ledger', $ledger['ledger_kind'] ?? null);
+        $this->assertSame('career.release_ledger.full_342.v1', $ledger['ledger_version'] ?? null);
+        $this->assertSame(342, (int) data_get($ledger, 'counts.tracking_counts.tracked_total_occupations'));
+        $this->assertCount(342, (array) ($ledger['members'] ?? []));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerFullReleaseLedgerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerFullReleaseLedgerServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_internal_full_342_release_ledger_with_expected_scope_and_count_boundaries(): void
+    {
+        $ledger = app(CareerFullReleaseLedgerService::class)->build()->toArray();
+
+        $this->assertSame('career_full_release_ledger', $ledger['ledger_kind'] ?? null);
+        $this->assertSame('career.release_ledger.full_342.v1', $ledger['ledger_version'] ?? null);
+        $this->assertSame('career_all_342', $ledger['scope'] ?? null);
+
+        $this->assertSame(342, (int) data_get($ledger, 'counts.tracking_counts.expected_total_occupations'));
+        $this->assertSame(342, (int) data_get($ledger, 'counts.tracking_counts.tracked_total_occupations'));
+        $this->assertSame(0, (int) data_get($ledger, 'counts.tracking_counts.missing_occupations'));
+        $this->assertTrue((bool) data_get($ledger, 'counts.tracking_counts.tracking_complete'));
+        $this->assertIsBool(data_get($ledger, 'counts.tracking_counts.first_wave_audit_available'));
+
+        $this->assertCount(342, (array) ($ledger['members'] ?? []));
+        $this->assertArrayHasKey('public_detail_indexable', data_get($ledger, 'counts.release_counts', []));
+        $this->assertArrayHasKey('public_detail_conservative', data_get($ledger, 'counts.release_counts', []));
+        $this->assertArrayHasKey('explorer_only', data_get($ledger, 'counts.release_counts', []));
+        $this->assertArrayHasKey('family_handoff', data_get($ledger, 'counts.release_counts', []));
+        $this->assertArrayHasKey('review_needed', data_get($ledger, 'counts.release_counts', []));
+        $this->assertArrayHasKey('blocked', data_get($ledger, 'counts.release_counts', []));
+
+        $this->assertNotSame(
+            (int) data_get($ledger, 'counts.tracking_counts.tracked_total_occupations'),
+            (int) data_get($ledger, 'counts.release_counts.public_detail_indexable', 0)
+            + (int) data_get($ledger, 'counts.release_counts.public_detail_conservative', 0)
+        );
+
+        $this->assertSame(
+            (int) data_get($ledger, 'counts.tracking_counts.tracked_total_occupations'),
+            array_sum((array) data_get($ledger, 'counts.release_counts', []))
+        );
+    }
+
+    public function test_it_keeps_family_handoff_separate_from_blocked_and_forbids_weak_truth_fields(): void
+    {
+        $ledger = app(CareerFullReleaseLedgerService::class)->build()->toArray();
+        $members = collect((array) ($ledger['members'] ?? []));
+
+        $familyMembers = $members->where('release_cohort', 'family_handoff')->values();
+        $this->assertNotEmpty($familyMembers);
+
+        foreach ($familyMembers as $member) {
+            $this->assertNotSame('blocked', $member['release_cohort'] ?? null);
+        }
+
+        $sample = (array) $members->first();
+        $this->assertArrayNotHasKey('demand_signal', $sample);
+        $this->assertArrayNotHasKey('novelty_score', $sample);
+        $this->assertArrayNotHasKey('canonical_conflict', $sample);
+    }
+}


### PR DESCRIPTION
## What Changed
- Added internal full-342 release ledger authority for career:
  - `CareerFullReleaseLedger` / `CareerFullReleaseLedgerMember` DTOs
  - `CareerFullReleaseLedgerService` (truth assembly + cohort mapping + blocker reasoning)
  - `CareerFullReleaseLedgerProjectionService` (machine-readable projection)
  - `career:export-full-release-ledger` command (internal artifact export, optional `--json`)
- Registered the new command in console kernel.
- Added PR train manifest/state entries and local check records for `PR-B80`.
- Added focused tests for ledger construction and export command behavior.
- Re-review fix: added explicit `first_wave_audit_available` signal and blocker propagation for first-wave members when readiness audit is unavailable.

## Why
- Consolidate currently distributed tracking/release/index/review/family-handoff truth into one backend-owned, internal-only, machine-readable authority for full 342 scope.
- Keep `tracking_complete` explicitly distinct from public-ready cohorts.
- Ensure `family_handoff` is independently represented (not collapsed into `blocked`).

## Validation Commands
- `cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `cd backend && vendor/bin/pint --test app/DTO/Career/CareerFullReleaseLedger*.php app/Domain/Career/Publish/CareerFullReleaseLedger*.php app/Console/Commands/CareerExportFullReleaseLedger.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `cd backend && php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`

## Intentionally Deferred
- Public API / OpenAPI exposure for full ledger
- Frontend/dashboard/reporting consumption
- Strong-index gate expansion (demand/novelty/canonical-conflict style signals)
- Dataset-hub/public contract expansions
