### PR TITLE
fix(career): harden directory import and content baselines

### DIFF
--- a/backend/app/Console/Commands/CareerImportOccupationDirectoryDrafts.php
+++ b/backend/app/Console/Commands/CareerImportOccupationDirectoryDrafts.php
@@ -115,13 +115,14 @@ final class CareerImportOccupationDirectoryDrafts extends Command
                     'status' => RunStatus::FAILED,
                     'finished_at' => now(),
                     'error_summary' => [[
-                        'message' => $throwable->getMessage(),
+                        'message' => $this->jsonSafeString($throwable->getMessage()),
                         'type' => 'fatal',
+                        'exception' => $throwable::class,
                     ]],
                 ])->save();
             }
 
-            $this->error($throwable->getMessage());
+            $this->error($this->jsonSafeString($throwable->getMessage()));
 
             return self::FAILURE;
         }
@@ -654,6 +655,20 @@ final class CareerImportOccupationDirectoryDrafts extends Command
             ->lower()
             ->squish()
             ->toString();
+    }
+
+    private function jsonSafeString(string $value): string
+    {
+        if (mb_check_encoding($value, 'UTF-8')) {
+            return $value;
+        }
+
+        $converted = @iconv('UTF-8', 'UTF-8//IGNORE', $value);
+        if (is_string($converted) && $converted !== '') {
+            return $converted;
+        }
+
+        return 'Non-UTF-8 exception message: '.bin2hex($value);
     }
 
     /**

--- a/backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
@@ -113,8 +113,9 @@ final class ContentPagesImportLocalBaseline extends Command
 
     private function resolveSourceDir(string $override): string
     {
-        $candidate = trim($override) !== ''
-            ? base_path(trim($override))
+        $override = trim($override);
+        $candidate = $override !== ''
+            ? ($this->isAbsolutePath($override) ? $override : base_path($override))
             : base_path('../content_baselines/content_pages');
 
         $real = realpath($candidate);
@@ -123,6 +124,12 @@ final class ContentPagesImportLocalBaseline extends Command
         }
 
         return $real;
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, DIRECTORY_SEPARATOR)
+            || preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) === 1;
     }
 
     /**

--- a/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
+++ b/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\ContentPage;
+use App\Services\Career\Bundles\CareerJobListBundleBuilder;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class ReleaseVerifyPublicContent extends Command
+{
+    protected $signature = 'release:verify-public-content
+        {--expected-occupations=2787 : Required full career dataset member count}
+        {--min-career-job-items=2786 : Required public career job list item count}
+        {--content-source-dir=../content_baselines/content_pages : Content page baseline directory to verify against}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Fail release when backend-authoritative public content required by frontend surfaces is incomplete.';
+
+    public function handle(
+        PublicCareerAuthorityResponseCache $careerAuthorityCache,
+        CareerJobListBundleBuilder $careerJobListBundleBuilder,
+    ): int {
+        $summary = [
+            'content_pages' => $this->verifyContentPages(),
+            'career_dataset' => $this->verifyCareerDataset($careerAuthorityCache),
+            'career_job_list' => $this->verifyCareerJobList($careerJobListBundleBuilder),
+        ];
+
+        $failures = [];
+        foreach ($summary as $section => $result) {
+            foreach ((array) ($result['failures'] ?? []) as $failure) {
+                $failures[] = [
+                    'section' => $section,
+                    'failure' => $failure,
+                ];
+            }
+        }
+
+        $payload = [
+            'ok' => $failures === [],
+            'summary' => $summary,
+            'failures' => $failures,
+        ];
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } else {
+            foreach ($summary as $section => $result) {
+                $this->line(sprintf('%s ok=%s', $section, ($result['ok'] ?? false) ? '1' : '0'));
+                foreach ((array) ($result['metrics'] ?? []) as $metric => $value) {
+                    $this->line(sprintf('%s.%s=%s', $section, $metric, is_bool($value) ? ($value ? '1' : '0') : (string) $value));
+                }
+            }
+
+            foreach ($failures as $failure) {
+                $this->error($failure['section'].': '.$failure['failure']);
+            }
+        }
+
+        return $failures === [] ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array{ok: bool, metrics: array<string, int>, failures: list<string>}
+     */
+    private function verifyContentPages(): array
+    {
+        $baselineRows = $this->loadContentPageBaselineRows();
+        $failures = [];
+
+        if ($baselineRows === []) {
+            $failures[] = 'content_page_baseline_empty';
+        }
+
+        foreach ($baselineRows as $row) {
+            $exists = ContentPage::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->where('slug', $row['slug'])
+                ->where('locale', $row['locale'])
+                ->where('kind', $row['kind'])
+                ->where('path', $row['path'])
+                ->where('status', ContentPage::STATUS_PUBLISHED)
+                ->where('is_public', true)
+                ->exists();
+
+            if (! $exists) {
+                $failures[] = sprintf('missing_content_page:%s:%s', $row['locale'], $row['slug']);
+            }
+        }
+
+        $publishedPublicCount = ContentPage::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('status', ContentPage::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->count();
+
+        return [
+            'ok' => $failures === [],
+            'metrics' => [
+                'baseline_count' => count($baselineRows),
+                'published_public_count' => $publishedPublicCount,
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return list<array{slug: string, locale: string, kind: string, path: string}>
+     */
+    private function loadContentPageBaselineRows(): array
+    {
+        $sourceDir = $this->resolveContentSourceDir();
+        $rows = [];
+
+        foreach (File::glob($sourceDir.DIRECTORY_SEPARATOR.'*.json') ?: [] as $file) {
+            $decoded = json_decode((string) file_get_contents($file), true);
+            if (! is_array($decoded)) {
+                continue;
+            }
+
+            foreach ($decoded as $row) {
+                if (! is_array($row)) {
+                    continue;
+                }
+
+                $slug = trim((string) ($row['slug'] ?? ''));
+                $locale = trim((string) ($row['locale'] ?? ''));
+                $kind = trim((string) ($row['kind'] ?? ''));
+                $path = trim((string) ($row['path'] ?? ''));
+
+                if ($slug === '' || $locale === '' || $kind === '' || $path === '') {
+                    continue;
+                }
+
+                $rows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'kind' => $kind,
+                    'path' => $path,
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    private function resolveContentSourceDir(): string
+    {
+        $sourceDir = trim((string) $this->option('content-source-dir'));
+        $candidate = $sourceDir !== '' && $this->isAbsolutePath($sourceDir)
+            ? $sourceDir
+            : base_path($sourceDir !== '' ? $sourceDir : '../content_baselines/content_pages');
+
+        $real = realpath($candidate);
+        if (! is_string($real) || ! is_dir($real)) {
+            throw new \RuntimeException("Content page baseline directory not found: {$candidate}");
+        }
+
+        return $real;
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, DIRECTORY_SEPARATOR)
+            || preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) === 1;
+    }
+
+    /**
+     * @return array{ok: bool, metrics: array<string, int|bool>, failures: list<string>}
+     */
+    private function verifyCareerDataset(PublicCareerAuthorityResponseCache $careerAuthorityCache): array
+    {
+        $expectedOccupations = max(0, (int) $this->option('expected-occupations'));
+        $payload = $careerAuthorityCache->datasetHubPayload();
+        $memberCount = (int) data_get($payload, 'collection_summary.member_count', 0);
+        $trackedTotal = (int) data_get($payload, 'collection_summary.tracking_counts.tracked_total_occupations', 0);
+        $missingOccupations = (int) data_get($payload, 'collection_summary.tracking_counts.missing_occupations', 0);
+        $trackingComplete = (bool) data_get($payload, 'collection_summary.tracking_counts.tracking_complete', false);
+
+        $failures = [];
+        if ($memberCount < $expectedOccupations) {
+            $failures[] = "career_dataset_member_count_below_expected:{$memberCount}<{$expectedOccupations}";
+        }
+
+        if ($expectedOccupations > 0 && ! $trackingComplete) {
+            $failures[] = 'career_dataset_tracking_incomplete';
+        }
+
+        if ($expectedOccupations > 0 && $missingOccupations !== 0) {
+            $failures[] = "career_dataset_missing_occupations:{$missingOccupations}";
+        }
+
+        return [
+            'ok' => $failures === [],
+            'metrics' => [
+                'expected_occupations' => $expectedOccupations,
+                'member_count' => $memberCount,
+                'tracked_total_occupations' => $trackedTotal,
+                'missing_occupations' => $missingOccupations,
+                'tracking_complete' => $trackingComplete,
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return array{ok: bool, metrics: array<string, int>, failures: list<string>}
+     */
+    private function verifyCareerJobList(CareerJobListBundleBuilder $careerJobListBundleBuilder): array
+    {
+        $minimumItems = max(0, (int) $this->option('min-career-job-items'));
+        $items = $careerJobListBundleBuilder->build();
+        $itemCount = count($items);
+        $failures = [];
+
+        if ($itemCount < $minimumItems) {
+            $failures[] = "career_job_list_count_below_expected:{$itemCount}<{$minimumItems}";
+        }
+
+        return [
+            'ok' => $failures === [],
+            'metrics' => [
+                'min_career_job_items' => $minimumItems,
+                'item_count' => $itemCount,
+            ],
+            'failures' => $failures,
+        ];
+    }
+}

--- a/backend/app/Services/Career/Directory/OccupationDirectoryDisplayNormalizer.php
+++ b/backend/app/Services/Career/Directory/OccupationDirectoryDisplayNormalizer.php
@@ -1430,8 +1430,9 @@ final class OccupationDirectoryDisplayNormalizer
         }
 
         $result = implode('', array_values(array_filter($translated, static fn (?string $part): bool => $part !== null && $part !== '')));
+        $result = preg_replace('/^(?:、|和)+|(?:、|和)+$/u', '', $result) ?? $result;
 
-        return trim($result, '、和');
+        return trim($result);
     }
 
     private function isWeakChineseTitle(string $title): bool

--- a/backend/docs/ops/career-occupation-directory-import-runbook.md
+++ b/backend/docs/ops/career-occupation-directory-import-runbook.md
@@ -145,6 +145,26 @@ A future publishable import or compile step must remain blocked until all of the
 5. Backend truth computation can generate canonical slugs, localized titles, searchable aliases, SEO state, and publication state.
 6. Imported records enter as draft or dataset-only records first; public pages must not appear until normal career publish readiness gates pass.
 
+## Release Guard
+
+Every production deploy that can affect career directory visibility or CMS-backed footer pages must run the public content release guard after baseline imports and career authority cache warming:
+
+```bash
+php artisan release:verify-public-content \
+  --expected-occupations=2787 \
+  --min-career-job-items=2786 \
+  --content-source-dir=/absolute/path/to/content_baselines/content_pages
+```
+
+The deploy recipe runs this command automatically. The release must stop if any of these fail:
+
+- every content page baseline row is not present as `status=published` and `is_public=true` in `content_pages`
+- the career dataset member count is below `2787`
+- career dataset tracking is incomplete or has missing occupations
+- the career job list item count is below `2786`
+
+If the guard fails, fix the backend-authoritative data import or compile path first. Do not patch frontend fallback content to hide the failure.
+
 ## Repository Rule Impact
 
 This runbook is backend import governance for a CMS/backend-authoritative career content surface. It does not add frontend fallback content, public editorial copy, public API behavior, sitemap enumeration, or runtime page-rendering authority.

--- a/backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
+++ b/backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ReleaseVerifyPublicContentCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_fails_when_backend_content_page_baselines_are_missing(): void
+    {
+        $this->artisan('release:verify-public-content', [
+            '--expected-occupations' => 0,
+            '--min-career-job-items' => 0,
+            '--content-source-dir' => '../content_baselines/content_pages',
+        ])
+            ->expectsOutputToContain('content_pages ok=0')
+            ->expectsOutputToContain('missing_content_page:zh-CN:about')
+            ->assertExitCode(1);
+    }
+
+    #[Test]
+    public function it_passes_when_content_pages_and_career_directory_counts_are_ready(): void
+    {
+        $this->artisan('content-pages:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/content_pages',
+        ])->assertExitCode(0);
+
+        $this->createDirectoryDraftOccupation('example-directory-job', 'Example directory job', '示例目录职业');
+        $this->createDirectoryDraftOccupation('sample-directory-job', 'Sample directory job', '样例目录职业');
+
+        $this->artisan('release:verify-public-content', [
+            '--expected-occupations' => 2,
+            '--min-career-job-items' => 2,
+            '--content-source-dir' => '../content_baselines/content_pages',
+        ])
+            ->expectsOutputToContain('content_pages ok=1')
+            ->expectsOutputToContain('career_dataset ok=1')
+            ->expectsOutputToContain('career_job_list ok=1')
+            ->assertExitCode(0);
+    }
+
+    private function createDirectoryDraftOccupation(string $slug, string $titleEn, string $titleZh): void
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'test-family'],
+            [
+                'title_en' => 'Test family',
+                'title_zh' => '测试职业族',
+            ],
+        );
+
+        Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'directory_draft',
+            'canonical_title_en' => $titleEn,
+            'canonical_title_zh' => $titleZh,
+            'search_h1_zh' => $titleZh,
+            'structural_stability' => null,
+            'task_prototype_signature' => null,
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => null,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/Career/OccupationDirectoryDisplayNormalizerTest.php
+++ b/backend/tests/Unit/Services/Career/OccupationDirectoryDisplayNormalizerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Directory\OccupationDirectoryDisplayNormalizer;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class OccupationDirectoryDisplayNormalizerTest extends TestCase
+{
+    #[Test]
+    public function english_title_translation_trims_connectors_without_corrupting_utf8(): void
+    {
+        $normalizer = new OccupationDirectoryDisplayNormalizer();
+
+        $title = $normalizer->titleZh([
+            'market' => 'US',
+            'identity' => [
+                'source_title_en' => 'Security Managers',
+                'canonical_title_zh' => '经理',
+            ],
+        ]);
+
+        $this->assertSame('安全经理', $title);
+        $this->assertTrue(mb_check_encoding($title, 'UTF-8'));
+    }
+}

--- a/deploy.php
+++ b/deploy.php
@@ -317,8 +317,16 @@ task('career:warm-public-authority-cache', function () {
     run('timeout 180 {{bin/php}} {{release_path}}/backend/artisan career:warm-public-authority-cache --no-interaction --ansi');
 });
 
+task('guard:public-content-release', function () {
+    run('timeout 180 {{bin/php}} {{release_path}}/backend/artisan release:verify-public-content --content-source-dir={{release_path}}/content_baselines/content_pages --no-interaction --ansi');
+});
+
 task('cms:import-landing-surface-baselines', function () {
     run('{{bin/php}} {{release_path}}/backend/artisan landing-surfaces:import-local-baseline --upsert --status=published --source-dir={{release_path}}/content_baselines/landing_surfaces --no-interaction --ansi');
+});
+
+task('cms:import-content-page-baselines', function () {
+    run('{{bin/php}} {{release_path}}/backend/artisan content-pages:import-local-baseline --upsert --status=published --source-dir={{release_path}}/content_baselines/content_pages --no-interaction --ansi');
 });
 
 task('artisan:view:cache', function () {
@@ -710,8 +718,10 @@ after('artisan:filament:assets', 'guard:filament-assets');
 after('artisan:config:cache', 'guard:sitemap-authority');
 after('artisan:migrate', 'guard:no-pending-migrations');
 after('guard:no-pending-migrations', 'cms:import-landing-surface-baselines');
-after('cms:import-landing-surface-baselines', 'career:warm-public-authority-cache');
-after('career:warm-public-authority-cache', 'ensure:release-runtime-perms');
+after('cms:import-landing-surface-baselines', 'cms:import-content-page-baselines');
+after('cms:import-content-page-baselines', 'career:warm-public-authority-cache');
+after('career:warm-public-authority-cache', 'guard:public-content-release');
+after('guard:public-content-release', 'ensure:release-runtime-perms');
 
 after('deploy:symlink', 'reload:php-fpm');
 after('deploy:symlink', 'reload:nginx');

--- a/docs/release/RELEASE_POLICY.md
+++ b/docs/release/RELEASE_POLICY.md
@@ -26,3 +26,22 @@
 1. `bash scripts/audit_smoke.sh dist/fap-api-release.zip`
 2. `bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/`
 3. `bash scripts/supply_chain_gate.sh ./_audit/fap-api-0212-5`
+
+## 生产内容发布守卫（必做）
+
+生产发布必须在迁移、CMS baseline import、职业 authority cache warm 之后执行：
+
+```bash
+php artisan release:verify-public-content \
+  --expected-occupations=2787 \
+  --min-career-job-items=2786 \
+  --content-source-dir=/absolute/path/to/content_baselines/content_pages
+```
+
+`deploy.php` 已自动串联该守卫。该命令失败时，本次发布不得标记成功；必须先修复 backend/CMS 权威数据，不允许用前端 fallback 内容掩盖。
+
+守卫覆盖：
+
+- `content_pages` 中公司、政策、帮助页 baseline 均已发布且公开
+- 职业完整数据集达到 2787 个追踪职业，且 tracking complete
+- 职业列表 API 对应的 backend bundle 至少有 2786 个可展示条目


### PR DESCRIPTION
## What changed
- Make career directory title normalization trim Chinese connectors with a Unicode-safe regex so UTF-8 titles are not corrupted during import.
- Store fatal career import errors with JSON-safe messages and the exception class so the original failure is not masked by invalid UTF-8 in the run summary.
- Let content page baseline imports accept absolute `--source-dir` values.
- Add the content page baseline import to production deploy before the public authority cache warm step.
- Add `release:verify-public-content` as a production release guard for backend-authoritative content readiness.
- Wire the release guard into deploy after CMS baseline imports and career authority cache warming.
- Document the guard in the career occupation directory import runbook and release policy.
- Add tests for the UTF-8 normalization regression and the public content release guard.

## Why
Production had two related release hazards: the career directory import could fail on corrupted UTF-8 generated by byte-wise trimming, leaving the public job list at the first-wave count, and content pages could be absent from the database, which left footer company/policy links as 404 after a frontend build.

This PR turns the operational fix into a standard release gate. Future deploys now fail before success if the backend-authoritative `content_pages` baseline is missing, if the career dataset is below 2787 tracked occupations, if tracking is incomplete, or if the career job list has fewer than 2786 visible entries.

## Validation
- `php -l deploy.php`
- `php -l backend/app/Console/Commands/CareerImportOccupationDirectoryDrafts.php`
- `php -l backend/app/Console/Commands/ContentPagesImportLocalBaseline.php`
- `php -l backend/app/Console/Commands/ReleaseVerifyPublicContent.php`
- `php -l backend/app/Services/Career/Directory/OccupationDirectoryDisplayNormalizer.php`
- `php -l backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php`
- `php -l backend/tests/Unit/Services/Career/OccupationDirectoryDisplayNormalizerTest.php`
- `php backend/artisan content-pages:import-local-baseline --dry-run --source-dir=/Users/rainie/Desktop/GitHub/fap-api/content_baselines/content_pages --no-interaction --ansi`
- `(cd backend && php artisan release:verify-public-content --content-source-dir=/Users/rainie/Desktop/GitHub/fap-api/content_baselines/content_pages --no-interaction --ansi)`
- `(cd backend && php artisan test tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php tests/Unit/Services/Career/OccupationDirectoryDisplayNormalizerTest.php tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php tests/Feature/ContentPages/ContentPagePublicApiTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php)`

## Intentionally deferred
- This does not change which career jobs have full public detail pages; the first-wave detail surface remains governed by existing career CMS/public API authority.
- This does not add frontend fallback content for company or policy pages.
- This does not change frontend footer routing for support/refund redirects.

## Repository rule impact
This reinforces the existing backend/CMS authority rule: company and policy pages continue to come from backend `content_pages`, and career content continues to come from backend career CMS/public APIs. The deploy now seeds and verifies backend-authoritative content page baselines and career public dataset readiness instead of relying on frontend fallback content.