### PR TITLE
PR-B88: harden first-wave authority runtime

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php
@@ -14,6 +14,11 @@ final class CareerFirstWaveNextStepLinksService
 
     public const SCOPE = 'career_first_wave_10';
 
+    /**
+     * @var list<array<string, mixed>>|null
+     */
+    private ?array $discoverabilityRoutes = null;
+
     public function __construct(
         private readonly CareerFirstWaveDiscoverabilityManifestService $discoverabilityManifestService,
     ) {}
@@ -34,9 +39,7 @@ final class CareerFirstWaveNextStepLinksService
             return null;
         }
 
-        $manifest = $this->discoverabilityManifestService->build()->toArray();
-        $routes = collect((array) ($manifest['routes'] ?? []))
-            ->filter(static fn (mixed $row): bool => is_array($row));
+        $routes = collect($this->discoverabilityRoutes());
 
         $jobRoutes = $routes
             ->where('route_kind', 'career_job_detail')
@@ -121,5 +124,23 @@ final class CareerFirstWaveNextStepLinksService
             counts: $counts,
             nextStepLinks: $dedupedLinks,
         );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function discoverabilityRoutes(): array
+    {
+        if ($this->discoverabilityRoutes !== null) {
+            return $this->discoverabilityRoutes;
+        }
+
+        $manifest = $this->discoverabilityManifestService->build()->toArray();
+        $this->discoverabilityRoutes = collect((array) ($manifest['routes'] ?? []))
+            ->filter(static fn (mixed $row): bool => is_array($row))
+            ->values()
+            ->all();
+
+        return $this->discoverabilityRoutes;
     }
 }

--- a/backend/app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php
+++ b/backend/app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php
@@ -6,7 +6,10 @@ namespace App\Domain\Career\Publish;
 
 use App\DTO\Career\CareerTrustFreshnessAuthority;
 use App\DTO\Career\CareerTrustFreshnessMember;
