### PR TITLE
PR-B87: harden career launch governance runtime cache

### DIFF
--- a/backend/app/Domain/Career/Operations/CareerCrosswalkBacklogConvergenceService.php
+++ b/backend/app/Domain/Career/Operations/CareerCrosswalkBacklogConvergenceService.php
@@ -47,7 +47,14 @@ final class CareerCrosswalkBacklogConvergenceService
 
     public function build(): CareerCrosswalkBacklogConvergenceSnapshot
     {
-        $ledger = $this->fullReleaseLedgerService->build()->toArray();
+        return $this->buildFromReleaseLedger($this->fullReleaseLedgerService->build()->toArray());
+    }
+
+    /**
+     * @param  array<string, mixed>  $ledger
+     */
+    public function buildFromReleaseLedger(array $ledger): CareerCrosswalkBacklogConvergenceSnapshot
+    {
         $trackedBySlug = $this->mapBySlug((array) ($ledger['members'] ?? []), 'canonical_slug');
 
         $patches = (array) (($this->patchAuthorityService->build(self::SCOPE)->toArray())['patches'] ?? []);

--- a/backend/app/Domain/Career/Publish/CareerLaunchGovernanceClosureService.php
+++ b/backend/app/Domain/Career/Publish/CareerLaunchGovernanceClosureService.php
@@ -38,9 +38,10 @@ final class CareerLaunchGovernanceClosureService
     public function build(): CareerLaunchGovernanceClosure
     {
         $releaseLedger = $this->fullReleaseLedgerService->build()->toArray();
-        $strongIndexSnapshot = $this->strongIndexEligibilityService->build()->toArray();
-        $backlogConvergence = $this->crosswalkBacklogConvergenceService->build()->toArray();
-        $lifecycleSummary = $this->lifecycleOperationalSummaryService->build()->toArray();
+        $strongIndexSnapshot = $this->strongIndexEligibilityService->buildFromReleaseLedger($releaseLedger)->toArray();
+        $backlogConvergence = $this->crosswalkBacklogConvergenceService->buildFromReleaseLedger($releaseLedger)->toArray();
+        $trackedSlugs = $this->trackedSlugsFromReleaseLedger($releaseLedger);
+        $lifecycleSummary = $this->lifecycleOperationalSummaryService->buildForTrackedSlugs($trackedSlugs)->toArray();
         $conversionClosure = $this->conversionClosureBuilder->build()->toArray();
 
         $strongIndexBySlug = $this->mapBySlug((array) ($strongIndexSnapshot['members'] ?? []), 'canonical_slug');
@@ -330,6 +331,29 @@ final class CareerLaunchGovernanceClosureService
         }
 
         return $mapped;
+    }
+
+    /**
+     * @param  array<string, mixed>  $releaseLedger
+     * @return list<string>
+     */
+    private function trackedSlugsFromReleaseLedger(array $releaseLedger): array
+    {
+        $slugs = [];
+        foreach ((array) ($releaseLedger['members'] ?? []) as $member) {
+            if (! is_array($member)) {
+                continue;
+            }
+
+            $slug = trim(strtolower((string) ($member['canonical_slug'] ?? '')));
+            if ($slug === '') {
+                continue;
+            }
+
+            $slugs[$slug] = true;
+        }
+
+        return array_keys($slugs);
     }
 
     private function normalizeState(mixed $value): ?string

--- a/backend/app/Domain/Career/Publish/CareerLifecycleOperationalSummaryService.php
+++ b/backend/app/Domain/Career/Publish/CareerLifecycleOperationalSummaryService.php
@@ -11,6 +11,7 @@ use App\Models\CareerShortlistItem;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
 use Carbon\CarbonInterface;
