### PR TITLE
PR-B81: Career strong-index gate completion

### DIFF
--- a/backend/app/Console/Commands/CareerExportStrongIndexEligibility.php
+++ b/backend/app/Console/Commands/CareerExportStrongIndexEligibility.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Publish\CareerStrongIndexEligibilityProjectionService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerExportStrongIndexEligibility extends Command
+{
+    protected $signature = 'career:export-strong-index-eligibility
+        {--timestamp= : Optional output directory timestamp segment}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Materialize internal full-342 strong-index eligibility snapshot to storage/app/private/career_strong_index_eligibility.';
+
+    public function __construct(
+        private readonly CareerStrongIndexEligibilityProjectionService $projectionService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $timestamp = $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null);
+            $rootDir = storage_path('app/private/career_strong_index_eligibility');
+            $finalDir = $rootDir.DIRECTORY_SEPARATOR.$timestamp;
+            $tmpDir = $finalDir.'.tmp';
+
+            if (is_dir($finalDir) || is_dir($tmpDir)) {
+                throw new \RuntimeException('strong-index snapshot output dir already exists: '.$finalDir);
+            }
+
+            $projected = $this->projectionService->build();
+            $snapshot = (array) ($projected[CareerStrongIndexEligibilityProjectionService::SNAPSHOT_FILENAME] ?? []);
+            if ($snapshot === []) {
+                throw new \RuntimeException('empty strong-index snapshot payload');
+            }
+
+            File::ensureDirectoryExists($tmpDir);
+            $path = $tmpDir.DIRECTORY_SEPARATOR.CareerStrongIndexEligibilityProjectionService::SNAPSHOT_FILENAME;
+            $encoded = json_encode($snapshot, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                throw new \RuntimeException('failed to encode strong-index snapshot payload');
+            }
+            File::put($path, $encoded.PHP_EOL);
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize strong-index snapshot output dir: '.$finalDir);
+            }
+
+            $payload = [
+                'status' => 'materialized',
+                'output_dir' => $finalDir,
+                'artifacts' => [
+                    CareerStrongIndexEligibilityProjectionService::SNAPSHOT_FILENAME => $finalDir.DIRECTORY_SEPARATOR.CareerStrongIndexEligibilityProjectionService::SNAPSHOT_FILENAME,
+                ],
+                'snapshot' => $snapshot,
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+                return self::SUCCESS;
+            }
+
+            $this->line('status=materialized');
+            $this->line('output_dir='.$finalDir);
+            $this->line('career-strong-index-eligibility='.(string) data_get($payload, 'artifacts.career-strong-index-eligibility.json', ''));
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            $normalized = now('UTC')->format('Ymd\\THis\\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for strong-index snapshot export');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -14,6 +14,7 @@ use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutBundleArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutWavePlanArtifact;
 use App\Console\Commands\CareerExportFullReleaseLedger;
+use App\Console\Commands\CareerExportStrongIndexEligibility;
 use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CiScaleImpact;
@@ -138,6 +139,7 @@ class Kernel extends ConsoleKernel
         CareerCompileAuthorityWave::class,
         CareerCrosswalkOps::class,
         CareerExportFullReleaseLedger::class,
+        CareerExportStrongIndexEligibility::class,
         CareerRunAssetBatch::class,
         CareerExportFirstWaveRolloutBundleArtifacts::class,
         CareerExportFirstWaveReleaseArtifacts::class,

