### PR TITLE
PR-V4-0B: sync backend content authority rules

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -71,3 +71,21 @@
 - Codex may draft, refactor, and open PRs.
 - Laravel/backend or the declared authority layer remains the source of truth where the manifest says so.
 - Never replace an authority layer with frontend or CMS fallback logic.
+
+## Content authority rules
+- CMS/backend is the source of truth for publishable content, operational metadata, mutable media references, public SEO fields, and publishing state.
+- Article content, article SEO, covers, categories/tags, related placement, and publication state must be managed through backend Article resources and APIs.
+- Homepage, tests hub, test category, career center, CTA text, module ordering, featured items, and landing SEO must be managed through `landing_surfaces` / `page_blocks`.
+- Help, policy, company, brand, careers, about, charter, foundation, privacy, terms, refund, support, and similar static-content pages must be managed through `content_pages`.
+- Career guides, career jobs, career recommendations, personality profiles, topic pages, FAQ, sections, and SEO must be managed through backend CMS resources and public APIs.
+- Mutable editorial, marketing, social, article, landing page, and SEO images must be uploaded to Media Library and referenced by CMS metadata or generated variants.
+- Public APIs must not emit historical Tencent/COS media URLs or ad hoc raw media URLs for CMS-backed surfaces.
+
+## Final V4 backend protocols
+- `content_baselines` may exist only for new environment initialization, DB recovery, baseline imports, disaster recovery, and dry-run validation. They must not be used as runtime page-rendering authority.
+- Large content imports must include schema validation and dry-run support before import, especially career DOCX conversion, slugs, sections, SEO fields, media references, and publication state.
+- CMS/API contracts must support frontend local development against local API, test/staging API, or mock API flows without requiring production CMS access.
+- Experimental surfaces, SBTI, and heavily interactive product experiences may remain product-code-side unless explicitly converted into operational content.
+- High-traffic CMS-backed entry pages must be served through an API/cache strategy that supports CMS/API content, stale last-known-good cache, then minimal shell behavior in the frontend. Do not rely on frontend hardcoded editorial copy as fallback.
+- Business priority is fixed as L1 MBTI, L2 Big Five, and L3 SBTI/articles/topics/career recommendations/non-core tests. API resource isolation, throttling, cache refresh, and degradation policies must preserve this order.
+- Long-term API resource isolation should separate lookup/questions read paths, auth/start/submit/result write paths, and non-core CMS/API paths.

--- a/backend/CONTRIBUTING.md
+++ b/backend/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+This repository follows the Night PR Train rules in `AGENTS.md`. Keep pull requests scoped, start from the latest `main`, run the manifest checks before push, and record PR train state transitions when a task is part of the train.
+
+## Content Authority
+
+FermatMind publishable content is CMS/backend-authoritative. Backend resources and APIs own operational content, SEO metadata, publishing state, and mutable media references.
+
+Backend-owned content includes:
+
+- Articles, article SEO, covers, categories, tags, related placement, and publication state.
+- Homepage, tests hub, test category pages, career center modules, CTA text, ordering, featured items, and landing SEO through `landing_surfaces` / `page_blocks`.
+- Help, policy, company, brand, careers, about, charter, foundation, privacy, terms, refund, support, and similar static pages through `content_pages`.
+- Career guides, career jobs, career recommendations, personality profiles, topics, FAQ, sections, and SEO through CMS resources and public APIs.
+- Mutable editorial, marketing, social, article, landing page, and SEO media through Media Library.
+
+Do not introduce runtime content authority in frontend repositories or ad hoc local file sources. Public APIs should expose CMS/backend content and media metadata in a shape the frontend can render and cache.
+
+## Baselines And Imports
+
+`content_baselines` are allowed only for:
+
+- New environment initialization.
+- Recovery after DB clearing.
+- Baseline content imports.
+- Disaster recovery.
+- Dry-run validation.
+
+They must not be used as runtime page-rendering authority.
+
+Large imports must validate schema and support dry-run before import, especially career DOCX conversion, slugs, sections, SEO fields, media references, and publication state.
+
+## Media
+
+Mutable media assets must flow through Media Library and generated variants. Public APIs must not emit historical Tencent/COS URLs or unmanaged raw external image URLs for CMS-backed surfaces.
+
+Media metadata should include alt text, dimensions, variants, caption, credit, and SEO/social image references when required by the consuming surface.
+
+## Runtime And Priority
+
+Backend APIs should support a frontend fallback order of CMS/API content, stale last-known-good cache, then minimal shell. Do not require frontend hardcoded editorial copy for operational fallback.
+
+Business priority is fixed:
+
+- L1: MBTI.
+- L2: Big Five.
+- L3: SBTI, articles, topics, career recommendations, and non-core tests.
+
+Throttle buckets, API resource isolation, cache refresh, and degradation behavior must preserve this priority.
+
+## PR Requirements
+
+Any PR that changes content ownership, CMS resources, public content APIs, media handling, SEO generation, sitemap or `llms.txt` enumeration, publishing workflow, importer behavior, or fallback behavior must include a `Repository rule impact` note in the PR body.
+
+The note must state whether the changed surface is:
+
+- CMS/backend-authoritative.
+- Frontend product-code-only.
+- Temporary migration fallback.
+- Deprecated.
+
+Temporary migration fallbacks must include an owner, removal condition, and target removal PR or issue.

