### PR TITLE
PR-V4-A1: add stability observation gate

### DIFF
--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:56:26+08:00",
+  "updated_at": "2026-04-19T22:57:47+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -9,7 +9,7 @@
     "PR-V4-A1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "github_checks_failed",
       "branch": "codex/pr-v4-a1-stability-observation-runbook",
       "commit_sha": "402b1af556c261bf4a213a70aa7e26d3f9759b8b",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/945",
@@ -24,9 +24,20 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24631933988/job/72020701596"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24631933988/job/72020703655"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "GitHub Actions hygiene failed immediately on PR #945 with no job steps and log not found; verify-mbti matrix was skipped. Local validation passed, matching the repository's existing CI startup failure pattern rather than a locally reproducible runbook regression.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,11 +1,37 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:17:03+08:00",
+  "updated_at": "2026-04-19T22:55:11+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
   "items": {
+    "PR-V4-A1": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/pr-v4-a1-stability-observation-runbook",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
     "PR-V4-A2": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:55:34+08:00",
+  "updated_at": "2026-04-19T22:56:26+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -9,10 +9,10 @@
     "PR-V4-A1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/pr-v4-a1-stability-observation-runbook",
       "commit_sha": "402b1af556c261bf4a213a70aa7e26d3f9759b8b",
-      "pr_url": "",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/945",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:55:11+08:00",
+  "updated_at": "2026-04-19T22:55:34+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -11,7 +11,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "local_checks_passed",
       "branch": "codex/pr-v4-a1-stability-observation-runbook",
-      "commit_sha": "",
+      "commit_sha": "402b1af556c261bf4a213a70aa7e26d3f9759b8b",
       "pr_url": "",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -6,6 +6,31 @@ require_clean_worktree: true
 execution_mode: local_clone_preferred
 
 prs:
+  - id: PR-V4-A1
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-v4-a1-stability-observation-runbook
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Final V4 A1 stability observation runbook. Document the 24-72 hour
+      observation window, MBTI runtime signals, A3 auth/guest single-flight
+      trigger gate, A4 API/FPM resource isolation gate, and stop conditions
+      without changing runtime behavior.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-V4-A2
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/docs/ops/final-v4-stability-observation-runbook.md
+++ b/backend/docs/ops/final-v4-stability-observation-runbook.md
@@ -1,0 +1,112 @@
+# Final V4 Stability Observation Runbook
+
+## Purpose
+
+This runbook defines the Phase 1 observation gate for the Final V4 upgrade. It decides whether the system can continue content migration work, whether frontend `/auth/guest` single-flight is justified, and when API/FPM resource isolation must be escalated.
+
+## Scope
+
+Observe the MBTI-first runtime path for 24 to 72 hours after any stability change:
+
+- `POST /api/v0.3/attempts/start`
+- `POST /api/v0.3/attempts/submit`
+- `POST /api/v0.3/auth/guest`
+- MBTI lookup/questions/read paths
+- MBTI result retrieval
+- PHP-FPM pool health
+- HTTP 429 and 5xx rates
+
+Do not use this runbook to approve content migrations for high-traffic hubs. Homepage, `/tests`, `/career`, and test category pages still require the Phase 3 stale last-known-good cache layer before migration.
+
+## Business Priority
+
+Runtime priority is fixed:
+
+1. L1: MBTI
+2. L2: Big Five
+3. L3: SBTI, articles, topics, career recommendations, and non-core tests
+
+Any degradation decision must preserve MBTI start, submit, take, and result before non-core CMS/API traffic.
+
+## Required Signals
+
+Collect these signals over the same window:
+
+- `attempts/start` request count, p50, p95, p99, 429, 5xx
+- `attempts/submit` request count, p50, p95, p99, 401, 429, 5xx
+- `/auth/guest` request count, p50, p95, p99, 202/200, 401, 429, 5xx
+- Ratio of `/auth/guest` calls to `attempts/submit` calls
+- Ratio of `attempts/start` calls to `attempts/submit` calls
+- `php-fpm` active processes, idle processes, listen queue, slow requests, and `max_children_reached`
+- DB slow query telemetry for attempt write and result paths
+- Cache hit/miss behavior for lookup/questions and result paths
+- Any deploy or content release events during the window
+
+## Pass Criteria
+
+The observation window passes only when all of these are true:
+
+- `attempts/start` has no sustained 429 or 5xx increase.
+- `attempts/submit` has no sustained 429 or 5xx increase.
+- `/auth/guest` volume is not amplifying relative to submit volume.
+- PHP-FPM does not reach `max_children_reached`.
+- PHP-FPM listen queue does not show sustained backlog.
+- MBTI landing, take, submit, and result remain usable throughout the window.
+- Non-core CMS/API traffic does not correlate with MBTI latency or error spikes.
+
+## A3 Auth Guest Single-Flight Gate
+
+Do not implement frontend `/auth/guest` single-flight unless the observation window proves amplification.
+
+Single-flight is justified if at least one condition is true:
+
+- `/auth/guest` request count is greater than 25% of `attempts/submit` count during normal traffic.
+- A 401 burst on submit produces more than one `/auth/guest` call per browser session within a 10-second window.
+- `/auth/guest` p95 latency or 429 rate increases during submit retry bursts.
+- `/auth/guest` contributes to PHP-FPM saturation or queue backlog.
+
+If none of these conditions are true, keep A3 deferred.
+
+## A4 API/FPM Resource Isolation Gate
+
+Escalate API/FPM resource isolation when any condition is true:
+
+- Non-core CMS/API routes correlate with MBTI start/submit/result latency or 5xx.
+- PHP-FPM reaches `max_children_reached` during mixed MBTI and CMS traffic.
+- FPM listen queue backlog persists while MBTI traffic is active.
+- Lookup/questions read paths and attempt write paths contend for the same saturated worker pool.
+- A content release or CMS spike degrades MBTI submit or result paths.
+
+Target isolation planes:
+
+- Lookup/questions read paths
+- Auth/start/submit/result write paths
+- Non-core CMS/API paths
+
+Acceptable implementation paths include separate API instances, separate FPM pools, route-based upstreams, or equivalent platform-level resource pools.
+
+## Stop Conditions
+
+Stop the train and do not start the next content migration PR if any of these happen:
+
+- `attempts/submit` has sustained 5xx or 429.
+- PHP-FPM reaches `max_children_reached`.
+- `/auth/guest` amplification meets the A3 gate and remains unmitigated.
+- Non-core CMS/API traffic degrades MBTI paths.
+- Required telemetry is missing or ambiguous.
+
+## Evidence To Record
+
+Before marking the observation as passed or failed, record:
+
+- Observation start and end timestamps.
+- Deploy SHA and deploy timestamp.
+- Request/error summaries for start, submit, guest auth, lookup/questions, and result.
+- PHP-FPM active/idle/listen queue/max children summary.
+- Slow query summary for attempt write and result paths.
+- Decision: passed, failed, or inconclusive.
+- Follow-up decision: continue migration, implement A3, implement A4, or pause.
+
+## Repository Rule Impact
+
+This runbook is backend runtime governance. It does not change content ownership, CMS resources, public content APIs, Media Library behavior, or frontend fallback behavior.


### PR DESCRIPTION
## What changed

- Added `docs/ops/final-v4-stability-observation-runbook.md`.
- Documented the 24-72 hour Final V4 observation window for MBTI start/submit/auth/result and PHP-FPM health.
- Added explicit gates for A3 `/auth/guest` single-flight and A4 API/FPM resource isolation.
- Added stop conditions before continuing high-risk content migration work.
- Registered `PR-V4-A1` in the PR train manifest/state.

## Why

Phase 1 cannot be considered complete with only A2 bucket separation. The remaining work needs a production-data decision gate so we do not implement A3 or A4 prematurely or continue migration while MBTI runtime health is ambiguous.

## Validation commands

- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Intentionally deferred items

- No runtime code changes.
- No `/auth/guest` single-flight implementation until the observation gate proves amplification.
- No API/FPM resource isolation implementation until the observation gate proves contention.
- No content migration changes.

## Repository rule impact

This PR is backend runtime governance only. It does not change content ownership, CMS resources, public content APIs, Media Library behavior, SEO generation, or frontend fallback behavior.
