### PR TITLE
PR-CMS1: CMS landing surface deploy import

### DIFF
--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2775,9 +2775,9 @@
     "PR-B88": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "status": "pr_open",
+      "status": "merged",
       "branch": "codex/pr-b88-career-first-wave-authority-runtime-hardening",
-      "commit_sha": "9c3269263d076dbddc07e47f53de65f99e2bca8f",
+      "commit_sha": "7c93d38190411cbef7a020322d050b4078830d7e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/933",
       "checks": {
         "local": [
@@ -2811,6 +2811,44 @@
           },
           {
             "command": "cd backend && bash scripts/ci_verify_mbti.sh",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-17T02:06:59Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-CMS1": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "status": "local_verified",
+      "branch": "codex/pr-cms1-home-surface-deploy-import",
+      "commit_sha": "4bd14ef927b7fb9f82b26059c05910b64f0a1569",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && vendor/bin/pint --test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php -l deploy.php",
             "status": "passed"
           },
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2829,10 +2829,10 @@
     "PR-CMS1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-cms1-home-surface-deploy-import",
-      "commit_sha": "b36306481f9d5bab30a680a4b63d0cbdc6783af2",
-      "pr_url": "",
+      "commit_sha": "28918b8f6f618d0ff3787745baeafb2aa596f1ad",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/941",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-17T01:08:00Z",
+  "updated_at": "2026-04-19T00:00:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -2831,7 +2831,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "status": "pr_open",
       "branch": "codex/pr-cms1-home-surface-deploy-import",
-      "commit_sha": "e54c24003f1693beb0b3495b04bcb19338a2dadf",
+      "commit_sha": "144d4234ec299ba75183c593f7adeeb9feda47a5",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/941",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2831,7 +2831,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "status": "pr_open",
       "branch": "codex/pr-cms1-home-surface-deploy-import",
-      "commit_sha": "28918b8f6f618d0ff3787745baeafb2aa596f1ad",
+      "commit_sha": "e54c24003f1693beb0b3495b04bcb19338a2dadf",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/941",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -2831,7 +2831,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
       "status": "local_verified",
       "branch": "codex/pr-cms1-home-surface-deploy-import",
-      "commit_sha": "4bd14ef927b7fb9f82b26059c05910b64f0a1569",
+      "commit_sha": "b36306481f9d5bab30a680a4b63d0cbdc6783af2",
       "pr_url": "",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -1645,3 +1645,31 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: PR-CMS1
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api
+    branch: codex/pr-cms1-home-surface-deploy-import
+    base: main
+    depends_on: ["PR-B88"]
+    mode: execute
+    scope: >
+      CMS landing surface deploy import.
+      Import published landing surface baselines during deploy so the backend CMS API remains
+      the homepage authority, and lock the zh-CN homepage hero copy to the current production
+      wording without reintroducing frontend fallback content.
+    checks:
+      - "cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "cd backend && vendor/bin/pint --test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php"
+      - "cd backend && php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php"
+      - "php -l deploy.php"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true

--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -36,6 +36,11 @@ final class LandingSurfacePublicApiTest extends TestCase
 
         $this->assertSame('published', (string) $home->status);
         $this->assertSame('FermatMind / 费马测试', (string) data_get($home->payload_json, 'hero.brand'));
+        $this->assertSame('看清自己，走好每一步', (string) data_get($home->payload_json, 'hero.title'));
+        $this->assertSame(
+            '费马测试把自我认知、职业探索与能力成长，做成可测量、可训练、可复盘的成长系统。',
+            (string) data_get($home->payload_json, 'hero.subhead')
+        );
         $this->assertCount(6, data_get($home->payload_json, 'quickStart.items'));
         $this->assertContains('霍兰德职业兴趣测试', array_column(data_get($home->payload_json, 'quickStart.items'), 'title'));
         $this->assertContains('抑郁焦虑综合症测试', array_column(data_get($home->payload_json, 'quickStart.items'), 'title'));
@@ -106,6 +111,11 @@ final class LandingSurfacePublicApiTest extends TestCase
             ->assertJsonPath('surface.surface_key', 'home')
             ->assertJsonPath('surface.locale', 'zh-CN')
             ->assertJsonPath('surface.payload_json.hero.brand', 'FermatMind / 费马测试')
+            ->assertJsonPath('surface.payload_json.hero.title', '看清自己，走好每一步')
+            ->assertJsonPath(
+                'surface.payload_json.hero.subhead',
+                '费马测试把自我认知、职业探索与能力成长，做成可测量、可训练、可复盘的成长系统。'
+            )
             ->assertJsonCount(6, 'surface.payload_json.quickStart.items')
             ->assertJsonPath('surface.payload_json.quickStart.items.3.title', '霍兰德职业兴趣测试')
             ->assertJsonPath('surface.payload_json.quickStart.items.3.href', '/career/tests/riasec')

--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -52,6 +52,18 @@ final class LandingSurfacePublicApiTest extends TestCase
             '/tests/clinical-depression-anxiety-assessment-professional-edition',
             array_column(data_get($home->payload_json, 'quickStart.items'), 'href')
         );