--- a/backend/docs/codex/final-v4-backend-rules.md
+++ b/backend/docs/codex/final-v4-backend-rules.md
@@ -1,0 +1,84 @@
+# Final V4 Backend Rules
+
+## Purpose
+
+This document syncs the backend repository with the FermatMind Final V4 upgrade plan. It defines backend responsibilities for content authority, runtime fallback support, media ownership, import validation, and product priority.
+
+## Backend Authority
+
+CMS/backend is the source of truth for publishable content and mutable media metadata. Frontend applications render, cache, and interact with content, but they must not become the editorial source of truth.
+
+Backend-owned surfaces include:
+
+- Articles, article SEO, covers, categories/tags, related placement, and publication state.
+- `landing_surfaces` / `page_blocks` for homepage, tests hub, test category pages, career center modules, CTA text, module ordering, featured items, and landing SEO.
+- `content_pages` for help, policy, company, brand, careers, about, charter, foundation, privacy, terms, refund, support, and similar pages.
+- Career guides, career jobs, career recommendations, personality profiles, topics, FAQ, sections, and SEO.
+- Media Library metadata and variants for mutable editorial, marketing, social, article, landing page, and SEO images.
+
+## Baseline Protocol
+
+`content_baselines` may be retained only for:
+
+- New environment initialization.
+- DB clearing recovery.
+- Baseline imports.
+- Disaster recovery.
+- Dry-run validation.
+
+They must not be queried as runtime page-rendering authority. Runtime content should flow through CMS resources, public APIs, and cache layers.
+
+## Import Validation Protocol
+
+Large content imports must be schema-validated and dry-run before import.
+
+Required validation areas:
+
+- Career DOCX to JSON/DB conversion.
+- Slugs.
+- Sections.
+- SEO fields.
+- Media references.
+- Publication state.
+
+Importers should fail closed on schema drift and produce reviewer-readable diagnostics before mutating production data.
+
+## Media Protocol
+
+Mutable operational media must flow through Media Library and generated variants.
+
+Public API media payloads should expose managed metadata, including alt, dimensions, variants, captions, credits, and SEO/social image references where relevant.
+
+Public APIs must not emit historical Tencent/COS URLs or unmanaged raw external URLs for CMS-backed surfaces.
+
+## Runtime Fallback Support
+
+Backend APIs should support frontend fallback behavior in this order:
+
+1. Fresh CMS/API content.
+2. Stale last-known-good cached content.
+3. Minimal shell or explicit empty/error state.
+
+Backend changes should not require the frontend to carry full hardcoded editorial fallback copy.
+
+## Priority And Resource Isolation
+
+Business priority is fixed:
+
+- L1: MBTI.
+- L2: Big Five.
+- L3: SBTI, articles, topics, career recommendations, and non-core tests.
+
+Backend rate limits, cache refreshes, FPM/API resource isolation, and degradation behavior must protect this ordering.
+
+Long-term resource isolation should separate:
+
+- Lookup/questions read paths.
+- Auth/start/submit/result write paths.
+- Non-core CMS/API paths.
+
+## Review Requirement
+
+Any PR changing CMS resources, public content APIs, content ownership, media handling, import behavior, SEO generation, sitemap or `llms.txt` enumeration, publishing workflow, or runtime fallback support must include a `Repository rule impact` note.
+
+The note must classify changed surfaces as CMS/backend-authoritative, frontend product-code-only, temporary migration fallback, or deprecated.

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:06:12+08:00",
+  "updated_at": "2026-04-19T22:06:33+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -11,7 +11,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "local_checks_passed",
       "branch": "codex/pr-content-authority-v4-backend-rules",
