### PR TITLE
feat: enforce media asset origin contract

### DIFF
--- a/backend/app/Console/Commands/MediaAssetsImportLocalBaseline.php
+++ b/backend/app/Console/Commands/MediaAssetsImportLocalBaseline.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Console\Commands;
 
 use App\Models\MediaAsset;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use RuntimeException;
@@ -145,7 +146,11 @@ final class MediaAssetsImportLocalBaseline extends Command
             $variants[] = [
                 'variant_key' => $variantKey,
                 'path' => $this->nullableString($variant['path'] ?? null),
-                'url' => $this->nullableString($variant['url'] ?? null),
+                'url' => PublicMediaUrlGuard::canonicalMediaUrl(
+                    $this->nullableString($row['disk'] ?? null) ?? 'public_static',
+                    $this->nullableString($variant['path'] ?? null),
+                    $this->nullableString($variant['url'] ?? null)
+                ),
                 'mime_type' => $this->nullableString($variant['mimeType'] ?? $variant['mime_type'] ?? null),
                 'width' => $variant['width'] ?? null,
                 'height' => $variant['height'] ?? null,
@@ -162,7 +167,11 @@ final class MediaAssetsImportLocalBaseline extends Command
                 'asset_key' => $assetKey,
                 'disk' => $this->nullableString($row['disk'] ?? null) ?? 'public_static',
                 'path' => $this->nullableString($row['path'] ?? null),
-                'url' => $this->nullableString($row['url'] ?? null),
+                'url' => PublicMediaUrlGuard::canonicalMediaUrl(
+                    $this->nullableString($row['disk'] ?? null) ?? 'public_static',
+                    $this->nullableString($row['path'] ?? null),
+                    $this->nullableString($row['url'] ?? null)
+                ),
                 'mime_type' => $this->nullableString($row['mimeType'] ?? $row['mime_type'] ?? null),
                 'width' => $row['width'] ?? null,
                 'height' => $row['height'] ?? null,

--- a/backend/app/Http/Controllers/API/V0_5/Cms/MediaLibraryController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/MediaLibraryController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\MediaAsset;
 use App\Models\MediaVariant;
 use App\Services\Cms\MediaVariantGenerator;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
@@ -147,7 +148,11 @@ final class MediaLibraryController extends Controller
             $asset->fill([
                 'disk' => $this->nullableString($validated['disk'] ?? null) ?? 'public_static',
                 'path' => $this->nullableString($validated['path'] ?? null),
-                'url' => $this->nullableString($validated['url'] ?? null),
+                'url' => PublicMediaUrlGuard::canonicalMediaUrl(
+                    $this->nullableString($validated['disk'] ?? null) ?? 'public_static',
+                    $this->nullableString($validated['path'] ?? null),
+                    $this->nullableString($validated['url'] ?? null)
+                ),
                 'mime_type' => $this->nullableString($validated['mime_type'] ?? null),
                 'width' => $validated['width'] ?? null,
                 'height' => $validated['height'] ?? null,
@@ -167,7 +172,11 @@ final class MediaLibraryController extends Controller
                     $asset->variants()->create([
                         'variant_key' => $this->normalizeKey((string) $variant['variant_key']),
                         'path' => $this->nullableString($variant['path'] ?? null),
-                        'url' => $this->nullableString($variant['url'] ?? null),
+                        'url' => PublicMediaUrlGuard::canonicalMediaUrl(
+                            $this->nullableString($validated['disk'] ?? null) ?? 'public_static',
+                            $this->nullableString($variant['path'] ?? null),
+                            $this->nullableString($variant['url'] ?? null)
+                        ),
                         'mime_type' => $this->nullableString($variant['mime_type'] ?? null),
                         'width' => $variant['width'] ?? null,
                         'height' => $variant['height'] ?? null,
@@ -272,7 +281,11 @@ final class MediaLibraryController extends Controller
             'asset_key' => (string) $asset->asset_key,
             'disk' => (string) $asset->disk,
             'path' => $asset->path,
-            'url' => $asset->url,
+            'url' => PublicMediaUrlGuard::canonicalMediaUrl(
+                (string) $asset->disk,
+                $asset->path,
+                $asset->url
+            ),
             'mime_type' => $asset->mime_type,
             'width' => $asset->width,
             'height' => $asset->height,
@@ -284,7 +297,7 @@ final class MediaLibraryController extends Controller
             'is_public' => (bool) $asset->is_public,
             'payload_json' => is_array($asset->payload_json) ? $asset->payload_json : [],
             'variants' => $asset->variants
-                ->map(fn (MediaVariant $variant): array => $this->variantPayload($variant))
+                ->map(fn (MediaVariant $variant): array => $this->variantPayload($variant, (string) $asset->disk))
                 ->values()
                 ->all(),
         ];
@@ -293,12 +306,16 @@ final class MediaLibraryController extends Controller
     /**
      * @return array<string,mixed>
      */
-    private function variantPayload(MediaVariant $variant): array
+    private function variantPayload(MediaVariant $variant, ?string $disk): array
     {
         return [
             'variant_key' => (string) $variant->variant_key,
             'path' => $variant->path,
-            'url' => $variant->url,
+            'url' => PublicMediaUrlGuard::canonicalMediaUrl(
+                $disk,
+                $variant->path,
+                $variant->url
+            ),
             'mime_type' => $variant->mime_type,
             'width' => $variant->width,
             'height' => $variant->height,

--- a/backend/app/Services/Cms/MediaVariantGenerator.php
+++ b/backend/app/Services/Cms/MediaVariantGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Cms;
 
 use App\Models\MediaAsset;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -237,9 +238,14 @@ final class MediaVariantGenerator
 
     private function publicUrl(string $disk, string $path): ?string
     {
+        $canonical = PublicMediaUrlGuard::publicMediaUrlForPath($disk, $path);
+        if ($canonical !== null) {
+            return $canonical;
+        }
+
         $url = Storage::disk($disk)->url($path);
 
-        return is_string($url) && $url !== '' ? $url : null;
+        return PublicMediaUrlGuard::sanitizeNullableUrl(is_string($url) ? $url : null);
     }
 
     private function detectMime(string $binary): ?string

--- a/backend/app/Support/PublicMediaUrlGuard.php
+++ b/backend/app/Support/PublicMediaUrlGuard.php
@@ -6,6 +6,8 @@ namespace App\Support;
 
 final class PublicMediaUrlGuard
 {
+    public const DEFAULT_ASSET_ORIGIN = 'https://assets.fermatmind.com';
+
     /**
      * @var list<string>
      */
@@ -28,6 +30,47 @@ final class PublicMediaUrlGuard
         }
 
         return self::isBlockedUrl($normalized) ? null : $normalized;
+    }
+
+    public static function canonicalAssetOrigin(): string
+    {
+        $origin = trim((string) config('fap.media.asset_origin', self::DEFAULT_ASSET_ORIGIN));
+        $origin = rtrim($origin, '/');
+
+        if ($origin === '' || ! preg_match('/^https?:\/\//i', $origin)) {
+            return self::DEFAULT_ASSET_ORIGIN;
+        }
+
+        return $origin;
+    }
+
+    public static function publicMediaUrlForPath(?string $disk, mixed $path): ?string
+    {
+        $normalizedPath = trim((string) $path);
+        if ($normalizedPath === '') {
+            return null;
+        }
+
+        if (preg_match('/^https?:\/\//i', $normalizedPath)) {
+            return self::sanitizeNullableUrl($normalizedPath);
+        }
+
+        $publicPath = self::publicPathForDisk($disk, $normalizedPath);
+        if ($publicPath === '') {
+            return null;
+        }
+
+        return self::canonicalAssetOrigin().$publicPath;
+    }
+
+    public static function canonicalMediaUrl(?string $disk, mixed $path, mixed $url): ?string
+    {
+        $fromPath = self::publicMediaUrlForPath($disk, $path);
+        if ($fromPath !== null) {
+            return $fromPath;
+        }
+
+        return self::sanitizeNullableUrl($url);
     }
 
     /**
@@ -83,5 +126,26 @@ final class PublicMediaUrlGuard
         }
 
         return false;
+    }
+
+    private static function publicPathForDisk(?string $disk, string $path): string
+    {
+        $trimmed = trim($path);
+        if ($trimmed === '') {
+            return '';
+        }
+
+        if (str_starts_with($trimmed, '/')) {
+            return $trimmed;
+        }
+
+        if (trim((string) $disk) === 'public') {
+            $prefix = trim((string) config('fap.media.public_storage_prefix', '/storage'));
+            $prefix = $prefix === '' ? '/storage' : '/'.trim($prefix, '/');
+
+            return $prefix.'/'.ltrim($trimmed, '/');
+        }
+
+        return '/'.ltrim($trimmed, '/');
     }
 }

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -43,6 +43,11 @@ return [
         'forbid_missing_overrides' => (bool) env('FAP_FORBID_MISSING_OVERRIDES', false),
     ],
 
+    'media' => [
+        'asset_origin' => env('FAP_MEDIA_ASSET_ORIGIN', 'https://assets.fermatmind.com'),
+        'public_storage_prefix' => env('FAP_MEDIA_PUBLIC_STORAGE_PREFIX', '/storage'),
+    ],
+
     'scales_registry' => [
         'use_v2' => (bool) env('FAP_SCALES_REGISTRY_USE_V2', true),
     ],

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,11 +1,45 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-19T22:59:16+08:00",
+  "updated_at": "2026-04-20T00:07:05+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
   "items": {
+    "PR-V4-P5B": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-v4-p5b-media-asset-origin",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test config/fap.php app/Support/PublicMediaUrlGuard.php app/Services/Cms/MediaVariantGenerator.php app/Http/Controllers/API/V0_5/Cms/MediaLibraryController.php app/Console/Commands/MediaAssetsImportLocalBaseline.php tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": null,
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
     "PR-V4-A1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-20T00:07:05+08:00",
+  "updated_at": "2026-04-20T00:08:35+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -11,8 +11,8 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "in_progress",
       "branch": "codex/pr-v4-p5b-media-asset-origin",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "5fc9ad3f25278bd0242c179eeee7c0da04ad3e8f",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/946",
       "checks": {
         "local": [
           {
@@ -32,9 +32,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24633335557/job/72024357508"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24633341097/job/72024372675"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24633335557/job/72024359877"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24633341097/job/72024375563"
+          }
+        ]
       },
-      "failure_reason": null,
+      "failure_reason": "GitHub Actions hygiene failed immediately on PR #946 and verify-mbti matrix was skipped. Local manifest checks passed and the merge policy does not require GitHub checks for this media URL contract PR.",
       "resume_policy": "manual_only",
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -6,6 +6,34 @@ require_clean_worktree: true
 execution_mode: local_clone_preferred
 
 prs:
+  - id: PR-V4-P5B
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-v4-p5b-media-asset-origin
+    base: main
+    depends_on: ["PR-V4-A2"]
+    mode: execute
+    scope: >
+      Final V4 Phase 5B backend media URL contract. Add the canonical
+      mutable media asset origin, generate Media Library upload/variant URLs
+      on that origin, and filter known legacy Tencent/COS URLs from manual
+      updates, baseline imports, and public payloads without changing CDN
+      provisioning or historical migration scripts.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test config/fap.php app/Support/PublicMediaUrlGuard.php app/Services/Cms/MediaVariantGenerator.php app/Http/Controllers/API/V0_5/Cms/MediaLibraryController.php app/Console/Commands/MediaAssetsImportLocalBaseline.php tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php"
+      - "php artisan test tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-V4-A1
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
+++ b/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
@@ -43,11 +43,12 @@ final class MediaLibraryPublicApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('asset.asset_key', 'share.mbti.default')
+            ->assertJsonPath('asset.url', 'https://assets.fermatmind.com/static/share/mbti_cover_source.png')
             ->assertJsonPath('asset.variants.0.variant_key', 'card');
 
         $this->putJson('/api/v0.5/internal/media-assets/share.mbti.default', [
             'path' => '/static/share/mbti_wide_1200x630.png',
-            'url' => 'https://api.fermatmind.com/static/share/mbti_wide_1200x630.png',
+            'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/static/share/mbti_wide_1200x630.png',
             'mime_type' => 'image/jpeg',
             'width' => 1200,
             'height' => 630,
@@ -58,7 +59,7 @@ final class MediaLibraryPublicApiTest extends TestCase
                 [
                     'variant_key' => 'og',
                     'path' => '/static/share/mbti_wide_1200x630.png',
-                    'url' => 'https://api.fermatmind.com/static/share/mbti_wide_1200x630.png',
+                    'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/static/share/mbti_wide_1200x630.png',
                     'mime_type' => 'image/jpeg',
                     'width' => 1200,
                     'height' => 630,
@@ -68,6 +69,8 @@ final class MediaLibraryPublicApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('asset.alt', 'Updated share image')
+            ->assertJsonPath('asset.url', 'https://assets.fermatmind.com/static/share/mbti_wide_1200x630.png')
+            ->assertJsonPath('asset.variants.0.url', 'https://assets.fermatmind.com/static/share/mbti_wide_1200x630.png')
             ->assertJsonPath('asset.variants.0.variant_key', 'og');
     }
 
@@ -102,6 +105,7 @@ final class MediaLibraryPublicApiTest extends TestCase
 
         $this->assertSame(1800, (int) $asset->width);
         $this->assertSame(1200, (int) $asset->height);
+        $this->assertStringStartsWith('https://assets.fermatmind.com/storage/media-library/sources/articleshero/', (string) $asset->url);
         $this->assertSame(6, $asset->variants()->count());
 
         foreach (['hero', 'card', 'thumbnail', 'og', 'preload'] as $variantKey) {
@@ -112,7 +116,36 @@ final class MediaLibraryPublicApiTest extends TestCase
 
             $this->assertSame('image/jpeg', (string) $variant->mime_type);
             $this->assertNotEmpty($variant->path);
+            $this->assertStringStartsWith('https://assets.fermatmind.com/storage/media-library/variants/articleshero/', (string) $variant->url);
             Storage::disk('public')->assertExists((string) $variant->path);
         }
+    }
+
+    public function test_media_library_filters_legacy_url_when_no_path_can_be_canonicalized(): void
+    {
+        $this->putJson('/api/v0.5/internal/media-assets/articles.legacy', [
+            'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/article.jpg',
+            'alt' => 'Legacy article image',
+            'status' => 'published',
+            'is_public' => true,
+            'variants' => [
+                [
+                    'variant_key' => 'card',
+                    'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/card.jpg',
+                    'mime_type' => 'image/jpeg',
+                    'width' => 800,
+                    'height' => 450,
+                ],
+            ],
+        ])
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('asset.url', null)
+            ->assertJsonPath('asset.variants.0.url', null);
+
+        $this->getJson('/api/v0.5/media-assets/articles.legacy?org_id=0')
+            ->assertOk()
+            ->assertJsonPath('asset.url', null)
+            ->assertJsonPath('asset.variants.0.url', null);
     }
 }


### PR DESCRIPTION
## What changed
- Added backend media config for the canonical mutable asset origin (`FAP_MEDIA_ASSET_ORIGIN`, default `https://assets.fermatmind.com`) and public storage URL prefix.
- Extended `PublicMediaUrlGuard` to canonicalize Media Library URLs from paths and filter known legacy Tencent/COS URLs.
- Updated Media Library manual updates, baseline imports, public/internal payloads, and upload variant generation to use the same URL contract.
- Added Media Library feature coverage for canonical baseline/update/upload URLs and legacy URL filtering.
- Added PR-V4-P5B to the backend PR train manifest and ledger.

## Why
Final V4 Phase 5 requires Media Library to be the backend authority for mutable media assets and to stop legacy Tencent/COS media URLs from leaking through public APIs. Frontend now has a guard; backend must enforce the same contract at source and payload boundaries.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test config/fap.php app/Support/PublicMediaUrlGuard.php app/Services/Cms/MediaVariantGenerator.php app/Http/Controllers/API/V0_5/Cms/MediaLibraryController.php app/Console/Commands/MediaAssetsImportLocalBaseline.php tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php`
- `php artisan test tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php`
- `git diff --check`

## Repository rule impact
- Media Library remains the backend authority for mutable editorial, social, article, landing, and SEO media assets.
- `content_baselines/media_assets` remains an importer baseline only; imported URLs are canonicalized and old COS/Tencent URLs are filtered.

## Intentionally deferred
- CDN/DNS provisioning for `assets.fermatmind.com`.
- Historical DB media URL cleanup migration/dry-run report.
- API/FPM resource isolation work.