-use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
+use App\Models\Occupation;
+use App\Models\OccupationTruthMetric;
+use App\Models\TrustManifest;
+use Carbon\CarbonInterface;
 
 final class CareerTrustFreshnessAuthorityService
 {
@@ -20,24 +23,28 @@ final class CareerTrustFreshnessAuthorityService
 
     public function __construct(
         private readonly CareerFirstWaveLaunchReadinessAuditService $launchReadinessAuditService,
-        private readonly CareerJobDetailBundleBuilder $jobDetailBundleBuilder,
     ) {}
 
     public function build(): CareerTrustFreshnessAuthority
     {
         $audit = $this->launchReadinessAuditService->build();
+        $slugs = array_values(array_unique(array_filter(array_map(
+            static fn (mixed $member): string => $member instanceof \App\DTO\Career\CareerFirstWaveLaunchReadinessAuditMember
+                ? trim((string) $member->canonicalSlug)
+                : '',
+            $audit->members,
+        ))));
+        $profiles = $this->freshnessProfilesBySlug($slugs);
         $members = [];
 
         foreach ($audit->members as $auditMember) {
-            $bundle = $this->jobDetailBundleBuilder->buildBySlug($auditMember->canonicalSlug);
-            $trustManifest = $bundle?->trustManifest ?? [];
-            $truthLayer = $bundle?->truthLayer ?? [];
+            $profile = $profiles[$auditMember->canonicalSlug] ?? [];
 
-            $reviewerStatus = $this->normalizeNullableString($trustManifest['reviewer_status'] ?? null);
-            $reviewedAt = $this->normalizeNullableString($trustManifest['reviewed_at'] ?? null);
-            $lastSubstantiveUpdateAt = $this->normalizeNullableString($trustManifest['last_substantive_update_at'] ?? null);
-            $nextReviewDueAt = $this->normalizeNullableString($trustManifest['next_review_due_at'] ?? null);
-            $truthLastReviewedAt = $this->normalizeNullableString($truthLayer['truth_last_reviewed_at'] ?? null);
+            $reviewerStatus = $this->normalizeNullableString($profile['reviewer_status'] ?? null);
+            $reviewedAt = $this->normalizeDateString($profile['reviewed_at'] ?? null);
+            $lastSubstantiveUpdateAt = $this->normalizeDateString($profile['last_substantive_update_at'] ?? null);
+            $nextReviewDueAt = $this->normalizeDateString($profile['next_review_due_at'] ?? null);
+            $truthLastReviewedAt = $this->normalizeDateString($profile['truth_last_reviewed_at'] ?? null);
 
             $members[] = new CareerTrustFreshnessMember(
                 canonicalSlug: $auditMember->canonicalSlug,
@@ -70,6 +77,100 @@ final class CareerTrustFreshnessAuthorityService
             scope: $audit->scope,
             members: $members,
         );
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, array<string, mixed>>
+     */
+    private function freshnessProfilesBySlug(array $slugs): array
+    {
+        if ($slugs === []) {
+            return [];
+        }
+
+        $occupations = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->get(['id', 'canonical_slug']);
+
+        $slugByOccupationId = [];
+        foreach ($occupations as $occupation) {
+            $occupationId = (string) $occupation->id;
+            $slug = trim((string) $occupation->canonical_slug);
+            if ($occupationId === '' || $slug === '') {
+                continue;
+            }
+
+            $slugByOccupationId[$occupationId] = $slug;
+        }
+
+        $profiles = [];
+        foreach ($slugs as $slug) {
+            $profiles[$slug] = [];
+        }
+
+        if ($slugByOccupationId === []) {
+            return $profiles;
+        }
+
+        $occupationIds = array_keys($slugByOccupationId);
+
+        $seenTrust = [];
+        TrustManifest::query()
+            ->whereIn('occupation_id', $occupationIds)
+            ->orderBy('occupation_id')
+            ->orderByDesc('reviewed_at')
+            ->orderByDesc('created_at')
+            ->get([
+                'occupation_id',
+                'reviewer_status',
+                'reviewed_at',
+                'last_substantive_update_at',
+                'next_review_due_at',
+                'created_at',
+            ])
+            ->each(function (TrustManifest $manifest) use (&$profiles, &$seenTrust, $slugByOccupationId): void {
+                $occupationId = (string) $manifest->occupation_id;
+                if (isset($seenTrust[$occupationId])) {
+                    return;
+                }
+
+                $slug = $slugByOccupationId[$occupationId] ?? null;
+                if ($slug === null || ! isset($profiles[$slug])) {
+                    return;
+                }
+
+                $seenTrust[$occupationId] = true;
+                $profiles[$slug]['reviewer_status'] = $manifest->reviewer_status;
+                $profiles[$slug]['reviewed_at'] = $manifest->reviewed_at;
+                $profiles[$slug]['last_substantive_update_at'] = $manifest->last_substantive_update_at;
+                $profiles[$slug]['next_review_due_at'] = $manifest->next_review_due_at;
+            });
+
+        $seenTruth = [];
+        OccupationTruthMetric::query()
+            ->whereIn('occupation_id', $occupationIds)
+            ->orderBy('occupation_id')
+            ->orderByDesc('reviewed_at')
+            ->orderByDesc('effective_at')
+            ->orderByDesc('updated_at')
+            ->get(['occupation_id', 'reviewed_at', 'effective_at', 'updated_at'])
+            ->each(function (OccupationTruthMetric $metric) use (&$profiles, &$seenTruth, $slugByOccupationId): void {
+                $occupationId = (string) $metric->occupation_id;
+                if (isset($seenTruth[$occupationId])) {
+                    return;
+                }
+
+                $slug = $slugByOccupationId[$occupationId] ?? null;
+                if ($slug === null || ! isset($profiles[$slug])) {
+                    return;
+                }
+
+                $seenTruth[$occupationId] = true;
+                $profiles[$slug]['truth_last_reviewed_at'] = $metric->reviewed_at;
+            });
+
+        return $profiles;
     }
 
     private function resolveFreshnessBasis(
@@ -120,5 +221,14 @@ final class CareerTrustFreshnessAuthorityService
         $normalized = trim($value);
 
         return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeDateString(mixed $value): ?string
+    {
+        if ($value instanceof CarbonInterface) {
+            return $value->toISOString();
+        }
+
+        return $this->normalizeNullableString($value);
     }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2775,10 +2775,10 @@
     "PR-B88": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-b88-career-first-wave-authority-runtime-hardening",
-      "commit_sha": "f54c859e66b8282f37320b8077850bba7855e78a",
-      "pr_url": "",
+      "commit_sha": "9c3269263d076dbddc07e47f53de65f99e2bca8f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/933",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2705,7 +2705,7 @@
     "PR-B87": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "status": "pr_open",
+      "status": "merged",
       "branch": "codex/pr-b87-career-launch-governance-runtime-cache-hardening",
       "commit_sha": "995935c6548987c92dd7142ee716c3accff7c5b1",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/932",
@@ -2757,6 +2757,60 @@
           },
           {
             "command": "php -l deploy.php",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-17T01:51:54Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-B88": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-b88-career-first-wave-authority-runtime-hardening",
+      "commit_sha": "f54c859e66b8282f37320b8077850bba7855e78a",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditService.php app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditV2Service.php app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php app/Domain/Career/Publish/CareerLaunchGovernanceClosureService.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan fap:schema:verify",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan career:warm-public-authority-cache --json",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan test --filter 'CareerDatasetPublicApiTest|CareerRecommendationDetailApiTest|CareerDatasetStructuredDataPolicyTest|CareerDatasetSitemapDiscoverabilityTest'",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && bash scripts/export_openapi.sh --check",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && bash scripts/ci_verify_mbti.sh",
             "status": "passed"
           },
           {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1614,3 +1614,34 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: PR-B88
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api
+    branch: codex/pr-b88-career-first-wave-authority-runtime-hardening
+    base: main
+    depends_on: ["PR-B87"]
+    mode: execute
+    scope: >
+      Career first-wave authority runtime hardening.
+      Remove remaining production timeout risk from launch-governance release-ledger
+      and strong-index dependencies by caching first-wave discoverability route assembly
+      within next-step link projection and deriving trust freshness from batched authority
+      tables instead of per-slug job detail bundle construction.
+    checks:
+      - "cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "cd backend && vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditService.php app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditV2Service.php app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php app/Domain/Career/Publish/CareerLaunchGovernanceClosureService.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php"
+      - "cd backend && php artisan fap:schema:verify"
+      - "cd backend && php artisan career:warm-public-authority-cache --json"
+      - "cd backend && php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php"
+      - "cd backend && bash scripts/export_openapi.sh --check"
+      - "cd backend && bash scripts/ci_verify_mbti.sh"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true


### PR DESCRIPTION
## What changed
- Added PR-B88 train/state entries for the remaining launch-governance production timeout follow-up.
- Cached first-wave discoverability route projection inside `CareerFirstWaveNextStepLinksService`, avoiding repeated full manifest construction while building launch-readiness audit members.
- Reworked `CareerTrustFreshnessAuthorityService` to derive freshness from batched `occupations`, `trust_manifests`, and `occupation_truth_metrics` reads instead of building per-slug job detail bundles.

## Why
PR-B87 removed lifecycle/conversion hot spots and bounded deploy warmup, but production profiling still showed:
- `release_ledger`: ~40s
- `strong_index_from_ledger`: ~81s

The remaining cost came from first-wave audit/trust freshness paths that repeatedly reconstructed discoverability and detail bundles. This PR keeps authority truth unchanged but removes the repeated heavy construction from launch-governance warmup and public cache paths.

## Validation commands
- `cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `cd backend && vendor/bin/pint --test app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditService.php app/Domain/Career/Publish/CareerFirstWaveLaunchReadinessAuditV2Service.php app/Domain/Career/Publish/CareerStrongIndexEligibilityService.php app/Domain/Career/Publish/CareerLaunchGovernanceClosureService.php tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php`
- `cd backend && php artisan fap:schema:verify`
- `cd backend && php artisan career:warm-public-authority-cache --json`
- `cd backend && php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditV2ServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLaunchReadinessAuditServiceTest.php tests/Unit/Services/Career/CareerStrongIndexEligibilityServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php`
- `cd backend && php artisan test --filter 'CareerDatasetPublicApiTest|CareerRecommendationDetailApiTest|CareerDatasetStructuredDataPolicyTest|CareerDatasetSitemapDiscoverabilityTest'`
- `cd backend && bash scripts/export_openapi.sh --check`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Runtime note
Local `php artisan career:warm-public-authority-cache --json` is now about 4s after this patch, down from about 17s after PR-B87.

## Intentionally deferred
- No public API contract changes.
- No frontend changes.
- No claim/SEO/attribution semantic changes.
- No replacement of authority truth with frontend/CMS fallback.