-      "commit_sha": "",
+      "commit_sha": "6e9661677033fbff74852c930019568d6568231e",
       "pr_url": "",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,11 +1,37 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T13:20:00Z",
+  "updated_at": "2026-04-19T22:06:12+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
   "items": {
+    "PR-V4-0B": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-content-authority-v4-backend-rules",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
     "PR-B7": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:07:25+08:00",
+  "updated_at": "2026-04-19T22:08:47+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -9,7 +9,7 @@
     "PR-V4-0B": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "github_checks_failed",
       "branch": "codex/pr-content-authority-v4-backend-rules",
       "commit_sha": "6e9661677033fbff74852c930019568d6568231e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/943",
@@ -24,9 +24,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24630978949/job/72018190611"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24630978949/job/72018194408"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions hygiene failed immediately on PR #943 with no job steps and log not found; verify-mbti matrix was skipped. Local validation passed, matching the repository's existing CI startup failure pattern rather than a locally reproducible backend rules-doc regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:06:33+08:00",
+  "updated_at": "2026-04-19T22:07:25+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -9,10 +9,10 @@
     "PR-V4-0B": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-content-authority-v4-backend-rules",
       "commit_sha": "6e9661677033fbff74852c930019568d6568231e",
-      "pr_url": "",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/943",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -6,6 +6,31 @@ require_clean_worktree: true
 execution_mode: local_clone_preferred
 
 prs:
+  - id: PR-V4-0B
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-content-authority-v4-backend-rules
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Final V4 backend rules synchronization. Document backend/CMS content
+      authority, content_baselines runtime limits, importer validation,
+      Media Library ownership, fallback support, and MBTI priority/resource
+      isolation principles without changing Laravel runtime behavior.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B7
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend


### PR DESCRIPTION
## What changed

- Added backend Final V4 content authority and runtime protocol rules to `AGENTS.md`.
- Added `CONTRIBUTING.md` for backend CMS authority, baseline/import, media, runtime priority, and PR requirements.
- Added `docs/codex/final-v4-backend-rules.md` to document backend responsibilities for content authority, `content_baselines`, importer validation, Media Library, fallback support, and MBTI priority/resource isolation.
- Registered `PR-V4-0B` in `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json`.

## Why

Frontend rules alone are not enough for the Final V4 plan. Backend/CMS must explicitly own publishable content, mutable media metadata, importer validation, and the API/cache contracts needed to keep frontend fallback out of hardcoded editorial copy.

## Validation commands

- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Intentionally deferred items

- No Laravel runtime behavior changes.
- No `content_baselines` implementation changes.
- No importer implementation changes.
- No Media Library schema or API changes.
- No start/submit throttle bucket changes.
- No API/FPM resource isolation implementation.
- No content migration.

## Repository rule impact

This PR updates backend repository rules only. It classifies publishable content and mutable media as CMS/backend-authoritative, limits `content_baselines` to initialization/recovery/import/dry-run usage, and records that backend APIs should support frontend fallback through CMS/API content, stale last-known-good cache, then minimal shell rather than frontend editorial copy.