--- a/backend/app/DTO/Career/CareerStrongIndexEligibilityMember.php
+++ b/backend/app/DTO/Career/CareerStrongIndexEligibilityMember.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerStrongIndexEligibilityMember
+{
+    /**
+     * @param  list<string>  $decisionReasons
+     * @param  array<string, mixed>  $decisionEvidence
+     */
+    public function __construct(
+        public readonly string $memberKind,
+        public readonly string $canonicalSlug,
+        public readonly string $strongIndexDecision,
+        public readonly array $decisionReasons,
+        public readonly array $decisionEvidence,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'member_kind' => $this->memberKind,
+            'canonical_slug' => $this->canonicalSlug,
+            'strong_index_decision' => $this->strongIndexDecision,
+            'decision_reasons' => $this->decisionReasons,
+            'decision_evidence' => $this->decisionEvidence,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerStrongIndexEligibilitySnapshot.php
+++ b/backend/app/DTO/Career/CareerStrongIndexEligibilitySnapshot.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerStrongIndexEligibilitySnapshot
+{
+    /**
+     * @param  array<string, int>  $counts
+     * @param  list<CareerStrongIndexEligibilityMember>  $members
+     * @param  array<string, mixed>  $decisionPolicy
+     */
+    public function __construct(
+        public readonly string $snapshotKind,
+        public readonly string $snapshotVersion,
+        public readonly string $scope,
+        public readonly array $counts,
+        public readonly array $members,
+        public readonly array $decisionPolicy,
+        public readonly bool $weakSignalGateDeferred,
+        public readonly string $derivedSignalGateState,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'snapshot_kind' => $this->snapshotKind,
+            'snapshot_version' => $this->snapshotVersion,
+            'scope' => $this->scope,
+            'counts' => $this->counts,
+            'decision_policy' => $this->decisionPolicy,
+            'weak_signal_gate_deferred' => $this->weakSignalGateDeferred,
+            'derived_signal_gate_state' => $this->derivedSignalGateState,
+            'members' => array_map(
+                static fn (CareerStrongIndexEligibilityMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerStrongIndexEligibilityProjectionService.php
+++ b/backend/app/Domain/Career/Publish/CareerStrongIndexEligibilityProjectionService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+final class CareerStrongIndexEligibilityProjectionService
+{
+    public const SNAPSHOT_FILENAME = 'career-strong-index-eligibility.json';
+
+    public function __construct(
+        private readonly CareerStrongIndexEligibilityService $strongIndexEligibilityService,
+    ) {}
+
+    /**
+     * @return array{career-strong-index-eligibility.json: array<string, mixed>}
+     */
+    public function build(): array
+    {
+        return [
+            self::SNAPSHOT_FILENAME => $this->strongIndexEligibilityService->build()->toArray(),
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php
+++ b/backend/app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Domain\Career\IndexStateValue;
+use App\DTO\Career\CareerStrongIndexEligibilityMember;
+use App\DTO\Career\CareerStrongIndexEligibilitySnapshot;
+use App\Services\Career\Config\CareerThresholdExperimentAuthorityService;
+
+final class CareerStrongIndexEligibilityService
+{
+    public const SNAPSHOT_KIND = 'career_strong_index_eligibility';
+
+    public const SNAPSHOT_VERSION = 'career.strong_index.v1';
+
+    public const SCOPE = 'career_all_342';
+
+    public const DECISION_STRONG_INDEX_READY = 'strong_index_ready';
+
+    public const DECISION_INDEXABLE_BUT_NOT_STRONG_READY = 'indexable_but_not_strong_ready';
+
+    public const DECISION_MANUAL_ONLY = 'manual_only';
+
+    public const DECISION_NOT_ELIGIBLE = 'not_eligible';
+
+    /**
+     * @var array<string, true>
+     */
+    private const STRONG_READY_CROSSWALK_MODES = [
+        'exact' => true,
+        'trust_inheritance' => true,
+    ];
+
+    /**
+     * @var array<string, true>
+     */
+    private const HARD_INELIGIBLE_CROSSWALK_MODES = [
+        'local_heavy_interpretation' => true,
+        'family_proxy' => true,
+        'unmapped' => true,
+    ];
+
+    public function __construct(
+        private readonly CareerFullReleaseLedgerService $fullReleaseLedgerService,
+        private readonly CareerFirstWaveLaunchReadinessAuditV2Service $launchReadinessAuditV2Service,
+        private readonly CareerThresholdExperimentAuthorityService $thresholdAuthorityService,
+    ) {}
+
+    public function build(): CareerStrongIndexEligibilitySnapshot
+    {
+        $ledger = $this->fullReleaseLedgerService->build()->toArray();
+        $firstWaveAuditBySlug = $this->safeFirstWaveAuditBySlug();
+
+        $stableConfidenceThreshold = $this->thresholdAuthorityService->confidenceStableMin();
+        $nextStepLinksMinimum = $this->thresholdAuthorityService->promotionNextStepLinksMin();
+
+        $counts = [
+            self::DECISION_STRONG_INDEX_READY => 0,
+            self::DECISION_INDEXABLE_BUT_NOT_STRONG_READY => 0,
+            self::DECISION_MANUAL_ONLY => 0,
+            self::DECISION_NOT_ELIGIBLE => 0,
+        ];
+
+        $members = [];
+        foreach ((array) ($ledger['members'] ?? []) as $ledgerMember) {
+            if (! is_array($ledgerMember)) {
+                continue;
+            }
+
+            $slug = trim((string) ($ledgerMember['canonical_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $auditRow = $firstWaveAuditBySlug[$slug] ?? [];
+            $evidence = $this->buildEvidence($ledgerMember, $auditRow);
+
+            [$decision, $decisionReasons] = $this->resolveDecision(
+                evidence: $evidence,
+                stableConfidenceThreshold: $stableConfidenceThreshold,
+                nextStepLinksMinimum: $nextStepLinksMinimum,
+            );
+
+            $counts[$decision]++;
+            $members[] = new CareerStrongIndexEligibilityMember(
+                memberKind: 'career_tracked_occupation',
+                canonicalSlug: $slug,
+                strongIndexDecision: $decision,
+                decisionReasons: $decisionReasons,
+                decisionEvidence: $evidence,
+            );
+        }
+
+        usort($members, static fn (CareerStrongIndexEligibilityMember $left, CareerStrongIndexEligibilityMember $right): int => strcmp(
+            $left->canonicalSlug,
+            $right->canonicalSlug,
+        ));
+
+        return new CareerStrongIndexEligibilitySnapshot(
+            snapshotKind: self::SNAPSHOT_KIND,
+            snapshotVersion: self::SNAPSHOT_VERSION,
+            scope: self::SCOPE,
+            counts: $counts,
+            members: $members,
+            decisionPolicy: [
+                'stable_confidence_threshold' => $stableConfidenceThreshold,
+                'next_step_links_minimum' => $nextStepLinksMinimum,
+                'strong_ready_crosswalk_modes' => array_keys(self::STRONG_READY_CROSSWALK_MODES),
+                'hard_ineligible_crosswalk_modes' => array_keys(self::HARD_INELIGIBLE_CROSSWALK_MODES),
+                'trust_freshness_manual_states' => ['review_due', 'review_unreviewed'],
+                'weak_signals_deferred' => ['demand_signal', 'novelty_score', 'canonical_conflict'],
+                'derived_signal_gate_state' => 'deferred',
+            ],
+            weakSignalGateDeferred: true,
+            derivedSignalGateState: 'deferred',
+        );
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function safeFirstWaveAuditBySlug(): array
+    {
+        try {
+            $payload = $this->launchReadinessAuditV2Service->build()->toArray();
+        } catch (\Throwable) {
+            return [];
+        }
+
+        $mapped = [];
+        foreach ((array) ($payload['members'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row['canonical_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $mapped[$slug] = $row;
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @param  array<string, mixed>  $ledgerMember
+     * @param  array<string, mixed>  $auditRow
+     * @return array<string, mixed>
+     */
+    private function buildEvidence(array $ledgerMember, array $auditRow): array
+    {
+        $trustFreshness = is_array($auditRow['trust_freshness'] ?? null)
+            ? $auditRow['trust_freshness']
+            : [];
+
+        return [
+            'current_index_state' => $this->normalizeIndexState((string) ($ledgerMember['current_index_state'] ?? '')),
+            'public_index_state' => $this->normalizePublicIndexState((string) ($ledgerMember['public_index_state'] ?? '')),
+            'index_eligible' => (bool) ($ledgerMember['index_eligible'] ?? false),
+            'reviewer_status' => $this->normalizeNullableString($auditRow['reviewer_status'] ?? null),
+            'confidence_score' => $this->normalizeNullableInt($auditRow['confidence_score'] ?? null),
+            'allow_strong_claim' => $this->normalizeNullableBool($auditRow['allow_strong_claim'] ?? null),
+            'crosswalk_mode' => $this->normalizeNullableString($ledgerMember['current_crosswalk_mode'] ?? null),
+            'blocked_governance_status' => $this->normalizeNullableString($auditRow['blocked_governance_status'] ?? null),
+            'next_step_links_count' => $this->normalizeNullableInt($auditRow['next_step_links_count'] ?? null),
+            'trust_freshness' => [
+                'review_due_known' => (bool) ($trustFreshness['review_due_known'] ?? false),
+                'review_staleness_state' => $this->normalizeNullableString($trustFreshness['review_staleness_state'] ?? null) ?? 'unknown_due_date',
+            ],
+            'release_cohort' => $this->normalizeNullableString($ledgerMember['release_cohort'] ?? null),
+            'review_queue_status' => $this->normalizeNullableString($ledgerMember['review_queue_status'] ?? null),
+            'override_applied' => $this->normalizeNullableBool($ledgerMember['override_applied'] ?? null),
+            'resolved_target_kind' => $this->normalizeNullableString($ledgerMember['resolved_target_kind'] ?? null),
+            'derived_signal_gate_state' => 'deferred',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array{string, list<string>}
+     */
+    private function resolveDecision(
+        array $evidence,
+        int $stableConfidenceThreshold,
+        int $nextStepLinksMinimum,
+    ): array {
+        $decisionReasons = [];
+
+        $publicIndexState = (string) ($evidence['public_index_state'] ?? IndexStateValue::NOINDEX);
+        $indexEligible = (bool) ($evidence['index_eligible'] ?? false);
+        $reviewerStatus = $this->normalizeNullableString($evidence['reviewer_status'] ?? null);
+        $confidenceScore = $this->normalizeNullableInt($evidence['confidence_score'] ?? null);
+        $allowStrongClaim = $this->normalizeNullableBool($evidence['allow_strong_claim'] ?? null);
+        $crosswalkMode = $this->normalizeNullableString($evidence['crosswalk_mode'] ?? null);
+        $blockedGovernanceStatus = $this->normalizeNullableString($evidence['blocked_governance_status'] ?? null);
+        $nextStepLinksCount = $this->normalizeNullableInt($evidence['next_step_links_count'] ?? null);
+        $reviewQueueStatus = $this->normalizeNullableString($evidence['review_queue_status'] ?? null);
+        $overrideApplied = $this->normalizeNullableBool($evidence['override_applied'] ?? null);
+        $releaseCohort = $this->normalizeNullableString($evidence['release_cohort'] ?? null);
+        $resolvedTargetKind = $this->normalizeNullableString($evidence['resolved_target_kind'] ?? null);
+        $trustStalenessState = $this->normalizeNullableString(data_get($evidence, 'trust_freshness.review_staleness_state')) ?? 'unknown_due_date';
+
+        $familyHandoff = $releaseCohort === 'family_handoff'
+            || $resolvedTargetKind === 'family'
+            || $crosswalkMode === 'family_proxy';
+
+        $manualSignals = [];
+        if (in_array($trustStalenessState, ['review_due', 'review_unreviewed'], true)) {
+            $manualSignals[] = 'trust_freshness_manual_review';
+        }
+        if ($crosswalkMode === 'functional_equivalent') {
+            $manualSignals[] = 'functional_equivalent_manual_review';
+        }
+        if ($reviewQueueStatus === 'queued' && $overrideApplied !== true) {
+            $manualSignals[] = 'review_queue_unresolved_manual_review';
+        }
+
+        $hardIneligibleReasons = [];
+        if ($familyHandoff) {
+            $hardIneligibleReasons[] = 'family_handoff_not_strong_index_subject';
+        }
+        if ($blockedGovernanceStatus !== null) {
+            $hardIneligibleReasons[] = 'governance_blocked';
+        }
+        if (! $indexEligible) {
+            $hardIneligibleReasons[] = 'index_eligible_false';
+        }
+        if ($crosswalkMode !== null && isset(self::HARD_INELIGIBLE_CROSSWALK_MODES[$crosswalkMode])) {
+            $hardIneligibleReasons[] = 'crosswalk_mode_not_eligible_for_strong_index';
+        }
+
+        if ($hardIneligibleReasons !== []) {
+            $decisionReasons = array_values(array_unique(array_merge($hardIneligibleReasons, $manualSignals)));
+
+            return [self::DECISION_NOT_ELIGIBLE, $decisionReasons];
+        }
+
+        $strongReady = $publicIndexState === IndexStateValue::INDEXABLE
+            && $indexEligible
+            && $confidenceScore !== null
+            && $confidenceScore >= $stableConfidenceThreshold
+            && $reviewerStatus === 'approved'
+            && $allowStrongClaim === true
+            && $blockedGovernanceStatus === null
+            && $nextStepLinksCount !== null
+            && $nextStepLinksCount >= $nextStepLinksMinimum
+            && $crosswalkMode !== null
+            && isset(self::STRONG_READY_CROSSWALK_MODES[$crosswalkMode])
+            && ! in_array($trustStalenessState, ['review_due', 'review_unreviewed'], true)
+            && ! $familyHandoff;
+
+        if ($strongReady) {
+            return [
+                self::DECISION_STRONG_INDEX_READY,
+                [
+                    'public_index_state_indexable',
+                    'index_eligible_true',
+                    'confidence_meets_stable_threshold',
+                    'reviewer_approved',
+                    'strong_claim_allowed',
+                    'next_step_links_sufficient',
+                    'crosswalk_mode_strong_safe',
+                    'trust_freshness_not_manual_state',
+                ],
+            ];
+        }
+
+        if ($manualSignals !== []) {
+            return [self::DECISION_MANUAL_ONLY, array_values(array_unique($manualSignals))];
+        }
+
+        if ($publicIndexState === IndexStateValue::INDEXABLE) {
+            if ($confidenceScore === null) {
+                $decisionReasons[] = 'confidence_score_unknown';
+            } elseif ($confidenceScore < $stableConfidenceThreshold) {
+                $decisionReasons[] = 'confidence_below_stable_threshold';
+            }
+
+            if ($reviewerStatus !== 'approved') {
+                $decisionReasons[] = 'reviewer_not_approved';
+            }
+            if ($allowStrongClaim !== true) {
+                $decisionReasons[] = 'strong_claim_not_allowed';
+            }
+            if ($nextStepLinksCount === null || $nextStepLinksCount < $nextStepLinksMinimum) {
+                $decisionReasons[] = 'next_step_links_below_minimum';
+            }
+            if ($crosswalkMode === null || ! isset(self::STRONG_READY_CROSSWALK_MODES[$crosswalkMode])) {
+                $decisionReasons[] = 'crosswalk_mode_not_strong_safe';
+            }
+            if ($trustStalenessState === 'unknown_due_date') {
+                $decisionReasons[] = 'trust_freshness_unknown_due_date';
+            }
+
+            if ($decisionReasons === []) {
+                $decisionReasons[] = 'indexable_without_full_strong_gate_alignment';
+            }
+
+            return [self::DECISION_INDEXABLE_BUT_NOT_STRONG_READY, array_values(array_unique($decisionReasons))];
+        }
+
+        $decisionReasons[] = 'public_index_state_not_indexable';
+
+        return [self::DECISION_NOT_ELIGIBLE, array_values(array_unique($decisionReasons))];
+    }
+
+    private function normalizeIndexState(string $state): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match ($normalized) {
+            CareerIndexLifecycleState::NOINDEX,
+            CareerIndexLifecycleState::PROMOTION_CANDIDATE,
+            CareerIndexLifecycleState::INDEXED,
+            CareerIndexLifecycleState::DEMOTED => $normalized,
+            default => CareerIndexLifecycleState::NOINDEX,
+        };
+    }
+
+    private function normalizePublicIndexState(string $state): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return match ($normalized) {
+            IndexStateValue::INDEXABLE,
+            IndexStateValue::TRUST_LIMITED,
+            IndexStateValue::NOINDEX => $normalized,
+            default => IndexStateValue::NOINDEX,
+        };
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeNullableInt(mixed $value): ?int
+    {
+        return is_numeric($value) ? (int) round((float) $value) : null;
+    }
+
+    private function normalizeNullableBool(mixed $value): ?bool
+    {
+        return is_bool($value) ? $value : null;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T13:12:38Z",
+  "updated_at": "2026-04-16T13:13:19Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2417,7 +2417,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "github_checks_failed",
       "branch": "codex/pr-b81-career-strong-index-gate-completion",
-      "commit_sha": "82056ab833c2e8be5605219a2b164edec7023d48",
+      "commit_sha": "883bec0bfdc684353cb4ad983364d24f596c6b89",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/926",
       "checks": {
         "local": [
@@ -2442,22 +2442,22 @@
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512170346/job/71645986232"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512216563/job/71646157150"
           },
           {
             "name": "hygiene",
             "status": "failed",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512186310/job/71646043857"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512218500/job/71646162794"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512170346/job/71646002533"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512216563/job/71646166738"
           },
           {
             "name": "verify-mbti-${{ matrix.mode }}",
             "status": "skipped",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512186310/job/71646057001"
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512218500/job/71646172210"
           }
         ]
       },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T12:44:50Z",
+  "updated_at": "2026-04-16T13:09:53Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2407,6 +2407,40 @@
         ]
       },
       "failure_reason": "GitHub Actions checks failed at workflow startup in CI (hygiene failed, MBTI matrix skipped) while all required local checks passed.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B81": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-b81-career-strong-index-gate-completion",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/DTO/Career/CareerStrongIndexEligibility*.php app/Domain/Career/Publish/CareerStrongIndexEligibility*.php app/Console/Commands/CareerExportStrongIndexEligibility.php tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Feature/Console/CareerExportStrongIndexEligibilityCommandTest.php app/Console/Kernel.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Feature/Console/CareerExportStrongIndexEligibilityCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T13:09:53Z",
+  "updated_at": "2026-04-16T13:12:38Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2415,10 +2415,10 @@
     "PR-B81": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b81-career-strong-index-gate-completion",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "82056ab833c2e8be5605219a2b164edec7023d48",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/926",
       "checks": {
         "local": [
           {
@@ -2438,9 +2438,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512170346/job/71645986232"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512186310/job/71646043857"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512170346/job/71646002533"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24512186310/job/71646057001"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions checks failed at workflow startup in CI (hygiene failed, MBTI matrix skipped) while all required local checks passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1391,6 +1391,33 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B81
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b81-career-strong-index-gate-completion
+    base: main
+    depends_on: ["PR-B80"]
+    mode: execute
+    scope: >
+      Career strong-index gate completion (internal-only).
+      Add full-342 strong-index eligibility authority + projection + export command,
+      formalizing strong_index_ready/indexable_but_not_strong_ready/manual_only/not_eligible
+      from existing backend truth while keeping trust freshness soft/manual and weak signals deferred.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/DTO/Career/CareerStrongIndexEligibility*.php app/Domain/Career/Publish/CareerStrongIndexEligibility*.php app/Console/Commands/CareerExportStrongIndexEligibility.php tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Feature/Console/CareerExportStrongIndexEligibilityCommandTest.php app/Console/Kernel.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Feature/Console/CareerExportStrongIndexEligibilityCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Console/CareerExportStrongIndexEligibilityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportStrongIndexEligibilityCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\Publish\CareerStrongIndexEligibilityProjectionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerExportStrongIndexEligibilityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = storage_path('app/private/career_strong_index_eligibility');
+        File::deleteDirectory($this->rootDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->rootDir);
+
+        parent::tearDown();
+    }
+
+    public function test_command_materializes_internal_full_342_strong_index_snapshot_and_supports_json_output(): void
+    {
+        $timestamp = 'b81-test-export';
+
+        $exitCode = Artisan::call('career:export-strong-index-eligibility', [
+            '--timestamp' => $timestamp,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('materialized', $payload['status'] ?? null);
+
+        $artifactPath = $payload['artifacts'][CareerStrongIndexEligibilityProjectionService::SNAPSHOT_FILENAME] ?? null;
+        $this->assertIsString($artifactPath);
+        $this->assertFileExists($artifactPath);
+
+        $snapshot = json_decode((string) file_get_contents($artifactPath), true);
+        $this->assertIsArray($snapshot);
+        $this->assertSame('career_strong_index_eligibility', $snapshot['snapshot_kind'] ?? null);
+        $this->assertSame('career.strong_index.v1', $snapshot['snapshot_version'] ?? null);
+        $this->assertSame('career_all_342', $snapshot['scope'] ?? null);
+        $this->assertCount(342, (array) ($snapshot['members'] ?? []));
+        $this->assertSame(342, array_sum(array_map(static fn ($value): int => (int) $value, (array) ($snapshot['counts'] ?? []))));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerStrongIndexEligibilityService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerStrongIndexEligibilityServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_full_342_internal_snapshot_with_safe_four_state_decisions(): void
+    {
+        $snapshot = app(CareerStrongIndexEligibilityService::class)->build()->toArray();
+
+        $this->assertSame('career_strong_index_eligibility', $snapshot['snapshot_kind'] ?? null);
+        $this->assertSame('career.strong_index.v1', $snapshot['snapshot_version'] ?? null);
+        $this->assertSame('career_all_342', $snapshot['scope'] ?? null);
+        $this->assertTrue((bool) ($snapshot['weak_signal_gate_deferred'] ?? false));
+        $this->assertSame('deferred', $snapshot['derived_signal_gate_state'] ?? null);
+
+        $counts = (array) ($snapshot['counts'] ?? []);
+        $this->assertEqualsCanonicalizing([
+            'strong_index_ready',
+            'indexable_but_not_strong_ready',
+            'manual_only',
+            'not_eligible',
+        ], array_keys($counts));
+
+        $members = (array) ($snapshot['members'] ?? []);
+        $this->assertCount(342, $members);
+        $this->assertSame(342, array_sum(array_map(static fn ($value): int => (int) $value, $counts)));
+
+        $allowedStates = [
+            'strong_index_ready' => true,
+            'indexable_but_not_strong_ready' => true,
+            'manual_only' => true,
+            'not_eligible' => true,
+        ];
+
+        foreach ($members as $member) {
+            $decision = (string) ($member['strong_index_decision'] ?? '');
+            $this->assertArrayHasKey($decision, $allowedStates);
+            $this->assertArrayHasKey('decision_evidence', $member);
+            $this->assertArrayNotHasKey('demand_signal', $member);
+            $this->assertArrayNotHasKey('novelty_score', $member);
+            $this->assertArrayNotHasKey('canonical_conflict', $member);
+
+            $reasons = (array) ($member['decision_reasons'] ?? []);
+            $this->assertNotContains('review_expired', $reasons);
+            $this->assertNotContains('trust_expired', $reasons);
+            $this->assertNotContains('review_stale', $reasons);
+            $this->assertNotContains('trust_review_due_hard_block', $reasons);
+        }
+
+        $strongReadyFamilyMembers = array_filter($members, static function (array $member): bool {
+            if (($member['strong_index_decision'] ?? null) !== 'strong_index_ready') {
+                return false;
+            }
+
+            $releaseCohort = data_get($member, 'decision_evidence.release_cohort');
+            $crosswalkMode = data_get($member, 'decision_evidence.crosswalk_mode');
+
+            return $releaseCohort === 'family_handoff' || $crosswalkMode === 'family_proxy';
+        });
+
+        $this->assertCount(0, $strongReadyFamilyMembers);
+    }
+
+    public function test_it_keeps_trust_freshness_soft_and_family_handoff_outside_strong_ready(): void
+    {
+        $service = app(CareerStrongIndexEligibilityService::class);
+        $resolver = new \ReflectionMethod($service, 'resolveDecision');
+        $resolver->setAccessible(true);
+
+        $manualEvidence = [
+            'public_index_state' => 'indexable',
+            'index_eligible' => true,
+            'reviewer_status' => 'approved',
+            'confidence_score' => 95,
+            'allow_strong_claim' => true,
+            'crosswalk_mode' => 'exact',
+            'blocked_governance_status' => null,
+            'next_step_links_count' => 3,
+            'review_queue_status' => null,
+            'override_applied' => null,
+            'release_cohort' => 'public_detail_indexable',
+            'resolved_target_kind' => null,
+            'trust_freshness' => [
+                'review_staleness_state' => 'review_due',
+            ],
+        ];
+        $manual = $resolver->invoke($service, $manualEvidence, 75, 2);
+
+        $this->assertSame('manual_only', $manual[0]);
+        $this->assertContains('trust_freshness_manual_review', $manual[1]);
+        $this->assertNotContains('trust_review_due_hard_block', $manual[1]);
+
+        $familyEvidence = [
+            'public_index_state' => 'indexable',
+            'index_eligible' => true,
+            'reviewer_status' => 'approved',
+            'confidence_score' => 95,
+            'allow_strong_claim' => true,
+            'crosswalk_mode' => 'family_proxy',
+            'blocked_governance_status' => null,
+            'next_step_links_count' => 3,
+            'review_queue_status' => 'queued',
+            'override_applied' => false,
+            'release_cohort' => 'family_handoff',
+            'resolved_target_kind' => 'family',
+            'trust_freshness' => [
+                'review_staleness_state' => 'review_scheduled',
+            ],
+        ];
+        $family = $resolver->invoke($service, $familyEvidence, 75, 2);
+
+        $this->assertSame('not_eligible', $family[0]);
+        $this->assertNotSame('strong_index_ready', $family[0]);
+    }
+}


### PR DESCRIPTION
## What Changed
- Added an internal full-342 strong-index eligibility authority:
  - `CareerStrongIndexEligibilitySnapshot` / `CareerStrongIndexEligibilityMember` DTOs
  - `CareerStrongIndexEligibilityService` decision engine
  - `CareerStrongIndexEligibilityProjectionService` projection builder
  - `career:export-strong-index-eligibility` export command
- Registered the new command in console kernel.
- Added focused tests:
  - Unit: strong-index decision contract and safety boundaries
  - Feature: export command materialization + JSON payload checks
- Added PR-B81 train manifest/state entries and recorded local verification status.

## Why
- Formalize strong-index as an internal auditable backend authority (full-342 scope), separate from baseline indexability.
- Produce machine-readable eligibility snapshot with explicit 4-state decisions:
  - `strong_index_ready`
  - `indexable_but_not_strong_ready`
  - `manual_only`
  - `not_eligible`
- Keep trust freshness conservative (manual/evidence handling only), keep weak signals deferred, and keep family-handoff outside strong-ready.

## Validation Commands
- `cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `cd backend && vendor/bin/pint --test app/DTO/Career/CareerStrongIndexEligibility*.php app/Domain/Career/Publish/CareerStrongIndexEligibility*.php app/Console/Commands/CareerExportStrongIndexEligibility.php tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Feature/Console/CareerExportStrongIndexEligibilityCommandTest.php app/Console/Kernel.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `cd backend && php artisan test tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Feature/Console/CareerExportStrongIndexEligibilityCommandTest.php`
- `cd backend && php artisan test tests/Unit/Services/Career/CareerFirstWaveIndexPolicyEngineTest.php tests/Unit/Services/Career/CareerFirstWavePromotionCandidateEngineTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php`

## Intentionally Deferred
- Public API / OpenAPI exposure
- Frontend/dashboard consumption
- Hard gating on derived signals
- Weak-signal truth (`demand_signal`, `novelty_score`, `canonical_conflict`)
- Stale/expired hard freshness semantics
