### PR TITLE
[codex] Update CMS test surface baselines

### DIFF
--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -36,6 +36,60 @@ final class LandingSurfacePublicApiTest extends TestCase
 
         $this->assertSame('published', (string) $home->status);
         $this->assertSame('FermatMind / 费马测试', (string) data_get($home->payload_json, 'hero.brand'));
+        $this->assertCount(6, data_get($home->payload_json, 'quickStart.items'));
+        $this->assertContains('霍兰德职业兴趣测试', array_column(data_get($home->payload_json, 'quickStart.items'), 'title'));
+        $this->assertContains('抑郁焦虑综合症测试', array_column(data_get($home->payload_json, 'quickStart.items'), 'title'));
+        $this->assertContains(
+            '/career/tests/riasec',
+            array_column(data_get($home->payload_json, 'quickStart.items'), 'href')
+        );
+        $this->assertContains(
+            '/tests/clinical-depression-anxiety-assessment-professional-edition',
+            array_column(data_get($home->payload_json, 'quickStart.items'), 'href')
+        );
+
+        $quickStartBlock = PageBlock::query()
+            ->where('landing_surface_id', $home->id)
+            ->where('block_key', 'quickstart')
+            ->firstOrFail();
+
+        $this->assertCount(6, data_get($quickStartBlock->payload_json, 'items'));
+        $this->assertContains('霍兰德职业兴趣测试', array_column(data_get($quickStartBlock->payload_json, 'items'), 'title'));
+        $this->assertContains('抑郁焦虑综合症测试', array_column(data_get($quickStartBlock->payload_json, 'items'), 'title'));
+        $this->assertContains(
+            '/career/tests/riasec',
+            array_column(data_get($quickStartBlock->payload_json, 'items'), 'href')
+        );
+        $this->assertContains(
+            '/tests/clinical-depression-anxiety-assessment-professional-edition',
+            array_column(data_get($quickStartBlock->payload_json, 'items'), 'href')
+        );
+
+        $tests = LandingSurface::query()
+            ->withoutGlobalScopes()
+            ->where('surface_key', 'tests')
+            ->where('locale', 'zh-CN')
+            ->firstOrFail();
+
+        $emotionFamily = collect(data_get($tests->payload_json, 'families.items'))
+            ->firstWhere('id', 'family-emotion-state');
+
+        $this->assertContains(
+            'depression-screening-test-standard-edition',
+            array_column(data_get($emotionFamily, 'tests'), 'key')
+        );
+        $this->assertContains(
+            '/zh/tests/depression-screening-test-standard-edition/take',
+            array_column(data_get($emotionFamily, 'tests'), 'href')
+        );
+        $this->assertContains(
+            'clinical-depression-anxiety-assessment-professional-edition',
+            array_column(data_get($emotionFamily, 'tests'), 'key')
+        );
+        $this->assertContains(
+            '/zh/tests/clinical-depression-anxiety-assessment-professional-edition/take',
+            array_column(data_get($emotionFamily, 'tests'), 'href')
+        );
     }
 
     public function test_public_and_internal_api_return_surface_payloads(): void
@@ -51,7 +105,12 @@ final class LandingSurfacePublicApiTest extends TestCase
             ->assertJsonPath('ok', true)
             ->assertJsonPath('surface.surface_key', 'home')
             ->assertJsonPath('surface.locale', 'zh-CN')
-            ->assertJsonPath('surface.payload_json.hero.brand', 'FermatMind / 费马测试');
+            ->assertJsonPath('surface.payload_json.hero.brand', 'FermatMind / 费马测试')
+            ->assertJsonCount(6, 'surface.payload_json.quickStart.items')
+            ->assertJsonPath('surface.payload_json.quickStart.items.3.title', '霍兰德职业兴趣测试')
+            ->assertJsonPath('surface.payload_json.quickStart.items.3.href', '/career/tests/riasec')
+            ->assertJsonPath('surface.payload_json.quickStart.items.5.title', '抑郁焦虑综合症测试')
+            ->assertJsonPath('surface.payload_json.quickStart.items.5.href', '/tests/clinical-depression-anxiety-assessment-professional-edition');
 
         $this->putJson('/api/v0.5/internal/landing-surfaces/home', [
             'locale' => 'zh-CN',

--- a/content_baselines/landing_surfaces/home.en.json
+++ b/content_baselines/landing_surfaces/home.en.json
@@ -53,11 +53,11 @@
           "meta": "Personality test"
         },
         {
-          "title": "EQ Test",
-          "description": "Review emotional recognition and collaboration skills.",
-          "href": "/tests/eq-test-emotional-intelligence-assessment",
+          "title": "Holland Career Interest Test",
+          "description": "Start from interest structure and career direction.",
+          "href": "/career/tests/riasec",
           "label": "Start test",
-          "meta": "Emotional ability"
+          "meta": "Career interest"
         },
         {
           "title": "IQ Test",
@@ -65,6 +65,13 @@
           "href": "/tests/iq-test-intelligence-quotient-assessment",
           "label": "Start test",
           "meta": "Ability assessment"
+        },
+        {
+          "title": "Depression and Anxiety Assessment",
+          "description": "Review depression and anxiety dimensions with a fuller recent-state reference.",
+          "href": "/tests/clinical-depression-anxiety-assessment-professional-edition",
+          "label": "Start test",
+          "meta": "Professional version"
         }
       ]
     },
