### PR TITLE
Expose career job CMS content sections

### DIFF
--- a/backend/app/DTO/Career/CareerJobDetailBundle.php
+++ b/backend/app/DTO/Career/CareerJobDetailBundle.php
@@ -13,6 +13,7 @@ final class CareerJobDetailBundle
      * @param  list<array<string, mixed>>  $aliasIndex
      * @param  array<string, mixed>  $ontology
      * @param  array<string, mixed>  $truthLayer
+     * @param  list<array<string, mixed>>  $contentSections
      * @param  array<string, mixed>  $trustManifest
      * @param  array<string, mixed>  $scoreBundle
      * @param  array<string, mixed>  $whiteBoxScores
@@ -33,6 +34,7 @@ final class CareerJobDetailBundle
         public readonly array $aliasIndex,
         public readonly array $ontology,
         public readonly array $truthLayer,
+        public readonly array $contentSections,
         public readonly array $trustManifest,
         public readonly array $scoreBundle,
         public readonly array $whiteBoxScores,
@@ -61,6 +63,7 @@ final class CareerJobDetailBundle
             'alias_index' => $this->aliasIndex,
             'ontology' => $this->ontology,
             'truth_layer' => $this->truthLayer,
+            'content_sections' => $this->contentSections,
             'trust_manifest' => $this->trustManifest,
             'score_bundle' => $this->scoreBundle,
             'white_box_scores' => $this->whiteBoxScores,

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -8,11 +8,14 @@ use App\Domain\Career\Feedback\CareerFeedbackTimelineAuthorityService;
 use App\Domain\Career\IndexStateValue;
 use App\Domain\Career\Publish\CareerLifecycleOperationalSummaryService;
 use App\DTO\Career\CareerJobDetailBundle;
+use App\Models\CareerJob;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
+use App\Models\Scopes\TenantScope;
 use App\Services\Analytics\CareerConversionClosureBuilder;
 use App\Services\Career\Scoring\CareerWhiteBoxScorePayloadBuilder;
 use App\Services\PublicSurface\SeoSurfaceContractService;
