### PR TITLE
PR-B82: Career crosswalk backlog convergence authority

### DIFF
--- a/backend/app/Console/Commands/CareerExportCrosswalkBacklogConvergence.php
+++ b/backend/app/Console/Commands/CareerExportCrosswalkBacklogConvergence.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Operations\CareerCrosswalkBacklogConvergenceProjectionService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerExportCrosswalkBacklogConvergence extends Command
+{
+    protected $signature = 'career:export-crosswalk-backlog-convergence
+        {--timestamp= : Optional output directory timestamp segment}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Materialize internal crosswalk backlog convergence snapshot to storage/app/private/career_crosswalk_backlog_convergence.';
+
+    public function __construct(
+        private readonly CareerCrosswalkBacklogConvergenceProjectionService $projectionService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $timestamp = $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null);
+            $rootDir = storage_path('app/private/career_crosswalk_backlog_convergence');
+            $finalDir = $rootDir.DIRECTORY_SEPARATOR.$timestamp;
+            $tmpDir = $finalDir.'.tmp';
+
+            if (is_dir($finalDir) || is_dir($tmpDir)) {
+                throw new \RuntimeException('crosswalk backlog convergence output dir already exists: '.$finalDir);
+            }
+
+            $projected = $this->projectionService->build();
+            $snapshot = (array) ($projected[CareerCrosswalkBacklogConvergenceProjectionService::SNAPSHOT_FILENAME] ?? []);
+            if ($snapshot === []) {
+                throw new \RuntimeException('empty crosswalk backlog convergence snapshot payload');
+            }
+
+            File::ensureDirectoryExists($tmpDir);
+            $path = $tmpDir.DIRECTORY_SEPARATOR.CareerCrosswalkBacklogConvergenceProjectionService::SNAPSHOT_FILENAME;
+            $encoded = json_encode($snapshot, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                throw new \RuntimeException('failed to encode crosswalk backlog convergence snapshot payload');
+            }
+            File::put($path, $encoded.PHP_EOL);
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize crosswalk backlog convergence output dir: '.$finalDir);
+            }
+
+            $payload = [
+                'status' => 'materialized',
+                'output_dir' => $finalDir,
+                'artifacts' => [
+                    CareerCrosswalkBacklogConvergenceProjectionService::SNAPSHOT_FILENAME => $finalDir.DIRECTORY_SEPARATOR.CareerCrosswalkBacklogConvergenceProjectionService::SNAPSHOT_FILENAME,
+                ],
+                'snapshot' => $snapshot,
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+                return self::SUCCESS;
+            }
+
+            $this->line('status=materialized');
+            $this->line('output_dir='.$finalDir);
+            $this->line('career-crosswalk-backlog-convergence='.(string) data_get($payload, 'artifacts.career-crosswalk-backlog-convergence.json', ''));
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            $normalized = now('UTC')->format('Ymd\\THis\\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for crosswalk backlog convergence export');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -10,6 +10,7 @@ use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCrosswalkOps;
+use App\Console\Commands\CareerExportCrosswalkBacklogConvergence;
 use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutBundleArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutWavePlanArtifact;
@@ -138,6 +139,7 @@ class Kernel extends ConsoleKernel
         CareerImportAuthorityWave::class,
         CareerCompileAuthorityWave::class,
         CareerCrosswalkOps::class,
+        CareerExportCrosswalkBacklogConvergence::class,
         CareerExportFullReleaseLedger::class,
         CareerExportStrongIndexEligibility::class,
         CareerRunAssetBatch::class,

--- a/backend/app/DTO/Career/CareerCrosswalkBacklogConvergenceMember.php
+++ b/backend/app/DTO/Career/CareerCrosswalkBacklogConvergenceMember.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerCrosswalkBacklogConvergenceMember
+{
+    /**
+     * @param  list<string>  $queueReason
+     * @param  array<string, mixed>  $evidenceRefs
+     */
+    public function __construct(
+        public readonly string $canonicalSlug,
+        public readonly ?string $currentCrosswalkMode,
+        public readonly string $convergenceState,
+        public readonly array $queueReason,
+        public readonly ?int $agingDays,
+        public readonly ?string $latestPatchStatus,
+        public readonly bool $overrideApplied,
+        public readonly ?string $resolvedTargetKind,
+        public readonly ?string $resolvedTargetSlug,
+        public readonly array $evidenceRefs,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'canonical_slug' => $this->canonicalSlug,
+            'current_crosswalk_mode' => $this->currentCrosswalkMode,
+            'convergence_state' => $this->convergenceState,
+            'queue_reason' => $this->queueReason,
+            'aging_days' => $this->agingDays,
+            'latest_patch_status' => $this->latestPatchStatus,
+            'override_applied' => $this->overrideApplied,
+            'resolved_target_kind' => $this->resolvedTargetKind,
+            'resolved_target_slug' => $this->resolvedTargetSlug,
+            'evidence_refs' => $this->evidenceRefs,
+        ];
+    }
+}

