### PR TITLE
feat: add media legacy URL audit

### DIFF
--- a/backend/app/Console/Commands/MediaAssetsAuditLegacyUrls.php
+++ b/backend/app/Console/Commands/MediaAssetsAuditLegacyUrls.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\MediaAsset;
+use App\Models\MediaVariant;
+use App\Support\PublicMediaUrlGuard;
+use Illuminate\Console\Command;
+
+final class MediaAssetsAuditLegacyUrls extends Command
+{
+    protected $signature = 'media-assets:audit-legacy-urls
+        {--fail-on-findings : Return a non-zero exit code when legacy URLs are found}';
+
+    protected $description = 'Dry-run audit for legacy Tencent/COS URLs in Media Library records.';
+
+    public function handle(): int
+    {
+        $assetFindings = MediaAsset::query()
+            ->withoutGlobalScopes()
+            ->whereNotNull('url')
+            ->get(['id', 'org_id', 'asset_key', 'url'])
+            ->filter(fn (MediaAsset $asset): bool => PublicMediaUrlGuard::isBlockedUrl((string) $asset->url))
+            ->values();
+
+        $variantFindings = MediaVariant::query()
+            ->whereNotNull('url')
+            ->get(['id', 'media_asset_id', 'variant_key', 'url'])
+            ->filter(fn (MediaVariant $variant): bool => PublicMediaUrlGuard::isBlockedUrl((string) $variant->url))
+            ->values();
+
+        $total = $assetFindings->count() + $variantFindings->count();
+
+        $this->line('dry_run=1');
+        $this->line('media_asset_legacy_url_count='.$assetFindings->count());
+        $this->line('media_variant_legacy_url_count='.$variantFindings->count());
+        $this->line('legacy_url_count='.$total);
+
+        foreach ($assetFindings->take(20) as $asset) {
+            $this->line(sprintf(
+                'media_asset id=%s org_id=%s asset_key=%s url=%s',
+                (string) $asset->id,
+                (string) $asset->org_id,
+                (string) $asset->asset_key,
+                (string) $asset->url
+            ));
+        }
+
+        foreach ($variantFindings->take(20) as $variant) {
+            $this->line(sprintf(
+                'media_variant id=%s media_asset_id=%s variant_key=%s url=%s',
+                (string) $variant->id,
+                (string) $variant->media_asset_id,
+                (string) $variant->variant_key,
+                (string) $variant->url
+            ));
+        }
+
+        if ($total > 0) {
+            $this->warn('legacy media URLs found; run a reviewed cleanup migration before treating Phase 5 data cleanup as complete.');
+
+            return (bool) $this->option('fail-on-findings') ? 1 : 0;
+        }
+
+        $this->info('no legacy media URLs found');
+
+        return 0;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,11 +1,45 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-20T00:09:40+08:00",
+  "updated_at": "2026-04-20T00:11:55+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
   "items": {
+    "PR-V4-P5C": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-v4-p5c-media-url-audit",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/MediaAssetsAuditLegacyUrls.php tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": null,
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
     "PR-V4-P5B": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-20T00:11:55+08:00",
+  "updated_at": "2026-04-20T00:12:47+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -11,8 +11,8 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "in_progress",
       "branch": "codex/pr-v4-p5c-media-url-audit",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "17383d9f87c143994dbdf948265a58b469d012fd",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/947",
       "checks": {
         "local": [
           {
@@ -32,9 +32,30 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24633432192/job/72024617894"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24633438067/job/72024633149"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24633432192/job/72024621635"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24633438067/job/72024635708"
+          }
+        ]
       },
-      "failure_reason": null,
+      "failure_reason": "GitHub Actions hygiene failed immediately on PR #947 and verify-mbti matrix was skipped. Local manifest checks passed and the merge policy does not require GitHub checks for this read-only media URL audit PR.",
       "resume_policy": "manual_only",
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -6,6 +6,33 @@ require_clean_worktree: true
 execution_mode: local_clone_preferred
 
 prs:
+  - id: PR-V4-P5C
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-v4-p5c-media-url-audit
+    base: main
+    depends_on: ["PR-V4-P5B"]
+    mode: execute
+    scope: >
+      Final V4 Phase 5C Media Library legacy URL dry-run audit. Add a
+      read-only command that reports legacy Tencent/COS URLs in media_assets
+      and media_variants, with an optional fail-on-findings gate, without
+      mutating database records or adding cleanup migrations.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands/MediaAssetsAuditLegacyUrls.php tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php"
+      - "php artisan test tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-V4-P5B
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
+++ b/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
@@ -148,4 +148,57 @@ final class MediaLibraryPublicApiTest extends TestCase
             ->assertJsonPath('asset.url', null)
             ->assertJsonPath('asset.variants.0.url', null);
     }
+
+    public function test_legacy_media_url_audit_reports_findings_without_writes(): void
+    {
+        $asset = MediaAsset::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'asset_key' => 'articles.legacy-audit',
+            'disk' => 'public_static',
+            'path' => null,
+            'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/article.jpg',
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+            'payload_json' => [],
+        ]);
+
+        $asset->variants()->create([
+            'variant_key' => 'card',
+            'path' => null,
+            'url' => 'https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/card.jpg',
+            'payload_json' => [],
+        ]);
+
+        $this->artisan('media-assets:audit-legacy-urls')
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('media_asset_legacy_url_count=1')
+            ->expectsOutputToContain('media_variant_legacy_url_count=1')
+            ->expectsOutputToContain('legacy_url_count=2')
+            ->assertExitCode(0);
+
+        $this->artisan('media-assets:audit-legacy-urls', ['--fail-on-findings' => true])
+            ->assertExitCode(1);
+
+        $asset->refresh();
+        $this->assertSame('https://fermatmind-1316873116.cos.ap-shanghai.myqcloud.com/article.jpg', (string) $asset->url);
+    }
+
+    public function test_legacy_media_url_audit_passes_when_no_findings_exist(): void
+    {
+        MediaAsset::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'asset_key' => 'articles.clean-audit',
+            'disk' => 'public_static',
+            'path' => '/static/articles/clean.jpg',
+            'url' => 'https://assets.fermatmind.com/static/articles/clean.jpg',
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+            'payload_json' => [],
+        ]);
+
+        $this->artisan('media-assets:audit-legacy-urls', ['--fail-on-findings' => true])
+            ->expectsOutputToContain('legacy_url_count=0')
+            ->expectsOutputToContain('no legacy media URLs found')
+            ->assertExitCode(0);
+    }
 }


### PR DESCRIPTION
## What changed
- Added `media-assets:audit-legacy-urls`, a read-only dry-run command that scans `media_assets.url` and `media_variants.url` for legacy Tencent/COS URLs.
- Added `--fail-on-findings` for CI or release-gate usage without mutating DB rows.
- Extended Media Library feature coverage for audit findings, fail-on-findings, clean state, and no-write behavior.
- Added PR-V4-P5C to the backend PR train manifest and ledger.

## Why
Final V4 Phase 5 needs a historical media URL cleanup path. Before any cleanup migration, ops needs a dry-run report that identifies current Media Library pollution without changing production data.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Console/Commands/MediaAssetsAuditLegacyUrls.php tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php`
- `php artisan test tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php`
- `git diff --check`

## Repository rule impact
- Media Library remains the backend authority for mutable media assets.
- This PR adds a read-only audit gate; it does not use `content_baselines` for runtime rendering and does not mutate media records.

## Intentionally deferred
- Actual cleanup migration or production data write.
- CDN/DNS provisioning for `assets.fermatmind.com`.
- Broader non-Media-Library content table URL audits.