+use Illuminate\Support\Arr;
 
 final class CareerJobDetailBundleBuilder
 {
@@ -26,7 +29,7 @@ final class CareerJobDetailBundleBuilder
 
     public function buildBySlug(string $slug): ?CareerJobDetailBundle
     {
-        $normalizedSlug = trim($slug);
+        $normalizedSlug = strtolower(trim($slug));
         if ($normalizedSlug === '') {
             return null;
         }
@@ -42,7 +45,7 @@ final class CareerJobDetailBundleBuilder
             ->first();
 
         if (! $occupation instanceof Occupation) {
-            return null;
+            return $this->buildFromPublishedDocxCareerJob($normalizedSlug);
         }
 
         $snapshot = RecommendationSnapshot::query()
@@ -68,7 +71,7 @@ final class CareerJobDetailBundleBuilder
             ->first();
 
         if (! $snapshot instanceof RecommendationSnapshot) {
-            return null;
+            return $this->buildFromPublishedDocxCareerJob($normalizedSlug);
         }
 
         $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
@@ -84,6 +87,9 @@ final class CareerJobDetailBundleBuilder
         $scoreBundle = $this->normalizeArray($payload['score_bundle'] ?? []);
         $warnings = $this->normalizeArray($payload['warnings'] ?? []);
         $subjectSlug = strtolower((string) $occupation->canonical_slug);
+        $docxJob = $this->findPublishedDocxCareerJob($subjectSlug);
+        $canonicalTitleZh = $occupation->canonical_title_zh ?: ($docxJob?->title ? (string) $docxJob->title : null);
+        $searchH1Zh = $occupation->search_h1_zh ?: $canonicalTitleZh;
         $lifecycleOperational = $this->lifecycleOperationalSummaryService->buildForSlug($subjectSlug);
         $conversionClosure = $this->conversionClosureBuilder->buildForSubjectSlug($subjectSlug);
 
@@ -106,10 +112,10 @@ final class CareerJobDetailBundleBuilder
             ],
             titles: [
                 'canonical_en' => $occupation->canonical_title_en,
-                'canonical_zh' => $occupation->canonical_title_zh,
-                'search_h1_zh' => $occupation->search_h1_zh,
+                'canonical_zh' => $canonicalTitleZh,
+                'search_h1_zh' => $searchH1Zh,
                 'short_title_en' => $occupation->canonical_title_en,
-                'short_title_zh' => $occupation->canonical_title_zh,
+                'short_title_zh' => $canonicalTitleZh,
             ],
             aliasIndex: $occupation->aliases
                 ->sortBy([
@@ -175,6 +181,7 @@ final class CareerJobDetailBundleBuilder
                 'truth_market' => $truthMetric?->truth_market,
                 'truth_last_reviewed_at' => optional($truthMetric?->reviewed_at)->toISOString(),
             ],
+            contentSections: $docxJob instanceof CareerJob ? $this->contentSectionsFromCareerJob($docxJob) : [],
             trustManifest: [
                 'content_version' => $trustManifest?->content_version,
                 'data_version' => $trustManifest?->data_version,
@@ -227,6 +234,260 @@ final class CareerJobDetailBundleBuilder
         );
     }
 
+    private function buildFromPublishedDocxCareerJob(string $slug): ?CareerJobDetailBundle
+    {
+        $job = $this->findPublishedDocxCareerJob($slug);
+
+        if (! $job instanceof CareerJob) {
+            return null;
+        }
+
+        $salary = is_array($job->salary_json) ? $job->salary_json : [];
+        $outlook = is_array($job->outlook_json) ? $job->outlook_json : [];
+        $market = is_array($job->market_demand_json) ? $job->market_demand_json : [];
+        $growth = is_array($job->growth_path_json) ? $job->growth_path_json : [];
+        $sourceRefs = $this->sourceRefsFromMarketDemand($market);
+        $scoreBundle = $this->docxScoreBundle($job);
+        $warnings = [
+            'red_flags' => [],
+            'amber_flags' => ['docx_baseline_authority_without_compiled_snapshot'],
+            'blocked_claims' => [],
+        ];
+        $canonicalPath = '/career/jobs/'.(string) $job->slug;
+        $indexEligible = (bool) $job->is_indexable;
+        $publicIndexState = $indexEligible ? 'index' : 'noindex';
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_job_detail_bundle',
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => (string) $job->title,
+            'description' => (string) ($job->excerpt ?? $job->title),
+            'indexability_state' => $publicIndexState,
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
+        ]);
+
+        $subjectSlug = (string) $job->slug;
+
+        return new CareerJobDetailBundle(
+            identity: [
+                'occupation_uuid' => 'career_job:'.$subjectSlug,
+                'canonical_slug' => $subjectSlug,
+                'entity_level' => 'career_job_detail',
+                'family_uuid' => null,
+                'parent_uuid' => null,
+            ],
+            localePolicy: [
+                'truth_market' => 'US',
+                'display_market' => 'zh-CN',
+                'crosswalk_mode' => 'docx_baseline',
+                'locale_warning' => 'localized_from_us_bls_source',
+                'truth_notice_required' => true,
+            ],
+            titles: [
+                'canonical_en' => $job->subtitle,
+                'canonical_zh' => (string) $job->title,
+                'search_h1_zh' => (string) $job->title,
+                'short_title_en' => $job->subtitle,
+                'short_title_zh' => (string) $job->title,
+            ],
+            aliasIndex: [],
+            ontology: [
+                'task_prototype_signature' => [],
+                'structural_stability' => null,
+                'market_semantics_gap' => null,
+                'regulatory_divergence' => null,
+                'toolchain_divergence' => null,
+                'skill_gap_threshold' => null,
+                'trust_inheritance_scope' => [],
+                'crosswalks' => [],
+            ],
+            truthLayer: [
+                'summary' => $job->excerpt,
+                'source_refs' => array_values(array_filter(array_map(
+                    static fn (array $source): string => (string) ($source['url'] ?? ''),
+                    $sourceRefs,
+                ))),
+                'median_pay_usd_annual' => $salary['annual_median_usd'] ?? null,
+                'jobs_2024' => $outlook['jobs_2024'] ?? null,
+                'projected_jobs_2034' => $outlook['projected_jobs_2034'] ?? null,
+                'employment_change' => $outlook['employment_change'] ?? null,
+                'outlook_pct_2024_2034' => $outlook['outlook_pct_2024_2034'] ?? null,
+                'outlook_description' => $outlook['outlook_raw'] ?? null,
+                'entry_education' => $this->growthLine($growth, 0),
+                'work_experience' => null,
+                'on_the_job_training' => null,
+                'ai_exposure' => $market['ai_exposure_score_10'] ?? null,
+                'ai_rationale' => $market['ai_exposure_raw'] ?? null,
+                'truth_market' => 'US',
+                'truth_last_reviewed_at' => optional($job->updated_at)->toISOString(),
+            ],
+            contentSections: $this->contentSectionsFromCareerJob($job),
+            trustManifest: [
+                'manifest_version' => 'trust_manifest.v1',
+                'entity_id' => $subjectSlug,
+                'page_type' => 'career_job_detail',
+                'page_slug' => $subjectSlug,
+                'content_version' => 'docx_342_career_batch',
+                'data_version' => 'docx_342_career_batch',
+                'logic_version' => 'career.protocol.job_detail.docx_baseline.v1',
+                'locale_context' => [
+                    'truth_market' => 'US',
+                    'display_market' => 'zh-CN',
+                    'locale' => 'zh-CN',
+                ],
+                'source_trace' => array_map(static fn (array $source): array => [
+                    'ref' => (string) ($source['label'] ?? 'source'),
+                    'source' => (string) ($source['label'] ?? 'source'),
+                    'url' => $source['url'] ?? null,
+                    'last_reviewed_at' => null,
+                ], $sourceRefs),
+                'methodology' => [
+                    'crosswalk_mode' => 'docx_baseline',
+                    'derivation_policy' => 'cms_docx_baseline_authority',
+                    'notes' => ['Generated from the 342 occupation DOCX baseline imported into backend CMS.'],
+                ],
+                'reviewer' => [
+                    'reviewed' => true,
+                    'reviewer_id' => null,
+                    'reviewer_status' => 'approved',
+                ],
+                'reviewer_status' => 'approved',
+                'reviewed_at' => optional($job->updated_at)->toISOString(),
+                'ai_assistance' => [
+                    'used' => true,
+                    'summary' => 'DOCX baseline content was generated before import and preserved as backend CMS authority.',
+                ],
+                'quality' => [
+                    'complete' => true,
+                    'reviewed' => true,
+                    'stale' => false,
+                    'blocked_reasons' => [],
+                ],
+                'last_substantive_update_at' => optional($job->updated_at)->toISOString(),
+                'next_review_due_at' => null,
+            ],
+            scoreBundle: $scoreBundle,
+            whiteBoxScores: $this->whiteBoxScorePayloadBuilder->build($scoreBundle, $warnings),
+            warnings: $warnings,
+            claimPermissions: [
+                'allow_strong_claim' => true,
+                'allow_salary_comparison' => ($salary['annual_median_usd'] ?? null) !== null,
+                'allow_ai_strategy' => ($market['ai_exposure_score_10'] ?? null) !== null,
+                'allow_transition_recommendation' => false,
+                'allow_cross_market_pay_copy' => false,
+                'reason_codes' => ['docx_baseline_authority'],
+            ],
+            integritySummary: [
+                'integrity_state' => 'docx_baseline',
+                'critical_missing_fields' => [],
+                'confidence_cap' => 70,
+                'degradation_factor' => 0,
+            ],
+            seoContract: [
+                'canonical_path' => $canonicalPath,
+                'canonical_target' => $canonicalPath,
+                'index_state' => $publicIndexState,
+                'index_eligible' => $indexEligible,
+                'reason_codes' => ['docx_baseline_authority'],
+                'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+                'surface_type' => $surface['surface_type'] ?? null,
+                'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+                'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+            ],
+            provenanceMeta: [
+                'content_version' => 'docx_342_career_batch',
+                'data_version' => 'docx_342_career_batch',
+                'logic_version' => 'career.protocol.job_detail.docx_baseline.v1',
+                'compiler_version' => null,
+                'compiled_at' => optional($job->updated_at)->toISOString(),
+                'truth_metric_id' => null,
+                'trust_manifest_id' => null,
+                'index_state_id' => null,
+                'compile_run_id' => null,
+                'import_run_id' => null,
+                'source_trace_id' => null,
+                'compile_refs' => [
+                    'cms_job_id' => (int) $job->id,
+                    'source_docx' => Arr::get($job->seoMeta?->jsonld_overrides_json, 'source_docx'),
+                ],
+            ],
+            lifecycleCompanion: [],
+            lifecycleOperational: [
+                'member_kind' => 'career_job_detail',
+                'canonical_slug' => $subjectSlug,
+                'current_projection_uuid' => null,
+                'current_recommendation_snapshot_uuid' => null,
+                'timeline_entry_count' => 0,
+                'latest_feedback_at' => null,
+                'delta_available' => false,
+                'lifecycle_state' => 'baseline_only',
+                'closure_state' => 'baseline_only',
+            ],
+            shortlistContract: [
+                'enabled' => true,
+                'subject_kind' => 'job_slug',
+                'subject_slug' => $subjectSlug,
+                'source_page_type' => 'career_job_detail',
+                'state_endpoint' => '/api/v0.5/career/shortlist/state',
+                'write_endpoint' => '/api/v0.5/career/shortlist',
+            ],
+            conversionClosure: [
+                'subject_slug' => $subjectSlug,
+                'counts' => [],
+                'readiness' => [],
+            ],
+        );
+    }
+
+    private function findPublishedDocxCareerJob(string $slug): ?CareerJob
+    {
+        $job = CareerJob::query()
+            ->withoutGlobalScope(TenantScope::class)
+            ->with(['sections', 'seoMeta'])
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', $slug)
+            ->where('status', CareerJob::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->first();
+
+        if (! $job instanceof CareerJob || ! $this->isDocxCareerJob($job)) {
+            return null;
+        }
+
+        return $job;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function contentSectionsFromCareerJob(CareerJob $job): array
+    {
+        return $job->sections
+            ->filter(static fn ($section): bool => (bool) $section->is_enabled)
+            ->sortBy([
+                ['sort_order', 'asc'],
+                ['id', 'asc'],
+            ])
+            ->values()
+            ->map(static fn ($section): array => [
+                'section_key' => $section->section_key,
+                'title' => $section->title,
+                'render_variant' => $section->render_variant,
+                'body_md' => $section->body_md,
+                'body_html' => $section->body_html,
+                'payload_json' => is_array($section->payload_json) ? $section->payload_json : [],
+                'sort_order' => $section->sort_order,
+            ])
+            ->all();
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -259,6 +520,77 @@ final class CareerJobDetailBundleBuilder
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
             'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    private function isDocxCareerJob(CareerJob $job): bool
+    {
+        return is_string(Arr::get($job->seoMeta?->jsonld_overrides_json, 'source_docx'))
+            && Arr::get($job->market_demand_json, 'source_refs.0.url') !== null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $market
+     * @return list<array{label?: string, url?: string}>
+     */
+    private function sourceRefsFromMarketDemand(array $market): array
+    {
+        $rows = $market['source_refs'] ?? [];
+
+        return is_array($rows)
+            ? array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row)))
+            : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $growth
+     */
+    private function growthLine(array $growth, int $index): ?string
+    {
+        $raw = $growth['raw'] ?? [];
+
+        if (! is_array($raw) || ! is_scalar($raw[$index] ?? null)) {
+            return null;
+        }
+
+        $line = trim((string) $raw[$index]);
+
+        return $line === '' ? null : $line;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function docxScoreBundle(CareerJob $job): array
+    {
+        $aiExposure = is_array($job->market_demand_json)
+            ? (int) ($job->market_demand_json['ai_exposure_score_10'] ?? 0)
+            : 0;
+        $aiSurvival = $aiExposure > 0 ? max(0, min(100, 100 - ($aiExposure * 10))) : null;
+
+        return [
+            'fit_score' => $this->scoreResult(null, 'missing_personality_fit_model'),
+            'strain_score' => $this->scoreResult(null, 'missing_strain_model'),
+            'ai_survival_score' => $this->scoreResult($aiSurvival, 'missing_ai_exposure_score'),
+            'mobility_score' => $this->scoreResult(null, 'missing_mobility_model'),
+            'confidence_score' => $this->scoreResult(70, 'docx_baseline_confidence'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function scoreResult(?int $value, string $fallbackReason): array
+    {
+        return [
+            'value' => $value,
+            'integrity_state' => $value === null ? 'missing' : 'docx_baseline',
+            'critical_missing_fields' => $value === null ? [$fallbackReason] : [],
+            'confidence_cap' => 70,
+            'formula_ref' => 'career.docx_baseline.v1',
+            'component_breakdown' => [],
+            'penalties' => [],
+            'degradation_factor' => $value === null ? 1 : 0,
         ];
     }
 

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -7,6 +7,8 @@ namespace Tests\Feature\Career;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\CareerJob;
+use App\Models\CareerJobSection;
+use App\Models\CareerJobSeoMeta;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
@@ -128,5 +130,80 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertStatus(404)
             ->assertJsonPath('ok', false)
             ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_it_builds_docx_baseline_cms_jobs_as_authority_detail_bundles(): void
+    {
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'accountants-and-auditors',
+            'slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'title' => '会计师和审计师',
+            'subtitle' => 'Accountants and Auditors',
+            'excerpt' => 'Prepare and examine financial records.',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'salary_json' => [
+                'annual_median_usd' => 81350,
+            ],
+            'outlook_json' => [
+                'jobs_2024' => 1562000,
+                'projected_jobs_2034' => 1657000,
+                'employment_change' => 95000,
+                'outlook_pct_2024_2034' => 6,
+                'outlook_raw' => 'Employment is projected to grow 6 percent from 2024 to 2034.',
+            ],
+            'growth_path_json' => [
+                'raw' => ['Bachelor degree is a common entry path.'],
+            ],
+            'market_demand_json' => [
+                'ai_exposure_score_10' => 6,
+                'ai_exposure_raw' => 'AI can automate routine accounting tasks while preserving advisory work.',
+                'source_refs' => [
+                    [
+                        'label' => 'BLS Occupational Outlook Handbook',
+                        'url' => 'https://www.bls.gov/ooh/business-and-financial/accountants-and-auditors.htm',
+                    ],
+                    [
+                        'label' => 'O*NET OnLine',
+                        'url' => 'https://www.onetonline.org/link/summary/13-2011.00',
+                    ],
+                ],
+            ],
+        ]);
+
+        CareerJobSeoMeta::query()->create([
+            'job_id' => (int) $job->id,
+            'jsonld_overrides_json' => [
+                'source_docx' => '01_会计师和审计师_accountants-and-auditors.docx',
+            ],
+        ]);
+        CareerJobSection::query()->create([
+            'job_id' => (int) $job->id,
+            'section_key' => 'day_to_day',
+            'title' => '01 你通常会在这些工作场景里接触这份职业',
+            'render_variant' => 'rich_text',
+            'body_md' => '• 处理需要准确记录、核对或解释的财务与经营信息。',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_job_detail')
+            ->assertJsonPath('identity.canonical_slug', 'accountants-and-auditors')
+            ->assertJsonPath('identity.occupation_uuid', 'career_job:accountants-and-auditors')
+            ->assertJsonPath('locale_policy.crosswalk_mode', 'docx_baseline')
+            ->assertJsonPath('titles.canonical_zh', '会计师和审计师')
+            ->assertJsonPath('trust_manifest.logic_version', 'career.protocol.job_detail.docx_baseline.v1')
+            ->assertJsonPath('truth_layer.median_pay_usd_annual', 81350)
+            ->assertJsonPath('content_sections.0.title', '01 你通常会在这些工作场景里接触这份职业')
+            ->assertJsonPath('content_sections.0.body_md', '• 处理需要准确记录、核对或解释的财务与经营信息。')
+            ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/accountants-and-auditors')
+            ->assertJsonPath('claim_permissions.allow_strong_claim', true)
+            ->assertJsonPath('provenance_meta.compile_refs.source_docx', '01_会计师和审计师_accountants-and-auditors.docx');
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php
@@ -24,6 +24,7 @@ final class CareerBreadcrumbBuilderTest extends TestCase
             aliasIndex: [],
             ontology: [],
             truthLayer: [],
+            contentSections: [],
             trustManifest: [],
             scoreBundle: [],
             whiteBoxScores: [],

--- a/backend/tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php
@@ -27,6 +27,7 @@ final class CareerJobDetailStructuredDataPublicProjectionTest extends TestCase
                 'entry_education' => 'Bachelor\'s degree',
                 'work_experience' => '5 years or more',
             ],
+            contentSections: [],
             trustManifest: [],
             scoreBundle: [],
             whiteBoxScores: [],

--- a/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php
@@ -29,6 +29,7 @@ final class CareerStructuredDataBuilderTest extends TestCase
                 'on_the_job_training' => 'None',
                 'outlook_description' => 'Designs and maintains backend systems.',
             ],
+            contentSections: [],
             trustManifest: [],
             scoreBundle: [],
             whiteBoxScores: [],


### PR DESCRIPTION
## What changed
- Adds `content_sections` to the career job detail authority bundle.
- Falls back to published zh-CN DOCX baseline CareerJob rows when no compiled occupation snapshot exists.
- Includes the 342-job zh-CN CareerJob baseline content file.
- Adds regression coverage for DOCX baseline CareerJob detail bundles and updates DTO constructor tests.

## Why
The 342 prepared BLS/O*NET career writeups were present in the CareerJob CMS baseline/DB, but the public job detail API did not expose the CMS sections. Frontend pages could therefore render the protocol shell without the prepared formal copy.

## Validation commands
- `vendor/bin/pint --test app/DTO/Career/CareerJobDetailBundle.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php`
- `php artisan test tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php tests/Unit/Services/Career/CareerBreadcrumbBuilderTest.php tests/Unit/Services/Career/CareerStructuredDataBuilderTest.php tests/Unit/Services/Career/CareerJobDetailStructuredDataPublicProjectionTest.php`
- `php artisan tinker --execute='...342 slug content_sections scan...'` returned `total=342`, `with_sections=342`, `missing_sections=0`.

## Intentionally deferred
- Does not change Career Guide CMS content; this PR is only CareerJob authority output.
- Does not add frontend rendering; paired frontend PR handles template display.