@@ -291,7 +298,7 @@
       "title": "FermatMind",
       "description": "FermatMind provides clear, reusable assessment results for personality, ability, and career direction.",
       "quickStartListTitle": "FermatMind core assessment entry points",
-      "quickStartListDescription": "Core homepage entry points including MBTI, Big Five, IQ, EQ, Enneagram, and emotional state check.",
+      "quickStartListDescription": "Core homepage entry points including MBTI, Big Five, IQ, Holland career interest, Enneagram, and depression-anxiety assessment.",
       "familyListTitle": "FermatMind lightweight exploration paths",
       "familyListDescription": "Lightweight homepage paths for all assessments, career exploration, fun experiments, and data method notes.",
       "organizationDescription": "FermatMind provides structured assessments for self-understanding, ability review, career direction, and collaboration judgment."
@@ -354,11 +361,11 @@
             "meta": "Personality test"
           },
           {
-            "title": "EQ Test",
-            "description": "Review emotional recognition and collaboration skills.",
-            "href": "/tests/eq-test-emotional-intelligence-assessment",
+            "title": "Holland Career Interest Test",
+            "description": "Start from interest structure and career direction.",
+            "href": "/career/tests/riasec",
             "label": "Start test",
-            "meta": "Emotional ability"
+            "meta": "Career interest"
           },
           {
             "title": "IQ Test",
@@ -366,6 +373,13 @@
             "href": "/tests/iq-test-intelligence-quotient-assessment",
             "label": "Start test",
             "meta": "Ability assessment"
+          },
+          {
+            "title": "Depression and Anxiety Assessment",
+            "description": "Review depression and anxiety dimensions with a fuller recent-state reference.",
+            "href": "/tests/clinical-depression-anxiety-assessment-professional-edition",
+            "label": "Start test",
+            "meta": "Professional version"
           }
         ]
       },

--- a/content_baselines/landing_surfaces/home.zh-CN.json
+++ b/content_baselines/landing_surfaces/home.zh-CN.json
@@ -53,11 +53,11 @@
           "meta": "人格测试"
         },
         {
-          "title": "EQ 情商测试",
-          "description": "了解你在情绪识别与协作沟通中的表现",
-          "href": "/tests/eq-test-emotional-intelligence-assessment",
+          "title": "霍兰德职业兴趣测试",
+          "description": "先得到兴趣结构与职业方向判断",
+          "href": "/career/tests/riasec",
           "label": "开始测试",
-          "meta": "情绪能力"
+          "meta": "职业兴趣"
         },
         {
           "title": "IQ 智商测试",
@@ -65,6 +65,13 @@
           "href": "/tests/iq-test-intelligence-quotient-assessment",
           "label": "开始测试",
           "meta": "能力测评"
+        },
+        {
+          "title": "抑郁焦虑综合症测试",
+          "description": "同时查看抑郁与焦虑两个维度，获得更完整的近期状态参考",
+          "href": "/tests/clinical-depression-anxiety-assessment-professional-edition",
+          "label": "开始测试",
+          "meta": "学术专业版"
         }
       ]
     },
@@ -291,7 +298,7 @@
       "title": "FermatMind / 费马测试",
       "description": "费马测试提供清晰、可继续使用的测评结果，帮助你看清人格、能力与职业方向。",
       "quickStartListTitle": "费马测试首页核心测评入口",
-      "quickStartListDescription": "首页核心测评入口，包括 MBTI、大五人格、IQ、EQ、九型人格与情绪状态自测。",
+      "quickStartListDescription": "首页核心测评入口，包括 MBTI、大五人格、IQ、霍兰德职业兴趣、九型人格与抑郁焦虑综合症测试。",
       "familyListTitle": "费马测试首页继续探索入口",
       "familyListDescription": "首页轻量继续探索入口，包括全部测评、职业探索、娱乐实验与数据方法。",
       "organizationDescription": "FermatMind / 费马测试提供用于自我理解、能力观察、职业方向与协作判断的结构化测评。"