--- a/backend/app/DTO/Career/CareerCrosswalkBacklogConvergenceSnapshot.php
+++ b/backend/app/DTO/Career/CareerCrosswalkBacklogConvergenceSnapshot.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Career;
+
+final class CareerCrosswalkBacklogConvergenceSnapshot
+{
+    /**
+     * @param  array<string, mixed>  $trackingCounts
+     * @param  array<string, int>  $counts
+     * @param  array<string, mixed>  $aging
+     * @param  array<string, mixed>  $patchCoverage
+     * @param  list<CareerCrosswalkBacklogConvergenceMember>  $members
+     * @param  array<string, mixed>  $convergencePolicy
+     */
+    public function __construct(
+        public readonly string $authorityKind,
+        public readonly string $authorityVersion,
+        public readonly string $scope,
+        public readonly array $trackingCounts,
+        public readonly array $counts,
+        public readonly array $aging,
+        public readonly array $patchCoverage,
+        public readonly array $members,
+        public readonly array $convergencePolicy,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'authority_kind' => $this->authorityKind,
+            'authority_version' => $this->authorityVersion,
+            'scope' => $this->scope,
+            'tracking_counts' => $this->trackingCounts,
+            'counts' => $this->counts,
+            'aging' => $this->aging,
+            'patch_coverage' => $this->patchCoverage,
+            'convergence_policy' => $this->convergencePolicy,
+            'members' => array_map(
+                static fn (CareerCrosswalkBacklogConvergenceMember $member): array => $member->toArray(),
+                $this->members,
+            ),
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Operations/CareerCrosswalkBacklogConvergenceProjectionService.php
+++ b/backend/app/Domain/Career/Operations/CareerCrosswalkBacklogConvergenceProjectionService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Operations;
+
+final class CareerCrosswalkBacklogConvergenceProjectionService
+{
+    public const SNAPSHOT_FILENAME = 'career-crosswalk-backlog-convergence.json';
+
+    public function __construct(
+        private readonly CareerCrosswalkBacklogConvergenceService $convergenceService,
+    ) {}
+
+    /**
+     * @return array{career-crosswalk-backlog-convergence.json: array<string, mixed>}
+     */
+    public function build(): array
+    {
+        return [
+            self::SNAPSHOT_FILENAME => $this->convergenceService->build()->toArray(),
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Operations/CareerCrosswalkBacklogConvergenceService.php
+++ b/backend/app/Domain/Career/Operations/CareerCrosswalkBacklogConvergenceService.php
@@ -1,0 +1,599 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Operations;
+
+use App\Domain\Career\Publish\CareerFullReleaseLedgerService;
+use App\DTO\Career\CareerCrosswalkBacklogConvergenceMember;
+use App\DTO\Career\CareerCrosswalkBacklogConvergenceSnapshot;
+
+final class CareerCrosswalkBacklogConvergenceService
+{
+    public const AUTHORITY_KIND = 'career_crosswalk_backlog_convergence';
+
+    public const AUTHORITY_VERSION = 'career.crosswalk_convergence.v1';
+
+    public const SCOPE = 'career_all_342';
+
+    public const STATE_STILL_UNRESOLVED = 'still_unresolved';
+
+    public const STATE_RESOLVED_BY_APPROVED_PATCH = 'resolved_by_approved_patch';
+
+    public const STATE_FAMILY_HANDOFF = 'family_handoff';
+
+    public const STATE_REVIEW_NEEDED = 'review_needed';
+
+    public const STATE_BLOCKED = 'blocked';
+
+    public const AGING_METRIC_BASIS = 'latest_unresolved_patch_created_at';
+
+    /**
+     * @var array<string, true>
+     */
+    private const UNRESOLVED_MODES = [
+        'local_heavy_interpretation' => true,
+        'family_proxy' => true,
+        'unmapped' => true,
+        'functional_equivalent' => true,
+    ];
+
+    public function __construct(
+        private readonly CareerFullReleaseLedgerService $fullReleaseLedgerService,
+        private readonly CareerCrosswalkReviewQueueService $reviewQueueService,
+        private readonly CareerEditorialPatchAuthorityService $patchAuthorityService,
+        private readonly CareerCrosswalkOverrideResolver $overrideResolver,
+    ) {}
+
+    public function build(): CareerCrosswalkBacklogConvergenceSnapshot
+    {
+        $ledger = $this->fullReleaseLedgerService->build()->toArray();
+        $trackedBySlug = $this->mapBySlug((array) ($ledger['members'] ?? []), 'canonical_slug');
+
+        $patches = (array) (($this->patchAuthorityService->build(self::SCOPE)->toArray())['patches'] ?? []);
+        $latestPatchBySlug = $this->latestPatchBySlug($patches);
+        $approvedPatchBySlug = $this->approvedPatchBySlug($patches);
+
+        $subjects = $this->buildQueueSubjects($trackedBySlug);
+        $queue = $this->reviewQueueService->build(
+            subjects: $subjects,
+            approvedPatchesBySlug: $approvedPatchBySlug,
+            batchContextBySlug: $this->batchContextBySlug($trackedBySlug),
+            scope: self::SCOPE,
+        )->toArray();
+        $queueBySlug = $this->mapBySlug((array) ($queue['items'] ?? []), 'subject_slug');
+
+        $resolved = $this->overrideResolver->resolve($subjects, $approvedPatchBySlug);
+        $resolvedBySlug = $this->mapBySlug((array) ($resolved['resolved'] ?? []), 'subject_slug');
+
+        $unresolvedByMode = $this->unresolvedByMode($queueBySlug, $approvedPatchBySlug);
+
+        $stateCounts = [
+            self::STATE_STILL_UNRESOLVED => 0,
+            self::STATE_RESOLVED_BY_APPROVED_PATCH => 0,
+            self::STATE_FAMILY_HANDOFF => 0,
+            self::STATE_REVIEW_NEEDED => 0,
+            self::STATE_BLOCKED => 0,
+        ];
+
+        $members = [];
+        foreach ($trackedBySlug as $slug => $ledgerMember) {
+            $queueRow = $queueBySlug[$slug] ?? null;
+            $resolvedRow = $resolvedBySlug[$slug] ?? null;
+            $latestPatch = $latestPatchBySlug[$slug] ?? null;
+            $hasApprovedPatch = isset($approvedPatchBySlug[$slug]);
+
+            $convergenceState = $this->resolveConvergenceState(
+                ledgerMember: $ledgerMember,
+                queueRow: $queueRow,
+                resolvedRow: $resolvedRow,
+                hasApprovedPatch: $hasApprovedPatch,
+            );
+            if ($convergenceState === null) {
+                continue;
+            }
+
+            $stateCounts[$convergenceState]++;
+            $members[] = new CareerCrosswalkBacklogConvergenceMember(
+                canonicalSlug: $slug,
+                currentCrosswalkMode: $this->nullableString($ledgerMember['current_crosswalk_mode'] ?? null),
+                convergenceState: $convergenceState,
+                queueReason: $this->normalizeStringList($queueRow['queue_reason'] ?? []),
+                agingDays: $this->resolveAgingDays($convergenceState, $latestPatch),
+                latestPatchStatus: is_array($latestPatch)
+                    ? $this->nullableString($latestPatch['patch_status'] ?? null)
+                    : null,
+                overrideApplied: is_array($resolvedRow) && (bool) ($resolvedRow['override_applied'] ?? false),
+                resolvedTargetKind: is_array($resolvedRow)
+                    ? $this->nullableString($resolvedRow['resolved_target_kind'] ?? null)
+                    : null,
+                resolvedTargetSlug: is_array($resolvedRow)
+                    ? $this->nullableString($resolvedRow['resolved_target_slug'] ?? null)
+                    : null,
+                evidenceRefs: [
+                    'release_ledger_kind' => (string) ($ledger['ledger_kind'] ?? ''),
+                    'release_cohort' => $this->nullableString($ledgerMember['release_cohort'] ?? null),
+                    'blocking_flags' => $this->normalizeStringList($queueRow['blocking_flags'] ?? []),
+                    'candidate_target_kind' => is_array($queueRow)
+                        ? $this->nullableString($queueRow['candidate_target_kind'] ?? null)
+                        : null,
+                    'candidate_target_slug' => is_array($queueRow)
+                        ? $this->nullableString($queueRow['candidate_target_slug'] ?? null)
+                        : null,
+                    'latest_unresolved_patch_created_at' => $convergenceState === self::STATE_STILL_UNRESOLVED
+                        ? $this->nullableString(is_array($latestPatch) ? ($latestPatch['created_at'] ?? null) : null)
+                        : null,
+                ],
+            );
+        }
+
+        usort($members, static fn (CareerCrosswalkBacklogConvergenceMember $left, CareerCrosswalkBacklogConvergenceMember $right): int => strcmp(
+            $left->canonicalSlug,
+            $right->canonicalSlug,
+        ));
+
+        $aging = $this->buildAgingSummary($members);
+
+        $trackingCounts = (array) ($ledger['tracking_counts'] ?? []);
+        $trackedTotal = (int) ($trackingCounts['tracked_total_occupations'] ?? count($trackedBySlug));
+
+        $counts = [
+            'unresolved_local_heavy_interpretation' => $unresolvedByMode['local_heavy_interpretation'],
+            'unresolved_family_proxy' => $unresolvedByMode['family_proxy'],
+            'unresolved_unmapped' => $unresolvedByMode['unmapped'],
+            'unresolved_functional_equivalent' => $unresolvedByMode['functional_equivalent'],
+            'resolved_by_approved_patch' => $stateCounts[self::STATE_RESOLVED_BY_APPROVED_PATCH],
+            'resolved_by_override' => $stateCounts[self::STATE_RESOLVED_BY_APPROVED_PATCH],
+            'family_handoff' => $stateCounts[self::STATE_FAMILY_HANDOFF],
+            'review_needed' => $stateCounts[self::STATE_REVIEW_NEEDED],
+            'blocked' => $stateCounts[self::STATE_BLOCKED],
+            'still_unresolved' => $stateCounts[self::STATE_STILL_UNRESOLVED],
+        ];
+
+        $patchCoverage = $this->buildPatchCoverage(
+            patches: $patches,
+            trackedBySlug: $trackedBySlug,
+            unresolvedByMode: $unresolvedByMode,
+            approvedPatchBySlug: $approvedPatchBySlug,
+        );
+
+        return new CareerCrosswalkBacklogConvergenceSnapshot(
+            authorityKind: self::AUTHORITY_KIND,
+            authorityVersion: self::AUTHORITY_VERSION,
+            scope: self::SCOPE,
+            trackingCounts: array_merge($trackingCounts, [
+                'members_in_convergence_scope' => count($members),
+                'members_outside_convergence_scope' => max(0, $trackedTotal - count($members)),
+            ]),
+            counts: $counts,
+            aging: $aging,
+            patchCoverage: $patchCoverage,
+            members: $members,
+            convergencePolicy: [
+                'convergence_states' => [
+                    self::STATE_STILL_UNRESOLVED,
+                    self::STATE_RESOLVED_BY_APPROVED_PATCH,
+                    self::STATE_FAMILY_HANDOFF,
+                    self::STATE_REVIEW_NEEDED,
+                    self::STATE_BLOCKED,
+                ],
+                'unresolved_modes' => array_keys(self::UNRESOLVED_MODES),
+                'aging_metric_basis' => self::AGING_METRIC_BASIS,
+                'queue_open_timestamp_authority_present' => false,
+            ],
+        );
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $trackedBySlug
+     * @return list<array<string, mixed>>
+     */
+    private function buildQueueSubjects(array $trackedBySlug): array
+    {
+        $subjects = [];
+
+        foreach ($trackedBySlug as $slug => $member) {
+            $publicIndexState = strtolower(trim((string) ($member['public_index_state'] ?? '')));
+            $readinessStatus = $publicIndexState === 'indexable'
+                ? 'publish_ready'
+                : 'blocked_override_eligible';
+
+            $subjects[] = [
+                'canonical_slug' => $slug,
+                'crosswalk_mode' => $this->nullableString($member['current_crosswalk_mode'] ?? null) ?? 'unmapped',
+                'readiness_status' => $readinessStatus,
+                'blocked_governance_status' => $this->blockedGovernanceStatus($member),
+            ];
+        }
+
+        return $subjects;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $trackedBySlug
+     * @return array<string, array{batch_origin:?string,publish_track:?string,family_slug:?string}>
+     */
+    private function batchContextBySlug(array $trackedBySlug): array
+    {
+        $context = [];
+        foreach ($trackedBySlug as $slug => $member) {
+            $context[$slug] = [
+                'batch_origin' => $this->nullableString($member['batch_origin'] ?? null),
+                'publish_track' => null,
+                'family_slug' => null,
+            ];
+        }
+
+        return $context;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     * @return array<string, array<string, mixed>>
+     */
+    private function latestPatchBySlug(array $patches): array
+    {
+        $grouped = [];
+        foreach ($patches as $patch) {
+            if (! is_array($patch)) {
+                continue;
+            }
+            $slug = trim((string) ($patch['subject_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $grouped[$slug][] = $patch;
+        }
+
+        $latest = [];
+        foreach ($grouped as $slug => $rows) {
+            usort($rows, static function (array $left, array $right): int {
+                $leftTime = strtotime((string) ($left['reviewed_at'] ?? $left['created_at'] ?? '')) ?: 0;
+                $rightTime = strtotime((string) ($right['reviewed_at'] ?? $right['created_at'] ?? '')) ?: 0;
+                if ($leftTime !== $rightTime) {
+                    return $rightTime <=> $leftTime;
+                }
+
+                return strcmp((string) ($right['patch_version'] ?? ''), (string) ($left['patch_version'] ?? ''));
+            });
+
+            $latest[$slug] = $rows[0];
+        }
+
+        return $latest;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     * @return array<string, array<string, mixed>>
+     */
+    private function approvedPatchBySlug(array $patches): array
+    {
+        $approved = [];
+
+        foreach ($patches as $patch) {
+            if (! is_array($patch)) {
+                continue;
+            }
+
+            $slug = trim((string) ($patch['subject_slug'] ?? ''));
+            $status = strtolower(trim((string) ($patch['patch_status'] ?? '')));
+            if ($slug === '' || $status !== 'approved') {
+                continue;
+            }
+
+            $existing = $approved[$slug] ?? null;
+            if (! is_array($existing)) {
+                $approved[$slug] = $patch;
+
+                continue;
+            }
+
+            $existingTime = strtotime((string) ($existing['reviewed_at'] ?? $existing['created_at'] ?? '')) ?: 0;
+            $candidateTime = strtotime((string) ($patch['reviewed_at'] ?? $patch['created_at'] ?? '')) ?: 0;
+
+            if ($candidateTime >= $existingTime) {
+                $approved[$slug] = $patch;
+            }
+        }
+
+        return $approved;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $queueBySlug
+     * @param  array<string, array<string, mixed>>  $approvedPatchBySlug
+     * @return array{local_heavy_interpretation:int,family_proxy:int,unmapped:int,functional_equivalent:int}
+     */
+    private function unresolvedByMode(array $queueBySlug, array $approvedPatchBySlug): array
+    {
+        $counts = [
+            'local_heavy_interpretation' => 0,
+            'family_proxy' => 0,
+            'unmapped' => 0,
+            'functional_equivalent' => 0,
+        ];
+
+        foreach ($queueBySlug as $slug => $queueRow) {
+            if (! is_array($queueRow)) {
+                continue;
+            }
+            if (isset($approvedPatchBySlug[$slug])) {
+                continue;
+            }
+
+            $mode = strtolower(trim((string) ($queueRow['current_crosswalk_mode'] ?? '')));
+            if (! isset(self::UNRESOLVED_MODES[$mode])) {
+                continue;
+            }
+
+            $counts[$mode]++;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param  array<string, mixed>  $ledgerMember
+     * @param  array<string, mixed>|null  $queueRow
+     * @param  array<string, mixed>|null  $resolvedRow
+     */
+    private function resolveConvergenceState(
+        array $ledgerMember,
+        ?array $queueRow,
+        ?array $resolvedRow,
+        bool $hasApprovedPatch,
+    ): ?string {
+        if ($this->isBlocked($ledgerMember)) {
+            return self::STATE_BLOCKED;
+        }
+
+        if ($queueRow !== null && ! $hasApprovedPatch) {
+            return self::STATE_STILL_UNRESOLVED;
+        }
+
+        $releaseCohort = strtolower(trim((string) ($ledgerMember['release_cohort'] ?? '')));
+        $overrideApplied = is_array($resolvedRow) && (bool) ($resolvedRow['override_applied'] ?? false);
+        $resolvedTargetKind = strtolower(trim((string) ($resolvedRow['resolved_target_kind'] ?? '')));
+        $candidateTargetKind = strtolower(trim((string) ($queueRow['candidate_target_kind'] ?? '')));
+
+        if ($overrideApplied && $hasApprovedPatch) {
+            if ($resolvedTargetKind === 'family' || $candidateTargetKind === 'family') {
+                return self::STATE_FAMILY_HANDOFF;
+            }
+
+            return self::STATE_RESOLVED_BY_APPROVED_PATCH;
+        }
+
+        if ($releaseCohort === 'family_handoff' || $resolvedTargetKind === 'family') {
+            return self::STATE_FAMILY_HANDOFF;
+        }
+
+        if ($queueRow !== null || $releaseCohort === 'review_needed') {
+            return self::STATE_REVIEW_NEEDED;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $ledgerMember
+     */
+    private function isBlocked(array $ledgerMember): bool
+    {
+        $releaseCohort = strtolower(trim((string) ($ledgerMember['release_cohort'] ?? '')));
+        if ($releaseCohort === 'blocked') {
+            return true;
+        }
+
+        foreach ($this->normalizeStringList($ledgerMember['blocker_reasons'] ?? []) as $reason) {
+            if ($reason === 'blocked_governance' || str_starts_with($reason, 'first_wave_readiness_blocked_')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $latestPatch
+     */
+    private function resolveAgingDays(string $convergenceState, ?array $latestPatch): ?int
+    {
+        if ($convergenceState !== self::STATE_STILL_UNRESOLVED || ! is_array($latestPatch)) {
+            return null;
+        }
+
+        $createdAt = trim((string) ($latestPatch['created_at'] ?? ''));
+        if ($createdAt === '') {
+            return null;
+        }
+
+        $timestamp = strtotime($createdAt);
+        if ($timestamp === false) {
+            return null;
+        }
+
+        $seconds = now('UTC')->timestamp - $timestamp;
+
+        return $seconds < 0 ? 0 : (int) floor($seconds / 86400);
+    }
+
+    /**
+     * @param  list<CareerCrosswalkBacklogConvergenceMember>  $members
+     * @return array<string, mixed>
+     */
+    private function buildAgingSummary(array $members): array
+    {
+        $known = [];
+        $unresolvedTotal = 0;
+
+        foreach ($members as $member) {
+            if ($member->convergenceState !== self::STATE_STILL_UNRESOLVED) {
+                continue;
+            }
+
+            $unresolvedTotal++;
+            if ($member->agingDays !== null) {
+                $known[] = $member->agingDays;
+            }
+        }
+
+        sort($known);
+        $count = count($known);
+        $median = 0;
+        if ($count > 0) {
+            $middle = intdiv($count, 2);
+            $median = $count % 2 === 1
+                ? $known[$middle]
+                : (int) floor(($known[$middle - 1] + $known[$middle]) / 2);
+        }
+
+        return [
+            'metric_basis' => self::AGING_METRIC_BASIS,
+            'max_days_open' => $count > 0 ? max($known) : 0,
+            'median_days_open' => $median,
+            'known_sample_size' => $count,
+            'unknown_sample_size' => max(0, $unresolvedTotal - $count),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     * @param  array<string, array<string, mixed>>  $trackedBySlug
+     * @param  array{local_heavy_interpretation:int,family_proxy:int,unmapped:int,functional_equivalent:int}  $unresolvedByMode
+     * @param  array<string, array<string, mixed>>  $approvedPatchBySlug
+     * @return array<string, mixed>
+     */
+    private function buildPatchCoverage(
+        array $patches,
+        array $trackedBySlug,
+        array $unresolvedByMode,
+        array $approvedPatchBySlug,
+    ): array {
+        $trackedSlugs = array_fill_keys(array_keys($trackedBySlug), true);
+
+        $approvedCount = 0;
+        $rejectedCount = 0;
+        $supersededCount = 0;
+
+        $approvedByMode = [
+            'local_heavy_interpretation' => 0,
+            'family_proxy' => 0,
+            'unmapped' => 0,
+            'functional_equivalent' => 0,
+        ];
+
+        foreach ($patches as $patch) {
+            if (! is_array($patch)) {
+                continue;
+            }
+            $slug = trim((string) ($patch['subject_slug'] ?? ''));
+            if ($slug === '' || ! isset($trackedSlugs[$slug])) {
+                continue;
+            }
+
+            $status = strtolower(trim((string) ($patch['patch_status'] ?? '')));
+            if ($status === 'approved') {
+                $approvedCount++;
+            } elseif ($status === 'rejected') {
+                $rejectedCount++;
+            } elseif ($status === 'superseded') {
+                $supersededCount++;
+            }
+        }
+
+        foreach ($approvedPatchBySlug as $slug => $patch) {
+            if (! is_array($patch) || ! isset($trackedBySlug[$slug])) {
+                continue;
+            }
+            $mode = strtolower(trim((string) ($trackedBySlug[$slug]['current_crosswalk_mode'] ?? '')));
+            if (isset($approvedByMode[$mode])) {
+                $approvedByMode[$mode]++;
+            }
+        }
+
+        return [
+            'approved_count' => $approvedCount,
+            'rejected_count' => $rejectedCount,
+            'superseded_count' => $supersededCount,
+            'unresolved_without_approved_patch' => array_sum($unresolvedByMode),
+            'by_mode' => [
+                'approved_count' => $approvedByMode,
+                'unresolved_without_approved_patch' => $unresolvedByMode,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $member
+     */
+    private function blockedGovernanceStatus(array $member): ?string
+    {
+        foreach ($this->normalizeStringList($member['blocker_reasons'] ?? []) as $reason) {
+            if ($reason === 'blocked_governance') {
+                return 'blocked_governance';
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $rows
+     * @return array<string, array<string, mixed>>
+     */
+    private function mapBySlug(array $rows, string $key): array
+    {
+        $mapped = [];
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = trim((string) ($row[$key] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $mapped[$slug] = $row;
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return list<string>
+     */
+    private function normalizeStringList(array $values): array
+    {
+        $result = [];
+        foreach ($values as $value) {
+            if (! is_string($value)) {
+                continue;
+            }
+
+            $normalized = trim($value);
+            if ($normalized === '') {
+                continue;
+            }
+
+            $result[] = $normalized;
+        }
+
+        return array_values(array_unique($result));
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T13:13:19Z",
+  "updated_at": "2026-04-16T14:36:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2462,6 +2462,40 @@
         ]
       },
       "failure_reason": "GitHub Actions checks failed at workflow startup in CI (hygiene failed, MBTI matrix skipped) while all required local checks passed.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-B82": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-b82-career-crosswalk-backlog-convergence-authority",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/DTO/Career/CareerCrosswalkBacklogConvergence*.php app/Domain/Career/Operations/CareerCrosswalkBacklogConvergence*.php app/Console/Commands/CareerExportCrosswalkBacklogConvergence.php tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php tests/Feature/Console/CareerExportCrosswalkBacklogConvergenceCommandTest.php app/Console/Kernel.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php tests/Feature/Console/CareerExportCrosswalkBacklogConvergenceCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerCrosswalkReadModelsTest.php tests/Unit/Services/Career/CareerCrosswalkPatchMutationServiceTest.php tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php tests/Feature/Internal/Career/CareerCrosswalkOpsApiTest.php",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-16T14:36:00Z",
+  "updated_at": "2026-04-16T14:49:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2191,10 +2191,10 @@
     "PR-B76X": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "github_checks_failed",
       "branch": "codex/pr-b76x-career-feedback-time-travel-baseline",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "fef72f6b99018af17ac97912a9a162d60c44fe1c",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/927",
       "checks": {
         "local": [
           {
@@ -2214,9 +2214,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24513421017/job/71650537742"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24513402441/job/71650468048"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24513421017/job/71650549648"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24513402441/job/71650480181"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions checks failed at workflow startup in CI (hygiene failed, MBTI matrix skipped) while all required local checks passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1418,6 +1418,33 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-B82
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-b82-career-crosswalk-backlog-convergence-authority
+    base: main
+    depends_on: ["PR-B81"]
+    mode: execute
+    scope: >
+      Career crosswalk backlog convergence authority (internal-only).
+      Add full-342 crosswalk backlog convergence DTO/service/projection + internal export command,
+      formalizing unresolved counts by mode, patch coverage, family/review distribution,
+      and patch-time aging basis into one machine-readable convergence snapshot.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/DTO/Career/CareerCrosswalkBacklogConvergence*.php app/Domain/Career/Operations/CareerCrosswalkBacklogConvergence*.php app/Console/Commands/CareerExportCrosswalkBacklogConvergence.php tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php tests/Feature/Console/CareerExportCrosswalkBacklogConvergenceCommandTest.php app/Console/Kernel.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php tests/Feature/Console/CareerExportCrosswalkBacklogConvergenceCommandTest.php"
+      - "php artisan test tests/Unit/Services/Career/CareerCrosswalkReadModelsTest.php tests/Unit/Services/Career/CareerCrosswalkPatchMutationServiceTest.php tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php tests/Feature/Internal/Career/CareerCrosswalkOpsApiTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-D1
     repo: fap-web
     repo_path: /Users/rainie/Desktop/GitHub/fap-web

--- a/backend/tests/Feature/Console/CareerExportCrosswalkBacklogConvergenceCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportCrosswalkBacklogConvergenceCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\Operations\CareerCrosswalkBacklogConvergenceProjectionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerExportCrosswalkBacklogConvergenceCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = storage_path('app/private/career_crosswalk_backlog_convergence');
+        File::deleteDirectory($this->rootDir);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->rootDir);
+
+        parent::tearDown();
+    }
+
+    public function test_command_materializes_internal_crosswalk_convergence_snapshot_and_supports_json_output(): void
+    {
+        $timestamp = 'b82-test-export';
+
+        $exitCode = Artisan::call('career:export-crosswalk-backlog-convergence', [
+            '--timestamp' => $timestamp,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('materialized', $payload['status'] ?? null);
+
+        $artifactPath = $payload['artifacts'][CareerCrosswalkBacklogConvergenceProjectionService::SNAPSHOT_FILENAME] ?? null;
+        $this->assertIsString($artifactPath);
+        $this->assertFileExists($artifactPath);
+
+        $snapshot = json_decode((string) file_get_contents($artifactPath), true);
+        $this->assertIsArray($snapshot);
+        $this->assertSame('career_crosswalk_backlog_convergence', $snapshot['authority_kind'] ?? null);
+        $this->assertSame('career.crosswalk_convergence.v1', $snapshot['authority_version'] ?? null);
+        $this->assertSame('career_all_342', $snapshot['scope'] ?? null);
+        $this->assertSame('latest_unresolved_patch_created_at', data_get($snapshot, 'aging.metric_basis'));
+
+        $counts = (array) ($snapshot['counts'] ?? []);
+        $this->assertArrayHasKey('unresolved_local_heavy_interpretation', $counts);
+        $this->assertArrayHasKey('unresolved_family_proxy', $counts);
+        $this->assertArrayHasKey('unresolved_unmapped', $counts);
+        $this->assertArrayHasKey('unresolved_functional_equivalent', $counts);
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Operations\CareerCrosswalkBacklogConvergenceService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerCrosswalkBacklogConvergenceServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_internal_convergence_snapshot_with_unresolved_mode_split_and_patch_time_aging_basis(): void
+    {
+        $snapshot = app(CareerCrosswalkBacklogConvergenceService::class)->build()->toArray();
+
+        $this->assertSame('career_crosswalk_backlog_convergence', $snapshot['authority_kind'] ?? null);
+        $this->assertSame('career.crosswalk_convergence.v1', $snapshot['authority_version'] ?? null);
+        $this->assertSame('career_all_342', $snapshot['scope'] ?? null);
+
+        $trackingCounts = (array) ($snapshot['tracking_counts'] ?? []);
+        $trackedTotal = (int) ($trackingCounts['tracked_total_occupations'] ?? 0);
+        $expectedTotal = (int) ($trackingCounts['expected_total_occupations'] ?? 0);
+        $this->assertGreaterThanOrEqual(0, $trackedTotal);
+        $this->assertGreaterThanOrEqual(0, $expectedTotal);
+        if ($expectedTotal > 0) {
+            $this->assertLessThanOrEqual($trackedTotal, $expectedTotal);
+        }
+
+        $counts = (array) ($snapshot['counts'] ?? []);
+        $this->assertEqualsCanonicalizing([
+            'unresolved_local_heavy_interpretation',
+            'unresolved_family_proxy',
+            'unresolved_unmapped',
+            'unresolved_functional_equivalent',
+            'resolved_by_approved_patch',
+            'resolved_by_override',
+            'family_handoff',
+            'review_needed',
+            'blocked',
+            'still_unresolved',
+        ], array_keys($counts));
+
+        $aging = (array) ($snapshot['aging'] ?? []);
+        $this->assertSame('latest_unresolved_patch_created_at', $aging['metric_basis'] ?? null);
+        $this->assertArrayNotHasKey('queue_opened_at', $aging);
+
+        $coverage = (array) ($snapshot['patch_coverage'] ?? []);
+        $this->assertArrayHasKey('approved_count', $coverage);
+        $this->assertArrayHasKey('rejected_count', $coverage);
+        $this->assertArrayHasKey('superseded_count', $coverage);
+        $this->assertArrayHasKey('unresolved_without_approved_patch', $coverage);
+
+        $members = (array) ($snapshot['members'] ?? []);
+        $allowedStates = [
+            'still_unresolved' => true,
+            'resolved_by_approved_patch' => true,
+            'family_handoff' => true,
+            'review_needed' => true,
+            'blocked' => true,
+        ];
+
+        foreach ($members as $member) {
+            $state = (string) ($member['convergence_state'] ?? '');
+            $this->assertArrayHasKey($state, $allowedStates);
+        }
+
+        $blockedFamilyMembers = array_filter($members, static function (array $member): bool {
+            if (($member['convergence_state'] ?? null) !== 'blocked') {
+                return false;
+            }
+
+            return ($member['resolved_target_kind'] ?? null) === 'family';
+        });
+        $this->assertCount(0, $blockedFamilyMembers);
+    }
+
+    public function test_it_keeps_family_proxy_unresolved_until_approved_override_and_separates_family_handoff(): void
+    {
+        $service = app(CareerCrosswalkBacklogConvergenceService::class);
+        $resolver = new \ReflectionMethod($service, 'resolveConvergenceState');
+        $resolver->setAccessible(true);
+
+        $stillUnresolvedFamilyProxy = $resolver->invokeArgs($service, [
+            [
+                'release_cohort' => 'family_handoff',
+                'blocker_reasons' => [],
+            ],
+            [
+                'candidate_target_kind' => 'family',
+            ],
+            [
+                'override_applied' => false,
+                'resolved_target_kind' => 'occupation',
+            ],
+            false,
+        ]);
+        $this->assertSame('still_unresolved', $stillUnresolvedFamilyProxy);
+
+        $familyHandoff = $resolver->invokeArgs($service, [
+            [
+                'release_cohort' => 'family_handoff',
+                'blocker_reasons' => [],
+            ],
+            [
+                'candidate_target_kind' => 'family',
+            ],
+            [
+                'override_applied' => true,
+                'resolved_target_kind' => 'family',
+            ],
+            true,
+        ]);
+        $this->assertSame('family_handoff', $familyHandoff);
+
+        $resolvedByPatch = $resolver->invokeArgs($service, [
+            [
+                'release_cohort' => 'review_needed',
+                'blocker_reasons' => [],
+            ],
+            [
+                'candidate_target_kind' => 'occupation',
+            ],
+            [
+                'override_applied' => true,
+                'resolved_target_kind' => 'occupation',
+            ],
+            true,
+        ]);
+        $this->assertSame('resolved_by_approved_patch', $resolvedByPatch);
+    }
+}


### PR DESCRIPTION
## What Changed
- Added internal full-342 convergence authority for crosswalk backlog:
  - `CareerCrosswalkBacklogConvergenceService`
  - `CareerCrosswalkBacklogConvergenceProjectionService`
  - `CareerCrosswalkBacklogConvergenceSnapshot`
  - `CareerCrosswalkBacklogConvergenceMember`
- Added internal export command:
  - `career:export-crosswalk-backlog-convergence`
  - materializes `career-crosswalk-backlog-convergence.json` under `storage/app/private/career_crosswalk_backlog_convergence/<timestamp>/`
- Registered command in console kernel.
- Added targeted tests:
  - `CareerCrosswalkBacklogConvergenceServiceTest`
  - `CareerExportCrosswalkBacklogConvergenceCommandTest`
- Updated PR train manifest/state with PR-B82 entry and local check ledger.

## Why
B70/B78X already provide queue/patch/override operational baseline, but repo lacked a single machine-readable authority proving backlog convergence posture. This PR closes that gap by consolidating existing backend truth into one auditable internal snapshot for:
- unresolved volume by mode
- patch coverage
- family/review/override/unresolved distribution
- conservative aging with explicit metric basis

## Validation Commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/DTO/Career/CareerCrosswalkBacklogConvergence*.php app/Domain/Career/Operations/CareerCrosswalkBacklogConvergence*.php app/Console/Commands/CareerExportCrosswalkBacklogConvergence.php tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php tests/Feature/Console/CareerExportCrosswalkBacklogConvergenceCommandTest.php app/Console/Kernel.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php tests/Feature/Console/CareerExportCrosswalkBacklogConvergenceCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerCrosswalkReadModelsTest.php tests/Unit/Services/Career/CareerCrosswalkPatchMutationServiceTest.php tests/Unit/Services/Career/CareerCrosswalkOverrideResolverTest.php tests/Feature/Internal/Career/CareerCrosswalkOpsApiTest.php`

## Intentionally Deferred
- Queue-open residency aging (no queue-open timestamp authority exists yet).
- Any public API/OpenAPI exposure.
- Any frontend/dashboard changes.
- Rewriting existing B70/B78X semantics.
