### PR TITLE
PR-V4-A2: split attempt start and submit throttle buckets

### DIFF
--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -443,7 +443,29 @@ class AppServiceProvider extends ServiceProvider
                 ->response($response('RATE_LIMIT_TRACK', 'Too many tracking requests. Please retry later.'));
         });
 
-        RateLimiter::for('api_attempt_submit', function (Request $request) use ($response, $shouldBypassRateLimits) {
+        $attemptRateLimitKey = function (Request $request): string {
+            $userId = (string) ($request->attributes->get('fm_user_id') ?? '');
+            if ($userId === '' && $request->user()) {
+                $userId = (string) $request->user()->getAuthIdentifier();
+            }
+
+            return $userId !== '' ? ('user:'.$userId) : ('ip:'.$request->ip());
+        };
+
+        RateLimiter::for('api_attempt_start', function (Request $request) use ($response, $shouldBypassRateLimits, $attemptRateLimitKey) {
+            if ($shouldBypassRateLimits()) {
+                return Limit::none();
+            }
+
+            $limit = (int) config('fap.rate_limits.api_attempt_start_per_minute', 60);
+            $limit = max(1, $limit);
+
+            return Limit::perMinute($limit)
+                ->by($attemptRateLimitKey($request))
+                ->response($response('RATE_LIMIT_ATTEMPT_START', 'Too many attempt start requests. Please retry later.'));
+        });
+
+        RateLimiter::for('api_attempt_submit', function (Request $request) use ($response, $shouldBypassRateLimits, $attemptRateLimitKey) {
             if ($shouldBypassRateLimits()) {
                 return Limit::none();
             }
@@ -451,15 +473,8 @@ class AppServiceProvider extends ServiceProvider
             $limit = (int) config('fap.rate_limits.api_attempt_submit_per_minute', 20);
             $limit = max(1, $limit);
 
-            $userId = (string) ($request->attributes->get('fm_user_id') ?? '');
-            if ($userId === '' && $request->user()) {
-                $userId = (string) $request->user()->getAuthIdentifier();
-            }
-
-            $key = $userId !== '' ? ('user:'.$userId) : ('ip:'.$request->ip());
-
             return Limit::perMinute($limit)
-                ->by($key)
+                ->by($attemptRateLimitKey($request))
                 ->response($response('RATE_LIMIT_ATTEMPT_SUBMIT', 'Too many attempt submissions. Please retry later.'));
         });
 

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -285,6 +285,7 @@ return [
     'rate_limits' => [
         'api_public_per_minute' => (int) env('FAP_RATE_LIMIT_PUBLIC_PER_MINUTE', 120),
         'api_auth_per_minute' => (int) env('FAP_RATE_LIMIT_AUTH_PER_MINUTE', 30),
+        'api_attempt_start_per_minute' => (int) env('FAP_RATE_LIMIT_ATTEMPT_START_PER_MINUTE', 60),
         'api_attempt_submit_per_minute' => (int) env('FAP_RATE_LIMIT_ATTEMPT_SUBMIT_PER_MINUTE', 20),
         'api_webhook_per_minute' => (int) env('FAP_RATE_LIMIT_WEBHOOK_PER_MINUTE', 60),
         'bypass_in_test_env' => (bool) env('FAP_RATE_LIMIT_BYPASS_IN_TEST_ENV', true),

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:14:30+08:00",
+  "updated_at": "2026-04-19T22:15:42+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -9,7 +9,7 @@
     "PR-V4-A2": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "github_checks_failed",
       "branch": "codex/pr-v4-a2-attempt-start-submit-buckets",
       "commit_sha": "cc9d31f3295fb82f604833ab061d111fddb1c937",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/944",
@@ -36,9 +36,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24631116952/job/72018557231"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24631116952/job/72018559656"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions hygiene failed immediately on PR #944 with no job steps and log not found; verify-mbti matrix was skipped. Local validation passed, matching the repository's existing CI startup failure pattern rather than a locally reproducible start/submit bucket regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,11 +1,49 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:10:10+08:00",
+  "updated_at": "2026-04-19T22:13:14+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
   "items": {
+    "PR-V4-A2": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-v4-a2-attempt-start-submit-buckets",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/contracts/openapi.snapshot.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test routes/api.php config/fap.php app/Providers/AppServiceProvider.php tests/Feature/V0_3/RateLimitKeyEndpointsTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/V0_3/RateLimitKeyEndpointsTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
     "PR-V4-0B": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:13:14+08:00",
+  "updated_at": "2026-04-19T22:13:41+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -11,7 +11,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "local_checks_passed",
       "branch": "codex/pr-v4-a2-attempt-start-submit-buckets",
-      "commit_sha": "",
+      "commit_sha": "cc9d31f3295fb82f604833ab061d111fddb1c937",
       "pr_url": "",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:13:41+08:00",
+  "updated_at": "2026-04-19T22:14:30+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -9,10 +9,10 @@
     "PR-V4-A2": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-v4-a2-attempt-start-submit-buckets",
       "commit_sha": "cc9d31f3295fb82f604833ab061d111fddb1c937",
-      "pr_url": "",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/944",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -6,6 +6,34 @@ require_clean_worktree: true
 execution_mode: local_clone_preferred
 
 prs:
+  - id: PR-V4-A2
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-v4-a2-attempt-start-submit-buckets
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Final V4 A2 attempts start/submit throttle bucket separation. Add a
+      dedicated api_attempt_start limiter and keep attempts/submit on
+      api_attempt_submit so start traffic no longer consumes submit quota,
+      without changing attempt write controller behavior or auth semantics.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "python3 -m json.tool docs/contracts/openapi.snapshot.json >/dev/null"
+      - "vendor/bin/pint --test routes/api.php config/fap.php app/Providers/AppServiceProvider.php tests/Feature/V0_3/RateLimitKeyEndpointsTest.php"
+      - "php artisan test tests/Feature/V0_3/RateLimitKeyEndpointsTest.php"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-V4-0B
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -190,7 +190,7 @@
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
                     "App\\Http\\Middleware\\ForcePublicAttemptRealm",
-                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_attempt_submit"
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_attempt_start"
                 ],
                 "x-laravel-name": "api.v0_3.attempts.start"
             }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -203,15 +203,14 @@ Route::prefix('v0.3')->middleware([
 
         // 2) Attempts lifecycle
         Route::middleware(ForcePublicAttemptRealm::class)->group(function () {
-            Route::middleware('throttle:api_attempt_submit')->group(function () {
-                Route::post('/attempts/start', [AttemptWriteController::class, 'start'])
-                    ->defaults('public_realm', true)
-                    ->name('api.v0_3.attempts.start');
-                Route::post('/attempts/submit', [AttemptWriteController::class, 'submit'])
-                    ->middleware(\App\Http\Middleware\FmTokenAuth::class)
-                    ->defaults('public_realm', true)
-                    ->name('api.v0_3.attempts.submit');
-            });
+            Route::post('/attempts/start', [AttemptWriteController::class, 'start'])
+                ->middleware('throttle:api_attempt_start')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.start');
+            Route::post('/attempts/submit', [AttemptWriteController::class, 'submit'])
+                ->middleware(['throttle:api_attempt_submit', \App\Http\Middleware\FmTokenAuth::class])
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.submit');
             Route::put('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'upsert'])
                 ->middleware('uuid:attempt_id');
             Route::get('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'show'])

--- a/backend/tests/Feature/V0_3/RateLimitKeyEndpointsTest.php
+++ b/backend/tests/Feature/V0_3/RateLimitKeyEndpointsTest.php
@@ -31,6 +31,14 @@ final class RateLimitKeyEndpointsTest extends TestCase
 
         $paymentWebhook = $this->findRoute('POST', 'api/v0.3/webhooks/payment/{provider}');
         $this->assertContains('throttle:api_webhook', $paymentWebhook->gatherMiddleware());
+
+        $attemptStart = $this->findRoute('POST', 'api/v0.3/attempts/start');
+        $this->assertContains('throttle:api_attempt_start', $attemptStart->gatherMiddleware());
+        $this->assertNotContains('throttle:api_attempt_submit', $attemptStart->gatherMiddleware());
+
+        $attemptSubmit = $this->findRoute('POST', 'api/v0.3/attempts/submit');
+        $this->assertContains('throttle:api_attempt_submit', $attemptSubmit->gatherMiddleware());
+        $this->assertNotContains('throttle:api_attempt_start', $attemptSubmit->gatherMiddleware());
     }
 
     public function test_auth_guest_rate_limit_returns_429_error_contract(): void
@@ -162,6 +170,8 @@ final class RateLimitKeyEndpointsTest extends TestCase
             'fap.rate_limits.api_auth_per_minute' => 30,
             'fap.rate_limits.api_order_lookup_per_minute' => 20,
             'fap.rate_limits.api_track_per_minute' => 60,
+            'fap.rate_limits.api_attempt_start_per_minute' => 60,
+            'fap.rate_limits.api_attempt_submit_per_minute' => 20,
             'fap.rate_limits.api_webhook_per_minute' => 60,
         ], $overrides));
     }


### PR DESCRIPTION
## What changed

- Added a dedicated `api_attempt_start` rate limiter with `FAP_RATE_LIMIT_ATTEMPT_START_PER_MINUTE` / `fap.rate_limits.api_attempt_start_per_minute`.
- Kept `attempts/submit` on `api_attempt_submit`.
- Split `/api/v0.3/attempts/start` and `/api/v0.3/attempts/submit` route middleware so start traffic no longer consumes submit quota.
- Reused the same user/IP keying behavior for both attempt buckets.
- Updated route wiring coverage and the OpenAPI middleware snapshot.
- Registered `PR-V4-A2` in the PR train manifest/state.

## Why

Final V4 treats MBTI as the L1 priority path. `attempts/start` and `attempts/submit` should not share a submit throttle bucket because start traffic can crowd out submit traffic under load, even when start reuse is working.

## Validation commands

- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -m json.tool docs/contracts/openapi.snapshot.json >/dev/null`
- `vendor/bin/pint --test routes/api.php config/fap.php app/Providers/AppServiceProvider.php tests/Feature/V0_3/RateLimitKeyEndpointsTest.php`
- `php artisan test tests/Feature/V0_3/RateLimitKeyEndpointsTest.php`
- `git diff --check`

## Intentionally deferred items

- No auth/guest single-flight changes.
- No API/FPM pool or upstream isolation changes.
- No attempt controller behavior changes.
- No submit auth semantics changes.
- No frontend changes.

## Repository rule impact

This PR changes backend runtime priority behavior for the MBTI attempt path. The surface remains backend-authoritative runtime infrastructure, not content authority. It preserves the L1 MBTI priority rule by separating start and submit throttle buckets without adding fallback content or changing CMS/media ownership.