@@ -354,11 +361,11 @@
             "meta": "人格测试"
           },
           {
-            "title": "EQ 情商测试",
-            "description": "了解你在情绪识别与协作沟通中的表现",
-            "href": "/tests/eq-test-emotional-intelligence-assessment",
+            "title": "霍兰德职业兴趣测试",
+            "description": "先得到兴趣结构与职业方向判断",
+            "href": "/career/tests/riasec",
             "label": "开始测试",
-            "meta": "情绪能力"
+            "meta": "职业兴趣"
           },
           {
             "title": "IQ 智商测试",
@@ -366,6 +373,13 @@
             "href": "/tests/iq-test-intelligence-quotient-assessment",
             "label": "开始测试",
             "meta": "能力测评"
+          },
+          {
+            "title": "抑郁焦虑综合症测试",
+            "description": "同时查看抑郁与焦虑两个维度，获得更完整的近期状态参考",
+            "href": "/tests/clinical-depression-anxiety-assessment-professional-edition",
+            "label": "开始测试",
+            "meta": "学术专业版"
           }
         ]
       },

--- a/content_baselines/landing_surfaces/tests.en.json
+++ b/content_baselines/landing_surfaces/tests.en.json
@@ -271,15 +271,30 @@
           "exploreHref": "/en/tests#family-emotion-state",
           "exploreLabel": "View this group",
           "representativeLabels": [
+            "Depression screening",
             "Clinical combo"
           ],
           "tests": [
             {
+              "key": "depression-screening-test-standard-edition",
+              "title": "Depression Screening Test",
+              "description": "When you want a faster depression-state screen and a recent-state reference.",
+              "questionsLabel": "20 questions",
+              "durationLabel": "3-5 min",
+              "outputLabel": "Depression screening reference",
+              "detailsHref": "/en/tests/depression-screening-test-standard-edition",
+              "secondaryLabel": "View details",
+              "scientificBasis": "Based on SDS",
+              "previewVariant": "summary",
+              "href": "/en/tests/depression-screening-test-standard-edition/take",
+              "primaryLabel": "Start test"
+            },
+            {
               "key": "clinical-depression-anxiety-assessment-professional-edition",
               "title": "Depression and Anxiety Assessment",
               "description": "When you want a fuller snapshot across both depression and anxiety dimensions.",
-              "questionsLabel": "90 questions",
-              "durationLabel": "15 min",
+              "questionsLabel": "68 questions",
+              "durationLabel": "12 min",
               "outputLabel": "Depression and anxiety state reference",
               "detailsHref": "/en/tests/clinical-depression-anxiety-assessment-professional-edition",
               "secondaryLabel": "View details",
@@ -726,15 +741,30 @@
             "exploreHref": "/en/tests#family-emotion-state",
             "exploreLabel": "View this group",
             "representativeLabels": [
+              "Depression screening",
               "Clinical combo"
             ],
             "tests": [
               {
+                "key": "depression-screening-test-standard-edition",
+                "title": "Depression Screening Test",
+                "description": "When you want a faster depression-state screen and a recent-state reference.",
+                "questionsLabel": "20 questions",
+                "durationLabel": "3-5 min",
+                "outputLabel": "Depression screening reference",
+                "detailsHref": "/en/tests/depression-screening-test-standard-edition",
+                "secondaryLabel": "View details",
+                "scientificBasis": "Based on SDS",
+                "previewVariant": "summary",
+                "href": "/en/tests/depression-screening-test-standard-edition/take",
+                "primaryLabel": "Start test"
+              },
+              {
                 "key": "clinical-depression-anxiety-assessment-professional-edition",
                 "title": "Depression and Anxiety Assessment",
                 "description": "When you want a fuller snapshot across both depression and anxiety dimensions.",
-                "questionsLabel": "90 questions",
-                "durationLabel": "15 min",
+                "questionsLabel": "68 questions",
+                "durationLabel": "12 min",
                 "outputLabel": "Depression and anxiety state reference",
                 "detailsHref": "/en/tests/clinical-depression-anxiety-assessment-professional-edition",
                 "secondaryLabel": "View details",

--- a/content_baselines/landing_surfaces/tests.zh-CN.json
+++ b/content_baselines/landing_surfaces/tests.zh-CN.json
@@ -72,7 +72,7 @@
           "href": "/zh/tests#family-emotion-state",
           "ctaLabel": "查看状态类测试",
           "scent": [
-            "综合抑郁焦虑"
+            "抑郁焦虑综合症"
           ]
         },
         {
@@ -271,15 +271,30 @@
           "exploreHref": "/zh/tests#family-emotion-state",
           "exploreLabel": "查看这一组测试",
           "representativeLabels": [
-            "综合抑郁焦虑"
+            "抑郁症标准版",
+            "抑郁焦虑综合症"
           ],
           "tests": [
             {
+              "key": "depression-screening-test-standard-edition",
+              "title": "抑郁症标准版测试",
+              "description": "当你想更快完成抑郁状态筛查，并获得近期状态参考时。",
+              "questionsLabel": "20 题",
+              "durationLabel": "约 3-5 分钟",
+              "outputLabel": "抑郁状态筛查参考",
+              "detailsHref": "/zh/tests/depression-screening-test-standard-edition",
+              "secondaryLabel": "查看详情",
+              "scientificBasis": "基于 SDS",
+              "previewVariant": "summary",
+              "href": "/zh/tests/depression-screening-test-standard-edition/take",
+              "primaryLabel": "开始测试"
+            },
+            {
               "key": "clinical-depression-anxiety-assessment-professional-edition",
-              "title": "综合抑郁焦虑评估",
+              "title": "抑郁焦虑综合症测试",
               "description": "当你想同时查看抑郁与焦虑两个维度，并获得更完整的近期状态参考时。",
-              "questionsLabel": "90 题",
-              "durationLabel": "约 15 分钟",
+              "questionsLabel": "68 题",
+              "durationLabel": "约 12 分钟",
               "outputLabel": "抑郁焦虑双维状态参考",
               "detailsHref": "/zh/tests/clinical-depression-anxiety-assessment-professional-edition",
               "secondaryLabel": "查看详情",
@@ -520,7 +535,7 @@
             "href": "/zh/tests#family-emotion-state",
             "ctaLabel": "查看状态类测试",
             "scent": [
-              "综合抑郁焦虑"
+              "抑郁焦虑综合症"
             ]
           },
           {
@@ -726,15 +741,30 @@
             "exploreHref": "/zh/tests#family-emotion-state",
             "exploreLabel": "查看这一组测试",
             "representativeLabels": [
-              "综合抑郁焦虑"
+              "抑郁症标准版",
+              "抑郁焦虑综合症"
             ],
             "tests": [
               {
+                "key": "depression-screening-test-standard-edition",
+                "title": "抑郁症标准版测试",
+                "description": "当你想更快完成抑郁状态筛查，并获得近期状态参考时。",
+                "questionsLabel": "20 题",
+                "durationLabel": "约 3-5 分钟",
+                "outputLabel": "抑郁状态筛查参考",
+                "detailsHref": "/zh/tests/depression-screening-test-standard-edition",
+                "secondaryLabel": "查看详情",
+                "scientificBasis": "基于 SDS",
+                "previewVariant": "summary",
+                "href": "/zh/tests/depression-screening-test-standard-edition/take",
+                "primaryLabel": "开始测试"
+              },
+              {
                 "key": "clinical-depression-anxiety-assessment-professional-edition",
-                "title": "综合抑郁焦虑评估",
+                "title": "抑郁焦虑综合症测试",
                 "description": "当你想同时查看抑郁与焦虑两个维度，并获得更完整的近期状态参考时。",
-                "questionsLabel": "90 题",
-                "durationLabel": "约 15 分钟",
+                "questionsLabel": "68 题",
+                "durationLabel": "约 12 分钟",
                 "outputLabel": "抑郁焦虑双维状态参考",
                 "detailsHref": "/zh/tests/clinical-depression-anxiety-assessment-professional-edition",
                 "secondaryLabel": "查看详情",


### PR DESCRIPTION
## What changed
- Updated home landing-surface baselines so the six core homepage entries replace EQ with Holland career interest and add the depression-anxiety assessment.
- Updated tests landing-surface baselines to expose both the standard depression screening and the professional depression-anxiety assessment in the emotion-state family.
- Extended the landing-surface API regression test to lock the CMS payload shape and routes.

## Why
- The homepage and tests hub should be driven by CMS baseline data instead of frontend fallback content.
- The frontend PR depends on these CMS payloads being present.

## Validation
- `vendor/bin/pint --test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php`
- `php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php`
- `python3 -m json.tool content_baselines/landing_surfaces/home.en.json`
- `python3 -m json.tool content_baselines/landing_surfaces/home.zh-CN.json`
- `python3 -m json.tool content_baselines/landing_surfaces/tests.en.json`
- `python3 -m json.tool content_baselines/landing_surfaces/tests.zh-CN.json`

## Intentionally deferred
- Deployment hook changes for importing CMS baselines are not included in this PR.
- OpenAPI snapshot regeneration is not included because this PR only changes CMS seed/surface content.