+        $this->assertSame(
+            ['免费测试、免费结果', '我们高度重视您的隐私。', '百万用户进行了多次测试'],
+            array_column(data_get($home->payload_json, 'trust.items'), 'title')
+        );
+        $this->assertSame(
+            [
+                '核心测评围绕自我认知、职业判断与能力成长设计，并提供清晰结果。',
+                '无需先注册账号，你可以先完成测试，再决定是否保存或继续深入。',
+                '从人格、能力到情绪状态，多个入口帮助你持续复盘自己的变化。',
+            ],
+            array_column(data_get($home->payload_json, 'trust.items'), 'summary')
+        );
 
         $quickStartBlock = PageBlock::query()
             ->where('landing_surface_id', $home->id)
@@ -120,7 +132,22 @@ final class LandingSurfacePublicApiTest extends TestCase
             ->assertJsonPath('surface.payload_json.quickStart.items.3.title', '霍兰德职业兴趣测试')
             ->assertJsonPath('surface.payload_json.quickStart.items.3.href', '/career/tests/riasec')
             ->assertJsonPath('surface.payload_json.quickStart.items.5.title', '抑郁焦虑综合症测试')
-            ->assertJsonPath('surface.payload_json.quickStart.items.5.href', '/tests/clinical-depression-anxiety-assessment-professional-edition');
+            ->assertJsonPath('surface.payload_json.quickStart.items.5.href', '/tests/clinical-depression-anxiety-assessment-professional-edition')
+            ->assertJsonPath('surface.payload_json.trust.items.0.title', '免费测试、免费结果')
+            ->assertJsonPath(
+                'surface.payload_json.trust.items.0.summary',
+                '核心测评围绕自我认知、职业判断与能力成长设计，并提供清晰结果。'
+            )
+            ->assertJsonPath('surface.payload_json.trust.items.1.title', '我们高度重视您的隐私。')
+            ->assertJsonPath(
+                'surface.payload_json.trust.items.1.summary',
+                '无需先注册账号，你可以先完成测试，再决定是否保存或继续深入。'
+            )
+            ->assertJsonPath('surface.payload_json.trust.items.2.title', '百万用户进行了多次测试')
+            ->assertJsonPath(
+                'surface.payload_json.trust.items.2.summary',
+                '从人格、能力到情绪状态，多个入口帮助你持续复盘自己的变化。'
+            );
 
         $this->putJson('/api/v0.5/internal/landing-surfaces/home', [
             'locale' => 'zh-CN',

--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -149,6 +149,29 @@ final class LandingSurfacePublicApiTest extends TestCase
                 '从人格、能力到情绪状态，多个入口帮助你持续复盘自己的变化。'
             );
 
+        $this->getJson('/api/v0.5/landing-surfaces/tests?locale=zh-CN&org_id=0')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('surface.surface_key', 'tests')
+            ->assertJsonPath('surface.locale', 'zh-CN')
+            ->assertJsonCount(5, 'surface.payload_json.quickStart.items')
+            ->assertJsonPath('surface.payload_json.quickStart.items.0.href', '/zh/tests/category/career')
+            ->assertJsonPath('surface.payload_json.quickStart.items.2.href', '/zh/tests#family-emotion-state')
+            ->assertJsonCount(5, 'surface.payload_json.families.items')
+            ->assertJsonPath('surface.payload_json.families.items.2.id', 'family-emotion-state')
+            ->assertJsonPath(
+                'surface.payload_json.families.items.2.tests.0.href',
+                '/zh/tests/depression-screening-test-standard-edition/take'
+            )
+            ->assertJsonPath(
+                'surface.payload_json.families.items.2.tests.1.href',
+                '/zh/tests/clinical-depression-anxiety-assessment-professional-edition/take'
+            )
+            ->assertJsonPath(
+                'surface.payload_json.families.items.3.tests.0.href',
+                '/zh/tests/iq-test-intelligence-quotient-assessment/take'
+            );
+
         $this->putJson('/api/v0.5/internal/landing-surfaces/home', [
             'locale' => 'zh-CN',
             'title' => '首页更新',

--- a/deploy.php
+++ b/deploy.php
@@ -317,6 +317,10 @@ task('career:warm-public-authority-cache', function () {
     run('timeout 180 {{bin/php}} {{release_path}}/backend/artisan career:warm-public-authority-cache --no-interaction --ansi');
 });
 
+task('cms:import-landing-surface-baselines', function () {
+    run('{{bin/php}} {{release_path}}/backend/artisan landing-surfaces:import-local-baseline --upsert --status=published --source-dir={{release_path}}/content_baselines/landing_surfaces --no-interaction --ansi');
+});
+
 task('artisan:view:cache', function () {
     writeln('<comment>Skip artisan:view:cache (no views)</comment>');
 });
@@ -705,7 +709,8 @@ after('artisan:filament:assets', 'guard:ops-theme-asset');
 after('artisan:filament:assets', 'guard:filament-assets');
 after('artisan:config:cache', 'guard:sitemap-authority');
 after('artisan:migrate', 'guard:no-pending-migrations');
-after('guard:no-pending-migrations', 'career:warm-public-authority-cache');
+after('guard:no-pending-migrations', 'cms:import-landing-surface-baselines');
+after('cms:import-landing-surface-baselines', 'career:warm-public-authority-cache');
 after('career:warm-public-authority-cache', 'ensure:release-runtime-perms');
 
 after('deploy:symlink', 'reload:php-fpm');


### PR DESCRIPTION
## What changed
- Added a deploy task that imports published CMS landing surface baselines with `landing-surfaces:import-local-baseline` after migrations and before career authority cache warmup.
- Locked the zh-CN home CMS surface hero copy in `LandingSurfacePublicApiTest` to the current production wording: `看清自己，走好每一步` plus the long FermatMind subhead.
- Added PR-CMS1 to the PR train manifest/state ledger and synchronized PR-B88 as merged.

## Why
The frontend now correctly reads homepage content from the CMS landing-surface API instead of keeping a frontend fallback. The current production API still returns 404 for `/api/v0.5/landing-surfaces/home?locale=zh-CN&org_id=0`, so local dev can fail or previously fall back to stale text. The backend deploy must seed/import the CMS surface as the authority layer.

## Validation commands
- `cd backend && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `cd backend && vendor/bin/pint --test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php`
- `cd backend && php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php`
- `php -l deploy.php`
- `git diff --check`

## Intentionally deferred
- No frontend fallback is reintroduced.
- No direct production database mutation is included in this PR; the import runs through the deployment task.
- No unrelated CMS page/article surfaces are changed.