+use Illuminate\Support\Collection;
 
 final class CareerLifecycleOperationalSummaryService
 {
@@ -21,6 +22,14 @@ final class CareerLifecycleOperationalSummaryService
     public const SCOPE = 'career_all_342';
 
     public function build(): CareerLifecycleOperationalSummary
+    {
+        return $this->buildForTrackedSlugs($this->trackedSlugs());
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    public function buildForTrackedSlugs(array $slugs): CareerLifecycleOperationalSummary
     {
         $counts = [
             'total' => 0,
@@ -33,14 +42,11 @@ final class CareerLifecycleOperationalSummaryService
         ];
 
         $members = [];
+        $trackedSlugs = $this->normalizeSlugs($slugs);
+        $profiles = $this->buildMemberProfiles($trackedSlugs);
 
-        foreach ($this->trackedSlugs() as $slugValue) {
-            $slug = trim(strtolower((string) $slugValue));
-            if ($slug === '') {
-                continue;
-            }
-
-            $member = $this->buildMember($slug);
+        foreach ($trackedSlugs as $slug) {
+            $member = $this->buildMemberFromProfile($slug, $profiles[$slug] ?? []);
             if (! $member instanceof CareerLifecycleOperationalMember) {
                 continue;
             }
@@ -116,11 +122,13 @@ final class CareerLifecycleOperationalSummaryService
      */
     public function buildForSlug(string $slug): array
     {
-        $member = $this->buildMember($slug);
+        $normalizedSlug = trim(strtolower($slug));
+        $profiles = $this->buildMemberProfiles([$normalizedSlug]);
+        $member = $this->buildMemberFromProfile($normalizedSlug, $profiles[$normalizedSlug] ?? []);
 
         return $member?->toArray() ?? [
             'member_kind' => 'career_tracked_occupation',
-            'canonical_slug' => trim(strtolower($slug)),
+            'canonical_slug' => $normalizedSlug,
             'current_projection_uuid' => null,
             'current_recommendation_snapshot_uuid' => null,
             'timeline_entry_count' => 0,
@@ -131,41 +139,133 @@ final class CareerLifecycleOperationalSummaryService
         ];
     }
 
-    private function buildMember(string $slug): ?CareerLifecycleOperationalMember
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, array<string, mixed>>
+     */
+    private function buildMemberProfiles(array $slugs): array
+    {
+        $normalizedSlugs = $this->normalizeSlugs($slugs);
+        if ($normalizedSlugs === []) {
+            return [];
+        }
+
+        /** @var Collection<int, Occupation> $occupations */
+        $occupations = Occupation::query()
+            ->whereIn('canonical_slug', $normalizedSlugs)
+            ->get(['id', 'canonical_slug']);
+
+        $occupationIdBySlug = [];
+        $slugByOccupationId = [];
+        foreach ($occupations as $occupation) {
+            $slug = trim(strtolower((string) $occupation->canonical_slug));
+            $id = (string) $occupation->id;
+            if ($slug === '' || $id === '') {
+                continue;
+            }
+
+            $occupationIdBySlug[$slug] = $id;
+            $slugByOccupationId[$id] = $slug;
+        }
+
+        $profiles = [];
+        foreach ($normalizedSlugs as $slug) {
+            $profiles[$slug] = [
+                'snapshot_count' => 0,
+                'current_projection_uuid' => null,
+                'current_recommendation_snapshot_uuid' => null,
+                'latest_feedback_at' => null,
+                'has_shortlist' => false,
+            ];
+        }
+
+        $occupationIds = array_values($occupationIdBySlug);
+        if ($occupationIds !== []) {
+            $snapshotCounts = RecommendationSnapshot::query()
+                ->selectRaw('occupation_id, COUNT(*) as aggregate_count')
+                ->whereIn('occupation_id', $occupationIds)
+                ->groupBy('occupation_id')
+                ->pluck('aggregate_count', 'occupation_id');
+
+            foreach ($snapshotCounts as $occupationId => $snapshotCount) {
+                $slug = $slugByOccupationId[(string) $occupationId] ?? null;
+                if ($slug !== null && isset($profiles[$slug])) {
+                    $profiles[$slug]['snapshot_count'] = (int) $snapshotCount;
+                }
+            }
+
+            $seenLatest = [];
+            RecommendationSnapshot::query()
+                ->whereIn('occupation_id', $occupationIds)
+                ->orderBy('occupation_id')
+                ->orderByDesc('compiled_at')
+                ->orderByDesc('created_at')
+                ->get(['id', 'occupation_id', 'profile_projection_id', 'compiled_at', 'created_at'])
+                ->each(function (RecommendationSnapshot $snapshot) use (&$profiles, &$seenLatest, $slugByOccupationId): void {
+                    $occupationId = (string) $snapshot->occupation_id;
+                    if (isset($seenLatest[$occupationId])) {
+                        return;
+                    }
+
+                    $slug = $slugByOccupationId[$occupationId] ?? null;
+                    if ($slug === null || ! isset($profiles[$slug])) {
+                        return;
+                    }
+
+                    $seenLatest[$occupationId] = true;
+                    $profiles[$slug]['current_projection_uuid'] = is_string($snapshot->profile_projection_id)
+                        ? $snapshot->profile_projection_id
+                        : null;
+                    $profiles[$slug]['current_recommendation_snapshot_uuid'] = is_string($snapshot->id)
+                        ? $snapshot->id
+                        : null;
+                });
+        }
+
+        $latestFeedbackBySlug = CareerFeedbackRecord::query()
+            ->selectRaw('subject_slug, MAX(created_at) as latest_feedback_at')
+            ->where('subject_kind', 'recommendation_type')
+            ->whereIn('subject_slug', $normalizedSlugs)
+            ->groupBy('subject_slug')
+            ->pluck('latest_feedback_at', 'subject_slug');
+
+        foreach ($latestFeedbackBySlug as $slug => $latestFeedbackAt) {
+            $normalizedSlug = trim(strtolower((string) $slug));
+            if ($normalizedSlug !== '' && isset($profiles[$normalizedSlug])) {
+                $profiles[$normalizedSlug]['latest_feedback_at'] = $latestFeedbackAt;
+            }
+        }
+
+        $shortlistSlugs = CareerShortlistItem::query()
+            ->select('subject_slug')
+            ->where('subject_kind', 'job_slug')
+            ->whereIn('subject_slug', $normalizedSlugs)
+            ->distinct()
+            ->pluck('subject_slug');
+
+        foreach ($shortlistSlugs as $slug) {
+            $normalizedSlug = trim(strtolower((string) $slug));
+            if ($normalizedSlug !== '' && isset($profiles[$normalizedSlug])) {
+                $profiles[$normalizedSlug]['has_shortlist'] = true;
+            }
+        }
+
+        return $profiles;
+    }
+
+    /**
+     * @param  array<string, mixed>  $profile
+     */
+    private function buildMemberFromProfile(string $slug, array $profile): ?CareerLifecycleOperationalMember
     {
         $normalizedSlug = trim(strtolower($slug));
         if ($normalizedSlug === '') {
             return null;
         }
 
-        $occupation = Occupation::query()
-            ->where('canonical_slug', $normalizedSlug)
-            ->first();
-
-        $snapshotCount = 0;
-        $currentSnapshot = null;
-        if ($occupation instanceof Occupation) {
-            $snapshotCount = RecommendationSnapshot::query()
-                ->where('occupation_id', $occupation->id)
-                ->count();
-
-            $currentSnapshot = RecommendationSnapshot::query()
-                ->where('occupation_id', $occupation->id)
-                ->orderByDesc('compiled_at')
-                ->orderByDesc('created_at')
-                ->first();
-        }
-
-        $latestFeedbackAt = CareerFeedbackRecord::query()
-            ->where('subject_kind', 'recommendation_type')
-            ->where('subject_slug', $normalizedSlug)
-            ->orderByDesc('created_at')
-            ->value('created_at');
-
-        $hasShortlist = CareerShortlistItem::query()
-            ->where('subject_kind', 'job_slug')
-            ->where('subject_slug', $normalizedSlug)
-            ->exists();
+        $snapshotCount = (int) ($profile['snapshot_count'] ?? 0);
+        $latestFeedbackAt = $profile['latest_feedback_at'] ?? null;
+        $hasShortlist = (bool) ($profile['has_shortlist'] ?? false);
 
         $hasFeedback = $latestFeedbackAt !== null;
         $deltaAvailable = $snapshotCount >= 2;
@@ -186,11 +286,11 @@ final class CareerLifecycleOperationalSummaryService
         return new CareerLifecycleOperationalMember(
             memberKind: 'career_tracked_occupation',
             canonicalSlug: $normalizedSlug,
-            currentProjectionUuid: is_string($currentSnapshot?->profile_projection_id)
-                ? $currentSnapshot->profile_projection_id
+            currentProjectionUuid: is_string($profile['current_projection_uuid'] ?? null)
+                ? $profile['current_projection_uuid']
                 : null,
-            currentRecommendationSnapshotUuid: is_string($currentSnapshot?->id)
-                ? $currentSnapshot->id
+            currentRecommendationSnapshotUuid: is_string($profile['current_recommendation_snapshot_uuid'] ?? null)
+                ? $profile['current_recommendation_snapshot_uuid']
                 : null,
             timelineEntryCount: $snapshotCount,
             latestFeedbackAt: $latestFeedbackAt instanceof CarbonInterface
@@ -200,5 +300,24 @@ final class CareerLifecycleOperationalSummaryService
             lifecycleState: $lifecycleState,
             closureState: $closureState,
         );
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return list<string>
+     */
+    private function normalizeSlugs(array $slugs): array
+    {
+        $normalized = [];
+        foreach ($slugs as $slug) {
+            $value = trim(strtolower((string) $slug));
+            if ($value === '') {
+                continue;
+            }
+
+            $normalized[$value] = true;
+        }
+
+        return array_keys($normalized);
     }
 }

--- a/backend/app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php
+++ b/backend/app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php
@@ -50,7 +50,14 @@ final class CareerStrongIndexEligibilityService
 
     public function build(): CareerStrongIndexEligibilitySnapshot
     {
-        $ledger = $this->fullReleaseLedgerService->build()->toArray();
+        return $this->buildFromReleaseLedger($this->fullReleaseLedgerService->build()->toArray());
+    }
+
+    /**
+     * @param  array<string, mixed>  $ledger
+     */
+    public function buildFromReleaseLedger(array $ledger): CareerStrongIndexEligibilitySnapshot
+    {
         $firstWaveAuditBySlug = $this->safeFirstWaveAuditBySlug();
 
         $stableConfidenceThreshold = $this->thresholdAuthorityService->confidenceStableMin();

--- a/backend/database/migrations/2026_04_17_002000_add_career_authority_runtime_indexes.php
+++ b/backend/database/migrations/2026_04_17_002000_add_career_authority_runtime_indexes.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->ensureIndex('events', 'events_scale_event_name_idx', ['scale_code', 'event_name']);
+        $this->ensureIndex('recommendation_snapshots', 'recommendation_snapshots_occ_compiled_created_idx', [
+            'occupation_id',
+            'compiled_at',
+            'created_at',
+        ]);
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to preserve production authority performance.
+    }
+
+    /**
+     * @param  list<string>  $columns
+     */
+    private function ensureIndex(string $tableName, string $indexName, array $columns): void
+    {
+        if (! Schema::hasTable($tableName) || SchemaIndex::indexExists($tableName, $indexName)) {
+            return;
+        }
+
+        foreach ($columns as $column) {
+            if (! Schema::hasColumn($tableName, $column)) {
+                return;
+            }
+        }
+
+        Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+};

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2705,10 +2705,10 @@
     "PR-B87": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-b87-career-launch-governance-runtime-cache-hardening",
-      "commit_sha": "28c23739f11a852e3cfaa88de63407bded908e8f",
-      "pr_url": "",
+      "commit_sha": "995935c6548987c92dd7142ee716c3accff7c5b1",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/932",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2700,5 +2700,77 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
     }
+  },
+  "prs": {
+    "PR-B87": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-b87-career-launch-governance-runtime-cache-hardening",
+      "commit_sha": "28c23739f11a852e3cfaa88de63407bded908e8f",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && vendor/bin/pint --test app/Domain/Career/Publish/CareerLifecycleOperationalSummaryService.php app/Domain/Career/Publish/CareerLaunchGovernanceClosureService.php app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php app/Domain/Career/Operations/CareerCrosswalkBacklogConvergenceService.php database/migrations/2026_04_17_002000_add_career_authority_runtime_indexes.php tests/Unit/Services/Career/CareerLifecycleOperationalSummaryServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan migrate --force --no-interaction",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan fap:schema:verify",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan career:warm-public-authority-cache --json",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan test tests/Unit/Services/Career/CareerLifecycleOperationalSummaryServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php tests/Feature/Console/CareerExportLaunchGovernanceClosureCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan test tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan test --filter 'MigrationSafetyTest|MigrationRollbackSafetyTest|MigrationsNoSilentCatchTest|MigrationProtectedTablesNoDropTest'",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan test --filter 'CareerDatasetPublicApiTest|CareerRecommendationDetailApiTest|CareerDatasetStructuredDataPolicyTest|CareerDatasetSitemapDiscoverabilityTest'",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && bash scripts/export_openapi.sh --check",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && bash scripts/ci_verify_mbti.sh",
+            "status": "passed"
+          },
+          {
+            "command": "php -l deploy.php",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    }
   }
 }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1584,3 +1584,33 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: PR-B87
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api
+    branch: codex/pr-b87-career-launch-governance-runtime-cache-hardening
+    base: main
+    depends_on: ["PR-B86"]
+    mode: execute
+    scope: >
+      Career launch-governance runtime cache hardening.
+      Remove production timeout risk from public launch-governance authority warmup
+      and frontend ISR/build paths by adding authority runtime indexes, batching lifecycle
+      aggregation, and bounding deploy warmup execution without changing public API contracts
+      or frontend attribution/SEO semantics.
+    checks:
+      - "cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "cd backend && vendor/bin/pint --test app/Domain/Career/Publish/CareerLifecycleOperationalSummaryService.php app/Domain/Career/Publish/CareerLaunchGovernanceClosureService.php app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php app/Domain/Career/Operations/CareerCrosswalkBacklogConvergenceService.php database/migrations/2026_04_17_002000_add_career_authority_runtime_indexes.php tests/Unit/Services/Career/CareerLifecycleOperationalSummaryServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php"
+      - "cd backend && php artisan migrate --force --no-interaction"
+      - "cd backend && php artisan fap:schema:verify"
+      - "cd backend && php artisan career:warm-public-authority-cache --json"
+      - "cd backend && php artisan test tests/Unit/Services/Career/CareerLifecycleOperationalSummaryServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php tests/Feature/Console/CareerExportLaunchGovernanceClosureCommandTest.php"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true

--- a/deploy.php
+++ b/deploy.php
@@ -314,7 +314,7 @@ BASH);
 });
 
 task('career:warm-public-authority-cache', function () {
-    run('{{bin/php}} {{release_path}}/backend/artisan career:warm-public-authority-cache --no-interaction --ansi');
+    run('timeout 180 {{bin/php}} {{release_path}}/backend/artisan career:warm-public-authority-cache --no-interaction --ansi');
 });
 
 task('artisan:view:cache', function () {


### PR DESCRIPTION
## What changed
- Added PR-B87 train/state entries for the production launch-governance runtime hardening follow-up.
- Added forward runtime indexes for career authority hot paths:
  - `events(scale_code, event_name)` for global career conversion event counts.
  - `recommendation_snapshots(occupation_id, compiled_at, created_at)` for lifecycle latest snapshot lookup.
- Reworked `CareerLifecycleOperationalSummaryService` to batch lifecycle aggregation across tracked slugs instead of issuing per-slug occupation/snapshot/feedback/shortlist queries.
- Added `buildFromReleaseLedger(...)` entrypoints for strong-index and crosswalk convergence services so launch governance can reuse its already-built release ledger instead of rebuilding it through nested authorities.
- Bounded Deployer's `career:warm-public-authority-cache` hook with `timeout 180` to fail finite instead of hanging indefinitely.

## Why
Production deploy and frontend build/ISR were blocked by `career:warm-public-authority-cache` and `GET /api/v0.5/career/launch-governance-closure` exceeding runtime limits. The backend authority truth remains unchanged, but runtime construction now does less duplicated work and has the missing database indexes needed by the production access path.

## Validation commands
- `cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `cd backend && vendor/bin/pint --test app/Domain/Career/Publish/CareerLifecycleOperationalSummaryService.php app/Domain/Career/Publish/CareerLaunchGovernanceClosureService.php app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php app/Domain/Career/Operations/CareerCrosswalkBacklogConvergenceService.php database/migrations/2026_04_17_002000_add_career_authority_runtime_indexes.php tests/Unit/Services/Career/CareerLifecycleOperationalSummaryServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php`
- `cd backend && php artisan migrate --force --no-interaction`
- `cd backend && php artisan fap:schema:verify`
- `cd backend && php artisan career:warm-public-authority-cache --json`
- `cd backend && php artisan test tests/Unit/Services/Career/CareerLifecycleOperationalSummaryServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php tests/Feature/Console/CareerExportLaunchGovernanceClosureCommandTest.php`
- `cd backend && php artisan test tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Unit/Services/Career/CareerCrosswalkBacklogConvergenceServiceTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php`
- `cd backend && php artisan test --filter 'MigrationSafetyTest|MigrationRollbackSafetyTest|MigrationsNoSilentCatchTest|MigrationProtectedTablesNoDropTest'`
- `cd backend && php artisan test --filter 'CareerDatasetPublicApiTest|CareerRecommendationDetailApiTest|CareerDatasetStructuredDataPolicyTest|CareerDatasetSitemapDiscoverabilityTest'`
- `cd backend && bash scripts/export_openapi.sh --check`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `php -l deploy.php`
- `git diff --check`

## Intentionally deferred
- No public API contract changes.
- No frontend changes.
- No new recommendation materialization semantics.
- No change to claim/SEO/attribution authority boundaries.
